### PR TITLE
fix(i18n): move to peer dependencies

### DIFF
--- a/packages/core/copy-uuid/README.md
+++ b/packages/core/copy-uuid/README.md
@@ -31,6 +31,7 @@ A Kong UI component for displaying uuid and copying it to clipboard.
 - `@kong/kongponents` must be available as a `dependency` in the host application, along with the package's style imports. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents). Specifically, the following Kongponents must be available:
   - `KClipboardProvider`
   - `KIcon`
+- `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 
 ## Usage
 

--- a/packages/core/copy-uuid/package.json
+++ b/packages/core/copy-uuid/package.json
@@ -35,15 +35,14 @@
     "test:component:open": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress open --component -b chrome --project '../../../.'"
   },
   "peerDependencies": {
+    "@kong-ui-public/i18n": "workspace:^0.4.2",
     "@kong/kongponents": "^8.40.4",
     "vue": "^3.2.47"
   },
   "devDependencies": {
+    "@kong-ui-public/i18n": "workspace:^0.4.2",
     "@kong/kongponents": "^8.40.4",
     "vue": "^3.2.47"
-  },
-  "dependencies": {
-    "@kong-ui-public/i18n": "workspace:^0.4.2"
   },
   "repository": {
     "type": "git",

--- a/packages/core/misc-widgets/README.md
+++ b/packages/core/misc-widgets/README.md
@@ -18,6 +18,7 @@ This package is a good home for random, one-off components that aren't complex a
 
 - `vue` must be initialized in the host application
 - `@kong/kongponents` must be available as a `dependency` in the host application, along with the package's style imports. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
+- `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 
 ## Usage
 

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -37,15 +37,14 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
   },
   "peerDependencies": {
+    "@kong-ui-public/i18n": "workspace:^0.4.2",
     "@kong/kongponents": "^8.40.4",
     "vue": "^3.2.47"
   },
   "devDependencies": {
+    "@kong-ui-public/i18n": "workspace:^0.4.2",
     "@kong/kongponents": "^8.40.4",
     "vue": "^3.2.47"
-  },
-  "dependencies": {
-    "@kong-ui-public/i18n": "workspace:^0.4.2"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,9 +171,8 @@ importers:
       '@kong-ui-public/i18n': workspace:^0.4.2
       '@kong/kongponents': ^8.40.4
       vue: ^3.2.47
-    dependencies:
-      '@kong-ui-public/i18n': link:../i18n
     devDependencies:
+      '@kong-ui-public/i18n': link:../i18n
       '@kong/kongponents': 8.40.4_vue@3.2.47
       vue: 3.2.47
 
@@ -192,9 +191,8 @@ importers:
       '@kong-ui-public/i18n': workspace:^0.4.2
       '@kong/kongponents': ^8.40.4
       vue: ^3.2.47
-    dependencies:
-      '@kong-ui-public/i18n': link:../i18n
     devDependencies:
+      '@kong-ui-public/i18n': link:../i18n
       '@kong/kongponents': 8.40.4_vue@3.2.47
       vue: 3.2.47
 


### PR DESCRIPTION
# Summary

Move i18n to peerDependencies in a few of the smaller packages

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
