### PR TITLE
fix: [KHCP-5864] running unit tests only in packages where unit tests are present.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       filter: ${{steps.changed_packages.outputs.filter}}
       spec: ${{steps.changed_packages.outputs.spec}}
-      utFilter: ${{steps.changed_packages.outputs.utFilter}}
+      unitTestFilter: ${{steps.changed_packages.outputs.unitTestFilter}}
 
     steps:
       - name: Checkout Source Code
@@ -48,7 +48,7 @@ jobs:
 
           filter=""
           specPackages=""
-          utFilter=""
+          unitTestFilter=""
 
           # get the list of changed packages, grab the location
           for pkgFolder in $(lerna ${lernaCommand} --l --json|jq -r '.[].location')
@@ -67,7 +67,7 @@ jobs:
 
             findRes=$(find "${pkgFolder}" -name "*.spec.ts" || true)
             if [[ -n "${findRes}" ]]; then
-                utFilter="${utFilter}${pkgFolder}|"
+                unitTestFilter="${unitTestFilter}${pkgFolder}|"
             fi
           done
 
@@ -75,8 +75,8 @@ jobs:
           filter="{("$(echo "${filter}" | sed 's/|$//')")}"
           echo "filter=${filter}"
 
-          utFilter="{("$(echo "${utFilter}" | sed 's/|$//')")}"
-          echo "utFilter=${utFilter}"
+          unitTestFilter="{("$(echo "${unitTestFilter}" | sed 's/|$//')")}"
+          echo "unitTestFilter=${unitTestFilter}"
 
           # remove trailing ',' from cypress spec
           specPackages=$(echo "${specPackages}" | sed 's/,$//')
@@ -85,7 +85,7 @@ jobs:
           # set github output
           echo "filter=${filter}" >> $GITHUB_OUTPUT
           echo "spec=${specPackages}" >> $GITHUB_OUTPUT
-          echo "utFilter=${utFilter}" >> $GITHUB_OUTPUT
+          echo "unitTestFilter=${unitTestFilter}" >> $GITHUB_OUTPUT
 
   build:
     name: Build And Test
@@ -111,7 +111,7 @@ jobs:
         run: pnpm --stream --filter "...${{needs.install-dependencies.outputs.filter}}..." run build
 
       - name: Run Unit Tests
-        run: pnpm --stream --filter "${{needs.install-dependencies.outputs.utFilter}}" run test:unit
+        run: pnpm --stream --filter "${{needs.install-dependencies.outputs.unitTestFilter}}" run test:unit
 
       - name: Prepare Cypress
         if: ${{ needs.install-dependencies.outputs.spec != '' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       filter: ${{steps.changed_packages.outputs.filter}}
       spec: ${{steps.changed_packages.outputs.spec}}
+      utFilter: ${{steps.changed_packages.outputs.utFilter}}
 
     steps:
       - name: Checkout Source Code
@@ -47,6 +48,7 @@ jobs:
 
           filter=""
           specPackages=""
+          utFilter=""
 
           # get the list of changed packages, grab the location
           for pkgFolder in $(lerna ${lernaCommand} --l --json|jq -r '.[].location')
@@ -62,10 +64,19 @@ jobs:
             if [[ -n "${findRes}" ]]; then
                 specPackages="${specPackages}${pkgFolder},"
             fi
+
+            findRes=$(find "${pkgFolder}" -name "*.spec.ts" || true)
+            if [[ -n "${findRes}" ]]; then
+                utFilter="${utFilter}${pkgFolder}|"
+            fi
           done
+
           # remove trailing '|' from pnpm filter
           filter="{("$(echo "${filter}" | sed 's/|$//')")}"
           echo "filter=${filter}"
+
+          utFilter="{("$(echo "${utFilter}" | sed 's/|$//')")}"
+          echo "utFilter=${utFilter}"
 
           # remove trailing ',' from cypress spec
           specPackages=$(echo "${specPackages}" | sed 's/,$//')
@@ -74,7 +85,7 @@ jobs:
           # set github output
           echo "filter=${filter}" >> $GITHUB_OUTPUT
           echo "spec=${specPackages}" >> $GITHUB_OUTPUT
-
+          echo "utFilter=${utFilter}" >> $GITHUB_OUTPUT
 
   build:
     name: Build And Test
@@ -100,7 +111,7 @@ jobs:
         run: pnpm --stream --filter "...${{needs.install-dependencies.outputs.filter}}..." run build
 
       - name: Run Unit Tests
-        run: pnpm --stream --filter "${{needs.install-dependencies.outputs.filter}}" run test:unit
+        run: pnpm --stream --filter "${{needs.install-dependencies.outputs.utFilter}}" run test:unit
 
       - name: Prepare Cypress
         if: ${{ needs.install-dependencies.outputs.spec != '' }}


### PR DESCRIPTION
# Summary

And when there are no UT found - exclude package from  `test:unit` even when package is changed. 

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
