### PR TITLE
fix(metric-cards): avoid showing Infinity in metrics cards

### DIFF
--- a/packages/analytics/metric-cards/src/components/MetricCardContainer.cy.ts
+++ b/packages/analytics/metric-cards/src/components/MetricCardContainer.cy.ts
@@ -79,7 +79,6 @@ describe('<MetricCardContainer />', () => {
     // Desktop (horiztonal layout)
     cy.viewport(1280, 400)
     cy.get(container).should('be.visible')
-
   })
 
   // Should display up arrow icon, and green trend value text
@@ -174,5 +173,33 @@ describe('<MetricCardContainer />', () => {
 
     // Check for approximate numbers.
     cy.get('.metricscard-value').should('contain', '1.2M')
+  })
+
+  it('Avoid divide-by-zero', () => {
+    cy.mount(MetricCardContainer, {
+      props: {
+        cards: [
+          {
+            currentValue: 1198904,
+            previousValue: 0,
+            title: 'Traffic',
+            increaseIsBad: false,
+          },
+        ],
+        cardSize: MetricCardSize.Large,
+        hasTrendAccess: true,
+        loading: false,
+      },
+    })
+
+    cy.get(container).should('be.visible')
+
+    // Desktop (horiztonal layout)
+    cy.viewport(1280, 400)
+    cy.get(container).should('be.visible')
+
+    // Check for neutral trend, zero value
+    cy.get('.metricscard-value-trend').should('have.class', 'neutral')
+    cy.get('.metricscard-value-trend').should('contain', '0.00%')
   })
 })

--- a/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
+++ b/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
@@ -47,7 +47,7 @@ import { computed, PropType } from 'vue'
 import approxNum from 'approximate-number'
 import { MetricCardSize } from '../constants'
 import { MetricCardDef, MetricCardDisplayValue } from '../types'
-import { changePolarity, metricChange, defineIcon } from '../utilities'
+import { changePolarity, metricChange, defineIcon, calculateChange } from '../utilities'
 import MetricsCard from './display/MetricsCard.vue'
 import MetricCardLoadingSkeleton from './display/MetricCardLoadingSkeleton.vue'
 
@@ -84,12 +84,8 @@ const props = defineProps({
 
 const allCardsHaveErrors = computed((): boolean => props.cards.every(val => val?.hasError === true))
 
-const calculateDelta = (curr: number, prev: number): number => {
-  return curr / prev - 1
-}
-
 const formatCardValues = (card: MetricCardDef): MetricCardDisplayValue => {
-  const change = calculateDelta(card.currentValue, card.previousValue) || 0
+  const change = calculateChange(card.currentValue, card.previousValue) || 0
   const polarity = changePolarity(change, props.hasTrendAccess, card.increaseIsBad)
 
   return {

--- a/packages/analytics/metric-cards/src/utilities/trend-display.ts
+++ b/packages/analytics/metric-cards/src/utilities/trend-display.ts
@@ -38,6 +38,16 @@ export const metricChange = (delta: number, hasTrendAccess: boolean, fallback: s
     : fallback
 }
 
+// Determine the percent change between `curr` and `prev`; avoid dividing by 0.
+export const calculateChange = (curr: number, prev: number) => {
+  if (prev === 0) {
+    // If we would calculate a +Infinity change, instead just say 0% to avoid ugliness.
+    return 0
+  } else {
+    return curr / prev - 1
+  }
+}
+
 /**
  * Determines whether to display an upward or downward trend, or no change
  */


### PR DESCRIPTION
Detect divide-by-zero situations and show 0 instead of Infinity.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
