### PR TITLE
fix(document-viewer): use default text for slug if there is no text

### DIFF
--- a/packages/portal/document-viewer/src/types/index.ts
+++ b/packages/portal/document-viewer/src/types/index.ts
@@ -45,6 +45,10 @@ export interface HeadingNode extends BaseNode<'heading'> {
   level: number
 }
 
+export function isHeadingNode(o: any): o is HeadingNode {
+  return !!(o?.type === 'heading')
+}
+
 export interface ListItemNode extends BaseNode<'list_item'> {}
 
 export interface ListNode extends BaseNode<'list'> {

--- a/packages/portal/document-viewer/src/types/index.ts
+++ b/packages/portal/document-viewer/src/types/index.ts
@@ -38,7 +38,7 @@ export interface TextNode extends BaseNode<'text'> {
 }
 
 export function isTextNode(o: any): o is TextNode {
-  return o.type === 'text'
+  return !!(o?.type === 'text')
 }
 
 export interface HeadingNode extends BaseNode<'heading'> {

--- a/packages/portal/document-viewer/src/utils/addUniqueHeadingSlugs.ts
+++ b/packages/portal/document-viewer/src/utils/addUniqueHeadingSlugs.ts
@@ -16,7 +16,7 @@ export function addUniqueHeadingSlugs<T = any>(children: Array<T>): Array<T> {
 }
 
 export function addSlug(child: any, slugMap: Map<string, number>, prefix = 'doc-heading-') {
-  const text = child.children[0].text
+  const text = child.children[0].text || 'heading'
   const slugCount = slugMap.get(text)
   slugMap.set(text, (slugCount || 0) + 1)
   const duplicateSuffix = slugCount && slugCount > 1 ? `-${slugCount}` : ''

--- a/packages/portal/document-viewer/src/utils/addUniqueHeadingSlugs.ts
+++ b/packages/portal/document-viewer/src/utils/addUniqueHeadingSlugs.ts
@@ -1,4 +1,4 @@
-import { HeadingNode, isHeadingNode, isTextNode } from 'src/types'
+import { HeadingNode, isHeadingNode, isTextNode } from '../types'
 import { toSlug } from './toSlug'
 export function addUniqueHeadingSlugs<T = any>(children: Array<T>): Array<T> {
 

--- a/packages/portal/document-viewer/src/utils/addUniqueHeadingSlugs.ts
+++ b/packages/portal/document-viewer/src/utils/addUniqueHeadingSlugs.ts
@@ -1,3 +1,4 @@
+import { HeadingNode, isHeadingNode, isTextNode } from 'src/types'
 import { toSlug } from './toSlug'
 export function addUniqueHeadingSlugs<T = any>(children: Array<T>): Array<T> {
 
@@ -7,7 +8,7 @@ export function addUniqueHeadingSlugs<T = any>(children: Array<T>): Array<T> {
   // loop through the children
   // if the child is a heading, add a slug property based on the text
   return children.map((child: any) => {
-    if (child.type === 'heading') {
+    if (isHeadingNode(child)) {
       return addSlug(child, slugMap)
     } else {
       return child
@@ -15,8 +16,12 @@ export function addUniqueHeadingSlugs<T = any>(children: Array<T>): Array<T> {
   })
 }
 
-export function addSlug(child: any, slugMap: Map<string, number>, prefix = 'doc-heading-') {
-  const text = child.children[0].text || 'heading'
+export function addSlug(child: HeadingNode, slugMap: Map<string, number>, prefix = 'doc-heading-') {
+  const firstChild = child.children?.[0]
+  const defaultText = `level-${child.level}`
+  const text = isTextNode(firstChild)
+    ? firstChild.text || defaultText
+    : defaultText
   const slugCount = slugMap.get(text)
   slugMap.set(text, (slugCount || 0) + 1)
   const duplicateSuffix = slugCount && slugCount > 1 ? `-${slugCount}` : ''


### PR DESCRIPTION
# Summary

If a heading node was in the markdown JSON without any text in the children, the `toSlug` could fail trying to call methods on undefined 

<img width="693" alt="Screenshot 2023-02-13 at 11 32 57 AM" src="https://user-images.githubusercontent.com/8764246/218518104-64866acf-5ce8-4d7d-9d4c-ffc57b23d6b9.png">

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
