### PR TITLE
ci: guard against private scoped packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,40 @@ jobs:
         with:
           pathspec: pnpm-lock.yaml
 
+      - name: Verify no packages are in the wrong scope and have the correct publishConfig.access
+        run: |
+          # Verify no packages are in the wrong scope and have the correct publishConfig.access
+
+          # Utilize the lerna command to determine the packages that were added/updated
+          # we execute lerna changed to grab all the packages changed
+          lernaCommand="changed"
+
+          # if lock-changed detects the change of pnpm-lock.yaml file - we will grap all the packages
+          if [[ "${{ steps.lock-changed.outputs.changed }}" == "true" ]]; then
+            lernaCommand="ls"
+          fi
+
+          echo "lernaCommand: ${lernaCommand}"
+
+          # Verify no packages exist from the `@kong-ui` scope; if yes, then exit with error
+          for packageLocation in $(pnpm --silent lerna ${lernaCommand} --l --json | jq -r '.[].location')
+          do
+            packageName=$(jq -r '.name' "$packageLocation"/package.json)
+            publishConfigAccess=$(jq -r '.publishConfig.access' "$packageLocation"/package.json)
+
+            # Check if package.json name contains the wrong scope
+            if [[ "$packageName" == *"@kong-ui/"* ]]; then
+              echo "::error::The '""$packageName""' package.json contains an incorrect npm scope '""@kong-ui""'. This repository requires packages to have the npm scope of '""@kong-ui-public""'."
+              exit 1
+            fi
+
+            # Check if the package.json publishConfig.access is incorrect for this repo
+            if [[ "$publishConfigAccess" != "public" ]]; then
+              echo "::error::The '""$packageName""' package.json contains the publishConfig.access of '""$publishConfigAccess""'. This repository requires packages to have a publishConfig.access of '""public""'."
+              exit 1
+            fi
+          done
+
       - name: Getting changed packages
         id: changed_packages
         run: |


### PR DESCRIPTION
# Summary

Fail CI if packages contain the wrong npm scope or `publishConfig.access` value.

### Wrong npm scope

![image](https://github.com/Kong/shared-ui-components/assets/2229946/78cb7676-dc54-4a20-8424-e610d31b1dbe)


### Wrong `publishConfig.access` value

![image](https://github.com/Kong/shared-ui-components/assets/2229946/a82fc01d-c55a-452f-8336-6746e4882a36)

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
