### PR TITLE
feat: Move i18n from private @kong-ui/core into its own public packag…

### DIFF
--- a/packages/core/cli/src/__template__/LICENSE
+++ b/packages/core/cli/src/__template__/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Kong, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/core/cli/src/__template__/package.json
+++ b/packages/core/cli/src/__template__/package.json
@@ -38,7 +38,7 @@
   },
   "repository": "https://github.com/Kong/public-ui-components/tree/main/packages/{%%WORKSPACE%%}/{%%PACKAGE_NAME%%}",
   "author": "Kong, Inc.",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "volta": {
     "extends": "../../../package.json"
   },

--- a/packages/core/i18n/LICENSE
+++ b/packages/core/i18n/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Kong, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/core/i18n/README.md
+++ b/packages/core/i18n/README.md
@@ -1,0 +1,304 @@
+# @kong-ui/core-i18n
+
+## Purpose
+
+This is a wrapper around [FormatJS](https://formatjs.io/docs/intl) that allows consuming application and components to have access to i18n functionality such as:
+
+- format messages
+- format numbers
+- format dates
+
+## Use in application
+
+When used in application we only need to instantiate `Intl` object once, during application hydration, and then we can use it anywhere in the app via `useI18n` composable.
+
+in `main.ts` (application hydration code):
+
+```ts
+import { createI18n } from '@kong-ui/core-i18n'
+import english from './locales/en.json'
+
+...
+
+// this will create Application instance of Intl object
+createI18n('en-us', english, true)
+```
+
+And then, anywhere in application code where `i18n` is needed:
+
+```html
+<template>
+  {{ i18n.t('global.ok') }}
+</template>
+
+<script setup lang="ts">
+import { useI18n } from '@kong-ui/core-i18n'
+const i18n = useI18n()
+</script>
+```
+
+
+## Use in shared component
+
+When used in [shared component](https://github.com/Kong/shared-ui-components/pull/118/files#diff-f296a0775f650cac9ecd4b5d7ccef015ca73587be833b40eeae1e396426b0f4fR45) (outside of application code),  we need `Intl` that is local to that component, so that it is using component's own localization strings:
+
+```html
+<template>
+  {{ i18n.t('component.message') }}
+</template>
+
+
+// assuming component is receiving locale code as a property
+<script setup lang="ts">
+import { createI18n } from '@kong-ui/core-i18n'
+import english from '../locales/en.json'
+
+// this will instantiate `Intl` local to this component, using component's english messages.
+// TODO: load and pass messages based on language passed from consuming application
+const i18n = createI18n(props.locale || 'en-us', english)
+</script>
+```
+
+## Formatting messages
+
+`en.json:`
+
+```json
+{
+  "global": {
+    "ok": "Okay"
+  },
+  "test": {
+    "withParams": "Good {dayPart}, My name is {name}!",
+    "withPluralization": "{count} {count, plural, =0 {versions} =1 {version} other {versions}} available"
+  }
+}
+```
+
+`code:`
+
+```html
+<template>
+  Simple formatting:
+    {{ i18n.t('global.ok') }}
+  With parameters:
+    {{ i18n.t('test.withParams', { dayPart: 'Morning', name: 'i18n' }) }}
+  With pluralization:
+    {{ i18n.t('test.withPluralization', { count: 0 }) }}
+    {{ i18n.t('test.withPluralization', { count: 1 }) }}
+    {{ i18n.t('test.withPluralization', { count: 11 }) }}
+</template>
+
+
+<script setup lang="ts">
+import { useI18n } from '@kong-ui/core-i18n'
+const i18n = useI18n()
+</script>
+```
+
+`result:`
+
+```txt
+Simple formatting:
+  Okay
+
+With parameters:
+  Good Morning, My name is i18n!
+
+With pluralization:
+  0 versions available
+  1 version available
+  11 version available
+```
+
+### Where is my helpText?
+
+In `khcp-ui` there are many places where instead of using Intl function we are accessing translations string directly (from the store). Even it is not recommended way of doing thing, but because there are too many places to change, we I18n implementation is supporting this for backwards compatibility.
+
+`en.json:`
+
+```json
+{
+    "components": {
+        "docUploadCard": {
+            "actions": {
+                "edit": "Upload New",
+                "delete": "Delete"
+            }
+        }
+    }
+}
+```
+
+`code:`
+
+```html
+<template>
+  {{ helpText.actions.edit }}
+</template>
+
+
+<script setup lang="ts">
+import { useI18n } from '@kong-ui/core-i18n'
+
+const i18n = useI18n()
+const helpText = i18n.source.components.docUploadCard
+</script>
+```
+
+_Please, do not use this method in any new code. This prevents using parameters/pluralization and other formatting features. use exposed methods instead._
+
+### HTML safe formatting
+
+Sometimes it is needed to render translated message with HTML as part of the parameters. For this Provided component can be used.
+
+`en.json:`
+
+```json
+{
+  "global": {
+    "default": "See the news at {0}. There is a lot there.",
+    "named": "{greeting}, my name is {name}. And I am {occupation}. I want {amount}"
+  }
+}
+```
+
+`main.ts` (registing component)
+
+```ts
+import { createI18n, Translation } from '@kong-ui/core-i18n'
+import english from './locales/en.json'
+
+...
+
+//this will create Application instance of Intl object
+const i18n = createI18n('en-us', english, true)
+// this will register <i18n-t> component
+app.use(Translation, { i18n })
+```
+
+And then, anywhere in application code where `i18n` is needed
+
+#### Formatting default slot
+
+`code:`
+
+```html
+<template>
+  <i18n-t keypath="global.default">
+      <a href="https://google.com">Google</a>
+  </i18n-t>
+</template>
+```
+
+`result:`
+
+```html
+<span>See the news at <a href="https://google.com">Google</a>. There is a lot there.</span>
+```
+
+#### Formatting named slots. Using tag to render into template
+
+`code:`
+
+```html
+<template>
+    <i18n-t
+      tag="h1"
+      keypath="global.named"
+    >
+      <template #greeting>
+        <b>Morning</b>
+      </template>
+
+      <template #name>
+        <i>Val</i>
+      </template>
+
+      <template #occupation>
+        <i>Money Asker</i>
+      </template>
+
+      <template #amount>
+        <div class="red">{{ i18n.formatNumber(1000, { style: 'currency', currency: 'USD' }) }}</div>
+      </template>
+    </i18n-t>
+</template>
+```
+
+`result:`
+
+```html
+<h1><b>Morning</b>, my name is <i>Val</i>. And I am <i>Money Asker</i>. I want <div class="red">$1,000.00</div></h1>
+```
+
+## Formatting numbers, dates and times
+
+This comes for free from FormatJS, and documentation on those methods can be found there: [FormatJS](https://formatjs.io/docs/intl)
+
+Unit tests for I18n wrapper in kong-ui/core also has view examples as a references for those.
+[FormatDate](https://github.com/Kong/shared-ui-components/blob/4a1f99d5cee2d4409f4370a9bce2377450a6429d/packages/core/src/useI18n/i18n.spec.ts#L81)
+[FormatNumber](https://github.com/Kong/shared-ui-components/blob/4a1f99d5cee2d4409f4370a9bce2377450a6429d/packages/core/src/useI18n/i18n.spec.ts#L68)
+
+Every single method listed in [FormatJS](https://formatjs.io/docs/intl) is exposed and available in i18n wrapper.
+
+## Additional service functions.
+
+(as previously exposed by vue18n-n)
+
+### te
+
+check if translation message exists
+
+`en.json`
+
+```json
+"global": {
+  "ok": "Okay"
+}
+```
+
+`code:`
+
+```ts
+const { te } = useI18n()
+console.log({p: te('global.ok'), n: te('global.not.ok')})
+console.log()
+```
+
+`result:`
+
+```json
+{"p": true, "n": false}
+```
+
+### tm
+
+returns array values defined for given key
+
+`en.json`
+
+```json
+ "global": {
+    "disabled": [
+      "You cannot update configurations for services",
+      "You cannot accept new developer portal applications",
+    ]
+  }
+```
+
+`code:`
+
+```ts
+const { tm } = useI18n()
+console.log(te('global.disabled'))
+```
+
+`result:`
+
+```json
+[
+  "You cannot update configurations for services",
+  "You cannot accept new developer portal applications",
+]
+```

--- a/packages/core/i18n/package.json
+++ b/packages/core/i18n/package.json
@@ -38,7 +38,7 @@
   },
   "repository": "https://github.com/Kong/public-ui-components/tree/main/packages/core/i18n",
   "author": "Kong, Inc.",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "volta": {
     "extends": "../../../package.json"
   },

--- a/packages/core/i18n/package.json
+++ b/packages/core/i18n/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@kong-ui/core-i18n",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./dist/core-i18n.umd.js",
+  "module": "./dist/core-i18n.es.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/core-i18n.es.js",
+      "require": "./dist/core-i18n.umd.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": "./dist/*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "dev": "cross-env USE_SANDBOX=true vite",
+    "build": "run-s typecheck build:package build:types",
+    "build:package": "vite build",
+    "build:types": "vue-tsc -p './tsconfig.build.json' --emitDeclarationOnly",
+    "preview:package": "vite preview --port 4173",
+    "preview": "cross-env USE_SANDBOX=true PREVIEW_SANDBOX=true run-s build:package preview:package",
+    "lint": "eslint '**/*.{js,jsx,ts,tsx,vue}' --ignore-path '../../../.eslintignore'",
+    "lint:fix": "eslint '**/*.{js,jsx,ts,tsx,vue}' --ignore-path '../../../.eslintignore' --fix",
+    "stylelint": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}'",
+    "stylelint:fix": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}' --fix",
+    "typecheck": "vue-tsc -p './tsconfig.build.json' --noEmit",
+    "test:component": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress run --component -b chrome --spec './src/**/*.cy.ts' --project '../../../.'",
+    "test:component:open": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress open --component -b chrome --project '../../../.'",
+    "test:unit": "cross-env FORCE_COLOR=1 vitest run",
+    "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
+  },
+  "repository": "https://github.com/Kong/public-ui-components/tree/main/packages/core/i18n",
+  "author": "Kong, Inc.",
+  "license": "UNLICENSED",
+  "volta": {
+    "extends": "../../../package.json"
+  },
+  "peerDependencies": {
+    "vue": "^3.2.38"
+  },
+  "dependencies": {
+    "@formatjs/intl": "^2.6.3",
+    "flat": "^5.0.2",
+    "intl-messageformat": "^10.2.5"
+  }
+}

--- a/packages/core/i18n/sandbox/App.vue
+++ b/packages/core/i18n/sandbox/App.vue
@@ -4,8 +4,8 @@
       <p>{{ i18n.t('global.ok') }}</p>
 
       <i18n-t
-        tag="h1"
         keypath="global.named"
+        tag="h1"
       >
         <template #greeting>
           <b>Morning</b>

--- a/packages/core/i18n/sandbox/App.vue
+++ b/packages/core/i18n/sandbox/App.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="sandbox-container">
+    <main>
+      <p>{{ i18n.t('global.ok') }}</p>
+
+      <i18n-t
+        tag="h1"
+        keypath="global.named"
+      >
+        <template #greeting>
+          <b>Morning</b>
+        </template>
+
+        <template #name>
+          <i>Val</i>
+        </template>
+
+        <template #occupation>
+          <i>Money Asker</i>
+        </template>
+
+        <template #amount>
+          <div class="red">
+            {{ i18n.formatNumber(1000, { style: 'currency', currency: 'USD' }) }}
+          </div>
+        </template>
+      </i18n-t>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from '../src'
+const i18n = useI18n()
+</script>

--- a/packages/core/i18n/sandbox/index.html
+++ b/packages/core/i18n/sandbox/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>core - I18n Component Sandbox</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+
+</html>

--- a/packages/core/i18n/sandbox/index.ts
+++ b/packages/core/i18n/sandbox/index.ts
@@ -1,0 +1,11 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+import { Translation, createI18n } from '../src/'
+import english from './locales/en.json'
+console.log(english)
+const i18n = createI18n('en-us', english, true)
+const app = createApp(App)
+app.use(Translation, { i18n })
+
+app.mount('#app')

--- a/packages/core/i18n/sandbox/locales/en.json
+++ b/packages/core/i18n/sandbox/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "global": {
+    "ok": "O-k-key",
+    "named": "{greeting}, my name is {name}. And I am {occupation}. I want {amount}"
+  }
+}

--- a/packages/core/i18n/sandbox/tsconfig.json
+++ b/packages/core/i18n/sandbox/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.vue",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/core/i18n/src/Translation.spec.ts
+++ b/packages/core/i18n/src/Translation.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Translation from './Translation'
+import useI18n, { createI18n } from './i18n'
+
+const english = {
+  global: {
+    ok: 'Okay',
+    default: 'See the news at {0}. There is a lot there.',
+    named: '{greeting}, my name is {name}. And I am {occupation}. I want {amount}',
+  },
+}
+
+const i18n = createI18n('en-us', english, true)
+
+describe('Translation', () => {
+  it('should render default slot', () => {
+    const wrapper = mount({
+      template: `
+        <i18n-t
+          keypath="global.default"
+        >
+          <a href="https://google.com">Google</a>
+        </i18n-t>
+      `,
+    }, {
+      global: {
+        plugins: [[Translation, { i18n }]],
+      },
+    })
+    expect(wrapper.html()).toEqual('<span keypath="global.default" tag="span">See the news at <a href="https://google.com">Google</a>. There is a lot there.</span>')
+  })
+
+  it('should render named slots in predefined tag', () => {
+    const wrapper = mount({
+      setup: () => {
+        return {
+          i18n: useI18n(),
+        }
+      },
+      template: `
+        <i18n-t
+          tag="h1"
+          keypath="global.named"
+        >
+        <template #greeting>
+          <b>Morning</b>
+        </template>
+
+        <template #name>
+          <i>Val</i>
+        </template>
+
+        <template #occupation>
+          <i>Money Asker</i>
+        </template>
+
+        <template #amount>
+          {{ i18n.formatNumber(1000, { style: 'currency', currency: 'USD' }) }}
+        </template>
+
+        </i18n-t>
+      `,
+    }, {
+      global: {
+        plugins: [[Translation, { i18n }]],
+      },
+    },
+    )
+    expect(wrapper.html()).toEqual('<h1 keypath="global.named" tag="h1"><b>Morning</b>, my name is <i>Val</i>. And I am <i>Money Asker</i>. I want $1,000.00</h1>')
+  })
+})

--- a/packages/core/i18n/src/Translation.ts
+++ b/packages/core/i18n/src/Translation.ts
@@ -1,0 +1,69 @@
+import { defineComponent, h } from 'vue'
+import type { VNodeChild, App } from 'vue'
+import type { IntlShapeEx } from './types'
+
+const TranslationComponent = (i18n: IntlShapeEx) => defineComponent({
+  name: 'I18nT',
+  props: {
+    keypath: {
+      type: String,
+      required: true,
+    },
+    tag: {
+      type: String,
+      default: 'span',
+    },
+  },
+  setup(props, { slots }) {
+    //  deconstructString('Previewing {rowsMax} of {rowsTotal} rows')
+    //  Result: (5)['Previewing ', '{rowsMax}', ' of ', '{rowsTotal}', ' rows']
+
+    /**
+     * Deconstruct the given translation string, splitting into an array based on `{(.*)}` matches
+     * @param {string} str The translation string to split
+     * @return {string[]} An array of strings
+     */
+    const deconstructString = (str: string): string[] => {
+      if (!str) {
+        return []
+      }
+
+      const matchRegex = /(\{[^}]+\})/g
+
+      return str.split(matchRegex).filter(Boolean)
+    }
+
+    return (): VNodeChild => {
+      const keys = Object.keys(slots).filter(key => key !== '_')
+      const sourceString = i18n.messages[props.keypath].toString()
+
+      let hArray: Array<any> = deconstructString(sourceString)
+
+      hArray = hArray.filter(a => a !== '')
+
+      // replacing slots
+      hArray.forEach((element: string, i: number) => {
+        if (!element.startsWith('{') && !element.endsWith('}')) {
+          return
+        }
+        // eslint-disable-next-line
+        const stripped = element.replace(/[\{\}]/g, '')
+        if (stripped === '0' && slots.default) {
+          hArray[i] = slots.default()
+        } else if (keys.includes(stripped) && slots[stripped]) {
+          // @ts-ignore
+          hArray[i] = slots[stripped]()
+        }
+      })
+      return h(props.tag, props, hArray)
+    }
+  },
+})
+
+// Export Vue plugin
+export default {
+  install(app: App, options: { i18n: IntlShapeEx }) {
+    const { i18n } = options
+    app.component('I18nT', TranslationComponent(i18n))
+  },
+}

--- a/packages/core/i18n/src/i18n.spec.ts
+++ b/packages/core/i18n/src/i18n.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import useI18n, { createI18n } from './i18n'
+
+const english = {
+  global: {
+    ok: 'Okay',
+  },
+  test: {
+    withParams: 'Good {dayPart}, My name is {name}!',
+    withPluralization: 'There are {count} {count, plural, =0 {versions} =1 {version} other {versions}} available',
+  },
+  array: {
+    disabled: [
+      'You cannot update configurations for services',
+      'You cannot accept new developer portal applications',
+    ],
+  },
+}
+
+describe('i18n', () => {
+  describe('createI18n & useI18n', () => {
+    it('Should create local instance of Intl', () => {
+      const localI18n = createI18n('en-us', english)
+      const globalI18n = useI18n()
+      expect(globalI18n).toBeUndefined()
+      expect(localI18n?.t).toBeTypeOf('function')
+      expect(localI18n?.messages['global.ok']).toEqual('Okay')
+      expect(localI18n?.source.global).toEqual({ ok: 'Okay' })
+    })
+
+    it('Should create global instance of Intl', () => {
+      createI18n('en-us', english, true)
+      const i18n = useI18n()
+
+      expect(i18n?.t).toBeTypeOf('function')
+      expect(i18n?.messages['global.ok']).toEqual('Okay')
+      expect(i18n?.source.global).toEqual({ ok: 'Okay' })
+    })
+
+    it('Local and global instances should be different', () => {
+      createI18n('en-us', { global: { ok: 'not Okay' } }, true)
+      const globalI18n = useI18n()
+
+      const localI18n = createI18n('en-us', english)
+
+      expect(globalI18n?.messages['global.ok']).not.toEqual(localI18n?.messages['global.ok'])
+    })
+  })
+
+  describe('function `t`', () => {
+    beforeAll(() => {
+      createI18n('en-us', english, true)
+    })
+    it('should format simple message', () => {
+      const { t } = useI18n()
+      expect(t('global.ok')).toEqual('Okay')
+    })
+
+    it('should format message with parameters', () => {
+      const { t } = useI18n()
+      expect(t('test.withParams', { dayPart: 'Morning', name: 'i18n' })).toEqual('Good Morning, My name is i18n!')
+    })
+
+    it('should format message with pluralization', () => {
+      const { t } = useI18n()
+      expect(t('test.withPluralization', { count: 0 })).toEqual('There are 0 versions available')
+      expect(t('test.withPluralization', { count: 1 })).toEqual('There are 1 version available')
+      expect(t('test.withPluralization', { count: 11 })).toEqual('There are 11 versions available')
+    })
+  })
+
+  describe('function `te`', () => {
+    beforeAll(() => {
+      createI18n('en-us', english, true)
+    })
+
+    it('should recognize exiting key', () => {
+      const { te } = useI18n()
+      expect(te('global.ok')).toBeTruthy()
+    })
+
+    it('should recognize non-exiting key', () => {
+      const { te } = useI18n()
+      expect(te('global.not.ok')).toBeFalsy()
+    })
+  })
+
+  describe('function `tm`', () => {
+    beforeAll(() => {
+      createI18n('en-us', english, true)
+    })
+
+    it('should return array for exiting key', () => {
+      const { tm } = useI18n()
+      expect(tm('array.disabled')).toEqual([
+        'You cannot update configurations for services',
+        'You cannot accept new developer portal applications',
+      ])
+    })
+
+    it('should return empty array for non-existing key', () => {
+      const { tm } = useI18n()
+      expect(tm('global.not.ok')).toEqual([])
+    })
+  })
+
+  // the cases bellow are for reference only. See https://formatjs.io/docs/intl/ for more details and usage
+
+  describe('formatNumber', () => {
+    beforeAll(() => {
+      createI18n('en-us', english, true)
+    })
+
+    it('should format currency', () => {
+      const { formatNumber } = useI18n()
+
+      const formattedNumber = formatNumber(1000, { style: 'currency', currency: 'USD' })
+      expect(formattedNumber).toEqual('$1,000.00')
+    })
+  })
+
+  describe('formatDate', () => {
+    beforeAll(() => {
+      createI18n('en-us', english, true)
+    })
+    it('should format date', () => {
+      const { formatDate } = useI18n()
+
+      const formattedDate = formatDate(Date.parse('12/12/2012'), {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      })
+      expect(formattedDate).toEqual('December 12, 2012')
+    })
+  })
+})

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -1,0 +1,54 @@
+// Important: do not utilize Vue reactive variables in this composable so that it may be used outside the setup() function
+import { Options as IntlMessageFormatOptions } from 'intl-messageformat'
+import { createIntl, createIntlCache, MessageDescriptor } from '@formatjs/intl'
+import { flatten } from 'flat'
+import type { IntlShapeEx, SupportedLocales, MessageFormatPrimitiveValue } from './types'
+
+// this is internal formatJS function that caches instance of Intl and prevent memory leaks
+const intlCache = createIntlCache()
+
+// this is global var to hold global (application) instance of Intl
+let globIntl: IntlShapeEx
+
+export const createI18n = (locale: SupportedLocales, messages: Record<string, any>, isGlobal: boolean = false): IntlShapeEx => {
+  const intl = createIntl(
+    {
+      locale,
+      messages: flatten(messages, {
+        safe: true, // Preserve arrays
+      }),
+    },
+    intlCache,
+  )
+
+  const t = (translationKey: string, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions): string => {
+    return intl.formatMessage(<MessageDescriptor>{ id: translationKey }, values, opts)
+  }
+
+  const te = (key: string): boolean => {
+    return !!intl.messages[key]
+  }
+
+  const tm = (key: string): Array<string> => {
+    // @ts-ignore
+    return intl.messages[key] || []
+  }
+
+  const localIntl = {
+    t,
+    te,
+    tm,
+    ...intl,
+    source: messages,
+  }
+  if (isGlobal) {
+    globIntl = localIntl
+  }
+
+  return localIntl
+}
+
+// this returns global (application of Intl)
+export default function useI18n(): IntlShapeEx {
+  return globIntl
+}

--- a/packages/core/i18n/src/index.ts
+++ b/packages/core/i18n/src/index.ts
@@ -1,0 +1,2 @@
+export { default as useI18n, createI18n } from './i18n'
+export { default as Translation } from './Translation'

--- a/packages/core/i18n/src/types/index.ts
+++ b/packages/core/i18n/src/types/index.ts
@@ -1,7 +1,6 @@
 import type { IntlShape } from '@formatjs/intl'
 import type { Options as IntlMessageFormatOptions } from 'intl-messageformat'
 
-
 export type MessageFormatPrimitiveValue = string | number | boolean | null | undefined
 
 export type SupportedLocales = 'en-us'

--- a/packages/core/i18n/src/types/index.ts
+++ b/packages/core/i18n/src/types/index.ts
@@ -1,0 +1,14 @@
+import type { IntlShape } from '@formatjs/intl'
+import type { Options as IntlMessageFormatOptions } from 'intl-messageformat'
+
+
+export type MessageFormatPrimitiveValue = string | number | boolean | null | undefined
+
+export type SupportedLocales = 'en-us'
+
+export type IntlShapeEx = IntlShape & {
+  t: (translationKey: string, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions) => string,
+  te: (translationKey: string) => boolean,
+  tm: (translationKey: string) => Array<string>,
+  source: Record<string, any>,
+}

--- a/packages/core/i18n/tsconfig.build.json
+++ b/packages/core/i18n/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.cy.ts",
+    "src/**/*.spec.ts",
+    "sandbox",
+    "dist"
+  ]
+}

--- a/packages/core/i18n/tsconfig.json
+++ b/packages/core/i18n/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declarationDir": "dist/types",
+    "types": [
+      "node",
+      "vite/client",
+      "cypress",
+      "../../../cypress/support"
+    ]
+  },
+  "include": [
+    "src/**/*",
+    "sandbox/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/core/i18n/vite.config.ts
+++ b/packages/core/i18n/vite.config.ts
@@ -1,0 +1,28 @@
+import sharedViteConfig from '../../../vite.config.shared'
+import { resolve } from 'path'
+import { defineConfig, mergeConfig } from 'vite'
+
+// Package name MUST always match the kebab-case package name inside the component's package.json file and the name of your `/packages/{package-name}` directory
+const packageName = 'core-i18n'
+
+// Merge the shared Vite config with the local one defined below
+const config = mergeConfig(sharedViteConfig, defineConfig({
+  build: {
+    lib: {
+      // The kebab-case name of the exposed global variable. MUST be in the format `kong-ui-{package-name}`
+      // Example: name: 'kong-ui-demo-component'
+      name: `kong-ui-${packageName}`,
+      entry: resolve(__dirname, './src/index.ts'),
+      fileName: (format) => `${packageName}.${format}.js`,
+    },
+  },
+}))
+
+// If we are trying to preview a build of the local `package/i18n/sandbox` directory,
+// unset the external and lib properties
+if (process.env.PREVIEW_SANDBOX) {
+  config.build.rollupOptions.external = undefined
+  config.build.lib = undefined
+}
+
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,16 @@ importers:
   packages/core/cli:
     specifiers: {}
 
+  packages/core/i18n:
+    specifiers:
+      '@formatjs/intl': ^2.6.3
+      flat: ^5.0.2
+      intl-messageformat: ^10.2.5
+    dependencies:
+      '@formatjs/intl': 2.6.3
+      flat: 5.0.2
+      intl-messageformat: 10.2.5
+
 packages:
 
   /@babel/code-frame/7.18.6:
@@ -648,6 +658,73 @@ packages:
     hasBin: true
     requiresBuild: true
     dev: true
+
+  /@formatjs/ecma402-abstract/1.14.3:
+    resolution: {integrity: sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==}
+    dependencies:
+      '@formatjs/intl-localematcher': 0.2.32
+      tslib: 2.4.1
+    dev: false
+
+  /@formatjs/fast-memoize/1.2.7:
+    resolution: {integrity: sha512-hPeM5LXUUjtCKPybWOUAWpv8lpja8Xz+uKprFPJcg5F2Rd+/bf1E0UUsLRpaAgOReAf5HMRtoIgv/UcyPICrTQ==}
+    dependencies:
+      tslib: 2.4.1
+    dev: false
+
+  /@formatjs/icu-messageformat-parser/2.1.14:
+    resolution: {integrity: sha512-0KqeVOb72losEhUW+59vhZGGd14s1f35uThfEMVKZHKLEObvJdFTiI3ZQwvTMUCzLEMxnS6mtnYPmG4mTvwd3Q==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      '@formatjs/icu-skeleton-parser': 1.3.18
+      tslib: 2.4.1
+    dev: false
+
+  /@formatjs/icu-skeleton-parser/1.3.18:
+    resolution: {integrity: sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      tslib: 2.4.1
+    dev: false
+
+  /@formatjs/intl-displaynames/6.2.3:
+    resolution: {integrity: sha512-teB0L68MDGM8jEKQg55w7nvFjzeLHE6e3eK/04s+iuEVYYmvjjiHJKHrthKENzcJ0F6mHf/AwXrbX+1mKxT6AQ==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      '@formatjs/intl-localematcher': 0.2.32
+      tslib: 2.4.1
+    dev: false
+
+  /@formatjs/intl-listformat/7.1.7:
+    resolution: {integrity: sha512-Zzf5ruPpfJnrAA2hGgf/6pMgQ3tx9oJVhpqycFDavHl3eEzrwdHddGqGdSNwhd0bB4NAFttZNQdmKDldc5iDZw==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      '@formatjs/intl-localematcher': 0.2.32
+      tslib: 2.4.1
+    dev: false
+
+  /@formatjs/intl-localematcher/0.2.32:
+    resolution: {integrity: sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==}
+    dependencies:
+      tslib: 2.4.1
+    dev: false
+
+  /@formatjs/intl/2.6.3:
+    resolution: {integrity: sha512-JaVZk14U/GypVfCZPevQ0KdruFkq16FXx7g398/Dm+YEx/W7sRiftbZeDy4wQ7WGryb45e763XycxD9o/vm9BA==}
+    peerDependencies:
+      typescript: ^4.7
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      '@formatjs/fast-memoize': 1.2.7
+      '@formatjs/icu-messageformat-parser': 2.1.14
+      '@formatjs/intl-displaynames': 6.2.3
+      '@formatjs/intl-listformat': 7.1.7
+      intl-messageformat: 10.2.5
+      tslib: 2.4.1
+    dev: false
 
   /@gar/promisify/1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -4516,7 +4593,6 @@ packages:
   /flat/5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
-    dev: true
 
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
@@ -5278,6 +5354,15 @@ packages:
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
+
+  /intl-messageformat/10.2.5:
+    resolution: {integrity: sha512-AievYMN6WLLHwBeCTv4aRKG+w3ZNyZtkObwgsKk3Q7GNTq8zDRvDbJSBQkb2OPeVCcAKcIXvak9FF/bRNavoww==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      '@formatjs/fast-memoize': 1.2.7
+      '@formatjs/icu-messageformat-parser': 2.1.14
+      tslib: 2.4.1
+    dev: false
 
   /ip/2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
@@ -8303,7 +8388,6 @@ packages:
 
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
-    dev: true
 
   /tsutils/3.21.0_typescript@4.9.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}


### PR DESCRIPTION
# Summary

Moving i18n code from private repository and share it as public package. 

## PR Checklist

* [X] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [X] **Tests pass:** check the output of all package unit and/or component tests.
  * [X] If this PR is the result of a bug, test coverage was added accordingly.
* [X] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [X] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [X] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
