### PR TITLE
chore(cli): remove vue plugin export

### DIFF
--- a/packages/core/cli/src/__template__/src/index.ts
+++ b/packages/core/cli/src/__template__/src/index.ts
@@ -1,15 +1,16 @@
-import type { App } from 'vue'
+// import type { App } from 'vue'
 import {%%COMPONENT_NAME%%} from './components/{%%COMPONENT_NAME%%}.vue'
 
-// Export Vue plugin as the default
-export default {
-  // Customize Vue plugin options as desired
-  // Providing a `name` property allows for customizing the registered
-  // name of your component (useful if exporting a single component).
-  install: (app: App, options: { name?: string, [key: string]: any } = {}): void => {
-    app.component(options.name || '{%%COMPONENT_NAME%%}', {%%COMPONENT_NAME%%})
-  },
-}
+// Export Vue plugin
+// We rarely want to export components as a plugin as we prefer to support proper tree-shaking in the host application. Only enable if you're packing a Vue plugin.
+// export default {
+//   // Customize Vue plugin options as desired
+//   // Providing a `name` property allows for customizing the registered
+//   // name of your component (useful if exporting a single component).
+//   install: (app: App, options: { name?: string, [key: string]: any } = {}): void => {
+//     app.component(options.name || '{%%COMPONENT_NAME%%}', {%%COMPONENT_NAME%%})
+//   },
+// }
 
 export { {%%COMPONENT_NAME%%} }
 


### PR DESCRIPTION
# Summary

Comment out the Vue plugin export since we typically do not want to include it.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
