### PR TITLE
fix(document-viewer): add spaces between nested text in paragraphs

### DIFF
--- a/packages/portal/document-viewer/src/components/nodes/Blockquote.vue
+++ b/packages/portal/document-viewer/src/components/nodes/Blockquote.vue
@@ -4,7 +4,7 @@
   </blockquote>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 blockquote {
   background: var(--document-viewer-blockquote-background, #f8f8fa);
   border-left: 2.5px solid var(--document-viewer-blockquote-border, var(--text_colors-accent, #0b172d));
@@ -12,5 +12,13 @@ blockquote {
   font-size: 14px;
   margin: var(--spacing-sm, 12px) var(--spacing-sm, 12px);
   padding: var(--spacing-sm, 12px);
+
+  :deep(blockquote p) {
+    margin-bottom: 0;
+  }
+
+  :deep(p:last-of-type) {
+    margin-bottom: 0;
+  }
 }
 </style>

--- a/packages/portal/document-viewer/src/components/nodes/Text.vue
+++ b/packages/portal/document-viewer/src/components/nodes/Text.vue
@@ -1,5 +1,5 @@
 <template>
-  {{ text }}<br v-if="hardBreak">
+  {{ text }}<span v-if="appendSpace">&nbsp;</span>
 </template>
 
 <script lang="ts">
@@ -13,7 +13,7 @@ defineProps({
     type: String,
     required: true,
   },
-  hardBreak: {
+  appendSpace: {
     type: Boolean,
     default: false,
   },

--- a/packages/portal/document-viewer/src/components/renderChildren.tsx
+++ b/packages/portal/document-viewer/src/components/renderChildren.tsx
@@ -61,6 +61,19 @@ export default function renderChildren<ChildTypes extends BaseNode>(children: Ar
       return null
     }
 
+    // This is to fix an issue with text blocks that are beside another element
+    // not having a space between them
+    if (child?.type === 'paragraph' && child.children) {
+      const paragraphChildren = child.children
+      const lastItemIndex = paragraphChildren.length - 1
+
+      paragraphChildren.forEach((paragraphChild, index) => {
+        if (paragraphChild.type === 'text' && !paragraphChild.text?.endsWith(' ') && index !== lastItemIndex) {
+          paragraphChild.appendSpace = true
+        }
+      })
+    }
+
     return (
       <component {...restProps} parent={parent}>
         {() => children && renderChildren(children, child)}

--- a/packages/portal/document-viewer/src/components/renderChildren.tsx
+++ b/packages/portal/document-viewer/src/components/renderChildren.tsx
@@ -1,5 +1,5 @@
 import { Component } from 'vue'
-import { BaseNode } from '../types'
+import { BaseNode, isTextNode } from '../types'
 import Blockquote from './nodes/Blockquote.vue'
 import Code from './nodes/Code.vue'
 import CodeBlock from './nodes/CodeBlock.vue'
@@ -63,12 +63,12 @@ export default function renderChildren<ChildTypes extends BaseNode>(children: Ar
 
     // This is to fix an issue with text blocks that are beside another element
     // not having a space between them
-    if (child?.type === 'paragraph' && child.children) {
+    if (child?.type === 'paragraph' && child?.children) {
       const paragraphChildren = child.children
       const lastItemIndex = paragraphChildren.length - 1
 
       paragraphChildren.forEach((paragraphChild, index) => {
-        if (paragraphChild.type === 'text' && !paragraphChild.text?.endsWith(' ') && index !== lastItemIndex) {
+        if (isTextNode(paragraphChild) && !paragraphChild.text?.endsWith(' ') && index !== lastItemIndex) {
           paragraphChild.appendSpace = true
         }
       })

--- a/packages/portal/document-viewer/src/types/index.ts
+++ b/packages/portal/document-viewer/src/types/index.ts
@@ -34,7 +34,7 @@ export interface TableRowNode extends BaseNode<'table_row'> {
 export interface TextNode extends BaseNode<'text'> {
   text: string
   children: undefined
-  hardBreak?: boolean
+  appendSpace?: boolean
 }
 
 export interface HeadingNode extends BaseNode<'heading'> {

--- a/packages/portal/document-viewer/src/types/index.ts
+++ b/packages/portal/document-viewer/src/types/index.ts
@@ -37,6 +37,10 @@ export interface TextNode extends BaseNode<'text'> {
   appendSpace?: boolean
 }
 
+export function isTextNode(o: any): o is TextNode {
+  return o.type === 'text'
+}
+
 export interface HeadingNode extends BaseNode<'heading'> {
   level: number
 }


### PR DESCRIPTION
# Summary
Adds spaces between nested text in paragraphs for the document viewer, along with some styling fixes.
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
