### PR TITLE
chore: using up-to-date from shared-actions. decreasing number of jobs [KHCP-7173]

### DIFF
--- a/.github/actions/up-to-date/action.yml
+++ b/.github/actions/up-to-date/action.yml
@@ -1,0 +1,105 @@
+name: 'PR Up To Date'
+description: 'Is/was the PR associated with the workflow commit up to date? Works for open PRs and Squash Merges.'
+
+inputs:
+  github_token:
+    description: 'GitHub Token'
+    required: true
+
+outputs:
+  status:
+    description: 'Up to Date Status'
+    value: ${{ steps.up-to-date.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Get PR Info
+      id: 'pr-info'
+      shell: bash
+      run: |
+        sha=${{ github.event.pull_request.head.sha || github.sha }}
+
+        response=$(curl \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ inputs.github_token }} " \
+          https://api.github.com/repos/${{ github.repository }}/commits/$sha/pulls)
+
+        echo "$response"
+
+        error_message=$(echo $response | jq 'try .message catch null')
+        data_length=$(echo $response | jq 'try length catch 0')
+
+        if [[ "$error_message" == null && "$data_length" -gt 0 ]]; then
+          echo "has_info=true" >> $GITHUB_OUTPUT
+          echo "merge_commit_sha=$(echo $response | jq '.[0].merge_commit_sha')" >> $GITHUB_OUTPUT
+          echo "head_commit_sha=$(echo $response | jq '.[0].head.sha')" >> $GITHUB_OUTPUT
+        else
+          echo "has_info=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Check if Up to Date
+      id: 'up-to-date'
+      shell: bash
+      run: |
+        if [ ${{ steps.pr-info.outputs.has_info }} == true ]; then
+          base_ref=${{ github.base_ref || github.ref_name }}
+
+          if [ ${{ github.event_name }} == 'pull_request' ]; then
+            merge_commit=${{ github.sha }}
+          else
+            merge_commit=${{ steps.pr-info.outputs.merge_commit_sha }}
+          fi
+          head_commit=${{ steps.pr-info.outputs.head_commit_sha }}
+
+          git fetch origin $base_ref
+          git fetch origin $head_commit
+
+          base_head=$(git rev-parse origin/$base_ref)
+          base_prev=$(git rev-parse origin/${base_ref}~1)
+
+          merge_base=$(git merge-base $merge_commit origin/$base_ref)
+          head_base=$(git merge-base $head_commit origin/$base_ref)
+
+          echo "**"
+          echo "BASE BRANCH: $base_ref"
+          echo "BASE BRANCH HEAD: $base_head"
+          echo "BASE BRANCH PREVIOUS: $base_prev"
+          echo "**"
+          echo "PR MERGE COMMIT: $merge_commit"
+          echo "PR HEAD COMMIT: $head_commit"
+          echo "**"
+          echo "PR MERGE BASE: $merge_base"
+          echo "PR HEAD BASE: $head_base"
+          echo "**"
+
+          if [ ${{ github.event_name }} == 'push' ]; then
+            if [ $head_base == $head_commit ]; then
+              echo "EVENT WAS NOT A SQUASH MERGE"
+              echo "status=false" >> $GITHUB_OUTPUT
+            else
+              if [ $head_base == $base_prev ]; then
+                echo "PR WAS UP TO DATE"
+                echo "status=true" >> $GITHUB_OUTPUT
+              else
+                echo "PR WAS OUT OF DATE"
+                echo "status=false" >> $GITHUB_OUTPUT
+              fi
+            fi
+          elif [ ${{ github.event_name }} == 'pull_request' ]; then
+            if [ $head_base == $base_head ]; then
+              echo "PR IS UP TO DATE"
+              echo "status=true" >> $GITHUB_OUTPUT
+            else
+              echo "PR IS OUT OF DATE"
+              echo "status=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+        else
+          echo "COMMIT HAS NO ASSOCIATED PR INFO"
+          echo "status=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+2name: CI
 
 on:
   push:
@@ -208,7 +208,7 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && steps.build.outputs.filter != '{()}'}}
+    if: ${{ github.event_name == 'push' && needs.build.outputs.filter != '{()}'}}
     env:
       GH_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ on:
 
 jobs:
 
-  install-dependencies:
-    name: Install Dependencies
+  build:
+    name: Build And Test
     runs-on: ubuntu-latest
     outputs:
       filter: ${{steps.changed_packages.outputs.filter}}
@@ -34,7 +34,7 @@ jobs:
       - name: Setup PNPM with Dependencies
         uses: ./.github/actions/setup-pnpm-with-dependencies/
         with:
-          force-install: 'true'
+          force-install: ${{ github.event_name != 'pull_request' }}
 
       - name: Check for pnpm-lock change
         id: lock-changed
@@ -94,50 +94,40 @@ jobs:
           echo "spec=${specPackages}" >> $GITHUB_OUTPUT
           echo "unitTestFilter=${unitTestFilter}" >> $GITHUB_OUTPUT
 
-  build:
-    name: Build And Test
-    needs: install-dependencies
-    # do not do anything unless changed package is detected
-    if: ${{ needs.install-dependencies.outputs.filter != '{()}' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Source Code
-        uses: actions/checkout@v3
-        with:
-         fetch-depth: 0
-
-      - name: Setup PNPM with Dependencies
-        uses: ./.github/actions/setup-pnpm-with-dependencies/
-
       - name: Stylelint Packages
-        run: pnpm --stream --filter "${{needs.install-dependencies.outputs.filter}}" run stylelint
+        if: ${{steps.changed_packages.outputs.filter != '{()}'}}
+        run: pnpm --stream --filter "${{steps.changed_packages.outputs.filter}}" run stylelint
 
       - name: Lint Packages
-        run: pnpm --stream --filter "${{needs.install-dependencies.outputs.filter}}" run lint
+        if: ${{steps.changed_packages.outputs.filter != '{()}'}}
+        run: pnpm --stream --filter "${{steps.changed_packages.outputs.filter}}" run lint
 
       - name: Build Packages
+        if: ${{steps.changed_packages.outputs.filter != '{()}'}}
         # The `...` syntax tells pnpm to include dependent packages
-        run: pnpm --stream --filter "...${{needs.install-dependencies.outputs.filter}}..." run build
+        run: pnpm --stream --filter "...${{steps.changed_packages.outputs.filter}}..." run build
 
       - name: Upload bundle-analyzer results
+        if: ${{steps.changed_packages.outputs.filter != '{()}'}}
         uses: actions/upload-artifact@v3
         with:
           name: rollup-plugin-visualizer
           path: packages/*/*/bundle-analyzer/stats-treemap.html
 
       - name: Run Unit Tests
-        run: pnpm --stream --filter "${{needs.install-dependencies.outputs.unitTestFilter}}" run test:unit
+        if: ${{ steps.changed_packages.outputs.filter != '{()}' && steps.run-tests.outputs.run-tests == 'true' }}
+        run: pnpm --stream --filter "${{steps.changed_packages.outputs.unitTestFilter}}" run test:unit
 
       - name: Prepare Cypress
-        if: ${{ needs.install-dependencies.outputs.spec != '' }}
+        if: ${{ steps.changed_packages.outputs.spec != '' && steps.run-tests.outputs.run-tests == 'true' }}
         run: pnpm cypress install
 
       - name: Run Component Tests
-        if: ${{ needs.install-dependencies.outputs.spec != '' }}
+        if: ${{ steps.changed_packages.outputs.spec != '' && steps.run-tests.outputs.run-tests == 'true' }}
         uses: cypress-io/github-action@v4
         with:
           install: false
-          command: pnpm run test:component:ci --spec ${{ needs.install-dependencies.outputs.spec }}
+          command: pnpm run test:component:ci --spec ${{ steps.changed_packages.outputs.spec }}
 
       - name: Upload Component Test Results
         uses: actions/upload-artifact@v3
@@ -150,14 +140,14 @@ jobs:
             cypress/screenshots/
 
       - name: Save Build Artifacts
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && steps.changed_packages.outputs.filter != '{()}' }}
         uses: actions/upload-artifact@v3
         with:
           name: package-dist-artifacts
           path: packages/*/*/dist
 
       - name: Publish Previews
-        if: github.event_name == 'pull_request'
+        if: ${{github.event_name == 'pull_request' && steps.changed_packages.outputs.filter != '{()}'}}
         run: |
           git config user.email "konnectx-engineers+kongponents-bot@konghq.com"
           git config user.name "Kong UI Bot"
@@ -172,7 +162,7 @@ jobs:
 
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
 
-          pnpmPublish=$(pnpm --stream --filter "${{needs.install-dependencies.outputs.filter}}" publish  --no-git-checks --access restricted --report-summary --tag "${tag}")
+          pnpmPublish=$(pnpm --stream --filter "${{needs.build.outputs.filter}}" publish  --no-git-checks --access restricted --report-summary --tag "${tag}")
 
           if [[ ! -z $(echo "${pnpmPublish}"|grep "There are no new packages that should be published") ]]; then
             echo "There are no new packages that should be published"
@@ -214,12 +204,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
 
   publish:
-    if: ${{ github.event_name == 'push' }}
     name: Publish
     needs:
-      - install-dependencies
       - build
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && steps.build.outputs.filter != '{()}'}}
     env:
       GH_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
 
@@ -257,7 +246,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          pnpm --stream --filter "${{needs.install-dependencies.outputs.filter}}" publish  --no-git-checks --access public
+          pnpm --stream --filter "${{needs.build.outputs.filter}}" publish  --no-git-checks --access public
 
   notify-slack:
     name: Slack Notification

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Check if PR Up to Date
         id: 'up-to-date'
         if: ${{github.event_name == 'push'}}
-        uses: Kong/shared-actions/pr-previews/up-to-date@feat/KHCP-7173_compare-main-to-pr
+        uses: ./.github/actions/up-to-date/
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-2name: CI
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,19 @@ jobs:
           echo "spec=${specPackages}" >> $GITHUB_OUTPUT
           echo "unitTestFilter=${unitTestFilter}" >> $GITHUB_OUTPUT
 
+      - name: Check if PR Up to Date
+        id: 'up-to-date'
+        if: ${{github.event_name == 'push'}}
+        uses: Kong/shared-actions/pr-previews/up-to-date@feat/KHCP-7173_compare-main-to-pr
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Need to run tests
+        id: 'run-tests'
+        run: |
+          echo "run-tests=${{ (github.event_name == 'push' && steps.up-to-date.outputs.status == 'true') && 'false' || 'true' }}"
+          echo "run-tests=${{ (github.event_name == 'push' && steps.up-to-date.outputs.status == 'true') && 'false' || 'true' }}" >> $GITHUB_OUTPUT
+
       - name: Stylelint Packages
         if: ${{steps.changed_packages.outputs.filter != '{()}'}}
         run: pnpm --stream --filter "${{steps.changed_packages.outputs.filter}}" run stylelint


### PR DESCRIPTION
# Summary

- Using `up-to-date` shared action to figure out if tests are needed on push
- each job in workflow takes a time to start and waits for free runner. so we can combine two jobs into one and shave all this time from the workflow run 
