### PR TITLE
feat(entitites): add `consumer-credentials` package

### DIFF
--- a/packages/entities/entities-consumer-credentials/LICENSE
+++ b/packages/entities/entities-consumer-credentials/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Kong, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/entities/entities-consumer-credentials/README.md
+++ b/packages/entities/entities-consumer-credentials/README.md
@@ -1,0 +1,47 @@
+# @kong-ui-public/entities-consumer-credentials
+
+Consumer credential entity components.
+
+- [Requirements](#requirements)
+- [Included components](#included-components)
+- [Usage](#usage)
+  - [Install](#install)
+  - [Registration](#registration)
+- [Individual component documentation](#individual-component-documentation)
+
+## Requirements
+
+- `vue` and `vue-router` must be initialized in the host application
+- `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
+- `@kong-ui-public/copy-uuid` must be available as a `dependency` in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file.
+- `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
+- `axios` must be installed as a dependency in the host application
+
+## Included components
+
+- `ConsumerCredentialList`
+
+Reference the [individual component docs](#individual-component-documentation) for more info.
+
+## Usage
+
+### Install
+
+Install the component in your host application
+
+```sh
+yarn add @kong-ui-public/entities-consumer-credentials
+```
+
+### Registration
+
+Import the component(s) in your host application as well as the package styles
+
+```ts
+import { ConsumerCredentialList } from '@kong-ui-public/entities-consumer-credentials'
+import '@kong-ui-public/entities-consumer-credentials/dist/style.css'
+```
+
+## Individual component documentation
+
+- [`<ConsumerCredentialList.vue />`](docs/consumer-credential-list.md)

--- a/packages/entities/entities-consumer-credentials/docs/consumer-credential-list.md
+++ b/packages/entities/entities-consumer-credentials/docs/consumer-credential-list.md
@@ -1,0 +1,157 @@
+# ConsumerCredentialList.vue
+
+A table component for consumer credentials.
+
+- [Requirements](#requirements)
+- [Usage](#usage)
+  - [Install](#install)
+  - [Props](#props)
+  - [Events](#events)
+  - [Usage example](#usage-example)
+- [TypeScript interfaces](#typescript-interfaces)
+
+## Requirements
+
+- `vue` and `vue-router` must be initialized in the host application
+- `@kong/kongponents` must be added as a `dependency` in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
+- `@kong-ui-public/copy-uuid` must be available as a `dependency` in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file.
+- `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
+- `axios` must be installed as a dependency in the host application
+
+## Usage
+
+### Install
+
+[See instructions for installing the `@kong-ui-public/entities-consumer-credentials` package.](../README.md#install)
+
+### Props
+
+#### `config`
+
+- type: `Object as PropType<KonnectConsumerCredentialListConfig | KongManagerConsumerCredentialListConfig>`
+- required: `true`
+- default: `undefined`
+- properties:
+  - `app`:
+    - type: `'konnect' | 'kongManager'`
+    - required: `true`
+    - default: `undefined`
+    - App name.
+
+  - `apiBaseUrl`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - Base URL for API requests.
+
+  - `requestHeaders`:
+    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+    - required: `false`
+    - default: `undefined`
+    - Additional headers to send with all Axios requests.
+
+  - `createRoute`:
+    - type: `RouteLocationRaw`
+    - required: `true`
+    - default: `undefined`
+    - Route for creating a consumer credential.
+
+  - `getEditRoute`:
+    - type: `(id: string) => RouteLocationRaw`
+    - required: `true`
+    - default: `undefined`
+    - A function that returns the route for editing a consumer credential.
+
+  - `consumerId`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - Current consumer ID.
+
+  - `plugin`:
+    - type: `CredentialPlugins`
+    - required: `true`
+    - default: `undefined`
+    - Current credential plugin name.
+
+  - `workspace`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - *Specific to Kong Manager*. Name of the current workspace.
+
+  - `controlPlaneId`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - *Specific to Konnect*. Name of the current control plane.
+
+The base konnect or kongManger config.
+
+#### `cacheIdentifier`
+
+- type: `String`
+- required: `false`
+- default: `''`
+
+Used to override the default unique identifier for the table's entry in the cache. This should be unique across the Vue App.
+Note: the default value is usually sufficient unless the app needs to support multiple separate instances of the table.
+
+#### `canCreate`
+
+- type: `Function as PropType<() => Promise<boolean>>`
+- required: `false`
+- default: `async () => true`
+
+An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+
+#### `canDelete`
+
+- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- required: `false`
+- default: `async () => true`
+
+An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+
+#### `canEdit`
+
+- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- required: `false`
+- default: `async () => true`
+
+An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+
+### Events
+
+#### error
+
+An `@error` event is emitted when the table fails to fetch consumer credentials or delete a consumer credential. The event payload is the response error.
+
+#### copy:success
+
+A `@copy:success` event is emitted when a consumer credential ID, key, secret or the entity JSON is successfully copied to clipboard. The event payload shape is CopyEventPayload.
+
+#### copy:error
+
+A `@copy:error` event is emitted when an error occurs when trying to copy a consumer credential ID, key, secret or the entity JSON. The event payload shape is CopyEventPayload.
+
+#### delete:success
+
+A `@delete:success` event is emitted when a consumer credential is successfully deleted. The event payload is the consumer credential item data object.
+
+### Usage example
+
+Please refer to the [sandbox](../sandbox/pages/ConsumerCredentialListPage.vue).
+
+## TypeScript interfaces
+
+TypeScript interfaces [are available here](https://github.com/Kong/public-ui-components/blob/main/packages/entities/entities-consumer-credentials/src/types/consumer-credential-list.ts) and can be directly imported into your host application. The following type interfaces are available for import:
+
+```ts
+import type {
+  CredentialPlugins,
+  BaseConsumerCredentialListConfig,
+  KonnectConsumerCredentialListConfig,
+  KongManagerConsumerCredentialListConfig,
+} from '@kong-ui-public/entities-consumer-credentials'
+```

--- a/packages/entities/entities-consumer-credentials/fixtures/mockData.ts
+++ b/packages/entities/entities-consumer-credentials/fixtures/mockData.ts
@@ -1,0 +1,107 @@
+// FetcherRawResponse is the raw format of the endpoint's response
+export interface FetcherRawResponse {
+  data: any[];
+  total: number;
+  offset?: string;
+}
+
+const now = Math.ceil(Date.now() / 1000)
+
+export const basicAuthCredentials: FetcherRawResponse = {
+  data: [
+    {
+      id: '1',
+      username: 'user-1',
+      created_at: now - 1,
+    },
+    {
+      id: '2',
+      username: 'user-2',
+      created_at: now - 2,
+    },
+  ],
+  total: 2,
+}
+
+export const basicAuthCredentials100: any[] = Array(100)
+  .fill(null)
+  .map((_, i) => ({
+    id: `${i + 1}`,
+    username: `user-${i + 1}`,
+    created_at: now - i,
+  }))
+
+export const keyAuthCredentials: FetcherRawResponse = {
+  data: [
+    {
+      id: '1',
+      key: 'key-1',
+      created_at: now - 1,
+    },
+  ],
+  total: 1,
+}
+
+export const keyAuthEncCredentials: FetcherRawResponse = {
+  data: [
+    {
+      id: '1',
+      key: 'key-1',
+      created_at: now - 1,
+    },
+  ],
+  total: 1,
+}
+
+export const oauth2Credentials: FetcherRawResponse = {
+  data: [
+    {
+      id: '1',
+      name: 'oauth2-1',
+      client_id: 'client-id-1',
+      client_secret: 'client-secret-1',
+      created_at: now - 1,
+    },
+  ],
+  total: 1,
+}
+
+export const hmacAuthCredentials: FetcherRawResponse = {
+  data: [
+    {
+      id: '1',
+      username: 'user-1',
+      secret: 'secret-1',
+      created_at: now - 1,
+    },
+  ],
+  total: 1,
+}
+
+export const jwtCredentials: FetcherRawResponse = {
+  data: [
+    {
+      id: '1',
+      key: 'key-1',
+      algorithm: 'algorithm-1',
+      created_at: now - 1,
+    },
+  ],
+  total: 1,
+}
+
+export const paginate = (
+  routes: any[],
+  size: number,
+  _offset: number,
+): FetcherRawResponse => {
+  const sliced = routes.slice(_offset, _offset + size)
+  const offset =
+    _offset + size < routes.length ? String(_offset + size) : undefined
+
+  return {
+    data: sliced,
+    total: sliced.length,
+    offset,
+  }
+}

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@kong-ui-public/entities-consumer-credentials",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/entities-consumer-credentials.umd.js",
+  "module": "./dist/entities-consumer-credentials.es.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/entities-consumer-credentials.es.js",
+      "require": "./dist/entities-consumer-credentials.umd.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": "./dist/*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@kong-ui-public/copy-uuid": "workspace:^",
+    "@kong-ui-public/i18n": "workspace:^",
+    "@kong/kongponents": "^8.116.2",
+    "axios": "^1.4.0",
+    "vue": "^3.3.4",
+    "vue-router": "^4.2.4"
+  },
+  "devDependencies": {
+    "@kong-ui-public/copy-uuid": "workspace:^",
+    "@kong-ui-public/i18n": "workspace:^",
+    "@kong/design-tokens": "^1.8.0",
+    "@kong/kongponents": "^8.116.2",
+    "axios": "^1.4.0",
+    "vue": "^3.3.4",
+    "vue-router": "^4.2.4"
+  },
+  "scripts": {
+    "dev": "cross-env USE_SANDBOX=true vite",
+    "build": "run-s typecheck build:package build:types",
+    "build:package": "vite build -m production",
+    "build:analyzer": "BUILD_VISUALIZER='entities/entities-consumer-credentials' vite build -m production",
+    "build:types": "vue-tsc -p './tsconfig.build.json' --emitDeclarationOnly",
+    "preview:package": "vite preview --port 4173",
+    "preview": "cross-env USE_SANDBOX=true PREVIEW_SANDBOX=true run-s build:package preview:package",
+    "lint": "eslint '**/*.{js,jsx,ts,tsx,vue}' --ignore-path '../../../.eslintignore'",
+    "lint:fix": "eslint '**/*.{js,jsx,ts,tsx,vue}' --ignore-path '../../../.eslintignore' --fix",
+    "stylelint": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}'",
+    "stylelint:fix": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}' --fix",
+    "typecheck": "vue-tsc -p './tsconfig.build.json' --noEmit",
+    "test:component": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress run --component -b chrome --spec './src/**/*.cy.ts' --project '../../../.'",
+    "test:component:open": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress open --component -b chrome --project '../../../.'",
+    "test:unit": "cross-env FORCE_COLOR=1 vitest run",
+    "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/public-ui-components.git",
+    "directory": "packages/entities/entities-consumer-credentials"
+  },
+  "homepage": "https://github.com/Kong/public-ui-components/tree/main/packages/entities/entities-consumer-credentials",
+  "author": "Kong, Inc.",
+  "license": "Apache-2.0",
+  "volta": {
+    "extends": "../../../package.json"
+  },
+  "distSizeChecker": {
+    "errorLimit": "300KB"
+  },
+  "dependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^"
+  }
+}

--- a/packages/entities/entities-consumer-credentials/sandbox/App.vue
+++ b/packages/entities/entities-consumer-credentials/sandbox/App.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="sandbox-container">
+    <main>
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+body, html {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+</style>
+
+<style lang="scss" scoped>
+.sandbox-container {
+  padding: 32px;
+}
+</style>

--- a/packages/entities/entities-consumer-credentials/sandbox/index.html
+++ b/packages/entities/entities-consumer-credentials/sandbox/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EntitiesConsumerCredentials Component Sandbox</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+      html,
+      body {
+        font-family: 'Inter', sans-serif;
+        margin: 0;
+        padding: 0;
+      }
+
+    </style>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+
+</html>

--- a/packages/entities/entities-consumer-credentials/sandbox/index.ts
+++ b/packages/entities/entities-consumer-credentials/sandbox/index.ts
@@ -1,0 +1,48 @@
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import App from './App.vue'
+import Kongponents from '@kong/kongponents'
+import '@kong/kongponents/dist/style.css'
+import CopyUuid from '@kong-ui-public/copy-uuid'
+import '@kong-ui-public/copy-uuid/dist/style.css'
+
+const app = createApp(App)
+
+// Initializing in an async function in order to fetch session and permissions data for the sandbox ONLY.
+// DO NOT DO THIS IN AN ACTUAL APP
+const init = async () => {
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      {
+        path: '/',
+        name: 'home',
+        component: () => import('./pages/HomePage.vue'),
+      },
+      {
+        path: '/consumer-credential-list',
+        name: 'consumer-credential-list',
+        component: () => import('./pages/ConsumerCredentialListPage.vue'),
+      },
+      {
+        path: '/consumer-credential/create',
+        name: 'create-consumer-credential',
+        component: () => import('./pages/FallbackPage.vue'),
+      },
+      {
+        path: '/consumer-credential/:id/edit',
+        name: 'edit-consumer-credential',
+        component: () => import('./pages/FallbackPage.vue'),
+      },
+    ],
+  })
+
+  app.use(Kongponents)
+  app.use(CopyUuid)
+
+  app.use(router)
+
+  app.mount('#app')
+}
+
+init()

--- a/packages/entities/entities-consumer-credentials/sandbox/pages/ConsumerCredentialListPage.vue
+++ b/packages/entities/entities-consumer-credentials/sandbox/pages/ConsumerCredentialListPage.vue
@@ -1,0 +1,98 @@
+<template>
+  <SandboxPermissionsControl
+    @update="handlePermissionsUpdate"
+  />
+  <h2>Konnect API</h2>
+  <ConsumerCredentialList
+    v-if="permissions"
+    :key="key"
+    cache-identifier="konnect"
+    :can-create="permissions.canCreate"
+    :can-delete="permissions.canDelete"
+    :can-edit="permissions.canEdit"
+    :config="konnectConfig"
+    @copy:error="onCopyError"
+    @copy:success="onCopySuccess"
+    @delete:success="onDeleteSuccess"
+    @error="onError"
+  />
+
+  <h2>Kong Manager API</h2>
+  <ConsumerCredentialList
+    v-if="permissions"
+    :key="key"
+    cache-identifier="kong-manager"
+    :can-create="permissions.canCreate"
+    :can-delete="permissions.canDelete"
+    :can-edit="permissions.canEdit"
+    :can-retrieve="permissions.canRetrieve"
+    :config="kongManagerConfig"
+    @copy:error="onCopyError"
+    @copy:success="onCopySuccess"
+    @delete:success="onDeleteSuccess"
+    @error="onError"
+  />
+</template>
+
+<script setup lang="ts">
+import type { AxiosError } from 'axios'
+import { computed, ref } from 'vue'
+import { ConsumerCredentialList, CredentialPlugins } from '../../src'
+import type { KonnectConsumerCredentialListConfig, KongManagerConsumerCredentialListConfig, EntityRow, CopyEventPayload } from '../../src'
+import SandboxPermissionsControl, { PermissionsActions } from '@entities-shared-sandbox/components/SandboxPermissionsControl.vue'
+
+const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
+const konnectConsumerId = import.meta.env.VITE_KONNECT_CONSUMER_ID || ''
+const kongManagerConsumerId = import.meta.env.VITE_KONG_MANAGER_CONSUMER_ID || ''
+
+// For Konnect, the plugin should be one of `acls`, `basic-auth`, `key-auth`, `hmac-auth`, and `jwt`
+// For Kong Manager, the plugin should be one of `acls`, `basic-auth`, `key-auth`, `key-auth-enc`, `oauth2`, `hmac-auth`, and `jwt`
+const activePlugin = ref<CredentialPlugins>('basic-auth')
+
+const konnectConfig = computed<KonnectConsumerCredentialListConfig>(() => ({
+  app: 'konnect',
+  apiBaseUrl: '/us/kong-api/konnect-api', // `/{geo}/kong-api/konnect-api`, with leading slash and no trailing slash; Consuming app would pass in something like `https://us.api.konghq.com`
+  // Set the root `.env.development.local` variable to a control plane your PAT can access
+  controlPlaneId,
+  // Set the root `.env.development.local` variable to a consumer your PAT can access
+  consumerId: konnectConsumerId,
+  plugin: activePlugin.value,
+  createRoute: { name: 'create-consumer-credential' },
+  getEditRoute: (id: string) => ({ name: 'edit-consumer-credential', params: { id } }),
+}))
+
+const kongManagerConfig = computed<KongManagerConsumerCredentialListConfig>(() => ({
+  app: 'kongManager',
+  workspace: 'default',
+  apiBaseUrl: '/kong-manager', // For local dev server proxy
+  // Set the root `.env.development.local` variable to a consumer your PAT can access
+  consumerId: kongManagerConsumerId,
+  plugin: activePlugin.value,
+  createRoute: { name: 'create-consumer-credential' },
+  getEditRoute: (id: string) => ({ name: 'edit-consumer-credential', params: { id } }),
+}))
+
+// Remount the tables in the sandbox when the permission props change; not needed outside of a sandbox
+const key = ref(1)
+const permissions = ref<PermissionsActions | null>(null)
+const handlePermissionsUpdate = (newPermissions: PermissionsActions) => {
+  permissions.value = newPermissions
+  key.value++
+}
+
+const onCopySuccess = (payload: CopyEventPayload) => {
+  console.log(payload.message)
+}
+
+const onCopyError = (payload: CopyEventPayload) => {
+  console.error(payload.message)
+}
+
+const onDeleteSuccess = (row: EntityRow) => {
+  console.log(`${row.id} successfully deleted`)
+}
+
+const onError = (error: AxiosError) => {
+  console.error(`Error: ${error}`)
+}
+</script>

--- a/packages/entities/entities-consumer-credentials/sandbox/pages/FallbackPage.vue
+++ b/packages/entities/entities-consumer-credentials/sandbox/pages/FallbackPage.vue
@@ -1,0 +1,19 @@
+<template>
+  <p>
+    <span>Path: </span>
+    <code>{{ route.path }}</code>
+  </p>
+  <p>
+    <span>Name: </span>
+    <code>{{ route.name }}</code>
+  </p>
+  <p>
+    <span>Params: </span>
+    <code>{{ route.params }}</code>
+  </p>
+</template>
+
+<script setup lang="ts">
+import { useRoute } from 'vue-router'
+const route = useRoute()
+</script>

--- a/packages/entities/entities-consumer-credentials/sandbox/pages/HomePage.vue
+++ b/packages/entities/entities-consumer-credentials/sandbox/pages/HomePage.vue
@@ -1,0 +1,9 @@
+<template>
+  <ul>
+    <li>
+      <router-link :to="{ name: 'consumer-credential-list' }">
+        ConsumerCredentialList
+      </router-link>
+    </li>
+  </ul>
+</template>

--- a/packages/entities/entities-consumer-credentials/sandbox/tsconfig.json
+++ b/packages/entities/entities-consumer-credentials/sandbox/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@entities-shared-sandbox/*": [
+        "../../entities-shared/sandbox/shared/*"
+      ]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.vue",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.cy.ts
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.cy.ts
@@ -1,0 +1,832 @@
+// Cypress component test spec file
+import ConsumerCredentialList from './ConsumerCredentialList.vue'
+import { v4 as uuidv4 } from 'uuid'
+import type { FetcherResponse } from '@kong-ui-public/entities-shared'
+
+import {
+  FetcherRawResponse,
+  paginate,
+  basicAuthCredentials,
+  basicAuthCredentials100,
+  keyAuthCredentials,
+  keyAuthEncCredentials,
+  oauth2Credentials,
+  hmacAuthCredentials,
+  jwtCredentials,
+} from '../../fixtures/mockData'
+import { KonnectConsumerCredentialListConfig, KongManagerConsumerCredentialListConfig } from '../types'
+
+const editRoute = 'edit-route'
+const createRoute = 'create-route'
+
+const baseConfigKonnect: KonnectConsumerCredentialListConfig = {
+  app: 'konnect',
+  controlPlaneId: '1234-abcd-ilove-cats-too',
+  apiBaseUrl: '/us/kong-api/konnect-api',
+  createRoute,
+  getEditRoute: () => editRoute,
+  consumerId: '1234-abcd',
+  plugin: 'basic-auth',
+}
+
+const baseConfigKM: KongManagerConsumerCredentialListConfig = {
+  app: 'kongManager',
+  workspace: 'default',
+  apiBaseUrl: '/kong-manager',
+  createRoute,
+  getEditRoute: () => editRoute,
+  consumerId: '1234-abcd',
+  plugin: 'basic-auth',
+}
+
+describe('<ConsumerCredentialList />', () => {
+  beforeEach(() => {
+    cy.on('uncaught:exception', err => !err.message.includes('ResizeObserver loop limit exceeded'))
+  })
+
+  describe('actions', () => {
+    const intercept = (mockData?: FetcherResponse) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumers/${baseConfigKonnect.consumerId}/*`,
+        },
+        {
+          statusCode: 200,
+          body: mockData ?? {
+            data: [],
+            total: 0,
+          },
+        },
+      )
+    }
+
+    it('should always show the Copy ID action', () => {
+      intercept(basicAuthCredentials)
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.getTestId('k-dropdown-trigger').eq(0).click()
+      cy.getTestId('action-entity-copy-id').should('be.visible')
+    })
+
+    it('should show the Copy Credential action for basic-auth', () => {
+      intercept(basicAuthCredentials)
+
+      cy.mount(ConsumerCredentialList, {
+        cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+        props: {
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.getTestId('k-dropdown-trigger').eq(0).click()
+      cy.getTestId('action-entity-copy-credential').should('be.visible')
+    })
+
+    it('should show the Copy Key action for key-auth', () => {
+      intercept(keyAuthCredentials)
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: {
+            ...baseConfigKonnect,
+            plugin: 'key-auth',
+          },
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.getTestId('k-dropdown-trigger').eq(0).click()
+      cy.getTestId('action-entity-copy-key').should('be.visible')
+    })
+
+    it('should show the Copy Key action for key-auth-enc', () => {
+      intercept(keyAuthEncCredentials)
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: {
+            ...baseConfigKonnect,
+            plugin: 'key-auth-enc',
+          },
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.getTestId('k-dropdown-trigger').eq(0).click()
+      cy.getTestId('action-entity-copy-key').should('be.visible')
+    })
+
+    it('should show the Copy Key action for jwt', () => {
+      intercept(jwtCredentials)
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: {
+            ...baseConfigKonnect,
+            plugin: 'key-auth-enc',
+          },
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.getTestId('k-dropdown-trigger').eq(0).click()
+      cy.getTestId('action-entity-copy-key').should('be.visible')
+    })
+
+    it('should show the Copy Secret action for oauth2', () => {
+      intercept(oauth2Credentials)
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: {
+            ...baseConfigKonnect,
+            plugin: 'hmac-auth',
+          },
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.getTestId('k-dropdown-trigger').eq(0).click()
+      cy.getTestId('action-entity-copy-secret').should('be.visible')
+    })
+
+    it('should show the Copy Secret action for hmac-auth', () => {
+      intercept(hmacAuthCredentials)
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: {
+            ...baseConfigKonnect,
+            plugin: 'hmac-auth',
+          },
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.getTestId('k-dropdown-trigger').eq(0).click()
+      cy.getTestId('action-entity-copy-secret').should('be.visible')
+    })
+
+    for (const expected of [false, true]) {
+      describe(`${expected ? 'allowed' : 'denied'}`, () => {
+        it(`should ${expected ? '' : 'not '}include the Edit action if canEdit evaluates to ${expected}`, () => {
+          intercept(basicAuthCredentials)
+
+          cy.mount(ConsumerCredentialList, {
+            cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+            props: {
+              config: baseConfigKonnect,
+              canCreate: () => {},
+              canEdit: () => expected,
+              canDelete: () => {},
+            },
+          })
+
+          cy.getTestId('k-dropdown-trigger').eq(0).click()
+          cy.getTestId('action-entity-edit').should(`${expected ? '' : 'not.'}exist`)
+        })
+
+        it(`should ${expected ? '' : 'not '}include the Delete action if canDelete evaluates to ${expected}`, () => {
+          intercept(basicAuthCredentials)
+
+          cy.mount(ConsumerCredentialList, {
+            props: {
+              cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+              config: baseConfigKonnect,
+              canCreate: () => {},
+              canEdit: () => {},
+              canDelete: () => expected,
+            },
+          })
+
+          cy.getTestId('k-dropdown-trigger').eq(0).click()
+          cy.getTestId('action-entity-delete').should(`${expected ? '' : 'not.'}exist`)
+        })
+      })
+    }
+  })
+
+  describe('Kong Manager', () => {
+    const interceptKM = (params?: {
+      mockData?: FetcherRawResponse;
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumers/${baseConfigKonnect.consumerId}/*`,
+        },
+        {
+          statusCode: 200,
+          body: params?.mockData ?? {
+            data: [],
+            total: 0,
+          },
+        },
+      ).as(params?.alias ?? 'getCredentials')
+    }
+
+    const interceptKMMultiPage = (params?: {
+      mockData?: FetcherRawResponse[];
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumers/${baseConfigKonnect.consumerId}/*`,
+        },
+        (req) => {
+          const size = req.query.size ? Number(req.query.size) : 30
+          const offset = req.query.offset ? Number(req.query.offset) : 0
+
+          req.reply({
+            statusCode: 200,
+            body: paginate(params?.mockData ?? [], size, offset),
+          })
+        },
+      ).as(params?.alias ?? 'getCredentialsMultiPage')
+    }
+
+    it('should show empty state and create credential cta', () => {
+      interceptKM()
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => true,
+          canEdit: () => true,
+          canDelete: () => true,
+        },
+      })
+
+      cy.wait('@getCredentials')
+      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+      cy.get('.k-table-empty-state').should('be.visible')
+      cy.get('[data-testid="new-basic-auth-credential"]').should('be.visible')
+    })
+
+    it('should hide empty state and create credential cta if user can not create', () => {
+      interceptKM()
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => false,
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getCredentials')
+      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+      cy.get('.k-table-empty-state').should('be.visible')
+      cy.get('[data-testid="new-basic-auth-credential"]').should('not.exist')
+    })
+
+    it('should handle error state', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumers/${baseConfigKonnect.consumerId}/*`,
+        },
+        {
+          statusCode: 500,
+          body: {},
+        },
+      ).as('getCredentials')
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getCredentials')
+      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+      cy.get('.k-table-error-state').should('be.visible')
+    })
+
+    it('should show credential items', () => {
+      interceptKM({
+        mockData: basicAuthCredentials,
+      })
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getCredentials')
+      cy.get('.kong-ui-entities-consumer-credentials-list tr[data-rowid="1"]').should(
+        'exist',
+      )
+      cy.get('.kong-ui-entities-consumer-credentials-list tr[data-rowid="2"]').should(
+        'exist',
+      )
+    })
+
+    it('should allow switching between pages', () => {
+      interceptKMMultiPage({
+        mockData: basicAuthCredentials100,
+      })
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      const l = '.kong-ui-entities-consumer-credentials-list'
+      const p = '[data-testid="k-table-pagination"]'
+
+      cy.wait('@getCredentialsMultiPage')
+
+      // Page #1
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="29"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="30"]`).should('exist')
+
+      cy.get(`${l} ${p}`).should('exist')
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      cy.wait('@getCredentialsMultiPage')
+
+      // Page #2
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr[data-rowid="31"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="32"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="59"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="60"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'not.have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      // Page #4
+      cy.get(`${l} tbody tr`).should('have.length', 10)
+      cy.get(`${l} tbody tr[data-rowid="91"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="92"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="99"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="100"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'not.have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`).should(
+        'have.class',
+        'disabled',
+      )
+    })
+
+    it('should allow picking different page sizes and persist the preference', () => {
+      interceptKMMultiPage({
+        mockData: basicAuthCredentials100,
+      })
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+        .then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      const l = '.kong-ui-entities-consumer-credentials-list'
+      const p = '[data-testid="k-table-pagination"]'
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="29"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="30"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '30 items per page',
+      )
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).click()
+      cy.get(
+        `${l} ${p} [data-testid="page-size-dropdown"] [value="15"]`,
+      ).click()
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 15)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="14"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="15"]`).should('exist')
+
+      // Unmount and mount
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.unmount())
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 15)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="14"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="15"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '15 items per page',
+      )
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).click()
+      cy.get(
+        `${l} ${p} [data-testid="page-size-dropdown"] [value="50"]`,
+      ).click()
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 50)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="49"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="50"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '50 items per page',
+      )
+    })
+  })
+
+  describe('Konnect', () => {
+    const interceptKonnect = (params?: {
+      mockData?: FetcherResponse;
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumers/${baseConfigKonnect.consumerId}/*`,
+        },
+        {
+          statusCode: 200,
+          body: params?.mockData ?? {
+            data: [],
+            total: 0,
+          },
+        },
+      ).as(params?.alias ?? 'getCredentials')
+    }
+
+    const interceptKonnectMultiPage = (params?: {
+      mockData?: FetcherRawResponse[];
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumers/${baseConfigKonnect.consumerId}/*`,
+        },
+        (req) => {
+          const size = req.query.size ? Number(req.query.size) : 30
+          const offset = req.query.offset ? Number(req.query.offset) : 0
+
+          req.reply({
+            statusCode: 200,
+            body: paginate(params?.mockData ?? [], size, offset),
+          })
+        },
+      ).as(params?.alias ?? 'getCredentialsMultiPage')
+    }
+
+    it('should show empty state and create credential cta', () => {
+      interceptKonnect()
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => true,
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.wait('@getCredentials')
+      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+      cy.get('.k-table-empty-state').should('be.visible')
+      cy.get('[data-testid="new-basic-auth-credential"]').should('be.visible')
+    })
+
+    it('should hide empty state and create credential cta if user can not create', () => {
+      interceptKonnect()
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.wait('@getCredentials')
+      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+      cy.get('.k-table-empty-state').should('be.visible')
+      cy.get('[data-testid="new-basic-auth-credential"]').should('not.exist')
+    })
+
+    it('should handle error state', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumers/${baseConfigKonnect.consumerId}/*`,
+        },
+        {
+          statusCode: 500,
+          body: {},
+        },
+      ).as('getCredentials')
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.wait('@getCredentials')
+      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+      cy.get('.k-table-error-state').should('be.visible')
+    })
+
+    it('should show route items', () => {
+      interceptKonnect({
+        mockData: basicAuthCredentials,
+      })
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.wait('@getCredentials')
+      cy.get('.kong-ui-entities-consumer-credentials-list tr[data-rowid="1"]').should(
+        'exist',
+      )
+      cy.get('.kong-ui-entities-consumer-credentials-list tr[data-rowid="2"]').should(
+        'exist',
+      )
+    })
+
+    it('should allow switching between pages', () => {
+      interceptKonnectMultiPage({
+        mockData: basicAuthCredentials100,
+      })
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      const l = '.kong-ui-entities-consumer-credentials-list'
+      const p = '[data-testid="k-table-pagination"]'
+
+      cy.wait('@getCredentialsMultiPage')
+
+      // Page #1
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="29"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="30"]`).should('exist')
+
+      cy.get(`${l} ${p}`).should('exist')
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      cy.wait('@getCredentialsMultiPage')
+
+      // Page #2
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr[data-rowid="31"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="32"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="59"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="60"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'not.have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      // Page #4
+      cy.get(`${l} tbody tr`).should('have.length', 10)
+      cy.get(`${l} tbody tr[data-rowid="91"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="92"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="99"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="100"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'not.have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`).should(
+        'have.class',
+        'disabled',
+      )
+    })
+
+    it('should allow picking different page sizes and persist the preference', () => {
+      interceptKonnectMultiPage({
+        mockData: basicAuthCredentials100,
+      })
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+        .then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      const l = '.kong-ui-entities-consumer-credentials-list'
+      const p = '[data-testid="k-table-pagination"]'
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="29"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="30"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '30 items per page',
+      )
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).click()
+      cy.get(
+        `${l} ${p} [data-testid="page-size-dropdown"] [value="15"]`,
+      ).click()
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 15)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="14"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="15"]`).should('exist')
+
+      // Unmount and mount
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.unmount())
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+        },
+      })
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 15)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="14"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="15"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '15 items per page',
+      )
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).click()
+      cy.get(
+        `${l} ${p} [data-testid="page-size-dropdown"] [value="50"]`,
+      ).click()
+
+      cy.wait('@getCredentialsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 50)
+      cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="2"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="49"]`).should('exist')
+      cy.get(`${l} tbody tr[data-rowid="50"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '50 items per page',
+      )
+    })
+  })
+})

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -1,0 +1,483 @@
+<template>
+  <div class="kong-ui-entities-consumer-credentials-list">
+    <EntityBaseTable
+      :cache-identifier="cacheIdentifier"
+      disable-pagination-page-jump
+      disable-sorting
+      :empty-state-options="emptyStateOptions"
+      enable-entity-actions
+      :error-message="errorMessage"
+      :fetcher="fetcher"
+      :fetcher-cache-key="fetcherCacheKey"
+      pagination-type="offset"
+      preferences-storage-key="kong-ui-entities-consumer-credentials-list"
+      :table-headers="tableHeaders"
+      @sort="resetPagination"
+    >
+      <!-- Create action -->
+      <template #toolbar-button>
+        <PermissionsWrapper :auth-function="() => canCreate()">
+          <KButton
+            appearance="primary"
+            data-testid="toolbar-add-credential"
+            icon="plus"
+            :to="config.createRoute"
+          >
+            {{ t(`credentials.list.toolbar_actions.${config.plugin}.new`) }}
+          </KButton>
+        </PermissionsWrapper>
+      </template>
+
+      <!-- Column Formatting -->
+      <template #group="{ rowValue }">
+        <b>{{ rowValue ?? '-' }}</b>
+      </template>
+      <template #name="{ rowValue }">
+        <b>{{ rowValue ?? '-' }}</b>
+      </template>
+      <template #username="{ rowValue }">
+        <span>{{ rowValue ?? '-' }}</span>
+      </template>
+      <template #password="{ row, rowValue }">
+        <CopyUuid
+          format="redacted"
+          :notify="(param: CopyUuidNotifyParam) => notifyCopyAction(param, row, 'password')"
+          :uuid="rowValue"
+        />
+      </template>
+      <template #key="{ row, rowValue }">
+        <CopyUuid
+          format="redacted"
+          :notify="(param: CopyUuidNotifyParam) => notifyCopyAction(param, row, 'key')"
+          :uuid="rowValue"
+        />
+      </template>
+      <template #client_secret="{ row, rowValue }">
+        <CopyUuid
+          format="redacted"
+          :notify="(param: CopyUuidNotifyParam) => notifyCopyAction(param, row, 'client_secret')"
+          :uuid="rowValue"
+        />
+      </template>
+      <template #secret="{ row, rowValue }">
+        <CopyUuid
+          format="redacted"
+          :notify="(param: CopyUuidNotifyParam) => notifyCopyAction(param, row, 'secret')"
+          :uuid="rowValue"
+        />
+      </template>
+      <template #created_at="{ rowValue }">
+        {{ formatUnixTimeStamp(rowValue) }}
+      </template>
+      <template #tags="{ rowValue }">
+        <KTruncate v-if="rowValue?.length > 0">
+          <KBadge
+            v-for="tag in rowValue"
+            :key="tag"
+            @click.stop
+          >
+            {{ tag }}
+          </KBadge>
+        </KTruncate>
+        <span v-else>-</span>
+      </template>
+
+      <!-- Row actions -->
+      <template #actions="{ row }">
+        <KClipboardProvider v-slot="{ copyToClipboard }">
+          <KDropdownItem
+            data-testid="action-entity-copy-id"
+            @click="copy(row, 'id', copyToClipboard)"
+          >
+            {{ t('credentials.actions.copy_id') }}
+          </KDropdownItem>
+        </KClipboardProvider>
+        <KClipboardProvider
+          v-if="config.plugin === 'basic-auth'"
+          v-slot="{ copyToClipboard }"
+        >
+          <KDropdownItem
+            data-testid="action-entity-copy-credential"
+            @click="copy(row, 'password', copyToClipboard)"
+          >
+            {{ t('credentials.actions.copy_credential') }}
+          </KDropdownItem>
+        </KClipboardProvider>
+        <KClipboardProvider
+          v-if="['key-auth', 'key-auth-enc', 'jwt'].includes(config.plugin)"
+          v-slot="{ copyToClipboard }"
+        >
+          <KDropdownItem
+            data-testid="action-entity-copy-key"
+            @click="copy(row, 'key', copyToClipboard)"
+          >
+            {{ t('credentials.actions.copy_key') }}
+          </KDropdownItem>
+        </KClipboardProvider>
+        <KClipboardProvider
+          v-if="config.plugin === 'oauth2'"
+          v-slot="{ copyToClipboard }"
+        >
+          <KDropdownItem
+            data-testid="action-entity-copy-secret"
+            @click="copy(row, 'client_secret', copyToClipboard)"
+          >
+            {{ t('credentials.actions.copy_secret') }}
+          </KDropdownItem>
+        </KClipboardProvider>
+        <KClipboardProvider
+          v-if="config.plugin === 'hmac-auth'"
+          v-slot="{ copyToClipboard }"
+        >
+          <KDropdownItem
+            data-testid="action-entity-copy-secret"
+            @click="copy(row, 'secret', copyToClipboard)"
+          >
+            {{ t('credentials.actions.copy_secret') }}
+          </KDropdownItem>
+        </KClipboardProvider>
+        <KClipboardProvider v-slot="{ copyToClipboard }">
+          <KDropdownItem
+            data-testid="action-entity-copy-json"
+            @click="copy(row, undefined, copyToClipboard)"
+          >
+            {{ t('credentials.actions.copy_json') }}
+          </KDropdownItem>
+        </KClipboardProvider>
+        <PermissionsWrapper :auth-function="() => canEdit(row)">
+          <KDropdownItem
+            data-testid="action-entity-edit"
+            has-divider
+            :item="getEditDropdownItem(row.id)"
+          />
+        </PermissionsWrapper>
+        <PermissionsWrapper :auth-function="() => canDelete(row)">
+          <KDropdownItem
+            data-testid="action-entity-delete"
+            has-divider
+            is-dangerous
+            @click="deleteRow(row)"
+          >
+            {{ t('credentials.actions.delete') }}
+          </KDropdownItem>
+        </PermissionsWrapper>
+      </template>
+    </EntityBaseTable>
+
+    <EntityDeleteModal
+      :action-pending="isDeletePending"
+      :description="t('credentials.delete.description')"
+      :entity-type="deleteModelEntityType"
+      :error="deleteModalError"
+      :title="t(`credentials.delete.${config.plugin}.title`)"
+      :visible="isDeleteModalVisible"
+      @cancel="hideDeleteModal"
+      @proceed="confirmDelete"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, PropType, ref, watch, onBeforeMount } from 'vue'
+import type { AxiosError } from 'axios'
+import composables from '../composables'
+import endpoints from '../consumer-credentials-endpoints'
+import {
+  EntityBaseTable,
+  EntityDeleteModal,
+  EntityTypes,
+  FetcherStatus,
+  PermissionsWrapper,
+  useAxios,
+  useFetcher,
+  useDeleteUrlBuilder,
+} from '@kong-ui-public/entities-shared'
+import type { CopyUuidNotifyParam } from '@kong-ui-public/copy-uuid'
+import type {
+  CredentialPlugins,
+  KongManagerConsumerCredentialListConfig,
+  KonnectConsumerCredentialListConfig,
+  EntityRow,
+  CopyEventPayload,
+} from '../types'
+import type {
+  BaseTableHeaders,
+  EmptyStateOptions,
+} from '@kong-ui-public/entities-shared'
+import '@kong-ui-public/entities-shared/dist/style.css'
+
+const emit = defineEmits<{
+  (e: 'error', error: AxiosError): void,
+  (e: 'copy:success', payload: CopyEventPayload): void,
+  (e: 'copy:error', payload: CopyEventPayload): void,
+  (e: 'delete:success', credential: EntityRow): void,
+}>()
+
+// Component props - This structure must exist in ALL entity components, with the exclusion of unneeded action props (e.g. if you don't need `canDelete`, just exclude it)
+const props = defineProps({
+  /** The base konnect or kongManger config. Pass additional config props in the shared entity component as needed. */
+  config: {
+    type: Object as PropType<KonnectConsumerCredentialListConfig | KongManagerConsumerCredentialListConfig>,
+    required: true,
+    validator: (config: KonnectConsumerCredentialListConfig | KongManagerConsumerCredentialListConfig): boolean => {
+      if (!config || !['konnect', 'kongManager'].includes(config?.app)) return false
+      if (!config.createRoute || !config.getEditRoute) return false
+      return true
+    },
+  },
+  // used to override the default identifier for the cache entry
+  cacheIdentifier: {
+    type: String,
+    default: '',
+  },
+  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  canCreate: {
+    type: Function as PropType<() => Promise<boolean>>,
+    required: false,
+    default: async () => true,
+  },
+  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  canDelete: {
+    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    required: false,
+    default: async () => true,
+  },
+  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  canEdit: {
+    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    required: false,
+    default: async () => true,
+  },
+})
+
+const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
+
+const { axiosInstance } = useAxios({
+  headers: props.config.requestHeaders,
+})
+const fetcherCacheKey = ref<number>(1)
+
+/**
+ * Table Headers
+ */
+const fields: Record<CredentialPlugins, BaseTableHeaders> = {
+  acls: {
+    group: { label: t('credentials.list.table_headers.acls.group') },
+    created_at: { label: t('credentials.list.table_headers.acls.created_at') },
+    tags: { label: t('credentials.list.table_headers.acls.tags') },
+  },
+  'basic-auth': {
+    password: { label: t('credentials.list.table_headers.basic-auth.password') },
+    username: { label: t('credentials.list.table_headers.basic-auth.username') },
+    created_at: { label: t('credentials.list.table_headers.basic-auth.created_at') },
+    tags: { label: t('credentials.list.table_headers.basic-auth.tags') },
+  },
+  'key-auth': {
+    key: { label: t('credentials.list.table_headers.key-auth.key') },
+    created_at: { label: t('credentials.list.table_headers.key-auth.created_at') },
+    tags: { label: t('credentials.list.table_headers.key-auth.tags') },
+  },
+  'key-auth-enc': {
+    key: { label: t('credentials.list.table_headers.key-auth-enc.key') },
+    created_at: { label: t('credentials.list.table_headers.key-auth-enc.created_at') },
+    tags: { label: t('credentials.list.table_headers.key-auth-enc.tags') },
+  },
+  oauth2: {
+    name: { label: t('credentials.list.table_headers.oauth2.name') },
+    client_id: { label: t('credentials.list.table_headers.oauth2.client_id') },
+    client_secret: { label: t('credentials.list.table_headers.oauth2.client_secret') },
+    created_at: { label: t('credentials.list.table_headers.oauth2.created_at') },
+    tags: { label: t('credentials.list.table_headers.oauth2.tags') },
+  },
+  'hmac-auth': {
+    username: { label: t('credentials.list.table_headers.hmac-auth.username') },
+    secret: { label: t('credentials.list.table_headers.hmac-auth.secret') },
+    created_at: { label: t('credentials.list.table_headers.hmac-auth.created_at') },
+    tags: { label: t('credentials.list.table_headers.hmac-auth.tags') },
+  },
+  jwt: {
+    key: { label: t('credentials.list.table_headers.jwt.key') },
+    algorithm: { label: t('credentials.list.table_headers.jwt.algorithm') },
+    created_at: { label: t('credentials.list.table_headers.jwt.created_at') },
+    tags: { label: t('credentials.list.table_headers.jwt.tags') },
+  },
+}
+const tableHeaders = computed<BaseTableHeaders>(() => fields[props.config.plugin])
+
+/**
+ * Fetcher & Filtering
+ */
+const fetcherBaseUrl = computed((): string => {
+  let url: string = `${props.config.apiBaseUrl}${endpoints.list[props.config.app]}`
+
+  if (props.config.app === 'konnect') {
+    url = url
+      .replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+      .replace(/{consumerId}/gi, props.config.consumerId || '')
+      .replace(/{plugin}/gi, props.config.plugin || '')
+  } else if (props.config.app === 'kongManager') {
+    url = url
+      .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
+      .replace(/{consumerId}/gi, props.config.consumerId || '')
+      .replace(/{plugin}/gi, props.config.plugin || '')
+  }
+
+  return url
+})
+
+const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl)
+
+const resetPagination = (): void => {
+  // Increment the cache key on sort
+  fetcherCacheKey.value++
+}
+
+/**
+ * loading, Error, Empty state
+ */
+const errorMessage = ref<string>('')
+
+/**
+ * Copy action
+ */
+const copy = (entity: EntityRow, field: string | undefined, copyToClipboard: (val: string) => boolean): void => {
+  const val = field ? entity[field] : JSON.stringify(entity)
+  if (!copyToClipboard(val)) {
+    onCopyError(entity, field)
+    return
+  }
+
+  onCopySuccess(entity, field)
+}
+
+const notifyCopyAction = (param: CopyUuidNotifyParam, entity: EntityRow, field: string) => {
+  const { type } = param
+  if (type === 'success') {
+    onCopySuccess(entity, field)
+  } else {
+    onCopyError(entity, field)
+  }
+}
+
+const onCopySuccess = (entity: EntityRow, field: string | undefined) => {
+  // Emit the success event for the host app
+  emit('copy:success', {
+    entity,
+    field,
+    message: field ? t('credentials.copy.success', { val: entity[field] }) : t('credentials.copy.success_brief'),
+  })
+}
+
+const onCopyError = (entity: EntityRow, field: string | undefined) => {
+  // Emit the error event for the host app
+  emit('copy:error', {
+    entity,
+    field,
+    message: t('credentials.error.copy'),
+  })
+}
+
+/**
+ * Edit action
+ */
+// Render the edit dropdown item as a router-link
+const getEditDropdownItem = (id: string) => {
+  return {
+    label: t('credentials.actions.edit'),
+    to: props.config.getEditRoute(id),
+  }
+}
+
+/**
+ * Delete action
+ */
+const itemToBeDeleted = ref<EntityRow | undefined>(undefined)
+const isDeleteModalVisible = ref<boolean>(false)
+const isDeletePending = ref<boolean>(false)
+const deleteModalError = ref<string>('')
+
+const buildDeleteUrl = useDeleteUrlBuilder(props.config, fetcherBaseUrl.value)
+
+const deleteModelEntityType = computed<EntityTypes>(() => {
+  // @ts-ignore
+  return EntityTypes[props.config.plugin]
+})
+
+const deleteRow = (row: EntityRow): void => {
+  itemToBeDeleted.value = row
+  isDeleteModalVisible.value = true
+}
+
+const hideDeleteModal = (): void => {
+  isDeleteModalVisible.value = false
+}
+
+const confirmDelete = async (): Promise<void> => {
+  if (!itemToBeDeleted.value?.id) {
+    return
+  }
+
+  isDeletePending.value = true
+
+  try {
+    await axiosInstance.delete(buildDeleteUrl(itemToBeDeleted.value.id))
+
+    isDeletePending.value = false
+    isDeleteModalVisible.value = false
+    fetcherCacheKey.value++
+
+    // Emit the success event for the host app
+    emit('delete:success', itemToBeDeleted.value)
+  } catch (error: any) {
+    deleteModalError.value = error.response?.data?.message ||
+      error.message ||
+      t('credentials.error.delete')
+
+    // Emit the error event for the host app
+    emit('error', error)
+  } finally {
+    isDeletePending.value = false
+  }
+}
+
+/**
+ * Watchers
+ */
+watch(fetcherState, (state) => {
+  if (state.status === FetcherStatus.Error) {
+    errorMessage.value = t('credentials.error.general')
+    // Emit the error for the host app
+    emit('error', state.error)
+
+    return
+  }
+
+  errorMessage.value = ''
+})
+
+// Initialize the empty state options assuming a user does not have create permissions
+// IMPORTANT: you must initialize this object assuming the user does **NOT** have create permissions so that the onBeforeMount hook can properly evaluate the props.canCreate function.
+const emptyStateOptions = ref<EmptyStateOptions>({
+  ctaPath: props.config.createRoute,
+  ctaText: undefined,
+  message: '',
+  title: t('credentials.title'),
+})
+
+onBeforeMount(async () => {
+  // Evaluate if the user has create permissions
+  const userCanCreate = await props.canCreate()
+
+  // If a user can create, we need to modify the empty state actions/messaging
+  if (userCanCreate) {
+    emptyStateOptions.value.title = t(`credentials.list.empty_state.${props.config.plugin}.title`)
+    emptyStateOptions.value.ctaText = t(`credentials.list.empty_state.${props.config.plugin}.cta`)
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.kong-ui-entities-consumer-credentials-list {
+  width: 100%;
+}
+</style>

--- a/packages/entities/entities-consumer-credentials/src/composables/index.ts
+++ b/packages/entities/entities-consumer-credentials/src/composables/index.ts
@@ -1,0 +1,6 @@
+import useI18n from './useI18n'
+
+// All composables must be exported as part of the default object for Cypress test stubs
+export default {
+  useI18n,
+}

--- a/packages/entities/entities-consumer-credentials/src/composables/useI18n.ts
+++ b/packages/entities/entities-consumer-credentials/src/composables/useI18n.ts
@@ -1,0 +1,11 @@
+import { createI18n, i18nTComponent } from '@kong-ui-public/i18n'
+import english from '../locales/en.json'
+
+export default function useI18n() {
+  const i18n = createI18n<typeof english>('en-us', english)
+
+  return {
+    i18n,
+    i18nT: i18nTComponent<typeof english>(i18n), // Translation component <i18n-t>
+  }
+}

--- a/packages/entities/entities-consumer-credentials/src/consumer-credentials-endpoints.ts
+++ b/packages/entities/entities-consumer-credentials/src/consumer-credentials-endpoints.ts
@@ -1,0 +1,6 @@
+export default {
+  list: {
+    konnect: '/api/runtime_groups/{controlPlaneId}/consumers/{consumerId}/{plugin}',
+    kongManager: '/{workspace}/consumers/{consumerId}/{plugin}',
+  },
+}

--- a/packages/entities/entities-consumer-credentials/src/global-components.d.ts
+++ b/packages/entities/entities-consumer-credentials/src/global-components.d.ts
@@ -1,0 +1,2 @@
+// Import globally available components
+import '@kong/kongponents/dist/types/global-components'

--- a/packages/entities/entities-consumer-credentials/src/index.ts
+++ b/packages/entities/entities-consumer-credentials/src/index.ts
@@ -1,0 +1,5 @@
+import ConsumerCredentialList from './components/ConsumerCredentialList.vue'
+
+export { ConsumerCredentialList }
+
+export * from './types'

--- a/packages/entities/entities-consumer-credentials/src/locales/en.json
+++ b/packages/entities/entities-consumer-credentials/src/locales/en.json
@@ -1,0 +1,144 @@
+{
+  "credentials": {
+    "title": "Consumer Credentials",
+    "list": {
+      "toolbar_actions": {
+        "acls": {
+          "new": "New ACL Credential"
+        },
+        "basic-auth": {
+          "new": "New Basic Auth Credential"
+        },
+        "key-auth": {
+          "new": "New Key Auth Credential"
+        },
+        "key-auth-enc": {
+          "new": "New Key Auth Encrypted Credential"
+        },
+        "oauth2": {
+          "new": "New OAuth 2.0 Credential"
+        },
+        "hmac-auth": {
+          "new": "New HMAC Credential"
+        },
+        "jwt": {
+          "new": "New JWT Credential"
+        }
+      },
+      "table_headers": {
+        "acls": {
+          "group": "Group",
+          "created_at": "Created At",
+          "tags": "Tags"
+        },
+        "basic-auth": {
+          "password": "Credential",
+          "username": "Username",
+          "created_at": "Created at",
+          "tags": "Tags"
+        },
+        "key-auth": {
+          "key": "Key",
+          "created_at": "Created at",
+          "tags": "Tags"
+        },
+        "key-auth-enc": {
+          "key": "Key",
+          "created_at": "Created at",
+          "tags": "Tags"
+        },
+        "oauth2": {
+          "name": "Name",
+          "client_id": "Client ID",
+          "client_secret": "Client secret",
+          "created_at": "Created at",
+          "tags": "Tags"
+        },
+        "hmac-auth": {
+          "username": "Username",
+          "secret": "Secret",
+          "created_at": "Created at",
+          "tags": "Tags"
+        },
+        "jwt": {
+          "key": "Key",
+          "algorithm": "Algorithm",
+          "created_at": "Created at",
+          "tags": "Tags"
+        }
+      },
+      "empty_state": {
+        "acls": {
+          "title": "Configure a New ACL Credential",
+          "cta": "New ACL Credential"
+        },
+        "basic-auth": {
+          "title": "Configure a New Basic Auth Credential",
+          "cta": "New Basic Auth Credential"
+        },
+        "key-auth": {
+          "title": "Configure a New Key Auth Credential",
+          "cta": "New Key Auth Credential"
+        },
+        "key-auth-enc": {
+          "title": "Configure a New Key Auth Encrypted Credential",
+          "cta": "New Key Auth Encrypted Credential"
+        },
+        "oauth2": {
+          "title": "Configure a New OAuth 2.0 Credential",
+          "cta": "New OAuth 2.0 Credential"
+        },
+        "hmac-auth": {
+          "title": "Configure a New HMAC Credential",
+          "cta": "New HMAC Credential"
+        },
+        "jwt": {
+          "title": "Configure a New JWT Credential",
+          "cta": "New JWT Credential"
+        }
+      }
+    },
+    "actions": {
+      "copy_id": "Copy ID",
+      "copy_credential": "Copy Credential",
+      "copy_key": "Copy Key",
+      "copy_secret": "Copy Secret",
+      "copy_json": "Copy JSON",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "delete": {
+      "acls": {
+        "title": "Delete an ACL Credential"
+      },
+      "basic-auth": {
+        "title": "Delete a Basic Auth Credential"
+      },
+      "key-auth": {
+        "title": "Delete a Key Auth Credential"
+      },
+      "key-auth-enc": {
+        "title": "Delete a Key Auth Encrypted Credential"
+      },
+      "oauth2": {
+        "title": "Delete an OAuth 2.0 Credential"
+      },
+      "hmac-auth": {
+        "title": "Delete an HMAC Credential"
+      },
+      "jwt": {
+        "title": "Delete a JWT Credential"
+      },
+      "description": "This action cannot be reversed."
+    },
+    "error": {
+      "general": "Credentials could not be retrieved",
+      "delete": "The credential could not be deleted at this time.",
+      "copy": "Failed to copy to clipboard"
+    },
+    "copy": {
+      "success": "Copied {val} to clipboard",
+      "success_brief": "Successfully copied to clipboard"
+    }
+  }
+}

--- a/packages/entities/entities-consumer-credentials/src/types/consumer-credential-list.ts
+++ b/packages/entities/entities-consumer-credentials/src/types/consumer-credential-list.ts
@@ -1,0 +1,35 @@
+import type { RouteLocationRaw } from 'vue-router'
+import { KongManagerBaseTableConfig, KonnectBaseTableConfig } from '@kong-ui-public/entities-shared'
+
+export type CredentialPlugins = 'acls' | 'basic-auth' | 'key-auth' | 'key-auth-enc' | 'oauth2' | 'hmac-auth' | 'jwt'
+
+export interface BaseConsumerCredentialListConfig {
+  /** Consumer ID */
+  consumerId: string
+  /** Credential plugin name */
+  plugin: CredentialPlugins
+  /** Route for creating a consumer credential */
+  createRoute: RouteLocationRaw
+  /** A function that returns the route for editing a consumer credential */
+  getEditRoute: (id: string) => RouteLocationRaw
+}
+
+/** Konnect consumer credential list config */
+export interface KonnectConsumerCredentialListConfig extends KonnectBaseTableConfig, BaseConsumerCredentialListConfig {}
+
+/** Kong Manager consumer credential list config */
+export interface KongManagerConsumerCredentialListConfig extends KongManagerBaseTableConfig, BaseConsumerCredentialListConfig {}
+
+export interface EntityRow extends Record<string, any> {
+  id: string
+}
+
+/** Copy field event payload */
+export interface CopyEventPayload {
+  /** The entity row */
+  entity: EntityRow
+  /** The field being copied. If omitted, the entity JSON is being copied. */
+  field?: string
+  /** The toaster message */
+  message: string
+}

--- a/packages/entities/entities-consumer-credentials/src/types/index.ts
+++ b/packages/entities/entities-consumer-credentials/src/types/index.ts
@@ -1,0 +1,4 @@
+// Export all types and interfaces from this index.ts
+// The actual types and interfaces should be contained in separate files within this folder.
+
+export * from './consumer-credential-list'

--- a/packages/entities/entities-consumer-credentials/tsconfig.build.json
+++ b/packages/entities/entities-consumer-credentials/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.cy.ts",
+    "src/**/*.spec.ts",
+    "sandbox",
+    "dist"
+  ]
+}

--- a/packages/entities/entities-consumer-credentials/tsconfig.json
+++ b/packages/entities/entities-consumer-credentials/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "declarationDir": "dist/types",
+    "types": [
+      "node",
+      "vite/client",
+      "cypress",
+      "cypress/vue",
+      "../../../cypress/support"
+    ]
+  },
+  "include": [
+    "src/**/*",
+    "sandbox/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/entities/entities-consumer-credentials/vite.config.ts
+++ b/packages/entities/entities-consumer-credentials/vite.config.ts
@@ -1,0 +1,35 @@
+import sharedViteConfig, { getApiProxies, sanitizePackageName } from '../../../vite.config.shared'
+import { resolve } from 'path'
+import { defineConfig, mergeConfig } from 'vite'
+
+// Package name MUST always match the kebab-case package name inside the component's package.json file and the name of your `/packages/{package-name}` directory
+const packageName = 'entities-consumer-credentials'
+const sanitizedPackageName = sanitizePackageName(packageName)
+
+// Merge the shared Vite config with the local one defined below
+const config = mergeConfig(sharedViteConfig, defineConfig({
+  build: {
+    lib: {
+      // The kebab-case name of the exposed global variable. MUST be in the format `kong-ui-public-{package-name}`
+      // Example: name: 'kong-ui-public-demo-component'
+      name: `kong-ui-public-${sanitizedPackageName}`,
+      entry: resolve(__dirname, './src/index.ts'),
+      fileName: (format) => `${sanitizedPackageName}.${format}.js`,
+    },
+  },
+  server: {
+    proxy: {
+      // Add the API proxies to inject the Authorization header
+      ...getApiProxies(),
+    },
+  },
+}))
+
+// If we are trying to preview a build of the local `package/entities-consumer-credentials/sandbox` directory,
+// unset the external and lib properties
+if (process.env.PREVIEW_SANDBOX) {
+  config.build.rollupOptions.external = undefined
+  config.build.lib = undefined
+}
+
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -388,6 +392,34 @@ importers:
       vue:
         specifier: ^3.3.4
         version: 3.3.4
+
+  packages/entities/entities-consumer-credentials:
+    dependencies:
+      '@kong-ui-public/entities-shared':
+        specifier: workspace:^
+        version: link:../entities-shared
+    devDependencies:
+      '@kong-ui-public/copy-uuid':
+        specifier: workspace:^
+        version: link:../../core/copy-uuid
+      '@kong-ui-public/i18n':
+        specifier: workspace:^
+        version: link:../../core/i18n
+      '@kong/design-tokens':
+        specifier: ^1.8.0
+        version: 1.8.0
+      '@kong/kongponents':
+        specifier: ^8.116.2
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
+      axios:
+        specifier: ^1.4.0
+        version: 1.4.0
+      vue:
+        specifier: ^3.3.4
+        version: 3.3.4
+      vue-router:
+        specifier: ^4.2.4
+        version: 4.2.4(vue@3.3.4)
 
   packages/entities/entities-consumer-groups:
     dependencies:
@@ -13856,7 +13888,3 @@ packages:
   /zenscroll@4.0.2:
     resolution: {integrity: sha512-jEA1znR7b4C/NnaycInCU6h/d15ZzCd1jmsruqOKnZP6WXQSMH3W2GL+OXbkruslU4h+Tzuos0HdswzRUk/Vgg==}
     dev: false
-
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Adds `entities-consumer-credentials`. Verified [here](https://github.com/Kong/kong-admin/actions/runs/5817691170?pr=2842).

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
