### PR TITLE
feat(i18n): add formatUnixTimeStamp and formatIsoDate to i18n [KHCP-7929]

### DIFF
--- a/packages/core/i18n/README.md
+++ b/packages/core/i18n/README.md
@@ -12,8 +12,8 @@
   - [HTML safe formatting with `<i18n-t>`](#html-safe-formatting-with-i18n-t)
 - [Formatting numbers, dates and times](#formatting-numbers-dates-and-times)
 - [Additional service functions.](#additional-service-functions)
-  - [format-unix-time-stamp](#format-unix-time-stamp)
-  - [format-iso-date](#format-iso-date)
+  - [formatUnixTimeStamp](#formatunixtimestamp)
+  - [formatIsoDate](#formatisodate)
   - [te](#te)
   - [tm](#tm)
 
@@ -397,7 +397,7 @@ Every single method listed in [FormatJS](https://formatjs.io/docs/intl) is expos
 
 (as previously exposed by vue18n-n)
 
-### format-unix-time-stamp
+### formatUnixTimeStamp
 
 Formats a unix timestamp into a formatted date string
 
@@ -415,7 +415,7 @@ console.log()
 May 16, 2019, 11:42 AM
 ```
 
-### format-iso-date
+### formatIsoDate
 
 Format an ISO formatted date
 

--- a/packages/core/i18n/README.md
+++ b/packages/core/i18n/README.md
@@ -12,6 +12,8 @@
   - [HTML safe formatting with `<i18n-t>`](#html-safe-formatting-with-i18n-t)
 - [Formatting numbers, dates and times](#formatting-numbers-dates-and-times)
 - [Additional service functions.](#additional-service-functions)
+  - [format-unix-time-stamp](#format-unix-time-stamp)
+  - [format-iso-date](#format-iso-date)
   - [te](#te)
   - [tm](#tm)
 
@@ -394,6 +396,42 @@ Every single method listed in [FormatJS](https://formatjs.io/docs/intl) is expos
 ## Additional service functions.
 
 (as previously exposed by vue18n-n)
+
+### format-unix-time-stamp
+
+Formats a unix timestamp into a formatted date string
+
+`code:`
+
+```ts
+const { formatUnixTimeStamp } = useI18n()
+console.log(formatUnixTimeStamp('1558006979'))
+console.log()
+```
+
+`result:`
+
+```json
+May 16, 2019, 11:42 AM
+```
+
+### format-iso-date
+
+Format an ISO formatted date
+
+`code:`
+
+```ts
+const { formatIsoDate } = useI18n()
+console.log(formatIsoDate('2019-05-16T11:42:59.000Z'))
+console.log()
+```
+
+`result:`
+
+```json
+May 16, 2019, 11:42 AM
+```
 
 ### te
 

--- a/packages/core/i18n/README.md
+++ b/packages/core/i18n/README.md
@@ -406,7 +406,6 @@ Formats a unix timestamp into a formatted date string
 ```ts
 const { formatUnixTimeStamp } = useI18n()
 console.log(formatUnixTimeStamp('1558006979'))
-console.log()
 ```
 
 `result:`
@@ -424,7 +423,6 @@ Format an ISO formatted date
 ```ts
 const { formatIsoDate } = useI18n()
 console.log(formatIsoDate('2019-05-16T11:42:59.000Z'))
-console.log()
 ```
 
 `result:`
@@ -450,7 +448,6 @@ check if translation message exists
 ```ts
 const { te } = useI18n()
 console.log({p: te('global.ok'), n: te('global.not.ok')})
-console.log()
 ```
 
 `result:`

--- a/packages/core/i18n/src/i18n.spec.ts
+++ b/packages/core/i18n/src/i18n.spec.ts
@@ -107,6 +107,54 @@ describe('i18n', () => {
     })
   })
 
+  describe('formatUnixTimeStamp()', () => {
+    beforeAll(() => {
+      createI18n<typeof english>('en-us', english, true)
+    })
+
+    it('should return a properly formatted date', () => {
+      const { formatUnixTimeStamp } = useI18n<typeof english>()
+      const formattedDateAM = formatUnixTimeStamp(1558006979)
+      const formattedDatePM = formatUnixTimeStamp(1558057179)
+      const january = formatUnixTimeStamp(1547506800)
+      const october = formatUnixTimeStamp(1570111995)
+      const november = formatUnixTimeStamp(1573772400)
+      const decimalTimestamp = formatUnixTimeStamp(1570111995.652561)
+      const integerTimestamp = formatUnixTimeStamp(1570111995)
+
+      expect(formattedDateAM).toBe('May 16, 2019, 11:42 AM')
+      expect(formattedDatePM).toBe('May 17, 2019, 1:39 AM')
+      expect(january.substring(0, 7)).toBe('Jan 14,')
+      expect(october.substring(0, 7)).toBe('Oct 3, ')
+      expect(november.substring(0, 7)).toBe('Nov 14,')
+      expect(decimalTimestamp).toEqual(integerTimestamp)
+    })
+  })
+
+  describe('formatIsoDate()', () => {
+    beforeAll(() => {
+      createI18n<typeof english>('en-us', english, true)
+    })
+
+    it('should return a properly formatted date', () => {
+      const { formatIsoDate } = useI18n<typeof english>()
+      const formattedDateAM = formatIsoDate('2019-05-16T11:42:59.000Z')
+      const formattedDatePM = formatIsoDate('2019-05-17T01:39:39.000Z')
+      const january = formatIsoDate('2019-01-14T23:00:00.000Z')
+      const october = formatIsoDate('2019-10-03T14:13:15.000Z')
+      const november = formatIsoDate('2019-11-14T23:00:00.000Z')
+      const decimalTimestamp = formatIsoDate('2019-10-03T14:13:15.000Z')
+      const integerTimestamp = formatIsoDate('2019-10-03T14:13:15.000Z')
+
+      expect(formattedDateAM).toBe('May 16, 2019, 11:42 AM')
+      expect(formattedDatePM).toBe('May 17, 2019, 1:39 AM')
+      expect(january.substring(0, 7)).toBe('Jan 14,')
+      expect(october.substring(0, 7)).toBe('Oct 3, ')
+      expect(november.substring(0, 7)).toBe('Nov 14,')
+      expect(decimalTimestamp).toEqual(integerTimestamp)
+    })
+  })
+
   // the cases bellow are for reference only. See https://formatjs.io/docs/intl/ for more details and usage
 
   describe('formatNumber', () => {

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -59,7 +59,7 @@ export const createI18n = <MessageSource extends Record<string, any>>
   }
 
   /**
-   * Format an ISO fomatted date
+   * Format an ISO formatted date
    * @param {String} isoDate ISO formatted date string
    * @returns {String} date formatted like 'Apr 6, 2022 10:50'
    */

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -32,6 +32,11 @@ export const createI18n = <MessageSource extends Record<string, any>>
     intlCache,
   )
 
+  // Remove the native $t function from intlOriginal
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { $t, ...otherProps } = intlOriginal
+  const intl = otherProps
+
   /**
    * Formats a unix timestamp into a formatted date string
    * @param {Number} timestamp a unix timestamp in seconds
@@ -68,11 +73,6 @@ export const createI18n = <MessageSource extends Record<string, any>>
 
     return formatUnixTimeStamp(date)
   }
-
-  // Remove the native $t function from intlOriginal
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { $t, ...otherProps } = intlOriginal
-  const intl = otherProps
 
   const t = (translationKey: PathToDotNotation<MessageSource, string>, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions): string => {
     return intl.formatMessage(<MessageDescriptor>{ id: translationKey }, values, opts)

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -32,6 +32,43 @@ export const createI18n = <MessageSource extends Record<string, any>>
     intlCache,
   )
 
+  /**
+   * Formats a unix timestamp into a formatted date string
+   * @param {Number} timestamp a unix timestamp in seconds
+   * @returns a date string formatted like 'Apr 6, 2022 10:50'
+   */
+  const formatUnixTimeStamp = (timestamp: number): string => {
+    const invalidDate = 'Invalid Date'
+    if (!timestamp) {
+      return invalidDate
+    }
+
+    try {
+      const date = new Date(timestamp * 1000)
+
+      return intl.formatDate(date, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      })
+    } catch (err) {
+      return invalidDate
+    }
+  }
+
+  /**
+   * Format an ISO fomatted date
+   * @param {String} isoDate ISO formatted date string
+   * @returns {String} date formatted like 'Apr 6, 2022 10:50'
+   */
+  const formatIsoDate = (isoDate: string): string => {
+    const date = Date.parse(isoDate) / 1000
+
+    return formatUnixTimeStamp(date)
+  }
+
   // Remove the native $t function from intlOriginal
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { $t, ...otherProps } = intlOriginal
@@ -51,6 +88,8 @@ export const createI18n = <MessageSource extends Record<string, any>>
   }
 
   const localIntl: IntlShapeEx<MessageSource> = {
+    formatUnixTimeStamp,
+    formatIsoDate,
     t,
     te,
     tm,

--- a/packages/core/i18n/src/types/index.ts
+++ b/packages/core/i18n/src/types/index.ts
@@ -15,6 +15,8 @@ export type PathToDotNotation<MessageSource, V> = MessageSource extends V ? '' :
 
 // Omit the native $t function
 export type IntlShapeEx<MessageSource extends Record<string, any>> = Omit<IntlShape, '$t'> & {
+  formatUnixTimeStamp: (timestamp: number) => string
+  formatIsoDate: (isoDate: string) => string
   t: (translationKey: PathToDotNotation<MessageSource, string>, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions) => string
   te: (translationKey: PathToDotNotation<MessageSource, string>) => boolean
   tm: (translationKey: PathToDotNotation<MessageSource, string>) => Array<string>


### PR DESCRIPTION
# Summary

feat(i18n): add formatUnixTimeStamp and formatIsoDate to i18n [KHCP-7929] 
https://konghq.atlassian.net/browse/KHCP-7929

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.


[KHCP-7929]: https://konghq.atlassian.net/browse/KHCP-7929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ