### PR TITLE
chore: bump swagger ui kong theme + refactor

### DIFF
--- a/packages/portal/swagger-ui-web-component/README.md
+++ b/packages/portal/swagger-ui-web-component/README.md
@@ -12,4 +12,4 @@ Note: This package currently requires linking the [swagger-ui-kong-theme](https:
 2. Run `yarn && yarn build && yarn link`
 3. Go to your local clone directory of this repository and run `yarn link "@kong/swagger-ui-kong-theme"`
 4. Run `yarn && yarn start`
-5. Local development server should be running on http://localhost:9000
+5. Local development server should be running on http://localhost:5173

--- a/packages/portal/swagger-ui-web-component/package.json
+++ b/packages/portal/swagger-ui-web-component/package.json
@@ -13,7 +13,7 @@
     "build": "webpack --mode production"
   },
   "dependencies": {
-    "@kong/swagger-ui-kong-theme-universal": "^4.1.0",
+    "@kong/swagger-ui-kong-theme-universal": "^4.1.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "swagger-client": "^3.18.5",

--- a/packages/portal/swagger-ui-web-component/public/index.html
+++ b/packages/portal/swagger-ui-web-component/public/index.html
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,600;0,700;0,900;1,400&display=swap" rel="stylesheet">
 </head>
 <body>
-    <kong-swagger-ui url="http://localhost:9000/petstore_v3.json"></kong-swagger-ui>
+    <kong-swagger-ui url="http://localhost:5173/petstore_v3.json"></kong-swagger-ui>
     <script src="/main.js"></script>
 </body>
 </html>

--- a/packages/portal/swagger-ui-web-component/public/petstore_v3.json
+++ b/packages/portal/swagger-ui-web-component/public/petstore_v3.json
@@ -19,7 +19,7 @@
   },
   "servers": [
     {
-      "url": "https://localhost:9000/api/v3"
+      "url": "https://localhost:5173/api/v3"
     }
   ],
   "tags": [

--- a/packages/portal/swagger-ui-web-component/webpack.config.js
+++ b/packages/portal/swagger-ui-web-component/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = (env, { mode, analyze = false }) => {
       maxEntrypointSize: 2 * 1024 * 1024, // 2 MiB
     },
     devServer: {
-      port: 9000,
+      port: 5173,
       static: {
         directory: path.join(__dirname, 'public'),
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,7 +231,7 @@ importers:
 
   packages/portal/swagger-ui-web-component:
     specifiers:
-      '@kong/swagger-ui-kong-theme-universal': ^4.1.0
+      '@kong/swagger-ui-kong-theme-universal': ^4.1.1
       css-loader: ^6.7.3
       raw-loader: ^4.0.2
       react: 17.0.2
@@ -245,7 +245,7 @@ importers:
       webpack-cli: ^5.0.1
       webpack-dev-server: ^4.11.1
     dependencies:
-      '@kong/swagger-ui-kong-theme-universal': 4.1.0_sfoxds7t5ydpegc3knd667wn6m
+      '@kong/swagger-ui-kong-theme-universal': 4.1.1_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       swagger-client: 3.18.5
@@ -1265,8 +1265,8 @@ packages:
       - debug
     dev: true
 
-  /@kong/swagger-ui-kong-theme-universal/4.1.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-teYkhCDkIdyW/F5BfXSt8rYdRw+XmxqzjfF1Htecm0tgoJOR9I4BbhjEj+113BcKepi15/lF6cxDqoMIHusCvw==}
+  /@kong/swagger-ui-kong-theme-universal/4.1.1_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-GxijX9GXlhxjvI1ZGy3bGnFEwhrXg66WMt9/piG3CusRCbhZrfMRL/hE7OgbZuzxN9Snt0ebte6G7tOmhayE9w==}
     peerDependencies:
       react: 17.0.2
     dependencies:
@@ -4555,8 +4555,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
# Summary
Bumping to fix some styling, and changing the port this runs on to `5173`, to be consistent with the other packages and not to conflict with some ports if you have `khcp` running.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
