### PR TITLE
fix(metric-cards): Fix default change format function

### DIFF
--- a/packages/analytics/metric-cards/src/components/MetricCardContainer.cy.ts
+++ b/packages/analytics/metric-cards/src/components/MetricCardContainer.cy.ts
@@ -1,7 +1,7 @@
 // Cypress component test spec file
 
 import MetricCardContainer from './MetricCardContainer.vue'
-import { DECIMAL_DISPLAY, metricChange } from '../utilities'
+import { DECIMAL_DISPLAY } from '../utilities'
 import { MetricCardSize } from '../constants'
 
 const cards = [
@@ -14,14 +14,14 @@ const cards = [
   {
     currentValue: 0.3014489796854011,
     previousValue: 0.29789116649461733,
-    formatValueFn: val => `${val.toFixed(DECIMAL_DISPLAY)}%`,
+    formatValueFn: (val: number) => `${val.toFixed(DECIMAL_DISPLAY)}%`,
     title: 'Average Error Rate',
     increaseIsBad: true,
   },
   {
     currentValue: 335,
     previousValue: 511,
-    formatValueFn: val => `${val}ms`,
+    formatValueFn: (val: number) => `${val}ms`,
     title: 'P99 Latency',
     increaseIsBad: true,
   },
@@ -81,7 +81,7 @@ describe('<MetricCardContainer />', () => {
     cy.get(container).should('be.visible')
   })
 
-  // Should display up arrow icon, and green trend value text
+  // Should display down arrow icon, and green trend value text
   it('Upward trend displayed for diff above threshold', () => {
     cy.mount(MetricCardContainer, {
       props: {
@@ -89,14 +89,14 @@ describe('<MetricCardContainer />', () => {
           {
             currentValue: 0.3012,
             previousValue: 0.3013,
-            formatValueFn: val => `${val.toFixed(DECIMAL_DISPLAY)}%`,
-            formatChangeFn: val => `${metricChange(val * 100, true, 'N/A')}`,
+            formatValueFn: (val: number) => `${val.toFixed(DECIMAL_DISPLAY)}%`,
             title: 'Average Error Rate',
             increaseIsBad: true,
           },
         ],
         cardSize: MetricCardSize.Large,
         hasTrendAccess: true,
+        fallbackDisplayText: 'N/A',
         loading: false,
       },
     })
@@ -109,7 +109,7 @@ describe('<MetricCardContainer />', () => {
 
     // Check for upward trend, non-zero value
     cy.get('.metricscard-value-trend').should('have.class', 'positive')
-    cy.get('.metricscard-value-trend').should('not.contain', '0.00%')
+    cy.get('.metricscard-value-trend').should('contain', '0.03%')
   })
 
   // Should display no icon, and gray trend value text
@@ -118,16 +118,16 @@ describe('<MetricCardContainer />', () => {
       props: {
         cards: [
           {
-            currentValue: 0.3017,
+            currentValue: 0.30171,
             previousValue: 0.3017,
-            formatValueFn: val => `${val.toFixed(DECIMAL_DISPLAY)}%`,
-            formatChangeFn: val => `${metricChange(val * 100, true, 'N/A')}`,
+            formatValueFn: (val: number) => `${val.toFixed(DECIMAL_DISPLAY)}%`,
             title: 'Average Error Rate',
             increaseIsBad: true,
           },
         ],
         cardSize: MetricCardSize.Large,
         hasTrendAccess: true,
+        fallbackDisplayText: 'N/A',
         loading: false,
       },
     })

--- a/packages/analytics/metric-cards/src/utilities/trend-display.ts
+++ b/packages/analytics/metric-cards/src/utilities/trend-display.ts
@@ -28,13 +28,13 @@ export const changePolarity = (delta: number, hasTrendAccess: boolean, thisIsBad
 
 /**
  * Determines the trend value to be displayed by the metric card
- * @param {number} delta The change amount during the given time period
+ * @param {number} delta The change amount during the given time period.  Assumed to be a percentage; e.g., delta = 0.1 will be rendered as '10.00%'.
  * @param {Boolean} hasTrendAccess Whether the user's Tier allows it
  * @returns {string}
  */
 export const metricChange = (delta: number, hasTrendAccess: boolean, fallback: string): string => {
   return hasTrendAccess
-    ? `${Math.abs(delta).toFixed(DECIMAL_DISPLAY)}%`
+    ? `${Math.abs(delta * 100).toFixed(DECIMAL_DISPLAY)}%`
     : fallback
 }
 


### PR DESCRIPTION
- Multiply by 100 to correctly format percentage in `metricChange`
- Update component test to catch issue
- Update typings in component test

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
