### PR TITLE
chore: cancel concurrent CI on PR. Wait for job to finish in main [KHCP-7168]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,11 @@ on:
     branches:
       - main
 
-jobs:
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+jobs:
   build:
     name: Build And Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

- cancel currently running workflow when PR branch receives a new commit and new workflow run is initiated
- when merging to main , wait for a new workflow to kick-off till previous workflow finishes