### PR TITLE
fix(app-layout): update layout content height

### DIFF
--- a/packages/core/app-layout/sandbox/pages/LayoutPage.vue
+++ b/packages/core/app-layout/sandbox/pages/LayoutPage.vue
@@ -5,7 +5,7 @@
     :sidebar-top-items="sidebarItemsTop"
     @sidebar-click="sidebarItemClick"
   >
-    <!-- <template #notification>
+    <template #notification>
       <KAlert
         alert-message="I'm an alert from the host app"
         appearance="warning"
@@ -13,7 +13,7 @@
         :is-showing="showAlert"
         @closed="handleCloseAlert"
       />
-    </template> -->
+    </template>
     <template #navbar-mobile-logo>
       <router-link
         class="navbar-logo-link"
@@ -86,10 +86,10 @@
     <p>This is the top.</p>
 
     <p
-      v-for="index in 10"
+      v-for="index in 9"
       :key="index"
     >
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Id quidem aperiam similique vitae beatae. Repellat quam voluptas vitae, maxime consequuntur praesentium suscipit. Numquam aliquid nulla vel esse accusantium reiciendis error?
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Id quidem aperiam similique vitae beatae. Repellat quam voluptas vitae, maxime consequuntur praesentium et suscipit. Numquam aliquid nulla vel esse accusantium reiciendis error?
     </p>
 
     <p>This is the bottom.</p>
@@ -323,10 +323,10 @@ const sidebarItemsBottom = computed((): SidebarPrimaryItem[] => {
   ]
 })
 
-// const showAlert = ref(true)
-// const handleCloseAlert = (): void => {
-//   showAlert.value = false
-// }
+const showAlert = ref(true)
+const handleCloseAlert = (): void => {
+  showAlert.value = false
+}
 </script>
 
 <style lang="scss" scoped>

--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -99,13 +99,15 @@
       data-testid="kong-ui-app-layout-main"
     >
       <div class="kong-ui-app-layout-content">
-        <!-- Default host app teleport container -->
-        <div id="kong-ui-app-layout-teleport-default-slot" />
-        <slot name="app-error" />
-        <slot
-          v-if="!defaultSlotIsHidden"
-          name="default"
-        />
+        <div class="kong-ui-app-layout-content-inner">
+          <!-- Default host app teleport container -->
+          <div id="kong-ui-app-layout-teleport-default-slot" />
+          <slot name="app-error" />
+          <slot
+            v-if="!defaultSlotIsHidden"
+            name="default"
+          />
+        </div>
       </div>
     </main>
   </div>
@@ -213,6 +215,7 @@ const { debounce } = useDebounce()
 const debouncedSetNotificationHeight = debounce((force = false): void => {
   // Only update the notificationHeight if the windowWidth changes
   if (force || (windowWidth.value !== window?.innerWidth || 0)) {
+    windowWidth.value = window?.innerWidth
     const notificationContainer: HTMLElement | null = document?.querySelector('.kong-ui-app-layout #kong-ui-app-layout-notification')
     if (notificationContainer) {
       notificationHeight.value = notificationContainer.offsetHeight
@@ -224,6 +227,7 @@ const debouncedSetNotificationHeight = debounce((force = false): void => {
 const resizeObserver = ref<ResizeObserver>()
 
 onMounted(() => {
+  console.log('local app layout')
   // Add classes to the `html` and `body` elements to scope styles
   document?.body?.classList.add('kong-ui-app-layout-body')
   document?.documentElement?.classList.add('kong-ui-app-layout-html')
@@ -306,7 +310,8 @@ onBeforeUnmount(() => {
   }
 
   .kong-ui-app-layout-main {
-    align-items: flex-start;
+    // align-items: flex-start;
+    align-items: stretch;
     background-color: var(--grey-100, #f8f8fa);
     box-shadow: $app-layout-main-box-shadow;
     display: flex;
@@ -328,12 +333,16 @@ onBeforeUnmount(() => {
     }
 
     .kong-ui-app-layout-content {
-      padding: var(--kong-ui-app-layout-content-padding, 16px);
       position: relative;
       width: 100%;
 
-      @media (min-width: $viewport-lg) {
-        padding: var(--kong-ui-app-layout-content-padding, 32px);
+      // Apply the padding to the inner element
+      &-inner {
+        padding: var(--kong-ui-app-layout-content-padding, 16px);
+
+        @media (min-width: $viewport-lg) {
+          padding: var(--kong-ui-app-layout-content-padding, 32px);
+        }
       }
     }
   }

--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -309,7 +309,6 @@ onBeforeUnmount(() => {
   }
 
   .kong-ui-app-layout-main {
-    // align-items: flex-start;
     align-items: stretch;
     background-color: var(--grey-100, #f8f8fa);
     box-shadow: $app-layout-main-box-shadow;

--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -227,7 +227,6 @@ const debouncedSetNotificationHeight = debounce((force = false): void => {
 const resizeObserver = ref<ResizeObserver>()
 
 onMounted(() => {
-  console.log('local app layout')
   // Add classes to the `html` and `body` elements to scope styles
   document?.body?.classList.add('kong-ui-app-layout-body')
   document?.documentElement?.classList.add('kong-ui-app-layout-html')


### PR DESCRIPTION
# Summary

Update the `AppLayout` component layout:

- `.kong-ui-app-layout-content` changes to `align-content: stretch` instead of `flex-start`
- Adds a new child container `.kong-ui-app-layout-content > .kong-ui-app-layout-content-inner` to provide proper padding on the host app content.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
