### PR TITLE
fix(document-viewer): allow codeblocks to render xml and fix image tags (TDX-2917) (TDX-2920)

### DIFF
--- a/packages/portal/document-viewer/src/components/DocumentViewer.cy.ts
+++ b/packages/portal/document-viewer/src/components/DocumentViewer.cy.ts
@@ -33,7 +33,7 @@ describe('<DocumentViewer />', () => {
     cy.get('.document-viewer').find('ul').should('be.visible')
     cy.get('.document-viewer').find('pre').should('be.visible')
     cy.get('.document-viewer').find('table').should('be.visible')
-    cy.get('.document-viewer').find('figure').should('be.visible')
+    cy.get('.document-viewer').find('img').should('be.visible')
   })
 
   it('renders error state when missing required props', () => {

--- a/packages/portal/document-viewer/src/components/nodes/Code.vue
+++ b/packages/portal/document-viewer/src/components/nodes/Code.vue
@@ -11,6 +11,6 @@ code {
   color: var(--document-viewer-code-color, inherit);
   font-family: var(--document-viewer-code-font-family, var(--document-viewer-font-family-monospace));
   font-size: var(--document-viewer-code-font-size, 14px);
-  padding: 4px 6px;
+  padding: 2px 6px;
 }
 </style>

--- a/packages/portal/document-viewer/src/components/nodes/CodeBlock.vue
+++ b/packages/portal/document-viewer/src/components/nodes/CodeBlock.vue
@@ -71,7 +71,7 @@ function highlight(obj: any) {
   }
 
   // Ensures Prism operates on the raw code and not on an already highlighted DOM fragment.
-  obj.codeElement.innerHTML = obj.language === 'html' ? escapeUnsafeCharacters(obj.code) : obj.code
+  obj.codeElement.innerHTML = escapeUnsafeCharacters(obj.code)
 
   Prism.highlightElement(obj.codeElement)
 
@@ -79,7 +79,7 @@ function highlight(obj: any) {
 }
 
 const escapeUnsafeCharacters = (unescapedCodeString: string): string => {
-  return unescapedCodeString.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#039;')
+  return unescapedCodeString.replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#039;')
 }
 
 // Should be used in the case there's multiple code blocks

--- a/packages/portal/document-viewer/src/components/nodes/Heading.vue
+++ b/packages/portal/document-viewer/src/components/nodes/Heading.vue
@@ -44,12 +44,12 @@ h1 {
   font-size: 32px;
   font-weight: 500;
   line-height: 38px;
-  margin-bottom: var(--spacing-xxl, 48px);
+  margin-bottom: var(--spacing-xl, 32px);
 }
 
 h2 {
   font-size: 24px;
-  line-height: 20px;
+  line-height: 26px;
   margin-bottom: var(--spacing-lg, 24px);
 }
 

--- a/packages/portal/document-viewer/src/components/nodes/Image.vue
+++ b/packages/portal/document-viewer/src/components/nodes/Image.vue
@@ -1,14 +1,9 @@
 <template>
-  <figure>
-    <img
-      :alt="alt"
-      :src="url"
-      :title="title"
-    >
-    <figcaption>
-      <slot />
-    </figcaption>
-  </figure>
+  <img
+    :alt="alt"
+    :src="url"
+    :title="title"
+  >
 </template>
 
 <script setup lang="ts">

--- a/packages/portal/document-viewer/src/components/nodes/ListItem.vue
+++ b/packages/portal/document-viewer/src/components/nodes/ListItem.vue
@@ -3,3 +3,9 @@
     <slot />
   </li>
 </template>
+
+<style scoped>
+li:not(:first-of-type) {
+  margin-top: 8px;
+}
+</style>


### PR DESCRIPTION
# Summary
`CodeBlock` was only escaping characters that would be tags for html language, but changed that logic to apply to all code. Also refactored the `Image` component to not render as a figure, and remove the `<figcaption>`. 

Includes various styling fixes 

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
