### PR TITLE
fix(spec-renderer): remove slimMode

### DIFF
--- a/packages/portal/spec-renderer/README.md
+++ b/packages/portal/spec-renderer/README.md
@@ -13,7 +13,6 @@ A Kong UI component for displaying API specs
   - [`hasSidebar`](#hassidebar)
   - [`relativeSidebar`](#relativesidebar)
   - [`essentialsOnly`](#essentialsonly)
-  - [`slimMode`](#slimmode)
 
 ## Features
 
@@ -103,13 +102,4 @@ Both `hasSidebar` and `essentialsOnly` must be `true` for the positioning to be 
 - required: `false`
 - default: `false`
 
-If enabled, only display the spec `paths` section; general information, schemes, models, etc. are hidden.
-
-### `slimMode`
-
-- type: `Boolean`
-- required: `false`
-- default: `false`
-
-If enabled, will apply styles to conserve space. Hides path descriptions, decreases font-size of headings.
-
+If enabled, only display the spec `paths` section; general information, schemes, models, actions (Authorize & Try it out), etc. are hidden.

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong-ui/portal-spec-renderer",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/portal-spec-renderer.umd.js",
   "module": "./dist/portal-spec-renderer.es.js",

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong-ui/portal-spec-renderer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "./dist/portal-spec-renderer.umd.js",
   "module": "./dist/portal-spec-renderer.es.js",

--- a/packages/portal/spec-renderer/sandbox/App.vue
+++ b/packages/portal/spec-renderer/sandbox/App.vue
@@ -22,19 +22,12 @@
               type="checkbox"
             > essentialsOnly
           </label>
-          <label class="ml-3">
-            <input
-              v-model="slimMode"
-              type="checkbox"
-            > slimMode
-          </label>
         </div>
         <SpecRenderer
           :key="key"
           :document="defaultDocument"
           :essentials-only="essentialsOnly"
           :has-sidebar="hasSidebar"
-          :slim-mode="slimMode"
         />
       </div>
     </main>
@@ -52,10 +45,9 @@ const defaultDocument = yamlContent
 // checkboxes for toggling options
 const hasSidebar = ref(true)
 const essentialsOnly = ref(false)
-const slimMode = ref(false)
 
 const key = ref(0)
-watch(() => [hasSidebar.value, essentialsOnly.value, slimMode.value], () => {
+watch(() => [hasSidebar.value, essentialsOnly.value], () => {
   key.value++
 }, { deep: true, immediate: true })
 </script>

--- a/packages/portal/spec-renderer/src/components/SpecRenderer.vue
+++ b/packages/portal/spec-renderer/src/components/SpecRenderer.vue
@@ -5,7 +5,6 @@
       :essentials-only="essentialsOnly"
       :has-sidebar="hasSidebar"
       :relative-sidebar="relativeSidebar"
-      :slim-mode="slimMode"
       :spec="document"
       :url="url"
     />
@@ -41,10 +40,6 @@ const props = defineProps({
     default: false,
   },
   essentialsOnly: {
-    type: Boolean,
-    default: false,
-  },
-  slimMode: {
     type: Boolean,
     default: false,
   },


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Remove `slimMode` since we have `spec-renderer-mini` instead.

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
