### PR TITLE
fix: [KHCP-6076] remove PR preview comment when closing PR

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,4 +1,4 @@
-name: Unpublish or Deprecate NPM previews for PR
+name: On PR close
 on:
   pull_request_target:
     types:
@@ -13,6 +13,13 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v3
+
+      - name: Remove preview consumption comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr_preview_consumption
+          delete: true
+          GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
 
       - name: Unpublish
         run: |


### PR DESCRIPTION
# Summary

We do not want PR comments referencing preview packages in closed PRs. Those previews are unpublished or deprecated, so no reason to keep those reference comments around