### PR TITLE
feat(copy-uuid): support tooltips instead of events

### DIFF
--- a/packages/core/copy-uuid/README.md
+++ b/packages/core/copy-uuid/README.md
@@ -16,6 +16,8 @@ A Kong UI component for displaying uuid and copying it to clipboard.
   - [`isHidden`](#ishidden)
   - [`notify`](#notify)
   - [`iconColor`](#iconcolor)
+  - [`tooltip`](#tooltip)
+  - [`successTooltip`](#successtooltip)
 - [Events](#events)
   - [`success`](#success)
   - [`error`](#error)
@@ -77,6 +79,7 @@ import { CopyUuid } from '@kong-ui/copy-uuid'
 You can set up an optional global `notify` method, and every `copy-uuid` component instance will use this method as a default.
 
 If you're using `copy-uuid` as a vue plugin:
+
 ```typescript
 // app entry file
 import { createApp } from 'vue'
@@ -93,6 +96,7 @@ app.use(CopyUuid, {
 ```
 
 If you prefer using `copy-uuid` as a component:
+
 ```typescript
 // app entry file
 import { createApp } from 'vue'
@@ -106,6 +110,7 @@ app.provide(COPY_UUID_NOTIFY_KEY, (props: CopyUuidNotifyParam) => {
 ```
 
 You could also set up a `notify` method for each `copy-uuid` component instance through its `prop`. If the `notify` prop is defined, it'll take precedence over the global `notify` method:
+
 ```html
 <template>
   <copy-uuid
@@ -171,6 +176,7 @@ An indicator of whether the UUID string is replaced with asterisks.
 - default: `undefined`
 
 A function that will be called when the copy button is clicked. The function will receive a `CopyUuidNotifyParam` object as its only argument. The `CopyUuidNotifyParam` object has the following properties:
+
 - `type`: `success` | `error`, indicating whether the copy operation is successful
 - `message`: `string`, the message to be displayed to the end user
 
@@ -182,7 +188,26 @@ A function that will be called when the copy button is clicked. The function wil
 
 The color of the `copy` icon.
 
+### `tooltip`
+
+- type: `String`
+- required: `false`
+- default: `''`
+
+Tooltip text to display on hovering over the copy icon. This field is required if `successTooltip` has a value.
+
+### `successTooltip`
+
+- type: `String`
+- required: `false`
+- default: `''`
+
+Note: The `tooltip` prop is required to have a value in order to use this prop. When using this prop the `@success` and `@error` events will not be fired, as the tooltip text will be updated instead.
+Tooltip text to display on successful copy.
+
 ## Events
+
+Success and error events are only emitted if NOT using the `successTooltip` prop.
 
 ### `success`
 

--- a/packages/core/copy-uuid/sandbox/App.vue
+++ b/packages/core/copy-uuid/sandbox/App.vue
@@ -33,6 +33,22 @@
           :uuid="uuid"
         />
       </div>
+      <div>
+        <h3>tooltip</h3>
+        <CopyUuid
+          tooltip="Click to copy"
+          :uuid="uuid"
+        />
+      </div>
+      <div>
+        <h3>tooltip + success tooltip</h3>
+        <CopyUuid
+          :notify="() => {}"
+          success-tooltip="Copied!"
+          tooltip="Click to copy"
+          :uuid="uuid"
+        />
+      </div>
     </main>
   </div>
 </template>

--- a/packages/core/copy-uuid/sandbox/index.ts
+++ b/packages/core/copy-uuid/sandbox/index.ts
@@ -1,13 +1,14 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import CopyUuid, { CopyUuidNotifyParam } from '../src'
-import { KClipboardProvider, KIcon } from '@kong/kongponents'
+import { KClipboardProvider, KIcon, KTooltip } from '@kong/kongponents'
 import '@kong/kongponents/dist/style.css'
 
 const app = createApp(App)
 
 app.component('KClipboardProvider', KClipboardProvider)
 app.component('KIcon', KIcon)
+app.component('KTooltip', KTooltip)
 
 app.use(CopyUuid, {
   notify: (props: CopyUuidNotifyParam) => {

--- a/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
+++ b/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
@@ -231,6 +231,7 @@ describe('<CopyUuid />', () => {
       cy.mount(CopyUuid, {
         props: {
           uuid,
+          tooltip: 'Click to copy',
           successTooltip: 'Copied!',
         },
       })

--- a/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
+++ b/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
@@ -87,76 +87,78 @@ describe('<CopyUuid />', () => {
     cy.get(container).find('.uuid-icon').should('be.visible')
   })
 
-  it('notify as a global provide', () => {
-    const spy = cy.spy(window, 'alert')
-    cy.mount(CopyUuid, {
-      props: {
-        uuid: '123',
-      },
-      global: {
-        provide: {
-          [COPY_UUID_NOTIFY_KEY]: (props: CopyUuidNotifyParam) => {
+  describe('notify', () => {
+    it('notify as a global provide', () => {
+      const spy = cy.spy(window, 'alert')
+      cy.mount(CopyUuid, {
+        props: {
+          uuid: '123',
+        },
+        global: {
+          provide: {
+            [COPY_UUID_NOTIFY_KEY]: (props: CopyUuidNotifyParam) => {
+              window.alert(props.message)
+            },
+          },
+        },
+      })
+
+      cy.get('[data-testid="copy-to-clipboard"]').click()
+      cy.wait(100).then(() => {
+        expect(spy).to.be.calledWith('"123" copied to clipboard')
+      })
+    })
+
+    it('notify as a prop', () => {
+      const spy = cy.spy(window, 'alert')
+      cy.mount(CopyUuid, {
+        props: {
+          uuid: '123',
+          notify: (props: CopyUuidNotifyParam) => {
             window.alert(props.message)
           },
         },
-      },
+      })
+
+      cy.get('[data-testid="copy-to-clipboard"]').click()
+      cy.wait(100).then(() => {
+        expect(spy).to.be.calledWith('"123" copied to clipboard')
+      })
     })
 
-    cy.get('[data-testid="copy-to-clipboard"]').click()
-    cy.wait(100).then(() => {
-      expect(spy).to.be.calledWith('"123" copied to clipboard')
-    })
-  })
-
-  it('notify as a prop', () => {
-    const spy = cy.spy(window, 'alert')
-    cy.mount(CopyUuid, {
-      props: {
-        uuid: '123',
-        notify: (props: CopyUuidNotifyParam) => {
-          window.alert(props.message)
+    it('notify with isHidden', () => {
+      const spy = cy.spy(window, 'alert')
+      cy.mount(CopyUuid, {
+        props: {
+          uuid,
+          isHidden: true,
+          notify: (props: CopyUuidNotifyParam) => {
+            window.alert(props.message)
+          },
         },
-      },
+      })
+
+      cy.get('[data-testid="copy-to-clipboard"]').click()
+      cy.wait(100).then(() => {
+        expect(spy).to.be.calledWith('Successfully copied to clipboard')
+      })
     })
 
-    cy.get('[data-testid="copy-to-clipboard"]').click()
-    cy.wait(100).then(() => {
-      expect(spy).to.be.calledWith('"123" copied to clipboard')
-    })
-  })
-
-  it('notify with isHidden', () => {
-    const spy = cy.spy(window, 'alert')
-    cy.mount(CopyUuid, {
-      props: {
-        uuid,
-        isHidden: true,
-        notify: (props: CopyUuidNotifyParam) => {
-          window.alert(props.message)
+    it('notify with long uuid', () => {
+      const spy = cy.spy(window, 'alert')
+      cy.mount(CopyUuid, {
+        props: {
+          uuid,
+          notify: (props: CopyUuidNotifyParam) => {
+            window.alert(props.message)
+          },
         },
-      },
-    })
+      })
 
-    cy.get('[data-testid="copy-to-clipboard"]').click()
-    cy.wait(100).then(() => {
-      expect(spy).to.be.calledWith('Successfully copied to clipboard')
-    })
-  })
-
-  it('notify with long uuid', () => {
-    const spy = cy.spy(window, 'alert')
-    cy.mount(CopyUuid, {
-      props: {
-        uuid,
-        notify: (props: CopyUuidNotifyParam) => {
-          window.alert(props.message)
-        },
-      },
-    })
-
-    cy.get('[data-testid="copy-to-clipboard"]').click()
-    cy.wait(100).then(() => {
-      expect(spy).to.be.calledWith(`"${uuid.substring(0, 15)}..." copied to clipboard`)
+      cy.get('[data-testid="copy-to-clipboard"]').click()
+      cy.wait(100).then(() => {
+        expect(spy).to.be.calledWith(`"${uuid.substring(0, 15)}..." copied to clipboard`)
+      })
     })
   })
 
@@ -174,6 +176,71 @@ describe('<CopyUuid />', () => {
 
     cy.get(container).find('.uuid-icon path')
       .should('have.attr', 'fill', 'var(--purple-400, #473cfb)')
+  })
+
+  describe('tooltips', () => {
+    it('renders with `tooltip` prop set', () => {
+      const tooltipText = 'Click to copy'
+
+      cy.mount(CopyUuid, {
+        props: {
+          uuid,
+          tooltip: tooltipText,
+        },
+      })
+
+      cy.get(container).should('be.visible')
+      cy.get(container).find('.k-tooltip').should('exist')
+      cy.get(container).find('.k-tooltip .k-popover-content').should('contain.text', tooltipText)
+    })
+
+    it('renders `successTooltip` with `tooltip` prop set', () => {
+      const tooltipText = 'Click to copy'
+      const successText = 'Copied!'
+
+      cy.mount(CopyUuid, {
+        props: {
+          uuid,
+          tooltip: tooltipText,
+          successTooltip: successText,
+        },
+      })
+
+      cy.get(container).should('be.visible')
+      cy.get(container).find('.k-tooltip').should('exist')
+      cy.get(container).find('.k-tooltip .k-popover-content').should('contain.text', tooltipText)
+      cy.get('[data-testid="copy-to-clipboard"]').click()
+      cy.get(container).find('.k-tooltip .k-popover-content').should('contain.text', successText)
+    })
+
+    it('does not render `successTooltip` without `tooltip` prop set', () => {
+      const successText = 'Copied!'
+
+      cy.mount(CopyUuid, {
+        props: {
+          uuid,
+          successTooltip: successText,
+        },
+      })
+
+      cy.get(container).should('be.visible')
+      cy.get(container).find('.k-tooltip').should('not.exist')
+    })
+
+    it('does not emit events when `successTooltip` prop is set', () => {
+      cy.mount(CopyUuid, {
+        props: {
+          uuid,
+          successTooltip: 'Copied!',
+        },
+      })
+
+      cy.get(container).should('be.visible')
+      cy.get(container).find('.k-tooltip').should('exist')
+      cy.get('[data-testid="copy-to-clipboard"]').click().then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'success')
+      })
+    })
   })
 
   it('emits event', () => {


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Add the ability to use tooltip text in place of events via the `tooltip` and `successTooltip` props.

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
