### PR TITLE
fix: using correct nodeJS version in cache-key [KHCP-7234]

### DIFF
--- a/.github/actions/setup-pnpm-with-dependencies/action.yaml
+++ b/.github/actions/setup-pnpm-with-dependencies/action.yaml
@@ -47,7 +47,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: '**/node_modules'
-        key: pnpm-${{ inputs.nodejs-version }}-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: pnpm-${{ steps.node-version.outputs.node-version }}-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
     - name: Install Dependencies
       if: ${{ inputs.force-install == 'true' || steps.dependency-cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
# Summary

missed in previous PR. now as we are reading node version for install from variable - we need to read same variable when formatting cache key. 