### PR TITLE
fix(document-viewer): link display within a list

### DIFF
--- a/packages/portal/document-viewer/src/components/nodes/ListItem.vue
+++ b/packages/portal/document-viewer/src/components/nodes/ListItem.vue
@@ -17,6 +17,10 @@ li {
     p, span {
       display: inline-flex;
       margin-bottom: 0;
+      
+      span {
+        display: inline;
+      }
 
       > input[type="checkbox"] {
         margin: 0 4px 0 0;


### PR DESCRIPTION
# Summary

Links rendered within a `ListItem.vue` render within a `span` tag that is set to `display: inline-flex`. This PR modifies the rule for `p span` to be `display: inline`.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
