### PR TITLE
fix(document-viewer): properly check if empty object is passed

### DIFF
--- a/packages/portal/document-viewer/src/components/DocumentViewer.vue
+++ b/packages/portal/document-viewer/src/components/DocumentViewer.vue
@@ -28,8 +28,11 @@ const props = defineProps({
 
 const { i18n } = composables.useI18n()
 
+const objectIsEmpty = (obj: any): boolean => (!obj || (Object.keys(obj).length === 0 && obj.constructor === Object))
+
 const hasRequiredProps = computed((): boolean => {
-  return !!props.document
+  // Ensure the document object that is passed in is not empty
+  return !objectIsEmpty(props.document)
 })
 
 const children = addUniqueHeadingSlugs(props.document?.children)


### PR DESCRIPTION
# Summary
Previously, `!!{}` would default to true so it would attempt to render the children (which would be empty) if an empty object is passed. This change would update the check on the document being passed, and then display an error message.

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
