### PR TITLE
fix(*): use lerna from pnpm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
           componentTestMatrix=""
 
           # get the list of changed packages, grab the location
-          for pkgFolder in $(lerna ${lernaCommand} --l --json|jq -r '.[].location')
+          for pkgFolder in $(pnpm lerna ${lernaCommand} --l --json|jq -r '.[].location')
           do
             # remove current folder from the location path
             pkgFolder="${pkgFolder/$(pwd)\//}"
@@ -187,7 +187,7 @@ jobs:
 
           git checkout ${{ github.head_ref }}
 
-          lerna version prerelease --preid ${preid} --allow-branch ${{ github.head_ref }} --conventional-prerelease --yes --amend || true
+          pnpm lerna version prerelease --preid ${preid} --allow-branch ${{ github.head_ref }} --conventional-prerelease --yes --amend || true
 
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
 
@@ -336,7 +336,7 @@ jobs:
         run: |
           git config user.email "konnectx-engineers+kongponents-bot@konghq.com"
           git config user.name "Kong UI Bot"
-          lerna version --conventional-commits --create-release github --yes --force-git-tag || true
+          pnpm lerna version --conventional-commits --create-release github --yes --force-git-tag || true
 
       - name: Publish packages to NPM
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -30,7 +30,7 @@ jobs:
 
           prNumber="${{github.event.number}}"
 
-          for pkgName in $(lerna ls --l --json|jq -r '.[].name')
+          for pkgName in $(pnpm lerna ls --l --json|jq -r '.[].name')
           do
             npm dist-tag rm "${pkgName}" "pr-${prNumber}" || true
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "test:component:ci": "BABEL_ENV=cypress cypress run --component -b chrome",
     "test:unit": "cross-env FORCE_COLOR=1 pnpm -r run test:unit",
     "test:unit:open": "cross-env FORCE_COLOR=1 pnpm -r run test:unit:open",
+    "create-package": "pnpm --filter \"@kong-ui-public/cli\" run create-package",
     "commit": "cz",
-    "create-package": "pnpm --filter \"@kong-ui-public/cli\" run create-package"
+    "lerna": "lerna"
   },
   "devDependencies": {
     "@babel/types": "^7.22.4",


### PR DESCRIPTION
# Summary

Use `pnpm lerna` in CI in order to enforce using the version delcared in `/package.json`

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
