### PR TITLE
chore: do not create git tags until CI publishes packages [KHCP-7169]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,11 +239,16 @@ jobs:
           name: package-dist-artifacts
           path: packages/
 
+      # for lerna version we use:
+      # --force-git-tag - if tag was already created it will be recreated instead of command failing and entire CI failing
+      # --yes - so CI doesn't wait for the confirmation keyboard import
+      # --create-release - so that release is created in github when version is changed
+      # --conventional-commits - so that package's version changed following semantic releases
       - name: Update package versions
         run: |
           git config user.email "konnectx-engineers+kongponents-bot@konghq.com"
           git config user.name "Kong UI Bot"
-          lerna version --conventional-commits --create-release github --yes
+          lerna version --conventional-commits --create-release github --yes --force-git-tag
 
       - name: Publish packages to NPM
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,11 +244,13 @@ jobs:
       # --yes - so CI doesn't wait for the confirmation keyboard import
       # --create-release - so that release is created in github when version is changed
       # --conventional-commits - so that package's version changed following semantic releases
+      #
+      # we shall ignore lerna version error as pnpm publish will fail or not publish in case of such error
       - name: Update package versions
         run: |
           git config user.email "konnectx-engineers+kongponents-bot@konghq.com"
           git config user.name "Kong UI Bot"
-          lerna version --conventional-commits --create-release github --yes --force-git-tag
+          lerna version --conventional-commits --create-release github --yes --force-git-tag || true
 
       - name: Publish packages to NPM
         env:


### PR DESCRIPTION
# Summary

# Summary

To resolve 
```
lerna ERR! Error: Command failed with exit code 128: git tag @kong-ui/entities-certificates@0.6.47 -m @kong-ui/entities-certificates@0.6.47
lerna ERR! fatal: tag '@kong-ui/entities-certificates@0.6.47' already exists
```

do not push anything from CI to remote till `publish` step is completed.

we use https://github.com/lerna/lerna/tree/main/libs/commands/version#--force-git-tag