### PR TITLE
chore: adding concurrency instructions to the CI [KHCP-7168]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,11 @@ on:
     branches:
       - main
 
-jobs:
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 
+jobs:
   install-dependencies:
     name: Install Dependencies
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

So that we do not have a conflict when jib running on main fails with

lerna ERR! lerna hint: Updates were rejected because the remote contains work that you do
lerna ERR! lerna hint: not have locally. This is usually caused by another repository pushing
lerna ERR! lerna hint: to the same ref. You may want to first integrate the remote changes