### PR TITLE
feat(githubStar): add tooltipText prop to GitHub Star component [KHCP-6183]

### DIFF
--- a/packages/core/misc-widgets/sandbox/App.vue
+++ b/packages/core/misc-widgets/sandbox/App.vue
@@ -3,7 +3,9 @@
     <main>
       <div>
         <h3>Awesome GitHub Star ⭐</h3>
-        <GithubStar :url="url" />
+        <GithubStar
+          :url="url"
+        />
       </div>
     </main>
   </div>

--- a/packages/core/misc-widgets/sandbox/index.ts
+++ b/packages/core/misc-widgets/sandbox/index.ts
@@ -1,7 +1,10 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import { GithubStar } from '../src'
+import Kongponents from '@kong/kongponents'
+import '@kong/kongponents/dist/style.css'
 
 const app = createApp(App)
+app.use(Kongponents)
 app.component('GithubStar', GithubStar)
 app.mount('#app')

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
@@ -24,13 +24,13 @@ describe('<GithubStar />', () => {
     cy.getTestId('github-star').find('.github-button').should('be.visible')
   })
 
-  it('renders default tooltip text on focus', () => {
+  it('renders default tooltip text on mouseenter', () => {
     cy.mount(GithubStar, {
       props: {
         url: 'http://github.com/kong/kong',
       },
     })
-    cy.getTestId('github-star').trigger('focus')
-    cy.get('.k-popover').should('exist')
+    cy.get('.github-button').trigger('mouseenter')
+    cy.get('.k-popover').should('be.visible')
   })
 })

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
@@ -32,5 +32,6 @@ describe('<GithubStar />', () => {
     })
     cy.get('.github-button').trigger('mouseenter')
     cy.get('.k-popover').should('be.visible')
+    cy.get('.k-popover').contains('Star this repository on Github')
   })
 })

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.cy.ts
@@ -23,4 +23,14 @@ describe('<GithubStar />', () => {
     cy.getTestId('github-star').find('a').should('be.visible')
     cy.getTestId('github-star').find('.github-button').should('be.visible')
   })
+
+  it('renders default tooltip text on focus', () => {
+    cy.mount(GithubStar, {
+      props: {
+        url: 'http://github.com/kong/kong',
+      },
+    })
+    cy.getTestId('github-star').trigger('focus')
+    cy.get('.k-popover').should('exist')
+  })
 })

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -5,16 +5,18 @@
     data-testid="github-star"
   >
     <KTooltip :label="tooltipText">
-      <a
-        aria-label="i18n.t('githubStar.ariaLabel')"
-        class="github-button"
-        data-color-scheme="no-preference: light; light: light; dark: light;"
-        data-show-count="true"
-        :href="url"
-        target="_blank"
-      >
-        {{ i18n.t('githubStar.title') }}
-      </a>
+      <span>
+        <a
+          :aria-label="i18n.t('githubStar.ariaLabel')"
+          class="github-button"
+          data-color-scheme="no-preference: light; light: light; dark: light;"
+          data-show-count="true"
+          :href="url"
+          target="_blank"
+        >
+          {{ i18n.t('githubStar.title') }}
+        </a>
+      </span>
     </KTooltip>
   </div>
 </template>

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -4,7 +4,7 @@
     class="kong-ui-public-misc-widgets-github-star"
     data-testid="github-star"
   >
-    <KTooltip :label="tooltipText">
+    <KTooltip :label="tooltipLabel">
       <span>
         <a
           :aria-label="i18n.t('githubStar.ariaLabel')"
@@ -22,13 +22,13 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import composables from '../../composables'
 import { KTooltip } from '@kong/kongponents'
 
 const { i18n } = composables.useI18n()
 
-defineProps({
+const props = defineProps({
   url: {
     type: String,
     required: true,
@@ -36,9 +36,11 @@ defineProps({
   tooltipText: {
     type: String,
     required: false,
-    default: 'Star this repository on Github',
+    default: '',
   },
 })
+
+const tooltipLabel = computed((): string => props.tooltipText || i18n.t('githubStar.tooltipLabel'))
 
 const scriptLoaded = ref<boolean>(false)
 

--- a/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
+++ b/packages/core/misc-widgets/src/components/github-star/GithubStar.vue
@@ -4,29 +4,39 @@
     class="kong-ui-public-misc-widgets-github-star"
     data-testid="github-star"
   >
-    <a
-      aria-label="i18n.t('githubStar.ariaLabel')"
-      class="github-button"
-      data-color-scheme="no-preference: light; light: light; dark: light;"
-      data-show-count="true"
-      :href="url"
-      target="_blank"
-    >{{ i18n.t('githubStar.title') }}</a>
+    <KTooltip :label="tooltipText">
+      <a
+        aria-label="i18n.t('githubStar.ariaLabel')"
+        class="github-button"
+        data-color-scheme="no-preference: light; light: light; dark: light;"
+        data-show-count="true"
+        :href="url"
+        target="_blank"
+      >
+        {{ i18n.t('githubStar.title') }}
+      </a>
+    </KTooltip>
   </div>
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import composables from '../../composables'
+import { KTooltip } from '@kong/kongponents'
+
+const { i18n } = composables.useI18n()
 
 defineProps({
   url: {
     type: String,
     required: true,
   },
+  tooltipText: {
+    type: String,
+    required: false,
+    default: 'Star this repository on Github',
+  },
 })
-
-const { i18n } = composables.useI18n()
 
 const scriptLoaded = ref<boolean>(false)
 

--- a/packages/core/misc-widgets/src/components/github-star/README.md
+++ b/packages/core/misc-widgets/src/components/github-star/README.md
@@ -21,3 +21,11 @@ A Github Star component for displaying number of stars received by the repo on G
 - required: `true`
 
 Full URL to the GitHub repository.
+
+#### `tooltipText`
+
+- type: `String`
+- required: `false`
+- default: `Star this repository on Github`
+
+String to display a tooltip when hovered.

--- a/packages/core/misc-widgets/src/locales/en.json
+++ b/packages/core/misc-widgets/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "githubStar": {
     "title": "Star",
-    "ariaLabel": "Star buttons/github-buttons on GitHub"
+    "ariaLabel": "Star buttons/github-buttons on GitHub",
+    "tooltipLabel": "Star this repository on Github"
   }
 }


### PR DESCRIPTION
https://konghq.atlassian.net/browse/KHCP-6183

# Summary
Adds a new tooltip text prop for the GitHub Star component that accepts a string to display a KTooltip when hovered. 
The default text reads, "Star this repository on Github".

<img width="498" alt="Screenshot 2023-02-16 at 3 47 52 PM" src="https://user-images.githubusercontent.com/2568272/219513663-862aca65-0d0c-4640-b637-e4a56c48e5d1.png">


## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
