### PR TITLE
feat(i18n): translation key autocomplete

### DIFF
--- a/packages/core/i18n/README.md
+++ b/packages/core/i18n/README.md
@@ -48,6 +48,16 @@ const i18n = useI18n()
 </script>
 ```
 
+If you want translation key suggestions on the global instance, update your import as shown here, passing the JSON file type to the function:
+
+```html
+<script setup lang="ts">
+import { useI18n } from '@kong-ui-public/i18n'
+import english from './locales/en.json'
+
+const i18n = useI18n<typeof english>()
+</script>
+```
 
 ## Use in shared component
 

--- a/packages/core/i18n/sandbox/App.vue
+++ b/packages/core/i18n/sandbox/App.vue
@@ -45,9 +45,9 @@ import { useI18n, createI18n, i18nTComponent } from '../src'
 import english from './locales/en.json'
 
 // this is grabbing i18n from global
-const i18n = useI18n()
+const i18n = useI18n<typeof english>()
 
 // this creates local i18n and component
-const i18nLocal = createI18n<typeof english>('en-us', english)
-const i18nNoPlugin = i18nTComponent(i18nLocal)
+const i18nLocal = createI18n('en-us', english)
+const i18nNoPlugin = i18nTComponent<typeof english>(i18nLocal)
 </script>

--- a/packages/core/i18n/sandbox/locales/en.json
+++ b/packages/core/i18n/sandbox/locales/en.json
@@ -7,7 +7,11 @@
   "custom_dogs": {
     "breeds": {
       "husky": "Husky",
-      "beagle": "Beagle"
+      "beagle": "Beagle",
+      "breeds": {
+        "husky": "Husky",
+        "beagle": "Beagle"
+      }
     }
   }
 }

--- a/packages/core/i18n/sandbox/locales/en.json
+++ b/packages/core/i18n/sandbox/locales/en.json
@@ -3,5 +3,11 @@
     "ok": "O-k-key",
     "named": "{greeting}, my name is {name}. And I am {occupation}. I want {amount}",
     "default": "See the news at {0}. There is a lot there."
+  },
+  "custom_dogs": {
+    "breeds": {
+      "husky": "Husky",
+      "beagle": "Beagle"
+    }
   }
 }

--- a/packages/core/i18n/src/Translation.ts
+++ b/packages/core/i18n/src/Translation.ts
@@ -2,11 +2,11 @@ import { defineComponent, h } from 'vue'
 import type { VNodeChild, App, PropType } from 'vue'
 import type { IntlShapeEx } from './types'
 
-export const i18nTComponent = (i18n: IntlShapeEx | null = null) => defineComponent({
+export const i18nTComponent = <MessageSource = any>(i18n: IntlShapeEx<MessageSource>) => defineComponent({
   name: 'I18nT',
   props: {
     i18n: {
-      type: Object as PropType<IntlShapeEx>,
+      type: Object as PropType<IntlShapeEx<MessageSource>>,
       default: null,
     },
     keypath: {
@@ -66,7 +66,7 @@ export const i18nTComponent = (i18n: IntlShapeEx | null = null) => defineCompone
 
 // Export Vue plugin
 export default {
-  install(app: App, options: { i18n: IntlShapeEx }) {
+  install<MessageSource = any>(app: App, options: { i18n: IntlShapeEx<MessageSource> }) {
     const { i18n } = options
     app.component('I18nT', i18nTComponent(i18n))
   },

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -10,7 +10,7 @@ const intlCache = createIntlCache()
 // this is global var to hold global (application) instance of Intl
 let globIntl: IntlShapeEx
 
-export const createI18n = <T>(locale: SupportedLocales, messages: T, isGlobal: boolean = false): IntlShapeEx<T> => {
+export const createI18n = <MessageSource>(locale: SupportedLocales, messages: MessageSource, isGlobal: boolean = false): IntlShapeEx<MessageSource> => {
   const intl = createIntl(
     {
       locale,
@@ -39,8 +39,10 @@ export const createI18n = <T>(locale: SupportedLocales, messages: T, isGlobal: b
     te,
     tm,
     ...intl,
+    $t: t, // override the default $t with our function
     source: messages,
   }
+
   if (isGlobal) {
     globIntl = localIntl
   }
@@ -49,6 +51,6 @@ export const createI18n = <T>(locale: SupportedLocales, messages: T, isGlobal: b
 }
 
 // this returns global (application of Intl)
-export default function useI18n(): IntlShapeEx {
+export default function useI18n<MessageSource>(): IntlShapeEx<MessageSource> {
   return globIntl
 }

--- a/packages/core/i18n/src/types/index.ts
+++ b/packages/core/i18n/src/types/index.ts
@@ -1,13 +1,26 @@
-import type { IntlShape } from '@formatjs/intl'
+import type { IntlShape as IntlShapeOriginal } from '@formatjs/intl'
 import type { Options as IntlMessageFormatOptions } from 'intl-messageformat'
 
 export type MessageFormatPrimitiveValue = string | number | boolean | null | undefined
 
 export type SupportedLocales = 'en-us'
 
-export type IntlShapeEx<T = any> = IntlShape & {
-  t: (translationKey: string, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions) => string
-  te: (translationKey: string) => boolean
-  tm: (translationKey: string) => Array<string>
-  source: T
+type Dot<T extends string, U extends string> =
+  '' extends U ? T : `${T}.${U}`
+
+export type PathToDotNotation<MessageSource, V> = MessageSource extends V ? '' : {
+  [K in Extract<keyof MessageSource, string>]: Dot<K, PathToDotNotation<MessageSource[K], V>>
+}[Extract<keyof MessageSource, string>]
+
+type IntlShape = Omit<IntlShapeOriginal, '$t'>
+
+type TFunction<T> = (translationKey: PathToDotNotation<T, string>, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions) => string
+
+export type IntlShapeEx<MessageSource = any> = IntlShape & {
+  t: TFunction<MessageSource>
+  // Override native $t function with our own
+  $t: TFunction<MessageSource>
+  te: (translationKey: PathToDotNotation<MessageSource, string>) => boolean
+  tm: (translationKey: PathToDotNotation<MessageSource, string>) => Array<string>
+  source: MessageSource
 }

--- a/packages/core/i18n/src/types/index.ts
+++ b/packages/core/i18n/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { IntlShape as IntlShapeOriginal } from '@formatjs/intl'
+import type { IntlShape } from '@formatjs/intl'
 import type { Options as IntlMessageFormatOptions } from 'intl-messageformat'
 
 export type MessageFormatPrimitiveValue = string | number | boolean | null | undefined
@@ -12,14 +12,11 @@ export type PathToDotNotation<MessageSource, V> = MessageSource extends V ? '' :
   [K in Extract<keyof MessageSource, string>]: Dot<K, PathToDotNotation<MessageSource[K], V>>
 }[Extract<keyof MessageSource, string>]
 
-type IntlShape = Omit<IntlShapeOriginal, '$t'>
+type TFunction<M> = (translationKey: PathToDotNotation<M, string>, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions) => string
 
-type TFunction<T> = (translationKey: PathToDotNotation<T, string>, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions) => string
-
-export type IntlShapeEx<MessageSource = any> = IntlShape & {
+// Omit the native $t function
+export type IntlShapeEx<MessageSource = any> = Omit<IntlShape, '$t'> & {
   t: TFunction<MessageSource>
-  // Override native $t function with our own
-  $t: TFunction<MessageSource>
   te: (translationKey: PathToDotNotation<MessageSource, string>) => boolean
   tm: (translationKey: PathToDotNotation<MessageSource, string>) => Array<string>
   source: MessageSource


### PR DESCRIPTION
# Summary

Provide auto-completion for translation keys when utilizing the `t(), te(), and tm()` functions.

At the moment, I can't get it to work with the `keypath` of the `i18n-t` component as I get an error: 

```
The inferred type of X references a type with a cyclic structure which cannot be trivially serialized.
```

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
