### PR TITLE
feat: fix(charts): empty state check [MA-1726]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
@@ -676,7 +676,7 @@ describe('<AnalyticsChart />', () => {
 
     cy.mount(AnalyticsChart, {
       props: {
-        chartData: {},
+        chartData: emptyExploreResult,
         chartOptions: {
           type: ChartTypes.DOUGHNUT,
         },
@@ -693,7 +693,7 @@ describe('<AnalyticsChart />', () => {
 
     cy.mount(AnalyticsChart, {
       props: {
-        chartData: {},
+        chartData: emptyExploreResult,
         chartOptions: {
           type: ChartTypes.DOUGHNUT,
         },

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -325,7 +325,7 @@ const hasValidChartData = computed(() => {
     return hasMillisecondTimestamps(computedChartData.value)
   }
 
-  return chartDataRef.value && chartDataRef.value.meta && chartDataRef.value.records
+  return chartDataRef.value && chartDataRef.value.meta && chartDataRef.value.records.length
 })
 
 const timeSeriesGranularity = computed<GranularityKeys>(() => {


### PR DESCRIPTION
# Summary

Only time based charts were properly displaying the KEmptyState, because the hasMillisecondTimestamps check was failing (as expected).

However, Doughnut were displaying an empty div. Need to check for the presence of **1 or more records** in the array, since the blank `records` array is present regardless.


Bug:
<img width="894" alt="Screen Shot 2023-06-27 at 2 38 45 PM" src="https://github.com/Kong/public-ui-components/assets/103061463/d8b335c2-de23-4c02-99a7-218d84c3ea9f">


## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
