### PR TITLE
feat(swagger-ui-web-comp): remove css contains [TDX-2278]

### DIFF
--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -74,7 +74,6 @@ export class SwaggerUIElement extends HTMLElement {
     super()
 
     this.rootElement = document.createElement('div')
-    this.rootElement.style.contain = 'content'
 
     this.attachShadow({ mode: 'open' })
     this.shadowRoot.appendChild(this.rootElement)


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This removes the CSS `contains: content` on the web-component root div. Having this prevented the modal for "authorize from displaying fixed backdrop over the whole page. 

It's possible that this has some wider ramifications, and breaks some other styles/functionality. I did not see any as far I could tell. 
![Screenshot 2023-02-06 at 11 09 46 PM](https://user-images.githubusercontent.com/15886900/217181733-59e91b1d-0321-43d9-8173-f614f3877746.png)


## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [x] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
