### PR TITLE
fix(document-viewer): add aria-label to task checkbox inputs

### DIFF
--- a/packages/portal/document-viewer/src/components/nodes/TaskCheckbox.vue
+++ b/packages/portal/document-viewer/src/components/nodes/TaskCheckbox.vue
@@ -1,5 +1,6 @@
 <template>
   <input
+    aria-label="Display-only checkbox for task"
     :checked="checked"
     type="checkbox"
   >


### PR DESCRIPTION
for a11y purposes, it's important to have an `aria-label` that describes an `<input>`. Since these checkboxes are really for display purposes only, it seems okay to add this situation as a note, but to not omit the property altogether.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
