### PR TITLE
fix: make renovate respect .npmrc settings. lock renovate to pnpm 8.5.1 [KHCP-7488]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,5 +33,9 @@
       ],
       "stabilityDays": 0
     }
-  ]
+  ],
+  "npmrcMerge": true,
+  "constraints": {
+    "pnpm": "8.5.1"
+  }
 }


### PR DESCRIPTION
# Summary

- This way the only source of thought for npm settings for renovate is .npmrc file. 
- also locking renovate to pnpm 8.5.1. we do not want anymore surprises when new version of pnpm is released. 