### PR TITLE
feat(misc-widgets): create new package

### DIFF
--- a/packages/core/cli/src/__template__/README.md
+++ b/packages/core/cli/src/__template__/README.md
@@ -6,6 +6,7 @@
 - [Requirements](#requirements)
 - [Usage](#usage)
   - [Install](#install)
+  - [Props](#props)
 
 ## Features
 
@@ -20,3 +21,11 @@
 ### Install
 
 {Installation instructions}
+
+### Props
+
+#### `example`
+
+- type: `Boolean`
+- required: `false`
+- default: `false`

--- a/packages/core/cli/src/__template__/src/components/Template.cy.ts
+++ b/packages/core/cli/src/__template__/src/components/Template.cy.ts
@@ -1,7 +1,6 @@
 // Cypress component test spec file
 
 import {%%COMPONENT_NAME%%} from './{%%COMPONENT_NAME%%}.vue'
-import { mount } from 'cypress/vue'
 
 describe('<{%%COMPONENT_NAME%%} />', () => {
   it('TODO: This is an example test', () => {

--- a/packages/core/misc-widgets/LICENSE
+++ b/packages/core/misc-widgets/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Kong, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/core/misc-widgets/README.md
+++ b/packages/core/misc-widgets/README.md
@@ -1,0 +1,49 @@
+# @kong-ui-public/misc-widgets
+
+A collection of miscellaneous components and widgets.
+
+This package is a good home for random, one-off components that aren't complex and a standalone package is not necessary.
+
+- [Components](#components)
+- [Requirements](#requirements)
+- [Usage](#usage)
+  - [Install](#install)
+  - [Register Components](#register-components)
+
+## Components
+
+- [Github Star](src/components/github-star/README.md)
+
+## Requirements
+
+- `vue` must be initialized in the host application
+- `@kong/kongponents` must be available as a `dependency` in the host application, along with the package's style imports. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
+
+## Usage
+
+### Install
+
+Install the package in your host application
+
+```sh
+yarn add @kong-ui-public/misc-widgets
+
+# OR
+
+pnpm --filter="@kong-ui/konnect-app-{name} add @kong-ui-public/misc-widgets"
+```
+
+### Register Components
+
+You can import individual components locally where they are being used. Don't forget to import the styles as well.
+
+```html
+<template>
+  <GithubStar />
+</template>
+
+<script setup lang="ts">
+import { GithubStar } from '@kong-ui-public/misc-widgets'
+import '@kong-ui-public/misc-widgets/dist/style.css'
+</script>
+```

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@kong-ui-public/misc-widgets",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./dist/misc-widgets.umd.js",
+  "module": "./dist/misc-widgets.es.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/misc-widgets.es.js",
+      "require": "./dist/misc-widgets.umd.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": "./dist/*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "dev": "cross-env USE_SANDBOX=true vite",
+    "build": "run-s typecheck build:package build:types",
+    "build:package": "vite build",
+    "build:types": "vue-tsc -p './tsconfig.build.json' --emitDeclarationOnly",
+    "build:visualize": "BUILD_VISUALIZER='core/misc-widgets' vite build -m production",
+    "preview:package": "vite preview --port 4173",
+    "preview": "cross-env USE_SANDBOX=true PREVIEW_SANDBOX=true run-s build:package preview:package",
+    "lint": "eslint '**/*.{js,jsx,ts,tsx,vue}' --ignore-path '../../../.eslintignore'",
+    "lint:fix": "eslint '**/*.{js,jsx,ts,tsx,vue}' --ignore-path '../../../.eslintignore' --fix",
+    "stylelint": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}'",
+    "stylelint:fix": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}' --fix",
+    "typecheck": "vue-tsc -p './tsconfig.build.json' --noEmit",
+    "test:component": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress run --component -b chrome --spec './src/**/*.cy.ts' --project '../../../.'",
+    "test:component:open": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress open --component -b chrome --project '../../../.'",
+    "test:unit": "cross-env FORCE_COLOR=1 vitest run",
+    "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
+  },
+  "peerDependencies": {
+    "@kong/kongponents": "^8.24.1",
+    "vue": "^3.2.47"
+  },
+  "devDependencies": {
+    "@kong/kongponents": "^8.24.1",
+    "vue": "^3.2.47"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/public-ui-components.git",
+    "directory": "packages/core/misc-widgets"
+  },
+  "homepage": "https://github.com/Kong/public-ui-components/tree/main/packages/core/misc-widgets",
+  "bugs": {
+    "url": "https://github.com/Kong/public-ui-components/issues"
+  },
+  "author": "Kong, Inc.",
+  "license": "Apache-2.0",
+  "volta": {
+    "extends": "../../../package.json"
+  }
+}

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -45,6 +45,9 @@
     "@kong/kongponents": "^8.24.1",
     "vue": "^3.2.47"
   },
+  "dependencies": {
+    "@kong-ui-public/i18n": "workspace:^0.2.8"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Kong/public-ui-components.git",
@@ -57,6 +60,7 @@
   "author": "Kong, Inc.",
   "license": "Apache-2.0",
   "volta": {
-    "extends": "../../../package.json"
+    "extends": "../../../package.json",
+    "yarn": "1.22.19"
   }
 }

--- a/packages/core/misc-widgets/sandbox/App.vue
+++ b/packages/core/misc-widgets/sandbox/App.vue
@@ -1,12 +1,14 @@
 <template>
   <div class="sandbox-container">
     <main>
-      <p>This is the component sandbox.</p>
-      <MiscWidgets />
+      <div>
+        <h3>Default</h3>
+        <GithubStar :url="url" />
+      </div>
     </main>
   </div>
 </template>
 
 <script setup lang="ts">
-import { MiscWidgets } from '../src'
+const url = 'https://github.com/kong/kong'
 </script>

--- a/packages/core/misc-widgets/sandbox/App.vue
+++ b/packages/core/misc-widgets/sandbox/App.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="sandbox-container">
+    <main>
+      <p>This is the component sandbox.</p>
+      <MiscWidgets />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { MiscWidgets } from '../src'
+</script>

--- a/packages/core/misc-widgets/sandbox/App.vue
+++ b/packages/core/misc-widgets/sandbox/App.vue
@@ -2,7 +2,7 @@
   <div class="sandbox-container">
     <main>
       <div>
-        <h3>Default</h3>
+        <h3>Awesome GitHub Star ⭐</h3>
         <GithubStar :url="url" />
       </div>
     </main>

--- a/packages/core/misc-widgets/sandbox/index.html
+++ b/packages/core/misc-widgets/sandbox/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MiscWidgets Component Sandbox</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+      html,
+      body {
+        font-family: "Inter", Helvetica, Arial, sans-serif;
+      }
+
+    </style>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+
+</html>

--- a/packages/core/misc-widgets/sandbox/index.ts
+++ b/packages/core/misc-widgets/sandbox/index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+const app = createApp(App)
+
+app.mount('#app')

--- a/packages/core/misc-widgets/sandbox/index.ts
+++ b/packages/core/misc-widgets/sandbox/index.ts
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import { GithubStar } from '../src'
 
 const app = createApp(App)
-
+app.component('GithubStar', GithubStar)
 app.mount('#app')

--- a/packages/core/misc-widgets/sandbox/tsconfig.json
+++ b/packages/core/misc-widgets/sandbox/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.vue",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
@@ -1,0 +1,10 @@
+// Cypress component test spec file
+import GithubStar from './GithubStar.vue'
+
+describe('<GithubStar />', () => {
+  it('TODO: This is an example test', () => {
+    cy.mount(GithubStar)
+
+    cy.get('.kong-ui-public-misc-widgets-github-star').should('be.visible')
+  })
+})

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
@@ -2,9 +2,25 @@
 import GithubStar from './GithubStar.vue'
 
 describe('<GithubStar />', () => {
-  it('TODO: This is an example test', () => {
-    cy.mount(GithubStar)
+  it('renders correctly with props', () => {
+    cy.mount(GithubStar, {
+      props: {
+        url: 'http://github.com/kong/kong',
+      },
+    })
 
     cy.get('.kong-ui-public-misc-widgets-github-star').should('be.visible')
+  })
+
+  it('renders content correctly', () => {
+    cy.mount(GithubStar, {
+      props: {
+        url: 'http://github.com/kong/kong',
+      },
+    })
+
+    cy.getTestId('github-star').should('have.class', 'kong-ui-public-misc-widgets-github-star')
+    cy.getTestId('github-star').find('a').should('be.visible')
+    cy.getTestId('github-star').find('.github-button').should('be.visible')
   })
 })

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -10,6 +10,7 @@
       data-color-scheme="no-preference: light; light: light; dark: light;"
       data-show-count="true"
       :href="url"
+      target="_blank"
     >{{ i18n.t('githubStar.title') }}</a>
   </div>
 </template>

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -16,10 +16,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import composables from '../../composables'
 
-const props = defineProps({
+defineProps({
   url: {
     type: String,
     required: true,
@@ -27,8 +27,6 @@ const props = defineProps({
 })
 
 const { i18n } = composables.useI18n()
-
-const url = computed(() => props.url)
 
 onMounted(async () => {
   const githubStarScript = document.createElement('script')

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -1,0 +1,16 @@
+<template>
+  <!-- The <div> tag here is just a placeholder for your component content. -->
+  <!-- We recommend wrapping your component with a unique class when possible, as shown below. -->
+  <div class="kong-ui-public-misc-widgets-github-star">
+    <p>This is the <b>Github Star</b> content.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style lang="scss" scoped>
+.kong-ui-public-misc-widgets-github-star {
+  // Add component styles as needed
+}
+</style>

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -1,12 +1,33 @@
 <template>
-  <!-- The <div> tag here is just a placeholder for your component content. -->
-  <!-- We recommend wrapping your component with a unique class when possible, as shown below. -->
   <div class="kong-ui-public-misc-widgets-github-star">
-    <p>This is the <b>Github Star</b> content.</p>
+    <a
+      aria-label="Star buttons/github-buttons on GitHub"
+      class="github-button"
+      data-color-scheme="no-preference: light; light: light; dark: light;"
+      data-show-count="true"
+      :href="url"
+    >Star</a>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted } from 'vue'
+
+const props = defineProps({
+  url: {
+    type: String,
+    required: false,
+    default: '',
+  },
+})
+
+const url = computed(() => props.url)
+
+onMounted(async () => {
+  const githubStarScript = document.createElement('script')
+  githubStarScript.setAttribute('src', 'https://buttons.github.io/buttons.js')
+  document.head.appendChild(githubStarScript)
+})
 </script>
 
 <style lang="scss" scoped>

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="url"
+    v-if="url && scriptLoaded"
     class="kong-ui-public-misc-widgets-github-star"
     data-testid="github-star"
   >
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
 import composables from '../../composables'
 
 defineProps({
@@ -28,8 +28,15 @@ defineProps({
 
 const { i18n } = composables.useI18n()
 
+const scriptLoaded = ref<boolean>(false)
+
 onMounted(async () => {
   const githubStarScript = document.createElement('script')
+
+  githubStarScript.addEventListener('load', () => {
+    scriptLoaded.value = true
+  })
+
   githubStarScript.setAttribute('src', 'https://buttons.github.io/buttons.js')
   document.head.appendChild(githubStarScript)
 })

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="kong-ui-public-misc-widgets-github-star">
+  <div
+    class="kong-ui-public-misc-widgets-github-star"
+    data-testid="github-star"
+  >
     <a
       aria-label="Star buttons/github-buttons on GitHub"
       class="github-button"
@@ -16,7 +19,7 @@ import { computed, onMounted } from 'vue'
 const props = defineProps({
   url: {
     type: String,
-    required: false,
+    required: true,
     default: '',
   },
 })

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -39,6 +39,8 @@ onMounted(async () => {
 
 <style lang="scss" scoped>
 .kong-ui-public-misc-widgets-github-star {
-  // Add component styles as needed
+  .github-button {
+    font-style: normal;
+  }
 }
 </style>

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -1,28 +1,31 @@
 <template>
   <div
+    v-if="url"
     class="kong-ui-public-misc-widgets-github-star"
     data-testid="github-star"
   >
     <a
-      aria-label="Star buttons/github-buttons on GitHub"
+      aria-label="i18n.t('githubStar.ariaLabel')"
       class="github-button"
       data-color-scheme="no-preference: light; light: light; dark: light;"
       data-show-count="true"
       :href="url"
-    >Star</a>
+    >{{ i18n.t('githubStar.title') }}</a>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
+import composables from '../../composables'
 
 const props = defineProps({
   url: {
     type: String,
     required: true,
-    default: '',
   },
 })
+
+const { i18n } = composables.useI18n()
 
 const url = computed(() => props.url)
 

--- a/packages/core/misc-widgets/src/components/github-star/README.md
+++ b/packages/core/misc-widgets/src/components/github-star/README.md
@@ -1,0 +1,21 @@
+# Github Star
+
+{A description of this component}
+
+- [Features](#features)
+- [Usage](#usage)
+  - [Props](#props)
+
+## Features
+
+- List of package features
+
+## Usage
+
+### Props
+
+#### `example`
+
+- type: `Boolean`
+- required: `false`
+- default: `false`

--- a/packages/core/misc-widgets/src/components/github-star/README.md
+++ b/packages/core/misc-widgets/src/components/github-star/README.md
@@ -18,7 +18,6 @@ A Github Star component for displaying number of stars received by the repo on G
 #### `url`
 
 - type: `String`
-- required: `false`
-- default: `''`
+- required: `true`
 
 Full URL to the GitHub repository.

--- a/packages/core/misc-widgets/src/components/github-star/README.md
+++ b/packages/core/misc-widgets/src/components/github-star/README.md
@@ -1,6 +1,6 @@
 # Github Star
 
-{A description of this component}
+A Github Star component for displaying number of stars received by the repo on Github
 
 - [Features](#features)
 - [Usage](#usage)
@@ -8,14 +8,17 @@
 
 ## Features
 
-- List of package features
+- Render number of stars received by the repo on Github
+- Customize the repo url that opens in a new tab upon clicking this component
 
 ## Usage
 
 ### Props
 
-#### `example`
+#### `url`
 
-- type: `Boolean`
+- type: `String`
 - required: `false`
-- default: `false`
+- default: `''`
+
+Repo url string.

--- a/packages/core/misc-widgets/src/components/github-star/README.md
+++ b/packages/core/misc-widgets/src/components/github-star/README.md
@@ -21,4 +21,4 @@ A Github Star component for displaying number of stars received by the repo on G
 - required: `false`
 - default: `''`
 
-Repo url string.
+Full URL to the GitHub repository.

--- a/packages/core/misc-widgets/src/components/index.ts
+++ b/packages/core/misc-widgets/src/components/index.ts
@@ -1,0 +1,2 @@
+// All exposed components should be exported from this root file
+export { default as GithubStar } from './github-star/GithubStar.vue'

--- a/packages/core/misc-widgets/src/composables/index.ts
+++ b/packages/core/misc-widgets/src/composables/index.ts
@@ -1,0 +1,6 @@
+import useI18n from './useI18n'
+
+// All composables must be exported as part of the default object for Cypress test stubs
+export default {
+  useI18n,
+}

--- a/packages/core/misc-widgets/src/composables/useI18n.ts
+++ b/packages/core/misc-widgets/src/composables/useI18n.ts
@@ -1,0 +1,11 @@
+import { createI18n, Translation } from '@kong-ui-public/i18n'
+import english from '../locales/en.json'
+
+export default function usei18n() {
+  const i18n = createI18n('en-us', english)
+
+  return {
+    i18n,
+    i18nT: Translation, // Translation component <i18n-t>
+  }
+}

--- a/packages/core/misc-widgets/src/global-components.d.ts
+++ b/packages/core/misc-widgets/src/global-components.d.ts
@@ -1,0 +1,2 @@
+// Import globally available components
+import '@kong/kongponents/dist/types/global-components'

--- a/packages/core/misc-widgets/src/index.ts
+++ b/packages/core/misc-widgets/src/index.ts
@@ -1,0 +1,16 @@
+import type { App } from 'vue'
+import MiscWidgets from './components/MiscWidgets.vue'
+
+// Export Vue plugin as the default
+export default {
+  // Customize Vue plugin options as desired
+  // Providing a `name` property allows for customizing the registered
+  // name of your component (useful if exporting a single component).
+  install: (app: App, options: { name?: string, [key: string]: any } = {}): void => {
+    app.component(options.name || 'MiscWidgets', MiscWidgets)
+  },
+}
+
+export { MiscWidgets }
+
+export * from './types'

--- a/packages/core/misc-widgets/src/index.ts
+++ b/packages/core/misc-widgets/src/index.ts
@@ -1,16 +1,2 @@
-import type { App } from 'vue'
-import MiscWidgets from './components/MiscWidgets.vue'
-
-// Export Vue plugin as the default
-export default {
-  // Customize Vue plugin options as desired
-  // Providing a `name` property allows for customizing the registered
-  // name of your component (useful if exporting a single component).
-  install: (app: App, options: { name?: string, [key: string]: any } = {}): void => {
-    app.component(options.name || 'MiscWidgets', MiscWidgets)
-  },
-}
-
-export { MiscWidgets }
-
+export * from './components'
 export * from './types'

--- a/packages/core/misc-widgets/src/locales/en.json
+++ b/packages/core/misc-widgets/src/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "header": {
+    "title": "Title of the header",
+    "content": "Content of the header"
+  }
+}

--- a/packages/core/misc-widgets/src/locales/en.json
+++ b/packages/core/misc-widgets/src/locales/en.json
@@ -1,6 +1,6 @@
 {
-  "header": {
-    "title": "Title of the header",
-    "content": "Content of the header"
+  "githubStar": {
+    "title": "Star",
+    "ariaLabel": "Star buttons/github-buttons on GitHub"
   }
 }

--- a/packages/core/misc-widgets/src/types/index.ts
+++ b/packages/core/misc-widgets/src/types/index.ts
@@ -1,0 +1,5 @@
+// Export all types and interfaces from this index.ts
+// The actual types and interfaces should be contained in separate files within this folder.
+
+// Example:
+// export * from './component-types'

--- a/packages/core/misc-widgets/src/types/index.ts
+++ b/packages/core/misc-widgets/src/types/index.ts
@@ -3,3 +3,5 @@
 
 // Example:
 // export * from './component-types'
+
+export {}

--- a/packages/core/misc-widgets/tsconfig.build.json
+++ b/packages/core/misc-widgets/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.cy.ts",
+    "src/**/*.spec.ts",
+    "sandbox",
+    "dist"
+  ]
+}

--- a/packages/core/misc-widgets/tsconfig.json
+++ b/packages/core/misc-widgets/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "declarationDir": "dist/types",
+    "types": [
+      "node",
+      "vite/client",
+      "cypress",
+      "cypress/vue",
+      "../../../cypress/support"
+    ]
+  },
+  "include": [
+    "src/**/*",
+    "sandbox/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/core/misc-widgets/vite.config.ts
+++ b/packages/core/misc-widgets/vite.config.ts
@@ -1,0 +1,28 @@
+import sharedViteConfig from '../../../vite.config.shared'
+import { resolve } from 'path'
+import { defineConfig, mergeConfig } from 'vite'
+
+// Package name MUST always match the kebab-case package name inside the component's package.json file and the name of your `/packages/{package-name}` directory
+const packageName = 'misc-widgets'
+
+// Merge the shared Vite config with the local one defined below
+const config = mergeConfig(sharedViteConfig, defineConfig({
+  build: {
+    lib: {
+      // The kebab-case name of the exposed global variable. MUST be in the format `kong-ui-public-{package-name}`
+      // Example: name: 'kong-ui-public-demo-component'
+      name: `kong-ui-public-${packageName}`,
+      entry: resolve(__dirname, './src/index.ts'),
+      fileName: (format) => `${packageName}.${format}.js`,
+    },
+  },
+}))
+
+// If we are trying to preview a build of the local `package/misc-widgets/sandbox` directory,
+// unset the external and lib properties
+if (process.env.PREVIEW_SANDBOX) {
+  config.build.rollupOptions.external = undefined
+  config.build.lib = undefined
+}
+
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,14 @@ importers:
       flat: 5.0.2
       intl-messageformat: 10.3.0
 
+  packages/core/misc-widgets:
+    specifiers:
+      '@kong/kongponents': ^8.24.1
+      vue: ^3.2.47
+    devDependencies:
+      '@kong/kongponents': 8.24.1_vue@3.2.47
+      vue: 3.2.47
+
   packages/portal/document-viewer:
     specifiers:
       '@kong-ui-public/i18n': workspace:^0.2.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,7 +183,7 @@ importers:
       '@kong/kongponents': ^8.24.1
       vue: ^3.2.47
     devDependencies:
-      '@kong/kongponents': 8.24.1_vue@3.2.47
+      '@kong/kongponents': 8.24.2_vue@3.2.47
       vue: 3.2.47
 
   packages/portal/document-viewer:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ importers:
     dependencies:
       '@kong-ui-public/i18n': link:../i18n
     devDependencies:
-      '@kong/kongponents': 8.24.2_vue@3.2.47
+      '@kong/kongponents': 8.25.0_vue@3.2.47
       vue: 3.2.47
 
   packages/portal/document-viewer:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,11 @@ importers:
 
   packages/core/misc-widgets:
     specifiers:
+      '@kong-ui-public/i18n': workspace:^0.2.8
       '@kong/kongponents': ^8.24.1
       vue: ^3.2.47
+    dependencies:
+      '@kong-ui-public/i18n': link:../i18n
     devDependencies:
       '@kong/kongponents': 8.24.2_vue@3.2.47
       vue: 3.2.47


### PR DESCRIPTION
# Summary

Create a new `@kong-ui-public/misc-widgets` package that can house one-off components that aren't complex and a standalone package is not necessary.

This PR also adds the Github Star component to the `misc-widgets` package. 
https://konghq.atlassian.net/browse/KHCP-6075

<img width="367" alt="Screenshot 2023-02-15 at 11 56 25 AM" src="https://user-images.githubusercontent.com/2568272/219138777-16c9358b-2b7b-4211-8199-3e1303ae4d43.png">

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
