### PR TITLE
feat(spec-details): add activeOperation property

### DIFF
--- a/packages/portal/spec-details/README.md
+++ b/packages/portal/spec-details/README.md
@@ -13,6 +13,7 @@ A Kong UI component for displaying API specs
   - [`hasSidebar`](#hassidebar)
   - [`relativeSidebar`](#relativesidebar)
   - [`essentialsOnly`](#essentialsonly)
+  - [`activeOperation`](#activeoperation)
 
 ## Features
 
@@ -103,3 +104,11 @@ Both `hasSidebar` and `essentialsOnly` must be `true` for the positioning to be 
 - default: `false`
 
 If enabled, only display the spec `paths` section; general information, schemes, models, actions (Authorize & Try it out), etc. are hidden.
+
+### `activeOperation`
+
+- type: `Object`
+- required: `false`
+- default: `null`
+
+Allows to expand specification operation details section for given operation and scroll the viewport to it.

--- a/packages/portal/spec-details/package.json
+++ b/packages/portal/spec-details/package.json
@@ -57,6 +57,7 @@
     "extends": "../../../package.json"
   },
   "dependencies": {
-    "@kong-ui-public/swagger-ui-web-component": "workspace:^0.1.6"
+    "@kong-ui-public/swagger-ui-web-component": "workspace:^0.1.6",
+    "openapi-types": "^12.1.0"
   }
 }

--- a/packages/portal/spec-details/package.json
+++ b/packages/portal/spec-details/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@modyfi/vite-plugin-yaml": "^1.0.4",
+    "openapi-types": "^12.1.0",
     "vue": "^3.2.45"
   },
   "repository": {
@@ -57,7 +58,6 @@
     "extends": "../../../package.json"
   },
   "dependencies": {
-    "@kong-ui-public/swagger-ui-web-component": "workspace:^0.1.6",
-    "openapi-types": "^12.1.0"
+    "@kong-ui-public/swagger-ui-web-component": "workspace:^0.1.6"
   }
 }

--- a/packages/portal/spec-details/sandbox/App.vue
+++ b/packages/portal/spec-details/sandbox/App.vue
@@ -3,27 +3,26 @@
     <main>
       <div>
         <h1>✨✨ Awesome SpecDetails ✨✨</h1>
-        <div
-          class="spec-controls"
-          :class="{
-            'has-sidebar': hasSidebar
-          }"
-        >
+        <div class="spec-controls">
           <h3>Try it Out:</h3>
-          <div class="props">
-            <label>
-              <input
-                v-model="hasSidebar"
-                type="checkbox"
-              > hasSidebar
-            </label>
-            <label class="ml-3">
-              <input
-                v-model="essentialsOnly"
-                type="checkbox"
-              > essentialsOnly
-            </label>
-            <div class="prop">
+          <div class="component-props">
+            <div class="component-prop">
+              <label>
+                <input
+                  v-model="hasSidebar"
+                  type="checkbox"
+                > hasSidebar
+              </label>
+            </div>
+            <div class="component-prop">
+              <label>
+                <input
+                  v-model="essentialsOnly"
+                  type="checkbox"
+                > essentialsOnly
+              </label>
+            </div>
+            <div class="component-prop">
               <label for="activeOperationInput">Active Operation Object</label>
               <textarea
                 id="activeOperationInput"
@@ -103,34 +102,22 @@ watch(() => [hasSidebar.value, essentialsOnly.value], () => {
 </script>
 
 <style lang="scss" scoped>
-.spec-details-sandbox {
-  --sidebar-width: 250px;
-
-  h1 {
-    text-align: center;
-  }
-
-  .spec-controls {
-    position: relative;
-    border-bottom: 1px solid #ddd;
-
-    label {
-      position: relative;
-      z-index: 1;
-    }
-  }
-
-  .ml-3 {
-    margin-left: 16px;
-  }
+h1 {
+  text-align: center;
 }
 
-.props {
+.spec-controls {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+  position: relative;
+}
+
+.component-props {
   display: flex;
   align-items: center;
 }
 
-.prop {
+.component-prop {
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/packages/portal/spec-details/sandbox/App.vue
+++ b/packages/portal/spec-details/sandbox/App.vue
@@ -10,21 +10,35 @@
           }"
         >
           <h3>Try it Out:</h3>
-          <label>
-            <input
-              v-model="hasSidebar"
-              type="checkbox"
-            > hasSidebar
-          </label>
-          <label class="ml-3">
-            <input
-              v-model="essentialsOnly"
-              type="checkbox"
-            > essentialsOnly
-          </label>
+          <div class="props">
+            <label>
+              <input
+                v-model="hasSidebar"
+                type="checkbox"
+              > hasSidebar
+            </label>
+            <label class="ml-3">
+              <input
+                v-model="essentialsOnly"
+                type="checkbox"
+              > essentialsOnly
+            </label>
+            <div class="prop">
+              <label for="activeOperationInput">Active Operation Object</label>
+              <textarea
+                id="activeOperationInput"
+                v-model="tempActiveOperation"
+              />
+              <div>
+                <button @click="updateActiveOperation">Update</button>
+                <button @click="insertExampleActiveOperation">Insert example</button>
+              </div>
+            </div>
+          </div>
         </div>
         <SpecDetails
           :key="key"
+          :active-operation="activeOperation"
           :document="defaultDocument"
           :essentials-only="essentialsOnly"
           :has-sidebar="hasSidebar"
@@ -38,13 +52,45 @@
 import { ref, watch } from 'vue'
 // @ts-ignore
 import yamlContent from './test.yaml'
-import SpecDetails from '../src'
+import SpecDetails, { Operation } from '../src'
 
 const defaultDocument = yamlContent
 
 // checkboxes for toggling options
-const hasSidebar = ref(true)
-const essentialsOnly = ref(false)
+const hasSidebar = ref<boolean>(true)
+const essentialsOnly = ref<boolean>(false)
+const activeOperation = ref<Operation | null>(null)
+const tempActiveOperation = ref<string>('')
+
+function updateActiveOperation() {
+  try {
+    const operation = JSON.parse(tempActiveOperation.value)
+
+    if (!Object.hasOwn(operation, 'path') || !Object.hasOwn(operation, 'method')) {
+      alert('Operation object requires "path" and "method" properties')
+    }
+
+    activeOperation.value = {
+      operationId: operation.operationId ?? null,
+      deprecated: operation.deprecated ?? false,
+      method: operation.method,
+      path: operation.path,
+      tag: operation.tag ?? null,
+      summary: operation.summary ?? null,
+    } as Operation
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+function insertExampleActiveOperation() {
+  tempActiveOperation.value = JSON.stringify({
+    operationId: 'updatePet',
+    path: '/pet',
+    method: 'post',
+    tag: 'pet',
+  })
+}
 
 const key = ref(0)
 watch(() => [hasSidebar.value, essentialsOnly.value], () => {
@@ -62,10 +108,7 @@ watch(() => [hasSidebar.value, essentialsOnly.value], () => {
 
   .spec-controls {
     position: relative;
-
-    &.has-sidebar {
-      left: calc(var(--sidebar-width) + 50px);
-    }
+    border-bottom: 1px solid #ddd;
 
     label {
       position: relative;
@@ -76,5 +119,21 @@ watch(() => [hasSidebar.value, essentialsOnly.value], () => {
   .ml-3 {
     margin-left: 16px;
   }
+}
+
+.props {
+  display: flex;
+  align-items: center;
+}
+
+.prop {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0 10px;
+}
+
+textarea {
+  min-height: 80px;
 }
 </style>

--- a/packages/portal/spec-details/sandbox/App.vue
+++ b/packages/portal/spec-details/sandbox/App.vue
@@ -30,8 +30,12 @@
                 v-model="tempActiveOperation"
               />
               <div>
-                <button @click="updateActiveOperation">Update</button>
-                <button @click="insertExampleActiveOperation">Insert example</button>
+                <button @click="updateActiveOperation">
+                  Update
+                </button>
+                <button @click="insertExampleActiveOperation">
+                  Insert example
+                </button>
               </div>
             </div>
           </div>

--- a/packages/portal/spec-details/src/components/SpecDetails.vue
+++ b/packages/portal/spec-details/src/components/SpecDetails.vue
@@ -2,6 +2,7 @@
   <div class="kong-portal-spec-details">
     <kong-swagger-ui
       v-if="hasRequiredProps"
+      ref="swaggerRef"
       :essentials-only="essentialsOnly"
       :has-sidebar="hasSidebar"
       :relative-sidebar="relativeSidebar"
@@ -19,12 +20,13 @@
 
 <script setup lang="ts">
 import '@kong-ui-public/swagger-ui-web-component'
-import { PropType, computed } from 'vue'
-import { Document } from '../types'
+import type { SwaggerUIElement } from '@kong-ui-public/swagger-ui-web-component'
+import { PropType, computed, ref, watch, onMounted } from 'vue'
+import { SpecDocument, Operation } from '../types'
 
 const props = defineProps({
   document: {
-    type: Object as PropType<Document>,
+    type: Object as PropType<SpecDocument>,
     default: null,
   },
   url: {
@@ -43,10 +45,37 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  activeOperation: {
+    type: Object as PropType<Operation>,
+    default: null,
+  },
 })
+
+const swaggerRef = ref<SwaggerUIElement | null>(null)
 
 const hasRequiredProps = computed((): boolean => {
   return !!(props.document || props.url)
+})
+
+function showAndScrollToOperation() {
+  if (!swaggerRef.value) {
+    return
+  }
+
+  swaggerRef.value.showOperation(props.activeOperation)
+  swaggerRef.value.scrollToOperation(props.activeOperation)
+}
+
+onMounted(() => {
+  if (props.activeOperation) {
+    showAndScrollToOperation()
+  }
+})
+
+watch(() => props.activeOperation, () => {
+  if (props.activeOperation) {
+    showAndScrollToOperation()
+  }
 })
 </script>
 
@@ -55,5 +84,6 @@ const hasRequiredProps = computed((): boolean => {
   color: var(--kong-portal-spec-details-text-color, #000);
   font-family: var(--kong-portal-spec-details-font-family-default, Roboto, Helvetica, sans-serif);
   font-size: var(--kong-portal-spec-details-font-size, 16px);
+  overflow: hidden;
 }
 </style>

--- a/packages/portal/spec-details/src/components/SpecDetails.vue
+++ b/packages/portal/spec-details/src/components/SpecDetails.vue
@@ -84,6 +84,5 @@ watch(() => props.activeOperation, () => {
   color: var(--kong-portal-spec-details-text-color, #000);
   font-family: var(--kong-portal-spec-details-font-family-default, Roboto, Helvetica, sans-serif);
   font-size: var(--kong-portal-spec-details-font-size, 16px);
-  overflow: hidden;
 }
 </style>

--- a/packages/portal/spec-details/src/swagger-ui-web-component.d.ts
+++ b/packages/portal/spec-details/src/swagger-ui-web-component.d.ts
@@ -1,1 +1,17 @@
-declare module '@kong-ui-public/swagger-ui-web-component'
+declare module '@kong-ui-public/swagger-ui-web-component' {
+  // Operation has to exist here until swagger-ui-web-component is typed
+  export interface Operation {
+    path: string
+    method: 'get' | 'put' | 'post' | 'delete' | 'patch' | 'options' | 'head' | 'connect' | 'trace'
+    operationId: string | null
+    summary: string | null
+    deprecated: boolean
+    tag: string | null
+  }
+
+  export class SwaggerUIElement extends HTMLElement {
+    showOperation(operation: Operation): boolean
+    hideOperation(operation: Operation): boolean
+    scrollToOperation(operation: Operation): boolean
+  }
+}

--- a/packages/portal/spec-details/src/types/index.ts
+++ b/packages/portal/spec-details/src/types/index.ts
@@ -1,9 +1,23 @@
-export interface BaseNode<Type extends string = string> {
-  type: Type
-  children?: Array<BaseNode>
-}
+import { OpenAPI } from 'openapi-types'
 
-export interface Document extends BaseNode<'document'> {
-  children: Array<BaseNode>
-  version: number
+/**
+ * OpenAPI specification document supporting OpenAPI v2 and v3 formats
+ */
+export type SpecDocument = OpenAPI.Document
+
+/**
+ * HTTP Method string
+ */
+export type MethodString = 'get' | 'put' | 'post' | 'delete' | 'patch' | 'options' | 'head' | 'connect' | 'trace'
+
+/**
+ * Operation details object.
+ */
+export interface Operation {
+  path: string
+  method: MethodString
+  operationId: string | null
+  summary: string | null
+  deprecated: boolean
+  tag: string | null
 }

--- a/packages/portal/swagger-ui-web-component/package.json
+++ b/packages/portal/swagger-ui-web-component/package.json
@@ -16,6 +16,7 @@
     "@kong/swagger-ui-kong-theme-universal": "^4.0.4",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "swagger-client": "^3.18.5",
     "swagger-ui": "^4.15.5"
   },
   "repository": {

--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -1,29 +1,9 @@
 import SwaggerUI from 'swagger-ui'
 import { SwaggerUIKongTheme } from '@kong/swagger-ui-kong-theme-universal'
+import kongThemeStyles from '@kong/swagger-ui-kong-theme-universal/dist/main.css'
 import { attributeValueToBoolean, operationToSwaggerThingArray, operationToSwaggerThingId } from './utils'
-
-// eslint-disable-next-line import/no-webpack-loader-syntax
-const kongThemeStyles = require('!!raw-loader!@kong/swagger-ui-kong-theme-universal/dist/main.css')
-const essentialsOnlyStyles = `
-/* hide non-essential sections & features */
-.info-augment-wrapper,
-.swagger-ui section,
-.swagger-ui .opblock-tag .info__externaldocs,
-.swagger-ui .auth-wrapper,
-.swagger-ui .schemes,
-.swagger-ui .try-out,
-.opblock-body .right-side-wrapper .code-snippet {
-  display: none !important;
-}
-/* fix copy button width */
-.swagger-ui .opblock .opblock-summary:hover .view-line-link.copy-to-clipboard {
-  width: 24px;
-}
-.swagger-ui .copy-to-clipboard {
-  margin-left: 8px !important;
-  right: unset !important;
-}
-`
+import overridesStyles from './styles/overrides.css'
+import essentialsOnlyStyles from './styles/essentialsOnly.css'
 
 const relativeSidebarStyles = `
 /* relative sidebar styles */
@@ -121,6 +101,15 @@ export class SwaggerUIElement extends HTMLElement {
     }
   }
 
+  disconnectedCallback() {
+    kongThemeStyles.unuse()
+    overridesStyles.unuse()
+
+    if (this.#essentialsOnly) {
+      essentialsOnlyStyles.unuse()
+    }
+  }
+
   init() {
     if (this.#instance) {
       throw new Error('SwaggerUI is already initialized')
@@ -139,11 +128,12 @@ export class SwaggerUIElement extends HTMLElement {
     }
 
     // load base styles
-    const styleTag = document.createElement('style')
-    styleTag.innerHTML = kongThemeStyles.default
-    styleTag.setAttribute('data-testid', 'default-styles')
-    this.shadowRoot.appendChild(styleTag)
+    kongThemeStyles.use({ target: this.shadowRoot, testId: 'default-styles' })
 
+    // load style overrides
+    overridesStyles.use({ target: this.shadowRoot, testId: 'overrides-styles' })
+
+    // TODO: Remove sidebar support
     // relatively position the sidebar if essentials only
     if (this.#hasSidebar && this.#essentialsOnly && this.#relativeSidebar) {
       const styleTag = document.createElement('style')
@@ -154,10 +144,7 @@ export class SwaggerUIElement extends HTMLElement {
 
     // hide non-essential sections
     if (this.#essentialsOnly) {
-      const styleTag = document.createElement('style')
-      styleTag.innerHTML = essentialsOnlyStyles
-      styleTag.setAttribute('data-testid', 'hide-essentials-styles')
-      this.shadowRoot.appendChild(styleTag)
+      essentialsOnlyStyles.use({ target: this.shadowRoot, testId: 'hide-essentials-styles' })
     }
 
     this.#instance = SwaggerUI({

--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -1,6 +1,6 @@
 import SwaggerUI from 'swagger-ui'
 import { SwaggerUIKongTheme } from '@kong/swagger-ui-kong-theme-universal'
-import { attributeValueToBoolean } from './utils'
+import { attributeValueToBoolean, operationToSwaggerThingArray, operationToSwaggerThingId } from './utils'
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 const kongThemeStyles = require('!!raw-loader!@kong/swagger-ui-kong-theme-universal/dist/main.css')
@@ -35,6 +35,8 @@ div#sidebar {
 `
 
 export class SwaggerUIElement extends HTMLElement {
+  static name = 'kong-swagger-ui'
+
   /**
    * Should SwaggerUI be automatically initialized after connecting?
    * @type {boolean}
@@ -80,6 +82,7 @@ export class SwaggerUIElement extends HTMLElement {
     super()
 
     this.rootElement = document.createElement('div')
+    this.rootElement.style.contain = 'content'
 
     this.attachShadow({ mode: 'open' })
     this.shadowRoot.appendChild(this.rootElement)
@@ -176,6 +179,47 @@ export class SwaggerUIElement extends HTMLElement {
         hasSidebar: this.#hasSidebar,
       },
     })
+  }
+
+  showOperation(operation) {
+    if (!this.#instance) {
+      return false
+    }
+
+    const thingArray = operationToSwaggerThingArray(operation)
+    this.#instance.layoutActions.show(thingArray, true)
+    return true
+  }
+
+  hideOperation(operation) {
+    if (!this.#instance) {
+      return false
+    }
+
+    const thingArray = operationToSwaggerThingArray(operation)
+    this.#instance.layoutActions.show(thingArray, false)
+    return true
+  }
+
+  scrollToOperation(operation) {
+    if (!this.#instance) {
+      return false
+    }
+
+    const operationElementId = operationToSwaggerThingId(operation)
+    const element = this.shadowRoot.getElementById(operationElementId)
+    if (!element) {
+      return false
+    }
+
+    // respect reduced motion settings
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: no-preference)')
+    let behavior
+    if (mediaQuery && mediaQuery.matches) {
+      behavior = 'smooth'
+    }
+
+    element.scrollIntoView({ behavior })
   }
 
   get autoInit() {

--- a/packages/portal/swagger-ui-web-component/src/register.js
+++ b/packages/portal/swagger-ui-web-component/src/register.js
@@ -1,5 +1,9 @@
 import { SwaggerUIElement } from './element'
 
 export function register() {
-  customElements.define('kong-swagger-ui', SwaggerUIElement)
+  if (!customElements.get(SwaggerUIElement.name)) {
+    customElements.define(SwaggerUIElement.name, SwaggerUIElement)
+  } else {
+    console.warn(`Cannot register ${SwaggerUIElement.name}. Element is already defined, ignoring`)
+  }
 }

--- a/packages/portal/swagger-ui-web-component/src/styles/essentialsOnly.css
+++ b/packages/portal/swagger-ui-web-component/src/styles/essentialsOnly.css
@@ -1,0 +1,18 @@
+/* hide non-essential sections & features */
+.info-augment-wrapper,
+.swagger-ui section,
+.swagger-ui .opblock-tag .info__externaldocs,
+.swagger-ui .auth-wrapper,
+.swagger-ui .schemes,
+.swagger-ui .try-out,
+.opblock-body .right-side-wrapper .code-snippet {
+  display: none !important;
+}
+/* fix copy button width */
+.swagger-ui .opblock .opblock-summary:hover .view-line-link.copy-to-clipboard {
+  width: 24px;
+}
+.swagger-ui .copy-to-clipboard {
+  margin-left: 8px !important;
+  right: unset !important;
+}

--- a/packages/portal/swagger-ui-web-component/src/styles/overrides.css
+++ b/packages/portal/swagger-ui-web-component/src/styles/overrides.css
@@ -1,0 +1,8 @@
+/* temporarily reset breadcrumb margin until it's fixed in swagger-ui-kong-theme */
+.breadcrumb-margin {
+  top: 0;
+}
+
+.swagger-ui .wrapper {
+  padding-top: 0;
+}

--- a/packages/portal/swagger-ui-web-component/src/utils.js
+++ b/packages/portal/swagger-ui-web-component/src/utils.js
@@ -1,3 +1,18 @@
+import { helpers } from 'swagger-client'
+
 export const attributeValueToBoolean = (value) => {
   return value && value.toLowerCase() === 'true'
 }
+
+// Yes, Swagger literally calls it "thing"
+export const escapeSwaggerThing = (str) => CSS.escape(str.trim().replace(/\s/g, '%20'))
+
+export const operationToSwaggerThingArray = (operation) => ([
+  'operations',
+  operation.tag ? escapeSwaggerThing(operation.tag) : 'default',
+  helpers.opId(operation, operation.path, operation.method),
+])
+
+export const operationToSwaggerThingId = (operation) => escapeSwaggerThing(
+  operationToSwaggerThingArray(operation).join('-'),
+)

--- a/packages/portal/swagger-ui-web-component/webpack.config.js
+++ b/packages/portal/swagger-ui-web-component/webpack.config.js
@@ -20,6 +20,9 @@ module.exports = (env, { mode, analyze = false }) => {
                 injectType: 'lazyStyleTag',
                 // custom insert function that accepts a target element to append <style> tag into
                 insert: function insertIntoTarget(element, options) {
+                  if (options.testId) {
+                    element.setAttribute('data-testid', options.testId)
+                  }
                   const parent = options.target || document.head
                   parent.appendChild(element)
                 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,9 +207,11 @@ importers:
     specifiers:
       '@kong-ui-public/swagger-ui-web-component': workspace:^0.1.6
       '@modyfi/vite-plugin-yaml': ^1.0.4
+      openapi-types: ^12.1.0
       vue: ^3.2.45
     dependencies:
       '@kong-ui-public/swagger-ui-web-component': link:../swagger-ui-web-component
+      openapi-types: 12.1.0
     devDependencies:
       '@modyfi/vite-plugin-yaml': 1.0.4
       vue: 3.2.45
@@ -230,6 +232,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2
       style-loader: ^3.3.1
+      swagger-client: ^3.18.5
       swagger-ui: ^4.15.5
       terser-webpack-plugin: ^5.3.6
       webpack: ^5.75.0
@@ -240,6 +243,7 @@ importers:
       '@kong/swagger-ui-kong-theme-universal': 4.0.4_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      swagger-client: 3.18.5
       swagger-ui: 4.15.5
     devDependencies:
       css-loader: 6.7.3_webpack@5.75.0
@@ -8843,6 +8847,10 @@ packages:
       is-docker: 2.2.1
       is-wsl: 2.2.0
     dev: true
+
+  /openapi-types/12.1.0:
+    resolution: {integrity: sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==}
+    dev: false
 
   /opener/1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,9 +211,9 @@ importers:
       vue: ^3.2.45
     dependencies:
       '@kong-ui-public/swagger-ui-web-component': link:../swagger-ui-web-component
-      openapi-types: 12.1.0
     devDependencies:
       '@modyfi/vite-plugin-yaml': 1.0.4
+      openapi-types: 12.1.0
       vue: 3.2.45
 
   packages/portal/spec-renderer-mini:
@@ -8850,7 +8850,7 @@ packages:
 
   /openapi-types/12.1.0:
     resolution: {integrity: sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==}
-    dev: false
+    dev: true
 
   /opener/1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}


### PR DESCRIPTION
# Summary

* Add `activeOperation` prop to spec-details
* Add `showOperation`, `hideOperation`, and `scrollToOperation` public methods to swagger-ui-web-component
* Fix spec-details types

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
