### PR TITLE
feat(spec-renderer-mini): fit & finish [khcp-5769]

### DIFF
--- a/packages/portal/spec-renderer-mini/README.md
+++ b/packages/portal/spec-renderer-mini/README.md
@@ -9,6 +9,7 @@ A Kong UI mini component for displaying API specs
   - [Register](#register)
 - [Props](#props)
   - [`spec`](#spec)
+  - [`tags`](#tags)
   - [`isSummary`](#issummary)
   - [`width`](#width)
 - [Slots](#slots)
@@ -84,6 +85,22 @@ The objects should conform to the following interface.
   deprecated: boolean
   selected?: boolean
   key?: string
+}
+```
+
+### `tags`
+
+- type: `Object[]`
+- required: `false`
+- default: `[]`
+
+Object array for tags. You can use this to specify tag information such as `description` and `externalDocs`.
+
+```typescript
+{
+  name: string
+  description?: string
+  externalDocs?: Object[]
 }
 ```
 

--- a/packages/portal/spec-renderer-mini/sandbox/App.vue
+++ b/packages/portal/spec-renderer-mini/sandbox/App.vue
@@ -96,7 +96,7 @@ const defaultDocument = ref<SpecItemType[]>([
   },
   {
     path: '/pet/{petId}',
-    method: 'post',
+    method: 'put',
     operationId: 'updatePetWithForm',
     tags: ['pet'],
     summary: 'Updates a pet in the store with form data',
@@ -114,7 +114,7 @@ const defaultDocument = ref<SpecItemType[]>([
     path: '/pet/{petId}',
     method: 'patch',
     operationId: 'updatePet',
-    tags: ['pet'],
+    tags: undefined,
     summary: 'Update an existing pet',
     deprecated: false,
   },

--- a/packages/portal/spec-renderer-mini/sandbox/App.vue
+++ b/packages/portal/spec-renderer-mini/sandbox/App.vue
@@ -39,6 +39,7 @@
             :key="key"
             :is-summary="isSummary"
             :spec="spec"
+            :tags="tags"
             :width="isSummary ? '550' : '350'"
             @selected="handleSelected"
           />
@@ -64,7 +65,7 @@
 
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue'
-import { SpecItemType } from '../src/types'
+import { SpecItemType, SpecTag } from '../src/types'
 import { KButton, KLabel } from '@kong/kongponents'
 import SpecRendererMini from '../src'
 
@@ -121,7 +122,7 @@ const defaultDocument = ref<SpecItemType[]>([
     path: '/pet',
     method: 'options',
     operationId: 'petOptions',
-    tags: ['pet', 'other'],
+    tags: undefined,
     summary: 'Get pet options',
     deprecated: false,
   },
@@ -129,7 +130,7 @@ const defaultDocument = ref<SpecItemType[]>([
     path: '/pet',
     method: 'head',
     operationId: 'petHead',
-    tags: ['pet', 'other'],
+    tags: ['pet', 'dog-go'],
     summary: 'Get pet head',
     deprecated: false,
   },
@@ -137,7 +138,7 @@ const defaultDocument = ref<SpecItemType[]>([
     path: '/pet',
     method: 'connect',
     operationId: 'petConnect',
-    tags: ['pet', 'other'],
+    tags: ['pet', 'dog-go'],
     summary: 'Get pet connect',
     deprecated: false,
   },
@@ -148,6 +149,20 @@ const defaultDocument = ref<SpecItemType[]>([
     tags: ['pet', 'other'],
     summary: 'Get pet trace',
     deprecated: false,
+  },
+])
+const tags = ref<SpecTag[]>([
+  {
+    name: 'pet',
+    description: 'Everything about your Pets',
+  },
+  {
+    name: 'dog-go',
+    description: 'This is an example of a very very ridiculously long description',
+  },
+  {
+    name: 'other',
+    description: 'Everything else',
   },
 ])
 const spec = ref<SpecItemType[]>([])

--- a/packages/portal/spec-renderer-mini/src/components/SpecItem.vue
+++ b/packages/portal/spec-renderer-mini/src/components/SpecItem.vue
@@ -138,6 +138,7 @@ const handleClick = (): void => {
 <style lang="scss" scoped>
 .mini-spec-item {
   $chicklet-size: 12px;
+  cursor: pointer;
 
   .spec-item-chicklet {
     height: $chicklet-size;
@@ -149,6 +150,19 @@ const handleClick = (): void => {
   .spec-item-label {
     font-size: 14px;
     font-weight: 400;
+  }
+
+  &.selected {
+    background-color: var(--grey-200);
+    color: var(--blue-500);
+
+    .spec-item-label {
+      font-weight: 700;
+    }
+  }
+
+  &:hover {
+    background-color: var(--grey-200);
   }
 
   &.is-summary {
@@ -166,22 +180,14 @@ const handleClick = (): void => {
       font-family: monospace;
       align-self: center;
     }
-  }
-
-  &.selected {
-    background-color: var(--grey-200);
-    color: var(--blue-500);
-
-    .spec-item-label {
-      font-weight: 700;
-    }
-  }
-
-  &:not(.is-summary) {
-    cursor: pointer;
 
     &:hover {
-      background-color: var(--grey-200);
+      background-color: var(--blue-100);
+    }
+
+    &.selected {
+      background-color: var(--blue-100);
+      border-left: 4px solid var(--blue-500);
     }
   }
 }

--- a/packages/portal/spec-renderer-mini/src/components/SpecItem.vue
+++ b/packages/portal/spec-renderer-mini/src/components/SpecItem.vue
@@ -1,11 +1,11 @@
 <template>
   <div
-    class="vue-mini-spec-item px-4 py-3"
+    class="mini-spec-item px-4 py-3"
     :class="{
       'selected': item.selected,
       'is-summary': isSummary
     }"
-    :data-testid="`vue-mini-spec-item-${item.path}`"
+    :data-testid="`mini-spec-item-${item.path}`"
     @click="handleClick"
   >
     <div
@@ -36,7 +36,6 @@
           :background-color="backgroundColor"
           class="spec-item-badge mr-2"
           :color="textColor"
-          is-bordered
         >
           {{ method ? method.toUpperCase() : '' }}
         </KBadge>
@@ -137,7 +136,7 @@ const handleClick = (): void => {
 </script>
 
 <style lang="scss" scoped>
-.vue-mini-spec-item {
+.mini-spec-item {
   $chicklet-size: 12px;
 
   .spec-item-chicklet {
@@ -148,11 +147,15 @@ const handleClick = (): void => {
   }
 
   .spec-item-label {
+    font-size: 14px;
     font-weight: 400;
   }
 
   &.is-summary {
+    border: 1px solid var(--grey-200);
+
     .spec-item-label {
+      font-size: 13px;
       font-weight: 700;
       color: var(--black-500);
     }

--- a/packages/portal/spec-renderer-mini/src/components/SpecRendererMini.vue
+++ b/packages/portal/spec-renderer-mini/src/components/SpecRendererMini.vue
@@ -63,6 +63,7 @@
           <SpecItem
             v-for="item in untaggedItems"
             :key="item.key"
+            class="mini-spec-renderer-untagged"
             :is-summary="isSummary"
             :item="item"
             @click="handleSelection"
@@ -230,6 +231,10 @@ const hasRequiredProps = (items: object[], requiredProps: string[]): boolean => 
     }
   }
 
+  .mini-spec-renderer-untagged {
+    margin-left: -12px;
+  }
+
   .is-summary {
     .mini-spec-renderer-section {
       border: 1px solid var(--grey-200);
@@ -249,6 +254,11 @@ const hasRequiredProps = (items: object[], requiredProps: string[]): boolean => 
         font-family: monospace;
         max-width: 65%;
       }
+    }
+
+    .mini-spec-renderer-untagged {
+      margin-top: 12px;
+      margin-left: unset;
     }
   }
 }

--- a/packages/portal/spec-renderer-mini/src/components/SpecRendererMini.vue
+++ b/packages/portal/spec-renderer-mini/src/components/SpecRendererMini.vue
@@ -204,7 +204,7 @@ const hasRequiredProps = (items: object[], requiredProps: string[]): boolean => 
 
   items.forEach((item: object) => {
     requiredProps.forEach((requiredProp: string) => {
-      if (!item[String(requiredProp)]) {
+      if (!item[requiredProp as keyof typeof item]) {
         isValid = false
       }
     })

--- a/packages/portal/spec-renderer-mini/src/components/SpecRendererMini.vue
+++ b/packages/portal/spec-renderer-mini/src/components/SpecRendererMini.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="kong-portal-spec-renderer-mini"
+    class="kong-spec-renderer-mini"
     :style="widthStyle"
   >
     <div
@@ -19,20 +19,32 @@
               class="mini-spec-renderer-section d-flex"
               @click="toggle()"
             >
-              <div class="mini-spec-renderer-section-label">
-                {{ section }}
-              </div>
-              <div class="mini-spec-renderer-section-toggle ml-auto">
+              <div class="mini-spec-renderer-section-toggle mr-2">
                 <KIcon
                   v-if="isCollapsed"
-                  color="var(--grey-500)"
-                  icon="chevronLeft"
+                  color="var(--grey-400)"
+                  icon="chevronUp"
+                  size="18"
                 />
                 <KIcon
                   v-else
-                  color="var(--grey-500)"
+                  color="var(--grey-600)"
                   icon="chevronDown"
+                  size="18"
                 />
+              </div>
+              <div
+                class="mini-spec-renderer-section-label"
+                :class="{ 'mr-2': isSummary }"
+              >
+                {{ section }}
+              </div>
+              <div
+                v-if="isSummary && getSectionDescription(section)"
+                class="mini-spec-renderer-section-description ml-auto truncate"
+                :title="getSectionDescription(section)"
+              >
+                {{ getSectionDescription(section) }}
               </div>
             </div>
           </template>
@@ -45,6 +57,17 @@
             @click="handleSelection"
           />
         </KCollapse>
+
+        <!-- Items without any tags -->
+        <div class="mt-2">
+          <SpecItem
+            v-for="item in untaggedItems"
+            :key="item.key"
+            :is-summary="isSummary"
+            :item="item"
+            @click="handleSelection"
+          />
+        </div>
       </div>
       <!-- Empty State -->
       <div
@@ -72,7 +95,7 @@
 
 <script setup lang="ts">
 import { PropType, onMounted, computed, ref } from 'vue'
-import type { SpecItemType } from '../types'
+import type { SpecItemType, SpecTag } from '../types'
 import { KCollapse, KIcon } from '@kong/kongponents'
 import SpecItem from './SpecItem.vue'
 
@@ -80,7 +103,12 @@ const props = defineProps({
   spec: {
     type: Array as PropType<SpecItemType[]>,
     required: true,
-    validator: (items: SpecItemType[]): boolean => !items.length || hasRequiredProps(items),
+    validator: (items: SpecItemType[]): boolean => !items.length || hasRequiredProps(items, ['method', 'path']),
+  },
+  tags: {
+    type: Array as PropType<SpecTag[]>,
+    default: () => [],
+    validator: (items: SpecTag[]): boolean => !items.length || hasRequiredProps(items, ['name']),
   },
   isSummary: {
     type: Boolean,
@@ -95,23 +123,6 @@ const props = defineProps({
 const emit = defineEmits(['selected'])
 
 const itemArray = ref<SpecItemType[]>([])
-const sectionHeadings = computed(() => {
-  const headings:string[] = []
-
-  itemArray.value.forEach((item: SpecItemType) => {
-    item.tags.forEach((tag: string) => {
-      if (tag && !headings.includes(tag)) {
-        headings.push(tag)
-      }
-    })
-  })
-
-  return headings
-})
-
-const hasData = computed((): boolean => {
-  return !!props.spec?.length
-})
 
 const getSizeFromString = (sizeStr: string): string => {
   return sizeStr === 'auto' || sizeStr.endsWith('%') || sizeStr.endsWith('vw') || sizeStr.endsWith('vh') || sizeStr.endsWith('px') ? sizeStr : sizeStr + 'px'
@@ -123,8 +134,34 @@ const widthStyle = computed(() => {
   }
 })
 
+const hasData = computed((): boolean => {
+  return !!props.spec?.length
+})
+
+const sectionHeadings = computed(() => {
+  const headings:string[] = []
+
+  itemArray.value.forEach((item: SpecItemType) => {
+    item.tags?.forEach((tag: string) => {
+      if (tag && !headings.includes(tag)) {
+        headings.push(tag)
+      }
+    })
+  })
+
+  return headings
+})
+
+const untaggedItems = computed((): SpecItemType[] => {
+  return itemArray.value.filter((item: SpecItemType) => !item.tags?.length)
+})
+
+const getSectionDescription = (section: string): string => {
+  return props.tags.filter((item: SpecTag) => item.name === section)?.[0].description || ''
+}
+
 const getSectionItems = (section: string): SpecItemType[] => {
-  return itemArray.value.filter((item: SpecItemType) => item.tags.includes(section))
+  return itemArray.value.filter((item: SpecItemType) => item.tags?.includes(section))
 }
 
 const handleSelection = (selectedItem: SpecItemType) => {
@@ -154,22 +191,33 @@ onMounted(() => {
 </script>
 
 <script lang="ts">
-const hasRequiredProps = (items: SpecItemType[]): boolean => {
-  items.forEach((item: SpecItemType) => {
-    if (item.method === undefined || item.summary === undefined || item.path === undefined) {
-      return false
-    }
+/**
+ * Check if all of the provided items have a non-falsey value for all of the provided required props
+ *
+ * @param items The items to validate the prop exists for
+ * @param requiredProps An array of all the required prop names
+ * @returns Boolean whether or not the items have all the required props
+ */
+const hasRequiredProps = (items: object[], requiredProps: string[]): boolean => {
+  let isValid = true
+
+  items.forEach((item: object) => {
+    requiredProps.forEach((requiredProp: string) => {
+      if (!item[String(requiredProp)]) {
+        isValid = false
+      }
+    })
   })
 
-  return true
+  return isValid
 }
 </script>
 
 <style lang="scss" scoped>
-.kong-portal-spec-renderer-mini {
-  font-family: var(--kong-portal-spec-renderer-mini-font-family-default, Roboto, Helvetica, sans-serif);
-  font-size: var(--kong-portal-spec-renderer-mini-font-size, 16px);
-  color: var(--kong-portal-spec-renderer-mini-text-color, #000);
+.kong-spec-renderer-mini {
+  font-family: var(--kong-spec-renderer-mini-font-family-default, Roboto, Helvetica, sans-serif);
+  font-size: var(--kong-spec-renderer-mini-font-size, 16px);
+  color: var(--kong-spec-renderer-mini-text-color, #000);
 
   .center {
     text-align: center;
@@ -184,8 +232,22 @@ const hasRequiredProps = (items: SpecItemType[]): boolean => {
 
   .is-summary {
     .mini-spec-renderer-section {
+      border: 1px solid var(--grey-200);
+      border-radius: 4px 4px 0 0;
+      padding: 10px 8px 10px 12px;
+
+      .mini-spec-renderer-section-toggle {
+        height: 18px;
+        align-self: end;
+      }
+
       .mini-spec-renderer-section-label {
         font-size: var(--type-lg);
+      }
+
+      .mini-spec-renderer-section-description {
+        font-family: monospace;
+        max-width: 65%;
       }
     }
   }
@@ -197,6 +259,16 @@ const hasRequiredProps = (items: SpecItemType[]): boolean => {
   // all but the first have top margin
   .k-collapse + .k-collapse {
     margin-top: var(--spacing-md);
+  }
+
+  .k-collapse .k-collapse-heading {
+    margin: 0 !important;
+  }
+
+  .k-collapse-hidden-content {
+    .mini-spec-item:last-of-type {
+      border-radius: 0 0 4px 4px;
+    }
   }
 }
 </style>

--- a/packages/portal/spec-renderer-mini/src/components/SpecRendererMini.vue
+++ b/packages/portal/spec-renderer-mini/src/components/SpecRendererMini.vue
@@ -255,7 +255,7 @@ const hasRequiredProps = (items: object[], requiredProps: string[]): boolean => 
 </style>
 
 <style lang="scss">
-.kong-portal-spec-renderer-mini {
+.kong-spec-renderer-mini {
   // all but the first have top margin
   .k-collapse + .k-collapse {
     margin-top: var(--spacing-md);

--- a/packages/portal/spec-renderer-mini/src/types/specs.ts
+++ b/packages/portal/spec-renderer-mini/src/types/specs.ts
@@ -10,3 +10,14 @@ export interface SpecItemType {
   selected?: boolean
   key?: string
 }
+
+interface SpecExternalDoc {
+  description: string
+  url: string
+}
+
+export interface SpecTag {
+  name: string
+  description?: string
+  externalDocs?: SpecExternalDoc[]
+}


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Fit & finish for `spec-renderer-mini`.
Addresses [KHCP-5769](https://konghq.atlassian.net/browse/KHCP-5769).

Includes:
- style updates
- new prop `tags`
- documentation updates

![image](https://user-images.githubusercontent.com/67973710/214644714-b803ca74-ea0d-4f6f-96e3-8673a43aa6d8.png)


## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.


[KHCP-5769]: https://konghq.atlassian.net/browse/KHCP-5769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ