### PR TITLE
docs: moving packages [KHCP-7979]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Monorepo for **open-source** Kong UI components and utilities.
   - [Generating type interface documentation](#generating-type-interface-documentation)
   - [Preview components](#preview-components)
   - [Running consuming application with local copy of the package](#running-consuming-application-with-local-copy-of-the-package)
+- [Moving packages to the public/private repo](#moving-packages-to-the-publicprivate-repo)
 - [Host App Troubleshooting](#host-app-troubleshooting)
   - [Analytics Packages are blocked by some ad-blockers](#analytics-packages-are-blocked-by-some-ad-blockers)
 
@@ -263,6 +264,12 @@ In some cases HMR (hot module reloading) is not working out of the box in this c
     yarn unlink "@kong-ui-public/forms"
     yarn install --force --frozen-lockfile
     ```
+
+## Moving packages to the public/private repo
+
+Sometimes packages are initially created in [`Kong/shared-ui-components`](https://github.com/Kong/shared-ui-components) where they are **privately** published, but need to be moved into the **public** [`Kong/public-ui-components`](https://github.com/Kong/public-ui-components) OSS repository so that the source code and npm package can be consumed by anyone.
+
+[View the docs on how to move packages between the private/public repositories here](./docs/moving-packages.md)
 
 ## Host App Troubleshooting
 

--- a/docs/moving-packages.md
+++ b/docs/moving-packages.md
@@ -1,0 +1,162 @@
+# Moving packages to the public or private repo
+
+This document outlines the suggested process for moving packages between [`Kong/shared-ui-components`](https://github.com/Kong/shared-ui-components) and [`Kong/public-ui-components`](https://github.com/Kong/public-ui-components).
+
+This process can be followed regardless of which repository is the source or destination.
+
+- [Copying a package](#copying-a-package)
+- [Package checklist](#package-checklist)
+  - [`package.json` \> `name`](#packagejson--name)
+  - [`package.json` \> `version`](#packagejson--version)
+  - [`package.json` \> `publishConfig`](#packagejson--publishconfig)
+  - [`package.json` \> script environment variables](#packagejson--script-environment-variables)
+  - [Repository paths](#repository-paths)
+  - [Update local package references](#update-local-package-references)
+  - [Install package dependencies](#install-package-dependencies)
+  - [Build dependent packages](#build-dependent-packages)
+  - [Update dependent packages](#update-dependent-packages)
+  - [Cleanup old package](#cleanup-old-package)
+
+## Copying a package
+
+While [creating a new package](./creating-a-package.md) is still **required** to go through the included CLI, since the two repositories are structured almost identically in terms of the nested workspaces, the easiest way to **move** a package is to simply copy/paste the package directory into its new location.
+
+Once you have copied the package structure and verified it is located in the proper workspace, please go through the checklist below to ensure a smooth migration.
+
+## Package checklist
+
+### `package.json` > `name`
+
+Update the `name` of your package for the **required** npm scope.
+
+Repository | NPM scope
+---------|----------
+`shared-ui-components` | `@kong-ui`
+`public-ui-components` | `@kong-ui-public`
+
+For example, if your package is moving from the private repo to the public repo:
+
+```txt
+// Old name
+@kong-ui/analytics-utilities
+
+// New name
+@kong-ui-public/analytics-utilities
+```
+
+### `package.json` > `version`
+
+The `version` of your package, now that it will be published under a new NPM scope, can remain the same, or you can choose to increment or reset the version.
+
+At a minimum, you should bump the `patch` version of the package; however, you may want to bump the major version to provide a clear division of when the package was changed to public/private.
+
+To update the `version`, manually change the version number in the `package.json` file.
+
+### `package.json` > `publishConfig`
+
+Update the `publishConfig.access` property for to publish the package as private or public.
+
+Repository | `publishConfig.access` property
+---------|----------
+`shared-ui-components` | `restricted`
+`public-ui-components` | `public`
+
+For example, if your package is moving from the private repo to the public repo:
+
+```jsonc
+// Old config
+"publishConfig": {
+  "access": "restricted"
+}
+
+// New config
+"publishConfig": {
+  "access": "public"
+}
+```
+
+### `package.json` > script environment variables
+
+Some of the scripts utilized in your package's `package.json` file are likely set to the workspace path, e.g. `BUILD_VISUALIZER`.
+
+Please ensure this path is still correct in the new repository, especially if your package was moved to a different workspace name.
+
+### Repository paths
+
+There are references to the repository URL in the `package.json` file of your package and possibly in your package's documentation.
+
+Search your package for any instances of the **old** repository path and replace it with the **new** path; including the `package.json` file, docs, etc.
+
+For example, in the `package.json` file, the `homepage` and `repository.url` values need to be updated.
+
+### Update local package references
+
+Your package may have been dependent on other packages in its old host repository, referenced by `workspace` versions in the `package.json` file.
+
+Since your package has been moved out of the same repository as the dependency, you will need to update the value for the package version.
+
+As an example, maybe your package depends on `@kong-ui/core` package:
+
+```jsonc
+"@kong-ui/core": "workspace:^0.17.0",
+```
+
+In the new repository, since this package is no longer locally available, you will need to update to the actual published version:
+
+```jsonc
+// Assuming that 1.2.3 is the latest version
+"@kong-ui/core": "^1.2.3",
+```
+
+The same logic applies for packages that were **not** previously available in the repository workspace, but now **are** available.
+
+You'll want to update to utilize the workspace version by applying the inverse of the example above.
+
+#### Utilize the install command
+
+If you are unsure what version/workspace version should be installed, you can run the normal install command and let pnpm do the work for you:
+
+```sh
+pnpm --filter "{your package name}" add {dependency package name}
+```
+
+For example:
+
+```sh
+pnpm --filter "@kong-ui/entities-shared" add @kong-ui/core@latest
+```
+
+### Install package dependencies
+
+After making the updates outlined above, you will want to install your package's dependencies in the new repository.
+
+From the root of the new repository, run the install command
+
+```sh
+pnpm install
+```
+
+### Build dependent packages
+
+If your package depends on other **local** packages in the same repository, you will want to build those packages in order to prepare them for consumption by your new package.
+
+For example:
+
+```sh
+pnpm --filter "@kong-ui/core" run build
+```
+
+### Update dependent packages
+
+Create Pull Requests in any consuming Kong project(s) to replace the old package with the new, keeping in mind the package name and version will be different.
+
+### Cleanup old package
+
+Once you have merged your new package into its new repository, you will want to **remove** the package from the old repo.
+
+1. Checkout a new branch in the old repository
+2. Delete the old package directory from its workspace folder (if your old package was the only one in the workspace, **leave the workspace folder in place**)
+3. Check the old repository for root `package.json` dependencies that were **only** utilized by your package. If they are no longer needed, utilize the proper `pnpm` command to remove them (be 100% certain here as this can break other packages)
+4. Run `pnpm install` to remove any dependencies and update the lockfile accordingly
+5. Push up a Pull Request to remove the code
+6. Decide if the old package should be unpublished or deprecated from NPM. **One or the other must be completed as part of this process**


### PR DESCRIPTION
# Summary


Add docs for moving packages between [`Kong/shared-ui-components`](https://github.com/Kong/shared-ui-components) and [`Kong/public-ui-components`](https://github.com/Kong/public-ui-components)

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
