### PR TITLE
fix: bump swagger-ui-kong-theme-universal to 4.2.0

### DIFF
--- a/packages/portal/swagger-ui-web-component/package.json
+++ b/packages/portal/swagger-ui-web-component/package.json
@@ -13,7 +13,7 @@
     "build": "webpack --mode production"
   },
   "dependencies": {
-    "@kong/swagger-ui-kong-theme-universal": "^4.1.9",
+    "@kong/swagger-ui-kong-theme-universal": "^4.2.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "swagger-client": "^3.19.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,7 +250,7 @@ importers:
 
   packages/portal/swagger-ui-web-component:
     specifiers:
-      '@kong/swagger-ui-kong-theme-universal': ^4.1.9
+      '@kong/swagger-ui-kong-theme-universal': ^4.2.0
       css-loader: ^6.7.3
       raw-loader: ^4.0.2
       react: 17.0.2
@@ -264,7 +264,7 @@ importers:
       webpack-cli: ^5.0.2
       webpack-dev-server: ^4.13.3
     dependencies:
-      '@kong/swagger-ui-kong-theme-universal': 4.1.9_sfoxds7t5ydpegc3knd667wn6m
+      '@kong/swagger-ui-kong-theme-universal': 4.2.0_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       swagger-client: 3.19.6
@@ -1359,8 +1359,8 @@ packages:
       - debug
     dev: true
 
-  /@kong/swagger-ui-kong-theme-universal/4.1.9_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-Td4mvUqwe9ZJJ5GHAp+qONPgqWX0p7vPModQ7Zln20J6x0ZKjyYXYv921XPijc+dlGHUJb+Eadn2kK1pUA08Tw==}
+  /@kong/swagger-ui-kong-theme-universal/4.2.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-EvP5iRIFv4miVro7PxwtTQUBjhFkaYRPHFoghnf4rtSOTG2gCF1FQBw4YrEPjuydqFQHf+JyY/shWnAsUPKX3g==}
     peerDependencies:
       react: 17.0.2
     dependencies:
@@ -4606,8 +4606,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
# Summary
Bumps to latest version of `swagger-ui-kong-theme-universal`
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
