### PR TITLE
feat(swagger-ui): add fire event on button presses TDX-2778

### DIFF
--- a/packages/portal/spec-details/src/components/SpecDetails.vue
+++ b/packages/portal/spec-details/src/components/SpecDetails.vue
@@ -2,7 +2,7 @@
   <div class="kong-portal-spec-details">
     <kong-swagger-ui
       v-if="hasRequiredProps"
-      ref="swaggerRef"
+      :application-registration-enabled="applicationRegistrationEnabled"
       :essentials-only="essentialsOnly"
       :has-sidebar="hasSidebar"
       :relative-sidebar="relativeSidebar"
@@ -48,6 +48,10 @@ const props = defineProps({
   activeOperation: {
     type: Object as PropType<Operation>,
     default: null,
+  },
+  applicationRegistrationEnabled: {
+    type: Boolean,
+    default: false,
   },
 })
 

--- a/packages/portal/spec-details/src/components/SpecDetails.vue
+++ b/packages/portal/spec-details/src/components/SpecDetails.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="kong-portal-spec-details">
-    <h1>LINKED</h1>
     <kong-swagger-ui
       v-if="hasRequiredProps"
       :application-registration-enabled="applicationRegistrationEnabled"

--- a/packages/portal/spec-details/src/components/SpecDetails.vue
+++ b/packages/portal/spec-details/src/components/SpecDetails.vue
@@ -1,8 +1,10 @@
 <template>
   <div class="kong-portal-spec-details">
+    <h1>LINKED</h1>
     <kong-swagger-ui
       v-if="hasRequiredProps"
       :application-registration-enabled="applicationRegistrationEnabled"
+      :current-version="currentVersion"
       :essentials-only="essentialsOnly"
       :has-sidebar="hasSidebar"
       :relative-sidebar="relativeSidebar"
@@ -52,6 +54,10 @@ const props = defineProps({
   applicationRegistrationEnabled: {
     type: Boolean,
     default: false,
+  },
+  currentVersion: {
+    type: String,
+    default: () => undefined,
   },
 })
 

--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -58,6 +58,13 @@ export class SwaggerUIElement extends HTMLElement {
    */
   #instance = null
 
+  /**
+   * True if application registration available for service version
+   * @type {boolean}
+   */
+  #applicationRegistrationEnabled = false
+
+
   constructor() {
     super()
 
@@ -91,6 +98,9 @@ export class SwaggerUIElement extends HTMLElement {
         break
       case 'essentials-only':
         this.essentialsOnly = newValue
+        break
+      case 'application-registration-enabled':
+        this.applicationRegistrationEnabled = newValue
         break
     }
   }
@@ -164,6 +174,9 @@ export class SwaggerUIElement extends HTMLElement {
       layout: 'KongLayout',
       theme: {
         hasSidebar: this.#hasSidebar,
+        onViewSpecClick: this.onViewSpecClick,
+        onRegisterClick: this.onRegisterClick,
+        applicationRegistrationEnabled: this.#applicationRegistrationEnabled
       },
     })
   }
@@ -273,7 +286,23 @@ export class SwaggerUIElement extends HTMLElement {
     this.#url = url
   }
 
+  get applicationRegistrationEnabled() {
+    return this.#applicationRegistrationEnabled
+  }
+
+  set applicationRegistrationEnabled(applicationRegistrationEnabled) {
+    this.#applicationRegistrationEnabled = attributeValueToBoolean(applicationRegistrationEnabled)
+  }
+
   static get observedAttributes() {
     return ['url', 'spec', 'auto-init', 'has-sidebar', 'relative-sidebar', 'essentials-only']
+  }
+
+  onViewSpecClick() {
+    this.dispatchEvent(new CustomEvent("clickedViewSpec"));
+  }
+
+  onRegisterClick() {
+    this.dispatchEvent(new CustomEvent("clickedRegister"));
   }
 }

--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -64,6 +64,11 @@ export class SwaggerUIElement extends HTMLElement {
    */
   #applicationRegistrationEnabled = false
 
+  /**
+   * name for selected version
+   * @type {string}
+   */
+  #currentVersion
 
   constructor() {
     super()
@@ -102,6 +107,9 @@ export class SwaggerUIElement extends HTMLElement {
       case 'application-registration-enabled':
         this.applicationRegistrationEnabled = newValue
         break
+      case 'current-version':
+        this.currentVersion = newValue
+        break
     }
   }
 
@@ -121,6 +129,8 @@ export class SwaggerUIElement extends HTMLElement {
   }
 
   init() {
+
+    alert('linked! 4')
     if (this.#instance) {
       throw new Error('SwaggerUI is already initialized')
     }
@@ -157,6 +167,16 @@ export class SwaggerUIElement extends HTMLElement {
       essentialsOnlyStyles.use({ target: this.shadowRoot, testId: 'hide-essentials-styles' })
     }
 
+    const onViewSpecClick = () => {
+      this.dispatchEvent(new CustomEvent('clicked-view-spec', { bubbles: true }))
+    }
+
+    const onRegisterClick = () => {
+      this.dispatchEvent(new CustomEvent('clicked-register', { bubbles: true }))
+    }
+
+    console.log('appreg status', this.#applicationRegistrationEnabled)
+
     this.#instance = SwaggerUI({
       url: this.#url,
       spec: this.#spec,
@@ -174,9 +194,10 @@ export class SwaggerUIElement extends HTMLElement {
       layout: 'KongLayout',
       theme: {
         hasSidebar: this.#hasSidebar,
-        onViewSpecClick: this.onViewSpecClick,
-        onRegisterClick: this.onRegisterClick,
-        applicationRegistrationEnabled: this.#applicationRegistrationEnabled
+        applicationRegistrationEnabled: this.#applicationRegistrationEnabled,
+        currentVersion: { version: this.#currentVersion },
+        onViewSpecClick,
+        onRegisterClick,
       },
     })
   }
@@ -294,15 +315,15 @@ export class SwaggerUIElement extends HTMLElement {
     this.#applicationRegistrationEnabled = attributeValueToBoolean(applicationRegistrationEnabled)
   }
 
+  get currentVersion() {
+    return this.#currentVersion
+  }
+
+  set currentVersion(currentVersion) {
+    this.#currentVersion = currentVersion
+  }
+
   static get observedAttributes() {
-    return ['url', 'spec', 'auto-init', 'has-sidebar', 'relative-sidebar', 'essentials-only']
-  }
-
-  onViewSpecClick() {
-    this.dispatchEvent(new CustomEvent("clickedViewSpec"));
-  }
-
-  onRegisterClick() {
-    this.dispatchEvent(new CustomEvent("clickedRegister"));
+    return ['url', 'spec', 'auto-init', 'has-sidebar', 'relative-sidebar', 'essentials-only', 'application-registration-enabled', 'current-version']
   }
 }

--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -129,8 +129,6 @@ export class SwaggerUIElement extends HTMLElement {
   }
 
   init() {
-
-    alert('linked! 4')
     if (this.#instance) {
       throw new Error('SwaggerUI is already initialized')
     }

--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -173,8 +173,6 @@ export class SwaggerUIElement extends HTMLElement {
       this.dispatchEvent(new CustomEvent('clicked-register', { bubbles: true }))
     }
 
-    console.log('appreg status', this.#applicationRegistrationEnabled)
-
     this.#instance = SwaggerUI({
       url: this.#url,
       spec: this.#spec,


### PR DESCRIPTION
# Summary

Enables View Raw, and Register button

This is done by firing a custom event which is listened to in the portal client application. 

works with with https://github.com/Kong/khcp/pull/5632
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
