### PR TITLE
fix(i18n): add source type interface

### DIFF
--- a/packages/core/i18n/sandbox/App.vue
+++ b/packages/core/i18n/sandbox/App.vue
@@ -48,7 +48,6 @@ import english from './locales/en.json'
 const i18n = useI18n()
 
 // this creates local i18n and component
-const i18nLocal = createI18n('en-us', english)
+const i18nLocal = createI18n<typeof english>('en-us', english)
 const i18nNoPlugin = i18nTComponent(i18nLocal)
-
 </script>

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -10,7 +10,7 @@ const intlCache = createIntlCache()
 // this is global var to hold global (application) instance of Intl
 let globIntl: IntlShapeEx
 
-export const createI18n = (locale: SupportedLocales, messages: Record<string, any>, isGlobal: boolean = false): IntlShapeEx => {
+export const createI18n = <T>(locale: SupportedLocales, messages: T, isGlobal: boolean = false): IntlShapeEx<T> => {
   const intl = createIntl(
     {
       locale,

--- a/packages/core/i18n/src/types/index.ts
+++ b/packages/core/i18n/src/types/index.ts
@@ -5,9 +5,9 @@ export type MessageFormatPrimitiveValue = string | number | boolean | null | und
 
 export type SupportedLocales = 'en-us'
 
-export type IntlShapeEx = IntlShape & {
-  t: (translationKey: string, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions) => string,
-  te: (translationKey: string) => boolean,
-  tm: (translationKey: string) => Array<string>,
-  source: Record<string, any>,
+export type IntlShapeEx<T = any> = IntlShape & {
+  t: (translationKey: string, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions) => string
+  te: (translationKey: string) => boolean
+  tm: (translationKey: string) => Array<string>
+  source: T
 }


### PR DESCRIPTION
# Summary

![image](https://user-images.githubusercontent.com/2229946/224070354-c60d562e-93da-4d84-9b18-724b4fd17a44.png)

Add an interface to the `i18n.source` object for auto-completion

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
