### PR TITLE
fix(document-viewer): handle empty props.lines [KHCP-8126]

### DIFF
--- a/packages/portal/document-viewer/src/components/nodes/CodeBlock.vue
+++ b/packages/portal/document-viewer/src/components/nodes/CodeBlock.vue
@@ -87,7 +87,7 @@ const escapeUnsafeCharacters = (unescapedCodeString: string): string => {
 const codeBlockKey = computed(() => `document-code-block-${props.codeBlockIndex}`)
 
 const stringifiedCode = computed(() => {
-  const code = props.lines.flatMap(line => line.text).join('')
+  const code = props.lines?.flatMap(line => line.text)?.join('') || ''
 
   // To remove an extra line at the end, in the case that
   // someone leaves that in their markdown.


### PR DESCRIPTION
# Summary

Resolves this [Datadog error](https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A6e430333-9e0f-4d6b-ac63-5f7d4ad9a641%20env%3Aprod%20-%40browser.name%3AHeadlessChrome%20%40issue.age%3A%3C%3D300000&issueId=4608d102-227b-11ee-9087-da7ad0900002&from_ts=1689362069000&to_ts=1689362369000&live=false)

![image](https://github.com/Kong/public-ui-components/assets/2229946/e0bf0192-8db5-4065-bf0c-a705572b85d6)

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
