### PR TITLE
fix: use correct token for npm cleanup job [KHCP-7461]

### DIFF
--- a/.github/workflows/cleanup-preview-packages.yaml
+++ b/.github/workflows/cleanup-preview-packages.yaml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.prepare.outputs.packages) }}
     env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN_PRIVATE_PUBLISH }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}
       GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
 
     steps:


### PR DESCRIPTION
# Summary

cut & paste error.  was using wrong token for cleanup NPM packages.
