### PR TITLE
fix(*): downgrade vue-tsc for type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "vitest": "^0.30.1",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6",
-    "vue-tsc": "^1.3.19"
+    "vue-tsc": "^1.4.4"
   },
   "workspaces": [
     "packages/*/*"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "vitest": "^0.30.1",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6",
-    "vue-tsc": "^1.4.4"
+    "vue-tsc": "^1.2.0"
   },
   "workspaces": [
     "packages/*/*"

--- a/packages/core/app-layout/src/index.ts
+++ b/packages/core/app-layout/src/index.ts
@@ -11,8 +11,7 @@ import AppError from './components/errors/AppError.vue'
 // Export Vue plugin as the default
 export default {
   // Customize Vue plugin options as desired
-  // Providing a `name` property allows for customizing the registered
-  // name of your component (useful if exporting a single component).
+  // Providing a `name` property allows for customizing the registered name of your component (useful if exporting a single component).
   install: (app: App, options: { name?: string, [key: string]: any } = {}): void => {
     app.component(options.name || 'AppLayout', AppLayout)
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
       vitest: ^0.30.1
       vue: ^3.2.47
       vue-router: ^4.1.6
-      vue-tsc: ^1.4.4
+      vue-tsc: ^1.2.0
     devDependencies:
       '@babel/types': 7.21.4
       '@commitlint/cli': 17.6.1
@@ -120,7 +120,7 @@ importers:
       vitest: 0.30.1_ct23yedwbzt3xjdeqhd5w77cte
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
-      vue-tsc: 1.4.4_typescript@4.9.5
+      vue-tsc: 1.2.0_typescript@4.9.5
 
   packages/analytics/analytics-utilities:
     specifiers:
@@ -2888,49 +2888,43 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@volar/language-core/1.4.1:
-    resolution: {integrity: sha512-EIY+Swv+TjsWpxOxujjMf1ZXqOjg9MT2VMXZ+1dKva0wD8W0L6EtptFFcCJdBbcKmGMFkr57Qzz9VNMWhs3jXQ==}
+  /@volar/language-core/1.3.0-alpha.0:
+    resolution: {integrity: sha512-W3uMzecHPcbwddPu4SJpUcPakRBK/y/BP+U0U6NiPpUX1tONLC4yCawt+QBJqtgJ+sfD6ztf5PyvPL3hQRqfOA==}
     dependencies:
-      '@volar/source-map': 1.4.1
+      '@volar/source-map': 1.3.0-alpha.0
     dev: true
 
-  /@volar/source-map/1.4.1:
-    resolution: {integrity: sha512-bZ46ad72dsbzuOWPUtJjBXkzSQzzSejuR3CT81+GvTEI2E994D8JPXzM3tl98zyCNnjgs4OkRyliImL1dvJ5BA==}
+  /@volar/source-map/1.3.0-alpha.0:
+    resolution: {integrity: sha512-jSdizxWFvDTvkPYZnO6ew3sBZUnS0abKCbuopkc0JrIlFbznWC/fPH3iPFIMS8/IIkRxq1Jh9VVG60SmtsdaMQ==}
     dependencies:
       muggle-string: 0.2.2
     dev: true
 
-  /@volar/typescript/1.4.1_typescript@4.9.5:
-    resolution: {integrity: sha512-phTy6p9yG6bgMIKQWEeDOi/aeT0njZsb1a/G1mrEuDsLmAn24Le4gDwSsGNhea6Uhu+3gdpUZn2PmZXa+WG2iQ==}
-    peerDependencies:
-      typescript: '*'
+  /@volar/typescript/1.3.0-alpha.0:
+    resolution: {integrity: sha512-5UItyW2cdH2mBLu4RrECRNJRgtvvzKrSCn2y3v/D61QwIDkGx4aeil6x8RFuUL5TFtV6QvVHXnsOHxNgd+sCow==}
     dependencies:
-      '@volar/language-core': 1.4.1
-      typescript: 4.9.5
+      '@volar/language-core': 1.3.0-alpha.0
     dev: true
 
-  /@volar/vue-language-core/1.4.4:
-    resolution: {integrity: sha512-c3hL6un+CfoOlusGvpypcodmk9ke/ImrWIUc0GkgI+imoQpUGzgu3tEQWlPs604R7AhxeZwWUi8hQNfax0R/zA==}
+  /@volar/vue-language-core/1.2.0:
+    resolution: {integrity: sha512-w7yEiaITh2WzKe6u8ZdeLKCUz43wdmY/OqAmsB/PGDvvhTcVhCJ6f0W/RprZL1IhqH8wALoWiwEh/Wer7ZviMQ==}
     dependencies:
-      '@volar/language-core': 1.4.1
-      '@volar/source-map': 1.4.1
+      '@volar/language-core': 1.3.0-alpha.0
+      '@volar/source-map': 1.3.0-alpha.0
       '@vue/compiler-dom': 3.2.47
       '@vue/compiler-sfc': 3.2.47
       '@vue/reactivity': 3.2.47
       '@vue/shared': 3.2.47
-      minimatch: 9.0.0
+      minimatch: 6.2.0
       muggle-string: 0.2.2
       vue-template-compiler: 2.7.14
     dev: true
 
-  /@volar/vue-typescript/1.4.4_typescript@4.9.5:
-    resolution: {integrity: sha512-L61Fk15jlJw3QtIddD4cVE5jei5i6zbLJRiaEMYDDnUKB259/qUrdvnMfnZUFVyDwlevzdstjtaUyreeG/0nPQ==}
-    peerDependencies:
-      typescript: '*'
+  /@volar/vue-typescript/1.2.0:
+    resolution: {integrity: sha512-zjmRi9y3J1EkG+pfuHp8IbHmibihrKK485cfzsHjiuvJMGrpkWvlO5WVEk8oslMxxeGC5XwBFE9AOlvh378EPA==}
     dependencies:
-      '@volar/typescript': 1.4.1_typescript@4.9.5
-      '@volar/vue-language-core': 1.4.4
-      typescript: 4.9.5
+      '@volar/typescript': 1.3.0-alpha.0
+      '@volar/vue-language-core': 1.2.0
     dev: true
 
   /@vue/babel-helper-vue-transform-on/1.0.2:
@@ -12749,15 +12743,14 @@ packages:
       he: 1.2.0
     dev: true
 
-  /vue-tsc/1.4.4_typescript@4.9.5:
-    resolution: {integrity: sha512-2XsCjF2mLo6gwOVcOpngwJkP8GzYQjNh20A+Pr2FGdsWzr9jjXJ0k08/DfcslfncsuCrTrnWtb4KEL3gcDtlNA==}
+  /vue-tsc/1.2.0_typescript@4.9.5:
+    resolution: {integrity: sha512-rIlzqdrhyPYyLG9zxsVRa+JEseeS9s8F2BbVVVWRRsTZvJO2BbhLEb2HW3MY+DFma0378tnIqs+vfTzbcQtRFw==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@volar/vue-language-core': 1.4.4
-      '@volar/vue-typescript': 1.4.4_typescript@4.9.5
-      semver: 7.3.8
+      '@volar/vue-language-core': 1.2.0
+      '@volar/vue-typescript': 1.2.0
       typescript: 4.9.5
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
       vitest: ^0.30.1
       vue: ^3.2.47
       vue-router: ^4.1.6
-      vue-tsc: ^1.3.19
+      vue-tsc: ^1.4.4
     devDependencies:
       '@babel/types': 7.21.4
       '@commitlint/cli': 17.6.1
@@ -120,7 +120,7 @@ importers:
       vitest: 0.30.1_ct23yedwbzt3xjdeqhd5w77cte
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
-      vue-tsc: 1.4.2_typescript@4.9.5
+      vue-tsc: 1.4.4_typescript@4.9.5
 
   packages/analytics/analytics-utilities:
     specifiers:
@@ -2888,32 +2888,32 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@volar/language-core/1.4.0:
-    resolution: {integrity: sha512-zZg771L/v4MCPwM1KJxvnQ3q3QgbGJtEytivqf+PsxPr0kQ7XtwB1J30dd+YSGN869pXXZ0V6vWdHkDpWC8F3A==}
+  /@volar/language-core/1.4.1:
+    resolution: {integrity: sha512-EIY+Swv+TjsWpxOxujjMf1ZXqOjg9MT2VMXZ+1dKva0wD8W0L6EtptFFcCJdBbcKmGMFkr57Qzz9VNMWhs3jXQ==}
     dependencies:
-      '@volar/source-map': 1.4.0
+      '@volar/source-map': 1.4.1
     dev: true
 
-  /@volar/source-map/1.4.0:
-    resolution: {integrity: sha512-gkV8ol9qtP7aMdgijc8a5Yoxxoo90TT55YCi9bsMbKxEUDsOAnlciFNlijR9Ebe42d67GV3w15/RzjveTRNGBw==}
+  /@volar/source-map/1.4.1:
+    resolution: {integrity: sha512-bZ46ad72dsbzuOWPUtJjBXkzSQzzSejuR3CT81+GvTEI2E994D8JPXzM3tl98zyCNnjgs4OkRyliImL1dvJ5BA==}
     dependencies:
       muggle-string: 0.2.2
     dev: true
 
-  /@volar/typescript/1.4.0_typescript@4.9.5:
-    resolution: {integrity: sha512-r6OMHj/LeS86iQy3LEjjS+qpmHr9I7BiH8gAwp9WEJP76FHlMPi/EPDQxhf3VcMQ/w6Pi5aBczqI+I3akr9t4g==}
+  /@volar/typescript/1.4.1_typescript@4.9.5:
+    resolution: {integrity: sha512-phTy6p9yG6bgMIKQWEeDOi/aeT0njZsb1a/G1mrEuDsLmAn24Le4gDwSsGNhea6Uhu+3gdpUZn2PmZXa+WG2iQ==}
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@volar/language-core': 1.4.0
+      '@volar/language-core': 1.4.1
       typescript: 4.9.5
     dev: true
 
-  /@volar/vue-language-core/1.4.2:
-    resolution: {integrity: sha512-bDdFowfnyHI7udELEgUWukOh4l9jVTaxb9jZtj0GxUp0Mjj0u81d9+jE2UC3fFJpbndQLGFR6F+ffguHgmrj6Q==}
+  /@volar/vue-language-core/1.4.4:
+    resolution: {integrity: sha512-c3hL6un+CfoOlusGvpypcodmk9ke/ImrWIUc0GkgI+imoQpUGzgu3tEQWlPs604R7AhxeZwWUi8hQNfax0R/zA==}
     dependencies:
-      '@volar/language-core': 1.4.0
-      '@volar/source-map': 1.4.0
+      '@volar/language-core': 1.4.1
+      '@volar/source-map': 1.4.1
       '@vue/compiler-dom': 3.2.47
       '@vue/compiler-sfc': 3.2.47
       '@vue/reactivity': 3.2.47
@@ -2923,13 +2923,14 @@ packages:
       vue-template-compiler: 2.7.14
     dev: true
 
-  /@volar/vue-typescript/1.4.2_typescript@4.9.5:
-    resolution: {integrity: sha512-A1m1cSvS0Pf7Sm9q0S/1riV4RQQeH2h5gGo0vR9fGK2SrAStvh4HuuxPOX4N9uMDbRsNMhC0ILXwtlvjQ/IXJA==}
+  /@volar/vue-typescript/1.4.4_typescript@4.9.5:
+    resolution: {integrity: sha512-L61Fk15jlJw3QtIddD4cVE5jei5i6zbLJRiaEMYDDnUKB259/qUrdvnMfnZUFVyDwlevzdstjtaUyreeG/0nPQ==}
+    peerDependencies:
+      typescript: '*'
     dependencies:
-      '@volar/typescript': 1.4.0_typescript@4.9.5
-      '@volar/vue-language-core': 1.4.2
-    transitivePeerDependencies:
-      - typescript
+      '@volar/typescript': 1.4.1_typescript@4.9.5
+      '@volar/vue-language-core': 1.4.4
+      typescript: 4.9.5
     dev: true
 
   /@vue/babel-helper-vue-transform-on/1.0.2:
@@ -12748,14 +12749,14 @@ packages:
       he: 1.2.0
     dev: true
 
-  /vue-tsc/1.4.2_typescript@4.9.5:
-    resolution: {integrity: sha512-8VFjVekJuFtFG+N4rEimoR0OvNubhoTIMl2dlvbpyAD40LVPR1PN2SUc2qZPnWGGRsXZAVmFgiBHX0RB20HGyA==}
+  /vue-tsc/1.4.4_typescript@4.9.5:
+    resolution: {integrity: sha512-2XsCjF2mLo6gwOVcOpngwJkP8GzYQjNh20A+Pr2FGdsWzr9jjXJ0k08/DfcslfncsuCrTrnWtb4KEL3gcDtlNA==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@volar/vue-language-core': 1.4.2
-      '@volar/vue-typescript': 1.4.2_typescript@4.9.5
+      '@volar/vue-language-core': 1.4.4
+      '@volar/vue-typescript': 1.4.4_typescript@4.9.5
       semver: 7.3.8
       typescript: 4.9.5
     dev: true

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
   "ignorePaths": [
     "packages/core/cli/src/__template__/package.json"
   ],
+  "ignoreDeps": [
+    "vue-tsc"
+  ],
   "labels": [
     "dependencies",
     "renovate-bot"


### PR DESCRIPTION
# Summary

Downgrade `vue-tsc` to version `1.2.0` to resolve built type errors stemming from version `1.2.1`

Link to opened issue: https://github.com/vuejs/language-tools/issues/2714

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
