### PR TITLE
feat(renovate): enable dependency dashboard and dev package grouping [KHCP-7899]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     ":automergePatch",
     ":automergeMinor"
   ],
+  "dependencyDashboard": true,
   "rangeStrategy": "bump",
   "platformAutomerge": true,
   "ignorePaths": [
@@ -32,6 +33,20 @@
         "^@kong-ui-public\/"
       ],
       "stabilityDays": 0
+    },
+    {
+      "automerge": true,
+      "groupName": "all non-major dependencies with stable version",
+      "groupSlug": "all-minor-patch",
+      "matchCurrentVersion": "!/^0/",
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "stabilityDays": 10
     }
   ],
   "npmrcMerge": true,


### PR DESCRIPTION

# Summary

Enable dependency dashboard and grouping dev non-major dependencies into combined renovate PRs
https://konghq.atlassian.net/browse/KHCP-7899

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
