### PR TITLE
feat(copy-uuid): supports new prop - format [KHCP-8505]

### DIFF
--- a/packages/core/copy-uuid/README.md
+++ b/packages/core/copy-uuid/README.md
@@ -163,16 +163,16 @@ An indicator of whether a `.mono` class is added to the UUID string. Make sure t
 
 ### `format`
 
-- type: `String`
+- type: `String as PropType<'uuid' | 'hidden' | 'redacted' | 'deleted'>`
 - required: `false`
 - default: `uuid`
 
-Determines the display format of the UUID string. The component can take following `format` values:
+Determines the display format of the UUID string. The component can take the following `format` values:
 
-- `uuid`
-- `hidden`
-- `redacted`
-- `deleted`
+- `uuid`: displays regular uuid
+- `hidden`: displays just a copy button without text
+- `redacted`: displays `*****`
+- `deleted`: displays `*<first-5-chars-of-uuid>`
 
 ### `notify`
 

--- a/packages/core/copy-uuid/README.md
+++ b/packages/core/copy-uuid/README.md
@@ -13,7 +13,7 @@ A Kong UI component for displaying uuid and copying it to clipboard.
   - [`uuid`](#uuid)
   - [`truncated`](#truncated)
   - [`useMono`](#usemono)
-  - [`isHidden`](#ishidden)
+  - [`format`](#format)
   - [`notify`](#notify)
   - [`iconColor`](#iconcolor)
   - [`tooltip`](#tooltip)
@@ -161,13 +161,13 @@ An indicator of whether a long UUID is truncated. When `true`, the UUID will be 
 
 An indicator of whether a `.mono` class is added to the UUID string. Make sure to import the Kongponents style file in your host application for this class to take effect.
 
-### `isHidden`
+### `format`
 
-- type: `Boolean`
+- type: `String`
 - required: `false`
-- default: `false`
+- default: `uuid`
 
-An indicator of whether the UUID string is replaced with asterisks.
+Determines the display format of the UUID string.
 
 ### `notify`
 

--- a/packages/core/copy-uuid/README.md
+++ b/packages/core/copy-uuid/README.md
@@ -167,7 +167,12 @@ An indicator of whether a `.mono` class is added to the UUID string. Make sure t
 - required: `false`
 - default: `uuid`
 
-Determines the display format of the UUID string.
+Determines the display format of the UUID string. The component can take following `format` values:
+
+- `uuid`
+- `hidden`
+- `redacted`
+- `deleted`
 
 ### `notify`
 

--- a/packages/core/copy-uuid/package.json
+++ b/packages/core/copy-uuid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong-ui-public/copy-uuid",
-  "version": "0.7.12",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/copy-uuid.umd.js",
   "module": "./dist/copy-uuid.es.js",

--- a/packages/core/copy-uuid/sandbox/App.vue
+++ b/packages/core/copy-uuid/sandbox/App.vue
@@ -20,9 +20,23 @@
         />
       </div>
       <div>
-        <h3>is-hidden=true</h3>
+        <h3>format=hidden</h3>
         <CopyUuid
-          is-hidden
+          format="hidden"
+          :uuid="uuid"
+        />
+      </div>
+      <div>
+        <h3>format=redacted</h3>
+        <CopyUuid
+          format="redacted"
+          :uuid="uuid"
+        />
+      </div>
+      <div>
+        <h3>format=deleted</h3>
+        <CopyUuid
+          format="deleted"
           :uuid="uuid"
         />
       </div>

--- a/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
+++ b/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
@@ -78,6 +78,7 @@ describe('<CopyUuid />', () => {
 
     cy.get(container).should('be.visible')
     cy.get(container).find('[data-testid="copy-to-clipboard"]').should('be.visible')
+    cy.get(container).find('[data-testid="copy-id"]').should('not.exist')
     cy.get(container).find('.uuid-icon').should('be.visible')
   })
 

--- a/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
+++ b/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
@@ -68,11 +68,49 @@ describe('<CopyUuid />', () => {
     cy.get(container).find('.uuid-icon').should('be.visible')
   })
 
-  it('renders with `isHidden` set to true', () => {
+  it('renders with `format` set to `hidden`', () => {
     cy.mount(CopyUuid, {
       props: {
         uuid,
-        isHidden: true,
+        format: 'hidden',
+      },
+    })
+
+    cy.get(container).should('be.visible')
+
+    cy.get(container).find('.uuid-container')
+      .should('have.class', 'truncated-uuid')
+      .should('have.class', 'mono')
+      .should('contain.text', '**********')
+
+    cy.get(container).find('[data-testid="copy-to-clipboard"]').should('be.visible')
+    cy.get(container).find('.uuid-icon').should('be.visible')
+  })
+
+  it('renders with `format` set to `redacted`', () => {
+    cy.mount(CopyUuid, {
+      props: {
+        uuid,
+        format: 'redacted',
+      },
+    })
+
+    cy.get(container).should('be.visible')
+
+    cy.get(container).find('.uuid-container')
+      .should('have.class', 'truncated-uuid')
+      .should('have.class', 'mono')
+      .should('contain.text', '**********')
+
+    cy.get(container).find('[data-testid="copy-to-clipboard"]').should('be.visible')
+    cy.get(container).find('.uuid-icon').should('be.visible')
+  })
+
+  it('renders with `format` set to `deleted`', () => {
+    cy.mount(CopyUuid, {
+      props: {
+        uuid,
+        format: 'deleted',
       },
     })
 

--- a/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
+++ b/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
@@ -77,12 +77,6 @@ describe('<CopyUuid />', () => {
     })
 
     cy.get(container).should('be.visible')
-
-    cy.get(container).find('.uuid-container')
-      .should('have.class', 'truncated-uuid')
-      .should('have.class', 'mono')
-      .should('contain.text', '**********')
-
     cy.get(container).find('[data-testid="copy-to-clipboard"]').should('be.visible')
     cy.get(container).find('.uuid-icon').should('be.visible')
   })
@@ -100,7 +94,7 @@ describe('<CopyUuid />', () => {
     cy.get(container).find('.uuid-container')
       .should('have.class', 'truncated-uuid')
       .should('have.class', 'mono')
-      .should('contain.text', '**********')
+      .should('contain.text', '*****')
 
     cy.get(container).find('[data-testid="copy-to-clipboard"]').should('be.visible')
     cy.get(container).find('.uuid-icon').should('be.visible')
@@ -119,7 +113,7 @@ describe('<CopyUuid />', () => {
     cy.get(container).find('.uuid-container')
       .should('have.class', 'truncated-uuid')
       .should('have.class', 'mono')
-      .should('contain.text', '**********')
+      .should('contain.text', '*12345')
 
     cy.get(container).find('[data-testid="copy-to-clipboard"]').should('be.visible')
     cy.get(container).find('.uuid-icon').should('be.visible')
@@ -164,12 +158,12 @@ describe('<CopyUuid />', () => {
       })
     })
 
-    it('notify with isHidden', () => {
+    it('notify with format set to hidden', () => {
       const spy = cy.spy(window, 'alert')
       cy.mount(CopyUuid, {
         props: {
           uuid,
-          isHidden: true,
+          format: 'hidden',
           notify: (props: CopyUuidNotifyParam) => {
             window.alert(props.message)
           },
@@ -179,6 +173,42 @@ describe('<CopyUuid />', () => {
       cy.get('[data-testid="copy-to-clipboard"]').click()
       cy.wait(100).then(() => {
         expect(spy).to.be.calledWith('Successfully copied to clipboard')
+      })
+    })
+
+    it('notify with format set to redacted', () => {
+      const spy = cy.spy(window, 'alert')
+      cy.mount(CopyUuid, {
+        props: {
+          uuid,
+          format: 'redacted',
+          notify: (props: CopyUuidNotifyParam) => {
+            window.alert(props.message)
+          },
+        },
+      })
+
+      cy.get('[data-testid="copy-to-clipboard"]').click()
+      cy.wait(100).then(() => {
+        expect(spy).to.be.calledWith('Successfully copied to clipboard')
+      })
+    })
+
+    it('notify with format set to deleted', () => {
+      const spy = cy.spy(window, 'alert')
+      cy.mount(CopyUuid, {
+        props: {
+          uuid: '123',
+          format: 'deleted',
+          notify: (props: CopyUuidNotifyParam) => {
+            window.alert(props.message)
+          },
+        },
+      })
+
+      cy.get('[data-testid="copy-to-clipboard"]').click()
+      cy.wait(100).then(() => {
+        expect(spy).to.be.calledWith('"123" copied to clipboard')
       })
     })
 

--- a/packages/core/copy-uuid/src/components/CopyUuid.vue
+++ b/packages/core/copy-uuid/src/components/CopyUuid.vue
@@ -80,7 +80,7 @@ const props = defineProps({
     default: '',
   },
   format: {
-    type: String,
+    type: String as PropType<'uuid' | 'hidden' | 'redacted' | 'deleted'>,
     required: false,
     default: 'uuid',
     validator: (val: string) => ['uuid', 'hidden', 'redacted', 'deleted'].includes(val),
@@ -142,7 +142,7 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
   }
 
   const isTruncated = props.uuid.length > notifyTrimLength
-  const messagePrefix = `"${props.uuid.substring(0, notifyTrimLength) + (isTruncated ? '...' : '')}"`
+  const messagePrefix = (props.format === 'hidden' || props.format === 'redacted') ? t('message.success.prefix') : `"${props.uuid.substring(0, notifyTrimLength) + (isTruncated ? '...' : '')}"`
 
   if (typeof notify === 'function') {
     notify({

--- a/packages/core/copy-uuid/src/components/CopyUuid.vue
+++ b/packages/core/copy-uuid/src/components/CopyUuid.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="kong-ui-copy-uuid">
     <div
+      v-if="format !== 'hidden'"
       data-testid="copy-id"
       :title="uuid"
     >
@@ -11,7 +12,7 @@
           useMono ? 'mono' : null
         ]"
       >
-        {{ isHidden ? '**********' : uuid }}
+        {{ uuidFormat }}
       </div>
     </div>
     <component
@@ -62,10 +63,6 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
-  isHidden: {
-    type: Boolean,
-    default: false,
-  },
   notify: {
     type: Function as PropType<(param: CopyUuidNotifyParam) => void>,
     default: undefined,
@@ -81,6 +78,12 @@ const props = defineProps({
   successTooltip: {
     type: String,
     default: '',
+  },
+  format: {
+    type: String,
+    required: false,
+    default: 'uuid',
+    validator: (val: string) => ['uuid', 'hidden', 'redacted', 'deleted'].includes(val),
   },
 })
 
@@ -102,6 +105,15 @@ const wrapperProps = computed(() => {
       placement: 'bottomStart',
     }
     : {}
+})
+
+const uuidFormat = computed(() => {
+  if (props.format === 'redacted') {
+    return '*****'
+  } else if (props.format === 'deleted') {
+    return `*${props.uuid.substring(0, 5)}`
+  }
+  return props.uuid
 })
 
 const updateTooltipText = (msg: string): void => {
@@ -130,9 +142,8 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
   }
 
   const isTruncated = props.uuid.length > notifyTrimLength
-  const messagePrefix = props.isHidden
-    ? t('message.success.prefix')
-    : `"${props.uuid.substring(0, notifyTrimLength) + (isTruncated ? '...' : '')}"`
+  const messagePrefix = `"${props.uuid.substring(0, notifyTrimLength) + (isTruncated ? '...' : '')}"`
+
   if (typeof notify === 'function') {
     notify({
       type: 'success',


### PR DESCRIPTION
BREAKING CHANGE: `isHidden` prop no longer available, now supports `format` prop to determine the uuid string display
Addresses:
[https://konghq.atlassian.net/browse/KHCP-8505](https://konghq.atlassian.net/browse/KHCP-8505)
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
