### PR TITLE
feat(copy-uuid): add option to completely hide uuid [MA-1908]

### DIFF
--- a/packages/core/copy-uuid/README.md
+++ b/packages/core/copy-uuid/README.md
@@ -18,6 +18,7 @@ A Kong UI component for displaying uuid and copying it to clipboard.
   - [`iconColor`](#iconcolor)
   - [`tooltip`](#tooltip)
   - [`successTooltip`](#successtooltip)
+  - [`showUuid`](#showuuid)
 - [Events](#events)
   - [`success`](#success)
   - [`error`](#error)
@@ -204,6 +205,14 @@ Tooltip text to display on hovering over the copy icon. This field is required i
 
 Note: The `tooltip` prop is required to have a value in order to use this prop. When using this prop the `@success` and `@error` events will not be fired, as the tooltip text will be updated instead.
 Tooltip text to display on successful copy.
+
+### `showUuid`
+
+- type: `Boolean`
+- required: `false`
+- default: `true`
+
+If false the UUID will not be shown at all. Useful for the case the host app wants to display something that the uuid resolves to, but still be able to copy the uuid behind the scenes.
 
 ## Events
 

--- a/packages/core/copy-uuid/sandbox/App.vue
+++ b/packages/core/copy-uuid/sandbox/App.vue
@@ -49,6 +49,13 @@
           :uuid="uuid"
         />
       </div>
+      <div>
+        <h3>Don't show uuid</h3>
+        <CopyUuid
+          :show-uuid="false"
+          :uuid="uuid"
+        />
+      </div>
     </main>
   </div>
 </template>

--- a/packages/core/copy-uuid/src/components/CopyUuid.vue
+++ b/packages/core/copy-uuid/src/components/CopyUuid.vue
@@ -11,7 +11,9 @@
           useMono ? 'mono' : null
         ]"
       >
-        {{ isHidden ? '**********' : uuid }}
+        <span v-if="showUuid">
+          {{ isHidden ? '**********' : uuid }}
+        </span>
       </div>
     </div>
     <component
@@ -81,6 +83,11 @@ const props = defineProps({
   successTooltip: {
     type: String,
     default: '',
+  },
+  showUuid: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
 })
 


### PR DESCRIPTION
sometimes we only want to show just the icon and no uuid at all, redacted or not.

# Summary

![image](https://github.com/Kong/public-ui-components/assets/6026470/f1dae772-cfe8-407d-a661-5067531c2643)

https://konghq.atlassian.net/browse/MA-1908
https://konghq.atlassian.net/browse/MA-1766

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
