### PR TITLE
feat(portal): update spec renderer to listen for "deselect"

### DIFF
--- a/packages/portal/spec-renderer/src/components/SpecOperationsList.cy.ts
+++ b/packages/portal/spec-renderer/src/components/SpecOperationsList.cy.ts
@@ -67,6 +67,31 @@ describe('<SpecOperationsList />', () => {
     cy.get('.item--selected').should('not.exist')
   })
 
+  // this test should behave the same as the one above
+  // because we cannot change props after mounting
+  it('resets selection when passed deselect property', () => {
+    cy.mount(SpecOperationsList, {
+      props: {
+        operations: operationsList,
+        tags,
+        deselect: false,
+      },
+    }).then(({ wrapper }) => {
+      // select an item
+      cy.getTestId(`spec-operations-list-item-${specOp.method}-pet-${specOp.tags?.[0]}`).click()
+      cy.get('.item--selected').should('have.length', 1).then(() => {
+        // deselect
+        wrapper.setProps({ deselect: true, operations: operationsList, tags }).then(() => {
+          // verify no items selected
+          cy.get('.item--selected').should('not.exist')
+        })
+
+      })
+
+    })
+
+  })
+
   it('allows selecting an item', () => {
     cy.mount(SpecOperationsList, {
       props: {

--- a/packages/portal/spec-renderer/src/components/SpecOperationsList.vue
+++ b/packages/portal/spec-renderer/src/components/SpecOperationsList.vue
@@ -273,8 +273,6 @@ watch(() => props.deselect, () => {
     selectedItem.value = undefined
   }
 })
-
-
 watch(() => props.operations, () => generateTaggedItems())
 
 watch(filterQuery, () => filterItems())

--- a/packages/portal/spec-renderer/src/components/SpecOperationsList.vue
+++ b/packages/portal/spec-renderer/src/components/SpecOperationsList.vue
@@ -270,8 +270,13 @@ const generateTaggedItems = (): void => {
 
 watch(() => props.deselect, () => {
   if (props.deselect) {
+    console.log('deselect changed, setting undefined')
     selectedItem.value = undefined
   }
+})
+
+watch(() => selectedItem.value, () => {
+  console.log('selectedItem changed, new state: ', JSON.stringify(selectedItem.value))
 })
 
 watch(() => props.operations, () => generateTaggedItems())

--- a/packages/portal/spec-renderer/src/components/SpecOperationsList.vue
+++ b/packages/portal/spec-renderer/src/components/SpecOperationsList.vue
@@ -270,14 +270,10 @@ const generateTaggedItems = (): void => {
 
 watch(() => props.deselect, () => {
   if (props.deselect) {
-    console.log('deselect changed, setting undefined')
     selectedItem.value = undefined
   }
 })
 
-watch(() => selectedItem.value, () => {
-  console.log('selectedItem changed, new state: ', JSON.stringify(selectedItem.value))
-})
 
 watch(() => props.operations, () => generateTaggedItems())
 

--- a/packages/portal/spec-renderer/src/components/SpecOperationsList.vue
+++ b/packages/portal/spec-renderer/src/components/SpecOperationsList.vue
@@ -157,6 +157,10 @@ const props = defineProps({
     }) as OperationListFilterFunction,
     validator: (maybeFunc) => !!maybeFunc && typeof maybeFunc === 'function',
   },
+  deselect: {
+    type: Boolean,
+    default: false,
+  },
   disableSelection: {
     type: Boolean,
     default: false,
@@ -263,6 +267,12 @@ const generateTaggedItems = (): void => {
   // Initial filtering to populate filteredItems
   filterItems()
 }
+
+watch(() => props.deselect, () => {
+  if (props.deselect) {
+    selectedItem.value = undefined
+  }
+})
 
 watch(() => props.operations, () => generateTaggedItems())
 

--- a/packages/portal/spec-renderer/src/components/SpecRenderer.vue
+++ b/packages/portal/spec-renderer/src/components/SpecRenderer.vue
@@ -6,6 +6,7 @@
     >
       <SpecOperationsList
         data-testid="spec-renderer-ops-list-content"
+        :deselect="deselect"
         :operations="operationsList"
         :tags="tags"
         :width="navWidth"
@@ -69,6 +70,10 @@ const props = defineProps({
   navWidth: {
     type: String,
     default: '310',
+  },
+  deselect: {
+    type: Boolean,
+    default: false,
   },
 })
 


### PR DESCRIPTION
# Summary

Essentially, we need a way to deselect an item from a parent component. This does it by passing it as a prop and listening for changes.
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [x] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.


I will note that I tried to add a test for this, but ran into problems with changing properties _after_ mount. If anyone has some hot tips, I'm happy to add a test!