### PR TITLE
fix(sourcemaps): enable sourcemaps for visualizer [KHCP-7683]

### DIFF
--- a/vite.config.shared.ts
+++ b/vite.config.shared.ts
@@ -53,7 +53,7 @@ export default defineConfig({
     outDir: './dist',
     cssCodeSplit: false,
     minify: true,
-    sourcemap: true,
+    sourcemap: !!process.env.BUILD_VISUALIZER,
     rollupOptions: {
       // Make sure to externalize deps that shouldn't be bundled into your library
       // If config.build.rollupOptions.external is also set at the package level, the arrays will be merged


### PR DESCRIPTION
# Summary

Enable sourcemaps when `BUILD_VISUALIZER` is set

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
