### PR TITLE
feat(operations-list): add more css variables to support dark mode (TDX-2928)

### DIFF
--- a/packages/portal/spec-renderer/docs/spec-operations-list.md
+++ b/packages/portal/spec-renderer/docs/spec-operations-list.md
@@ -203,8 +203,9 @@ This is emitted whenever an item in the spec is clicked.
 | `--kong-ui-spec-renderer-operations-list-item-selected-bar-width`            | Operations list selected item highlight bar width      | `4px`                           |
 | `--kong-ui-spec-renderer-operations-list-item-selected-bar-background`       | Operations list selected item highlight bar background | `#1155cb`                       |
 | `--kong-ui-spec-renderer-operations-list-item-path-font-family`              | Operations list item resource path font family         | `monospace`                     |
-| `--kong-ui-spec-renderer-operations-list-item-summary-text-color`            | Operations list selected item summary text color       | `#0B172D`                       |
-| `--kong-ui-spec-renderer-operations-list-item-summary-text-color-selected`   | Operations list item summary text color                | `#3C4557`                       |
+| `--kong-ui-spec-renderer-operations-list-item-summary-text-color`            | Operations list item summary text color                | `#0B172D`                       |
+| `--kong-ui-spec-renderer-operations-list-item-summary-text-color-hover`      | Operations list item hover summary text color          | `#3C4557`                       |
+| `--kong-ui-spec-renderer-operations-list-item-summary-text-color-selected`   | Operations list selected item summary text color       | `#3C4557`                       |
 | `--kong-ui-spec-renderer-method-color-get`                                   | Operations list item GET method badge color            | `#1155cb`                       |
 | `--kong-ui-spec-renderer-method-background-get`                              | Operations list item GET method badge background       | `#f2f6fe`                       |
 | `--kong-ui-spec-renderer-method-color-post`                                  | Operations list item POST method badge color           | `#13755e`                       |

--- a/packages/portal/spec-renderer/src/components/operations-list/OperationsListItem.vue
+++ b/packages/portal/spec-renderer/src/components/operations-list/OperationsListItem.vue
@@ -94,6 +94,10 @@ const methodName = computed((): string => {
 
   &:hover {
     background: var(--kong-ui-spec-renderer-operations-list-item-background-hover, var(--blue-100, #f2f6fe));
+
+    .summary, .path {
+      color: var(--kong-ui-spec-renderer-operations-list-item-summary-text-color-hover, var(--black-500, #0B172D));
+    }
   }
 
   &:last-of-type {
@@ -114,6 +118,14 @@ const methodName = computed((): string => {
     position: absolute;
     top: 0;
     width: var(--kong-ui-spec-renderer-operations-list-item-selected-bar-width, 4px);
+  }
+
+  .summary {
+    color: var(--kong-ui-spec-renderer-operations-list-item-summary-text-color-selected, var(--black-500, #0B172D));
+  }
+
+  .path {
+    color: var(--kong-ui-spec-renderer-operations-list-item-summary-text-color-selected, var(--black-500, #0B172D));
   }
 }
 
@@ -170,10 +182,6 @@ const methodName = computed((): string => {
   margin: 0 0 4px;
 }
 
-.item--selected .summary {
-  color: var(--kong-ui-spec-renderer-operations-list-item-summary-text-color-selected, var(--black-500, #0B172D));
-}
-
 .details {
   display: flex;
 }
@@ -191,7 +199,7 @@ const methodName = computed((): string => {
 
 .path {
   align-self: center;
-  color: var(--grey-600);
+  color: var(--kong-ui-spec-renderer-operations-list-item-summary-text-color, var(--grey-600, #3c4557));
   font-family: var(--kong-ui-spec-renderer-operations-list-item-path-font-family, var(--kong-ui-spec-renderer-font-family-monospace, monospace));
   font-size: 13px;
 }


### PR DESCRIPTION
# Summary
Adds a few more variables to the `spec-operations-list` so that we are able to support a dark mode in portal.
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
