### PR TITLE
feat(app-layout): add sidebar footer slot [KHCP-6623]

### DIFF
--- a/packages/core/app-layout/docs/sidebar.md
+++ b/packages/core/app-layout/docs/sidebar.md
@@ -105,6 +105,8 @@ An array of `SidebarPrimaryItem` objects to display in the bottom navigation lis
 
 An array of `SidebarProfileItem` objects to display in the sidebar footer profile popup menu.
 
+This prop is ignored if [`footer` slot content](#footer) is provided.
+
 #### `profileName`
 
 - type: `string`
@@ -112,6 +114,8 @@ An array of `SidebarProfileItem` objects to display in the sidebar footer profil
 - default: `''`
 
 A string to display in the sidebar footer profile area.
+
+This prop is ignored if [`footer` slot content](#footer) is provided.
 
 #### `headerHeight`
 
@@ -222,6 +226,12 @@ Utilize the `header` slot to inject your application's logo into the top of the 
 #### `top`
 
 Utilize the `top` slot to inject additional UI into the top of the sidebar, below the `header` slot, above the `topItems`.
+
+#### `footer`
+
+Utilize the `footer` slot to inject content into the fixed area at the bottom of the sidebar, below the `bottomItems`.
+
+If `footer` slot content is provided, it will override the `profileItems` and `profileName`, preventing the sidebar bottom profile menu and popup menu from appearing.
 
 ### Events
 

--- a/packages/core/app-layout/sandbox/pages/LayoutPage.vue
+++ b/packages/core/app-layout/sandbox/pages/LayoutPage.vue
@@ -68,6 +68,11 @@
         <div>Top Slot Content</div>
       </div>
     </template>
+    <template #sidebar-footer>
+      <div class="sidebar-footer-slot-content">
+        <div>Footer Slot Content</div>
+      </div>
+    </template>
 
     <!-- Default slot content -->
 

--- a/packages/core/app-layout/sandbox/pages/SidebarPage.vue
+++ b/packages/core/app-layout/sandbox/pages/SidebarPage.vue
@@ -49,11 +49,6 @@
           </router-link>
         </div>
       </template>
-      <!-- <template #footer>
-        <div class="example-footer">
-          <p>This is example footer <a href="#">with a link</a></p>
-        </div>
-      </template> -->
     </AppSidebar>
     <main>
       <p>This is the SIDEBAR page.</p>

--- a/packages/core/app-layout/sandbox/pages/SidebarPage.vue
+++ b/packages/core/app-layout/sandbox/pages/SidebarPage.vue
@@ -49,6 +49,11 @@
           </router-link>
         </div>
       </template>
+      <!-- <template #footer>
+        <div class="example-footer">
+          <p>This is example footer <a href="#">with a link</a></p>
+        </div>
+      </template> -->
     </AppSidebar>
     <main>
       <p>This is the SIDEBAR page.</p>

--- a/packages/core/app-layout/src/components/AppLayout.cy.ts
+++ b/packages/core/app-layout/src/components/AppLayout.cy.ts
@@ -195,6 +195,18 @@ describe('<AppLayout />', () => {
         cy.get('[data-testid="app-layout-sidebar-top-slot-content"]').should('be.visible')
       })
 
+      it('should render content passed in through sidebar-footer slot', () => {
+        cy.mount(AppLayout, {
+          slots: {
+            'sidebar-footer': [
+              '<span data-testid="app-layout-sidebar-footer-slot-content">Sidebar footer</span>',
+            ],
+          },
+        })
+
+        cy.get('[data-testid="app-layout-sidebar-footer-slot-content"]').should('be.visible')
+      })
+
       it('should have a top-left border-radius on the main content container', () => {
         cy.mount(AppLayout)
 

--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -88,6 +88,12 @@
       >
         <slot name="sidebar-top" />
       </template>
+      <template
+        v-if="slotContent.sidebarFooter"
+        #footer
+      >
+        <slot name="sidebar-footer" />
+      </template>
     </AppSidebar>
 
     <main
@@ -171,6 +177,7 @@ const slotContent = reactive({
   navbarMobileLogo: computed((): boolean => !!slots['navbar-mobile-logo']),
   sidebarHeader: computed((): boolean => !!slots['sidebar-header']),
   sidebarTop: computed((): boolean => !!slots['sidebar-top']),
+  sidebarFooter: computed((): boolean => !!slots['sidebar-footer']),
 })
 
 // Evaluate variables from injected symbols; fallback to prop values.

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.cy.ts
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.cy.ts
@@ -244,7 +244,7 @@ describe('<AppSidebar />', () => {
 
         // Profile items
         describe('profile items', () => {
-          it('does not render the profile item if no profileItems or profileName are passed', () => {
+          it('does not render the profile items if no profileItems or profileName are passed', () => {
             cy.mount(AppSidebar, {
               props: {
                 open: ['mobile', 'tablet'].includes(viewportName), // force mobile sidebar to be open
@@ -254,7 +254,29 @@ describe('<AppSidebar />', () => {
               },
             })
 
-            cy.get('.kong-ui-app-sidebar').find('.sidebar-footer').should('not.exist')
+            cy.get('.kong-ui-app-sidebar').find('.sidebar-footer-nav').should('not.exist')
+          })
+
+          it('does not render the profile items if footer slot content is provided', () => {
+            const name = 'Marty McFly'
+            const footerSlotContent = 'We don\'t have enough road to get up to 88.'
+
+            cy.mount(AppSidebar, {
+              props: {
+                open: ['mobile', 'tablet'].includes(viewportName), // force mobile sidebar to be open
+                mobileEnabled: true,
+                topItems,
+                bottomItems,
+                profileItems,
+                profileName: name,
+              },
+              slots: {
+                footer: () => h('div', {}, footerSlotContent),
+              },
+            })
+
+            cy.get('.kong-ui-app-sidebar').find('.sidebar-footer-nav').should('not.exist')
+            cy.get('.kong-ui-app-sidebar').find('.sidebar-footer').should('contain.text', footerSlotContent)
           })
 
           it('renders just the profileName if no nav items are passed', () => {
@@ -560,7 +582,7 @@ describe('<AppSidebar />', () => {
 
         // Slots
         describe('slots', () => {
-          // Header slot
+          // header slot
           describe('header', () => {
             it('renders header slot content', () => {
               const headerSlotText = 'This is my logo'
@@ -598,6 +620,7 @@ describe('<AppSidebar />', () => {
             })
           })
 
+          // top slot
           describe('top', () => {
             it('renders top slot content', () => {
               const headerSlotText = 'This is my logo'
@@ -618,6 +641,27 @@ describe('<AppSidebar />', () => {
 
               cy.get('.sidebar-header').should('contain.text', headerSlotText)
               cy.get('.sidebar-top').should('contain.text', topSlotText)
+            })
+          })
+
+          // footer slot
+          describe('footer', () => {
+            it('renders footer slot content', () => {
+              const footerSlotText = 'This is my footer text'
+
+              cy.mount(AppSidebar, {
+                props: {
+                  open: ['mobile', 'tablet'].includes(viewportName), // force mobile sidebar to be open
+                  mobileEnabled: true,
+                  mobileHeaderVisible: ['mobile', 'tablet'].includes(viewportName), // force mobile header to be visible
+                  headerHeight: 100,
+                },
+                slots: {
+                  footer: () => h('div', {}, footerSlotText),
+                },
+              })
+
+              cy.get('.sidebar-footer').should('contain.text', footerSlotText)
             })
           })
         })

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -68,37 +68,41 @@
         </nav>
       </div>
 
-      <SidebarFooter
-        v-if="profileName || profileItems.length"
-        class="sidebar-profile-menu"
-        :item-count="profileItems.length"
-        :name="profileName"
-      >
-        <KDropdownItem
-          v-for="item in profileItems"
-          :key="item.name"
-          :class="[{ 'has-divider': item.hasDivider },{ 'external-profile-dropdown-link': (item.external || item.newWindow) && typeof item.to === 'string' }]"
-          :has-divider="item.hasDivider"
-          :item="(item.external || item.newWindow) && typeof item.to === 'string' ? undefined : { label: item.name, to: item.to }"
-          @click="itemClick(item)"
-        >
-          <a
-            v-if="(item.external || item.newWindow) && typeof item.to === 'string'"
-            class="sidebar-item-external-link"
-            :href="item.to"
-            :target="item.newWindow ? '_blank' : undefined"
+      <div class="sidebar-footer">
+        <slot name="footer">
+          <SidebarFooter
+            v-if="profileName || profileItems.length"
+            class="sidebar-profile-menu"
+            :item-count="profileItems.length"
+            :name="profileName"
           >
-            {{ item.name }}
-            <KIcon
-              v-if="item.newWindow"
-              color="var(--black-70, rgba(0,0,0,0.7))"
-              icon="externalLink"
-              size="20"
-              viewBox="0 0 20 20"
-            />
-          </a>
-        </KDropdownItem>
-      </SidebarFooter>
+            <KDropdownItem
+              v-for="item in profileItems"
+              :key="item.name"
+              :class="[{ 'has-divider': item.hasDivider },{ 'external-profile-dropdown-link': (item.external || item.newWindow) && typeof item.to === 'string' }]"
+              :has-divider="item.hasDivider"
+              :item="(item.external || item.newWindow) && typeof item.to === 'string' ? undefined : { label: item.name, to: item.to }"
+              @click="itemClick(item)"
+            >
+              <a
+                v-if="(item.external || item.newWindow) && typeof item.to === 'string'"
+                class="sidebar-item-external-link"
+                :href="item.to"
+                :target="item.newWindow ? '_blank' : undefined"
+              >
+                {{ item.name }}
+                <KIcon
+                  v-if="item.newWindow"
+                  color="var(--black-70, rgba(0,0,0,0.7))"
+                  icon="externalLink"
+                  size="20"
+                  viewBox="0 0 20 20"
+                />
+              </a>
+            </KDropdownItem>
+          </SidebarFooter>
+        </slot>
+      </div>
     </aside>
   </FocusTrap>
 </template>
@@ -407,6 +411,13 @@ onBeforeUnmount(() => {
     &:hover {
       @include scrollbarVisible;
     }
+  }
+
+  .sidebar-footer {
+    color: var(--steel-300, #A3B6D9);
+    display: flex;
+    align-items: center;
+    width: 100%;
   }
 
   :deep(.k-dropdown-item) {

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -414,9 +414,10 @@ onBeforeUnmount(() => {
   }
 
   .sidebar-footer {
+    align-items: center;
     color: var(--steel-300, #A3B6D9);
     display: flex;
-    align-items: center;
+    font-weight: 500;
     width: 100%;
   }
 

--- a/packages/core/app-layout/src/components/sidebar/SidebarFooter.vue
+++ b/packages/core/app-layout/src/components/sidebar/SidebarFooter.vue
@@ -2,7 +2,7 @@
   <nav
     aria-haspopup="true"
     aria-label="Profile Menu"
-    class="sidebar-footer"
+    class="sidebar-footer-nav"
   >
     <div class="sidebar-profile-link">
       <div class="sidebar-item-icon">
@@ -18,7 +18,7 @@
           </div>
           <KDropdownMenu
             v-else
-            :kpop-attributes="{ placement: 'right', popoverClasses: 'ml-5 sidebar-profile-menu-popover', target: '.sidebar-footer' }"
+            :kpop-attributes="{ placement: 'right', popoverClasses: 'ml-5 sidebar-profile-menu-popover', target: '.sidebar-footer-nav' }"
             width="240"
           >
             <a
@@ -61,6 +61,10 @@ const hasProfileItems = computed((): boolean => props.itemCount > 0)
 
 <style lang="scss" scoped>
 @import "../../styles/variables";
+
+.sidebar-footer-nav {
+  width: 100%;
+}
 
 .sidebar-item-icon {
   display: flex;


### PR DESCRIPTION
# Summary

Adds a new `footer` slot in the `AppSidebar.vue` component (exposed as the `sidebar-footer` slot in the `AppLayout.vue` component) in preparation for removing the sidebar profile menu and replacing it with the Geo Switcher.

If `footer` slot content is provided, it will override the `profile-items` and `profile-name` props, preventing the default sidebar footer with the profile menu from being rendered.

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
