### PR TITLE
feat(entities): add `consumer-groups` package

### DIFF
--- a/packages/entities/entities-consumer-groups/LICENSE
+++ b/packages/entities/entities-consumer-groups/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Kong, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/entities/entities-consumer-groups/README.md
+++ b/packages/entities/entities-consumer-groups/README.md
@@ -1,0 +1,48 @@
+# @kong-ui-public/entities-consumer-groups
+
+Consumer Groups entity components.
+
+- [Requirements](#requirements)
+- [Included components](#included-components)
+- [Usage](#usage)
+  - [Install](#install)
+  - [Registration](#registration)
+- [Individual component documentation](#individual-component-documentation)
+
+## Requirements
+
+Check the [individual component docs](#individual-component-documentation) for more info.
+
+## Included components
+
+- `ConsumerGroupList`
+- `ConsumerGroupForm`
+- `ConsumerGroupConfigCard`
+
+Reference the [individual component docs](#individual-component-documentation) for more info.
+
+## Usage
+
+### Install
+
+Install the component in your host application
+
+```sh
+yarn add @kong-ui-public/entities-consumer-groups
+```
+
+### Registration
+
+Import the component(s) in your host application as well as the package styles
+
+```ts
+import { ConsumerGroupList, ConsumerGroupForm } from '@kong-ui-public/entities-consumer-groups'
+import '@kong-ui-public/entities-consumer-groups/dist/style.css'
+```
+
+## Individual component documentation
+
+- [`<ConsumerGroupList.vue />`](docs/consumer-group-list.md)
+- [`<ConsumerGroupForm.vue />`](docs/consumer-group-form.md)
+- [`<ConsumerGroupConfigCard.vue />`](docs/consumer-group-config-card.md)
+

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-config-card.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-config-card.md
@@ -1,0 +1,112 @@
+# ConsumerGroupConfigCard.vue
+
+A config card component for consumer groups.
+
+- [Requirements](#requirements)
+- [Usage](#usage)
+  - [Install](#install)
+  - [Props](#props)
+  - [Events](#events)
+  - [Usage example](#usage-example)
+- [TypeScript interfaces](#typescript-interfaces)
+
+## Requirements
+
+- `vue` and `vue-router` must be initialized in the host application
+- `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
+- `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
+- `axios` must be installed as a dependency in the host application
+
+## Usage
+
+### Install
+
+[See instructions for installing the `@kong-ui-public/entities-consumer-groups` package.](../README.md#install)
+
+### Props
+
+#### `config`
+
+- type: `Object as PropType<KonnectConsumerGroupEntityConfig | KongManagerConsumerGroupEntityConfig>`
+- required: `true`
+- default: `undefined`
+- properties:
+  - `app`:
+    - type: `'konnect' | 'kongManager'`
+    - required: `true`
+    - default: `undefined`
+    - App name.
+
+  - `apiBaseUrl`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - Base URL for API requests.
+
+  - `requestHeaders`:
+    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+    - required: `false`
+    - default: `undefined`
+    - Additional headers to send with all Axios requests.
+
+  - `workspace`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - *Specific to Kong Manager*. Name of the current workspace.
+
+  - `controlPlaneId`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - *Specific to Konnect*. Name of the current control plane.
+
+  - `entityId`:
+    - type: `string`
+    - required: `true`
+    - default: `''`
+    - The ID of the Consumer Group to display the config for
+
+The base konnect or kongManger config.
+
+#### `hideTitle`
+
+- type: `Boolean`
+- required: `false`
+- default: `false`
+
+Set this value to `true` to hide the card title.
+
+### Events
+
+#### fetch:error
+
+An `@fetch:error` event is emitted when the form fails to fetch the Consumer Group. The event payload is the response error.
+
+#### fetch:success
+
+A `@fetch:success` event is emitted when the Consumer Group is successfully fetched. The event payload is the Consumer Group object.
+
+#### loading
+
+A `@loading` event is emitted when loading state changes. The event payload is a boolean.
+
+#### copy:success
+
+A `@copy:success` event is emitted when a user clicks the `Copy JSON` button and the JSON object is copied successfully.
+
+### Usage example
+
+Please refer to the [sandbox](../sandbox/pages/ConsumerGroupConfigCardPage.vue). The page is accessible by clicking on the row or `View details` button of an existing Consumer Group.
+
+## TypeScript interfaces
+
+TypeScript interfaces [are available here](../src/types/consumer-group-config-card.ts) and can be directly imported into your host application. The following type interfaces are available for import:
+
+```ts
+import type {
+  ConsumerGroupConfigurationSchema,
+  KonnectConsumerGroupEntityConfig,
+  KongManagerConsumerGroupEntityConfig,
+} from '@kong-ui-public/entities-consumer-groups'
+```

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-form.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-form.md
@@ -1,0 +1,106 @@
+# ConsumerGroupForm.vue
+
+A form component to create/edit Consumer Group.
+
+- [Requirements](#requirements)
+- [Usage](#usage)
+    - [Install](#install)
+    - [Props](#props)
+    - [Events](#events)
+    - [Usage example](#usage-example)
+- [TypeScript interfaces](#typescript-interfaces)
+
+## Requirements
+
+- `vue` and `vue-router` must be initialized in the host application
+- `@kong/kongponents` must be added as a `dependency` in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
+- `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
+- `axios` must be installed as a dependency in the host application
+
+## Usage
+
+### Install
+
+[See instructions for installing the `@kong-ui-public/entities-consumer-groups` package.](../README.md#install)
+
+### Props
+
+#### `config`
+- type: `Object as PropType<KonnectConsumerGroupFormConfig | KongManagerConsumerGroupFormConfig>`
+- required: `true`
+- default: `undefined`
+- properties:
+    - `app`:
+        - type: `'konnect' | 'kongManager'`
+        - required: `true`
+        - default: `undefined`
+        - App name.
+    - `apiBaseUrl`:
+        - type: `string`
+        - required: `true`
+        - default: `undefined`
+        - Base URL for API requests.
+    - `requestHeaders`:
+        - type: `RawAxiosRequestHeaders | AxiosHeaders`
+        - required: `false`
+        - default: `undefined`
+        - Additional headers to send with all Axios requests.
+    - `cancelRoute`:
+        - type: `RouteLocationRaw`
+        - required: `true`
+        - default: `undefined`
+        - Route to return to when canceling creation of a Consumer.
+
+    - `workspace`:
+        - type: `string`
+        - required: `true`
+        - default: `undefined`
+        - *Specific to Kong Manager*. Name of the current workspace.
+
+    - `controlPlaneId`:
+        - type: `string`
+        - required: `true`
+        - default: `undefined`
+        - *Specific to Konnect*. Name of the current control plane.
+
+#### `consumerGroupId`
+- type: `string`
+- required: `false`
+- default: `''`
+- If a valid consumerGroupId is provided, it will put the form in Edit mode instead of Create.
+
+### Events
+
+#### update
+
+A `@update` event is emitted when the form is saved. The event payload has `ConsumerGroupData` interface.
+
+#### error
+
+An `@error` event is emitted when the form fails to fetch Consumer Group data or save Consumer Group data. The event payload is the response error (interface `AxiosError`).
+
+#### loading
+
+A `@loading` event is emitted when loading state changes. The event payload is a boolean.
+
+### Usage example
+
+Please refer to the [sandbox](../sandbox/pages/ConsumerGroupFormPage.vue). The form is accessible by clicking the `+ New Consumer Group` button or `Edit` action of an existing Consumer Group.
+
+## TypeScript interfaces
+
+TypeScript interfaces [are available here](https://github.com/Kong/public-ui-components/blob/main/packages/entities/entities-consumer-groups/src/types/consumer-group-form.ts) and can be directly imported into your host application. The following type interfaces are available for import:
+
+```ts
+import type {
+ BaseConsumerGroupFormConfig,
+ KonnectConsumerGroupFormConfig,
+ KongManagerConsumerGroupFormConfig,
+ ConsumerGroupFields,
+ ConsumerGroupPayload,
+ ConsumerGroupState,
+ Consumer,
+ ConsumerGroupActions,
+ ConsumerGroupData,
+} from '@kong-ui-public/entities-consumer-groups'
+```

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
@@ -1,0 +1,197 @@
+# ConsumerGroupList.vue
+
+A table component for consumer groups.
+
+- [Requirements](#requirements)
+- [Usage](#usage)
+  - [Install](#install)
+  - [Props](#props)
+  - [Events](#events)
+  - [Usage example](#usage-example)
+- [TypeScript interfaces](#typescript-interfaces)
+
+## Requirements
+
+- `vue` and `vue-router` must be initialized in the host application
+- `@kong/kongponents` must be added as a `dependency` in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
+- `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
+- `axios` must be installed as a dependency in the host application
+
+## Usage
+
+### Install
+
+[See instructions for installing the `@kong-ui-public/entities-consumer-groups` package.](../README.md#install)
+
+### Props
+
+#### `config`
+
+- type: `Object as PropType<KonnectConsumerGroupListConfig | KongManagerConsumerGroupListConfig>`
+- required: `true`
+- default: `undefined`
+- properties:
+  - `app`:
+    - type: `'konnect' | 'kongManager'`
+    - required: `true`
+    - default: `undefined`
+    - App name.
+
+  - `apiBaseUrl`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - Base URL for API requests.
+
+  - `requestHeaders`:
+    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+    - required: `false`
+    - default: `undefined`
+    - Additional headers to send with all Axios requests.
+
+  - `createRoute`:
+    - type: `RouteLocationRaw`
+    - required: `true`
+    - default: `undefined`
+    - Route for creating a consumer group.
+
+  - `getViewRoute`:
+    - type: `(id: string) => RouteLocationRaw`
+    - required: `true`
+    - default: `undefined`
+    - A function that returns the route for viewing a consumer group.
+
+  - `getEditRoute`:
+    - type: `(id: string) => RouteLocationRaw`
+    - required: `true`
+    - default: `undefined`
+    - A function that returns the route for editing a consumer group.
+
+  - `consumerId`:
+    - type: `string`
+    - required: `false`
+    - default: `null`
+    - Current consumer id if the ConsumerGroupList in nested in the consumer groups tab on a consumer detail page.
+
+  - `consumerUsername`:
+    - type: `string`
+    - required: `false`
+    - default: `null`
+    - Current consumer username if the ConsumerGroupList in nested in the consumer groups tab on a consumer detail page.
+
+  - `workspace`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - *Specific to Kong Manager*. Name of the current workspace.
+
+  - `isExactMatch`:
+    - type: `boolean`
+    - required: `false`
+    - default: `undefined`
+    - *Specific to Kong Manager*. Whether to use exact match.
+
+  - `disableSorting`:
+    - type: `boolean`
+    - required: `false`
+    - default: `undefined`
+    - *Specific to Kong Manager*. Whether to disable table sorting.
+
+  - `filterSchema`:
+    - type: `FilterSchema`
+    - required: `false`
+    - default: `undefined`
+    - *Specific to Kong Manager*. FilterSchema for fuzzy match.
+
+  - `controlPlaneId`:
+    - type: `string`
+    - required: `true`
+    - default: `undefined`
+    - *Specific to Konnect*. Name of the current control plane.
+
+The base konnect or kongManger config.
+
+#### `cacheIdentifier`
+
+- type: `String`
+- required: `false`
+- default: `''`
+
+Used to override the default unique identifier for the table's entry in the cache. This should be unique across the Vue App.
+Note: the default value is usually sufficient unless the app needs to support multiple separate instances of the table.
+
+#### `canCreate`
+
+- type: `Function as PropType<() => Promise<boolean>>`
+- required: `false`
+- default: `async () => true`
+
+An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+Note: When ConsumerGroupList config specifies a `consumerId` the `canCreate` permission is applied to the action of adding the consumer to another consumer group instead of creating a new consumer group.
+
+#### `canDelete`
+
+- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- required: `false`
+- default: `async () => true`
+
+An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+Note: When ConsumerGroupList config specifies a `consumerId` the `canDelete` permission is applied to the action of exiting from a consumer group instead of deleting a consumer group.
+
+#### `canEdit`
+
+- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- required: `false`
+- default: `async () => true`
+
+An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+
+#### `canRetrieve`
+
+- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- required: `false`
+- default: `async () => true`
+
+An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+
+### Events
+
+#### error
+
+An `@error` event is emitted when the table fails to fetch consumer groups or delete a consumer group. The event payload is the response error.
+
+#### copy:success
+
+A `@copy:success` event is emitted when a consumer group ID or the entity JSON is successfully copied to clipboard. The event payload shape is CopyEventPayload.
+
+#### copy:error
+
+A `@copy:error` event is emitted when an error occurs when trying to copy a consumer group ID or the entity JSON. The event payload shape is CopyEventPayload.
+
+#### delete:success
+
+A `@delete:success` event is emitted when a consumer group is successfully deleted. The event payload is the consumer group item data object.
+
+#### add:success
+
+A `@add:success` event is emitted when the consumer is successfully added to one or more consumer groups. The event payload is an array of the id's of the consumer groups.
+
+#### remove:success
+
+An `@remove:success` event is emitted when the consumer successfully exits a consumer group. The event payload is the consumer group item data object.
+
+### Usage example
+
+Please refer to the [sandbox](../sandbox/pages/ConsumerGroupListPage.vue).
+
+## TypeScript interfaces
+
+TypeScript interfaces [are available here](https://github.com/Kong/public-ui-components/blob/main/packages/entities/entities-consumer-groups/src/types/consumer-group-list.ts) and can be directly imported into your host application. The following type interfaces are available for import:
+
+```ts
+import type {
+  BaseConsumerGroupListConfig,
+  KonnectConsumerGroupListConfig,
+  KongManagerConsumerGroupListConfig,
+} from '@kong-ui-public/entities-consumer-groups'
+```

--- a/packages/entities/entities-consumer-groups/fixtures/mockData.ts
+++ b/packages/entities/entities-consumer-groups/fixtures/mockData.ts
@@ -1,0 +1,126 @@
+// FetcherRawResponse is the raw format of the endpoint's response
+import { Consumer } from '../src'
+
+export type ConsumerGroup = {
+  name: string;
+  consumers_count?: number;
+  id: string;
+  tags?: string[];
+};
+
+export interface FetcherRawResponse<T = any> {
+  data: T[];
+  total: number;
+  offset?: string;
+}
+
+export const consumerGroups5: ConsumerGroup[] = Array(5)
+  .fill(null)
+  .map((_, i) => ({
+    id: `${i + 1}`,
+    name: `consumerGroup.${i + 1}`,
+    consumers_count: i * 10,
+  }))
+
+export const consumerGroups100: ConsumerGroup[] = Array(100)
+  .fill(null)
+  .map((_, i) => ({
+    id: `${i + 1}`,
+    name: `consumerGroup.${i + 1}`,
+    consumers_count: i * 2,
+  }))
+
+export const paginate = (
+  consumerGroups: ConsumerGroup[],
+  size: number,
+  _offset: number,
+): FetcherRawResponse<ConsumerGroup> => {
+  const sliced = consumerGroups.slice(_offset, _offset + size)
+  const offset =
+    _offset + size < consumerGroups.length ? String(_offset + size) : undefined
+
+  return {
+    data: sliced,
+    total: sliced.length,
+    offset,
+  }
+}
+
+export const consumersList5: Consumer[] = Array(5)
+  .fill(null)
+  .map((_, i) => ({
+    created_at: i + 123456,
+    id: `${i + 1}`,
+    tags: [`tag_${i}`],
+    updated_at: i + 133345,
+    username: `existingConsumer.${i + 1}`,
+  }))
+
+export const CreateConsumerGroupKonnectResponse: Record<string, object> = {
+  item: {
+    created_at: 1682620687,
+    id: 'c0b7eac5-6b6d-48ad-bd0d-3253036cfebb',
+    name: 'Test_999',
+    updated_at: 1682620687,
+  },
+}
+
+export const konnectGroup: Record<string, Record<string, any>> = {
+  item: {
+    created_at: 1682602931,
+    id: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+    name: 'Test_create_2',
+    tags: ['tag1', 'tag5'],
+    updated_at: 1682691637,
+  },
+}
+export const CreateConsumerGroupKMResponse: Record<string, number| string> = {
+  created_at: 1682620687,
+  id: 'c0b7eac5-6b6d-48ad-bd0d-3253036cfebb',
+  name: 'Test_999',
+  updated_at: 1682620687,
+}
+
+export const KMGroup: Record<string, Record<string, any>> = {
+  consumer_group: {
+    created_at: 1682697358,
+    id: '45e55c56-eaa2-4913-8d04-1074d50ea93e',
+    name: 'Test',
+    tags: ['tag 1'],
+    updated_at: 1682697358,
+  },
+  consumers: [
+    {
+      created_at: 123457,
+      id: '1',
+      tags: ['tag_1'],
+      updated_at: 133346,
+      username: 'existingConsumer.1',
+    },
+  ],
+}
+export const KMGroup2: Record<string, Record<string, any>> = {
+  consumer_group: {
+    created_at: 1682697358,
+    id: '45e55c56-eaa2-4913-8d04-1074d50ea93e',
+    name: 'Test',
+    tags: ['tag 1'],
+    updated_at: 1682697358,
+  },
+  consumers: [
+    {
+      created_at: 123457,
+      id: '1',
+      tags: ['tag_1'],
+      updated_at: 133346,
+      username: 'existingConsumer.1',
+    },
+    {
+      created_at: 123458,
+      id: '2',
+      tags: ['tag_2'],
+      updated_at: 133347,
+      username: 'existingConsumer.2',
+    },
+  ],
+}

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@kong-ui-public/entities-consumer-groups",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/entities-consumer-groups.umd.js",
+  "module": "./dist/entities-consumer-groups.es.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/entities-consumer-groups.es.js",
+      "require": "./dist/entities-consumer-groups.umd.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": "./dist/*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@kong-ui-public/i18n": "workspace:^",
+    "@kong/kongponents": "^8.116.2",
+    "axios": "^1.4.0",
+    "vue": "^3.3.4",
+    "vue-router": "^4.2.4"
+  },
+  "devDependencies": {
+    "@kong-ui-public/i18n": "workspace:^",
+    "@kong/design-tokens": "^1.8.0",
+    "@kong/kongponents": "^8.116.2",
+    "axios": "^1.4.0",
+    "vue": "^3.3.4",
+    "vue-router": "^4.2.4"
+  },
+  "scripts": {
+    "dev": "cross-env USE_SANDBOX=true vite",
+    "build": "run-s typecheck build:package build:types",
+    "build:package": "vite build -m production",
+    "build:analyzer": "BUILD_VISUALIZER='entities/entities-consumer-groups' vite build -m production",
+    "build:types": "vue-tsc -p './tsconfig.build.json' --emitDeclarationOnly",
+    "preview:package": "vite preview --port 4173",
+    "preview": "cross-env USE_SANDBOX=true PREVIEW_SANDBOX=true run-s build:package preview:package",
+    "lint": "eslint '**/*.{js,jsx,ts,tsx,vue}' --ignore-path '../../../.eslintignore'",
+    "lint:fix": "eslint '**/*.{js,jsx,ts,tsx,vue}' --ignore-path '../../../.eslintignore' --fix",
+    "stylelint": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}'",
+    "stylelint:fix": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}' --fix",
+    "typecheck": "vue-tsc -p './tsconfig.build.json' --noEmit",
+    "test:component": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress run --component -b chrome --spec './src/**/*.cy.ts' --project '../../../.'",
+    "test:component:open": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress open --component -b chrome --project '../../../.'",
+    "test:unit": "cross-env FORCE_COLOR=1 vitest run",
+    "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/public-ui-components.git",
+    "directory": "packages/entities/entities-consumer-groups"
+  },
+  "homepage": "https://github.com/Kong/public-ui-components/tree/main/packages/entities/entities-consumer-groups",
+  "author": "Kong, Inc.",
+  "license": "Apache-2.0",
+  "volta": {
+    "extends": "../../../package.json"
+  },
+  "distSizeChecker": {
+    "errorLimit": "400KB"
+  },
+  "dependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^"
+  }
+}

--- a/packages/entities/entities-consumer-groups/sandbox/App.vue
+++ b/packages/entities/entities-consumer-groups/sandbox/App.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="sandbox-container">
+    <main>
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+body, html {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+</style>
+
+<style lang="scss" scoped>
+.sandbox-container {
+  padding: 32px;
+}
+</style>

--- a/packages/entities/entities-consumer-groups/sandbox/index.html
+++ b/packages/entities/entities-consumer-groups/sandbox/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EntitiesConsumerGroups Component Sandbox</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+      html,
+      body {
+        font-family: 'Inter', sans-serif;
+        margin: 0;
+        padding: 0;
+      }
+
+    </style>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+
+</html>

--- a/packages/entities/entities-consumer-groups/sandbox/index.ts
+++ b/packages/entities/entities-consumer-groups/sandbox/index.ts
@@ -1,0 +1,53 @@
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import App from './App.vue'
+import Kongponents from '@kong/kongponents'
+import '@kong/kongponents/dist/style.css'
+
+const app = createApp(App)
+
+// Initializing in an async function in order to fetch session and permissions data for the sandbox ONLY.
+// DO NOT DO THIS IN AN ACTUAL APP
+const init = async () => {
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      {
+        path: '/',
+        name: 'home',
+        redirect: { name: 'consumer-group-list' },
+      },
+      {
+        path: '/consumer-group-list',
+        name: 'consumer-group-list',
+        component: () => import('./pages/ConsumerGroupListPage.vue'),
+      },
+      {
+        path: '/consumer-group/create',
+        name: 'create-consumer-group',
+        component: () => import('./pages/ConsumerGroupFormPage.vue'),
+        props: true,
+      },
+      {
+        path: '/consumer-group/:id',
+        name: 'view-consumer-group',
+        component: () => import('./pages/ConsumerGroupConfigCardPage.vue'),
+        props: true,
+      },
+      {
+        path: '/consumer-group/:id/edit',
+        name: 'edit-consumer-group',
+        component: () => import('./pages/ConsumerGroupFormPage.vue'),
+        props: true,
+      },
+    ],
+  })
+
+  app.use(Kongponents)
+
+  app.use(router)
+
+  app.mount('#app')
+}
+
+init()

--- a/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupConfigCardPage.vue
+++ b/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupConfigCardPage.vue
@@ -1,0 +1,58 @@
+<template>
+  <h2>Konnect API</h2>
+  <ConsumerGroupConfigCard
+    :config="konnectConfig"
+    @copy:success="onCopy"
+    @fetch:error="onError"
+    @fetch:success="onSuccess"
+  />
+
+  <h2>Kong Manager API</h2>
+  <ConsumerGroupConfigCard
+    :config="kongManagerConfig"
+    @copy:success="onCopy"
+    @fetch:error="onError"
+    @fetch:success="onSuccess"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { AxiosError } from 'axios'
+import type { KonnectConsumerGroupEntityConfig, KongManagerConsumerGroupEntityConfig } from '../../src'
+import { ConsumerGroupConfigCard } from '../../src'
+
+const props = defineProps({
+  /** Grab the ConsumerGroup id from the route params */
+  id: {
+    type: String,
+    required: false,
+    default: '',
+  },
+})
+
+const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
+const konnectConfig = ref<KonnectConsumerGroupEntityConfig>({
+  app: 'konnect',
+  apiBaseUrl: '/us/kong-api/konnect-api', // `/{geo}/kong-api`, with leading slash and no trailing slash; Consuming app would pass in something like `https://us.api.konghq.com`
+  // Set the root `.env.development.local` variable to a control plane your PAT can access
+  controlPlaneId,
+  entityId: props.id,
+})
+const kongManagerConfig = ref<KongManagerConsumerGroupEntityConfig>({
+  app: 'kongManager',
+  workspace: 'default',
+  apiBaseUrl: '/kong-manager', // For local dev server proxy
+  entityId: props.id,
+})
+
+const onError = (error: AxiosError) => {
+  console.log(`Error: ${error}`)
+}
+const onSuccess = (payload: Record<string, any>) => {
+  console.log('fetch:success', payload)
+}
+const onCopy = (payload: Record<string, any>) => {
+  console.log('copy:success', payload)
+}
+</script>

--- a/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupFormPage.vue
+++ b/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupFormPage.vue
@@ -1,0 +1,73 @@
+<template>
+  <div>
+    <h2>Konnect API</h2>
+    <ConsumerGroupForm
+      :config="konnectConfig"
+      :consumer-group-id="id"
+      @error="onError($event)"
+      @loading="onLoading($event)"
+      @update="onUpdate($event)"
+    />
+
+    <h2>Kong Manager API</h2>
+    <ConsumerGroupForm
+      :config="KMConfig"
+      :consumer-group-id="id"
+      @error="onError($event)"
+      @loading="onLoading($event)"
+      @update="onUpdate($event)"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import ConsumerGroupForm from '../../src/components/ConsumerGroupForm.vue'
+import { useRouter } from 'vue-router'
+import { ref } from 'vue'
+import { KongManagerConsumerGroupFormConfig, KonnectConsumerGroupFormConfig } from '../../src'
+import { AxiosError } from 'axios'
+
+const router = useRouter()
+
+defineProps({
+  /** Grab the ConsumerGroup id from the route params */
+  id: {
+    type: String,
+    required: false,
+    default: '',
+  },
+})
+
+const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
+
+const konnectConfig = ref<KonnectConsumerGroupFormConfig>({
+  app: 'konnect',
+  apiBaseUrl: '/us/kong-api/konnect-api',
+  controlPlaneId,
+  cancelRoute: { name: 'consumer-group-list' },
+})
+
+const KMConfig = ref<KongManagerConsumerGroupFormConfig>({
+  app: 'kongManager',
+  workspace: 'default',
+  apiBaseUrl: '/kong-manager', // For local dev server proxy
+  cancelRoute: { name: 'consumer-group-list' },
+})
+
+const onLoading = (val: boolean): void => {
+  console.log(`Loading: ${val}`)
+}
+
+const onError = (val: AxiosError): void => {
+  console.log(`Error: ${val}`)
+}
+
+const onUpdate = (val: Record<string, any>): void => {
+  console.log(`Updated: ${val}`)
+  router.push({ name: 'consumer-group-list' })
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupListPage.vue
+++ b/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupListPage.vue
@@ -1,0 +1,115 @@
+<template>
+  <SandboxPermissionsControl
+    @update="handlePermissionsUpdate"
+  />
+  <h2>Konnect API</h2>
+  <ConsumerGroupList
+    v-if="permissions"
+    :key="key"
+    cache-identifier="konnect"
+    :can-create="permissions.canCreate"
+    :can-delete="permissions.canDelete"
+    :can-edit="permissions.canEdit"
+    :can-retrieve="permissions.canRetrieve"
+    :config="konnectConfig"
+    @add:success="onAddSuccess"
+    @copy:error="onCopyIdError"
+    @copy:success="onCopyIdSuccess"
+    @delete-route:success="onDeleteRouteSuccess"
+    @error="onError"
+    @remove:success="onRemoveSuccess"
+  />
+
+  <h2>Kong Manager API</h2>
+  <ConsumerGroupList
+    v-if="permissions"
+    :key="key"
+    cache-identifier="kong-manager"
+    :can-create="permissions.canCreate"
+    :can-delete="permissions.canDelete"
+    :can-edit="permissions.canEdit"
+    :can-retrieve="permissions.canRetrieve"
+    :config="kongManagerConfig"
+    @add:success="onAddSuccess"
+    @copy:error="onCopyIdError"
+    @copy:success="onCopyIdSuccess"
+    @delete-route:success="onDeleteRouteSuccess"
+    @error="onError"
+    @remove:success="onRemoveSuccess"
+  />
+</template>
+
+<script setup lang="ts">
+import type { AxiosError } from 'axios'
+import { ref } from 'vue'
+import { ConsumerGroupList } from '../../src'
+import type { KonnectConsumerGroupListConfig, KongManagerConsumerGroupListConfig, EntityRow, CopyEventPayload } from '../../src'
+import SandboxPermissionsControl, { PermissionsActions } from '@entities-shared-sandbox/components/SandboxPermissionsControl.vue'
+
+const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
+
+const konnectConfig = ref<KonnectConsumerGroupListConfig>({
+  app: 'konnect',
+  apiBaseUrl: '/us/kong-api/konnect-api', // `/{geo}/kong-api`, with leading slash and no trailing slash; Consuming app would pass in something like `https://us.api.konghq.com`
+  // Set the root `.env.development.local` variable to a control plane your PAT can access
+  controlPlaneId,
+  // Uncomment to test Consumer -> Consumer Groups
+  // consumerId: '48211768-aaf8-44da-b1ba-1a8c388b0975',
+  // consumerUsername: 'c-1',
+  createRoute: { name: 'create-consumer-group' },
+  getViewRoute: (id: string) => ({ name: 'view-consumer-group', params: { id } }),
+  getEditRoute: (id: string) => ({ name: 'edit-consumer-group', params: { id } }),
+})
+
+const kongManagerConfig = ref<KongManagerConsumerGroupListConfig>({
+  app: 'kongManager',
+  workspace: 'default',
+  apiBaseUrl: '/kong-manager', // For local dev server proxy
+  isExactMatch: false,
+  // Uncomment to test Consumer -> Consumer Groups
+  // consumerId: 'b20b1848-6640-4200-9102-73a184de976e',
+  // consumerUsername: 'c-1',
+  createRoute: { name: 'create-consumer-group' },
+  getViewRoute: (id: string) => ({ name: 'view-consumer-group', params: { id } }),
+  getEditRoute: (id: string) => ({ name: 'edit-consumer-group', params: { id } }),
+  filterSchema: {
+    username: {
+      type: 'text',
+    },
+    custom_id: {
+      type: 'text',
+    },
+  },
+})
+
+// Remount the tables in the sandbox when the permission props change; not needed outside of a sandbox
+const key = ref(1)
+const permissions = ref<PermissionsActions | null>(null)
+const handlePermissionsUpdate = (newPermissions: PermissionsActions) => {
+  permissions.value = newPermissions
+  key.value++
+}
+
+const onAddSuccess = (payload: string[]) => {
+  console.log(`Successfully added to ${payload.length} groups`)
+}
+const onRemoveSuccess = () => {
+  console.log('Successfully exited from group')
+}
+
+const onCopyIdSuccess = (payload: CopyEventPayload) => {
+  console.log(payload.message)
+}
+
+const onCopyIdError = (payload: CopyEventPayload) => {
+  console.error(payload.message)
+}
+
+const onDeleteRouteSuccess = (row: EntityRow) => {
+  console.log(`${row.id} successfully deleted`)
+}
+
+const onError = (error: AxiosError) => {
+  console.error(`Error: ${error}`)
+}
+</script>

--- a/packages/entities/entities-consumer-groups/sandbox/tsconfig.json
+++ b/packages/entities/entities-consumer-groups/sandbox/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@entities-shared-sandbox/*": [
+        "../../entities-shared/sandbox/shared/*"
+      ]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.vue",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/entities/entities-consumer-groups/src/components/AddToGroupModal.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/AddToGroupModal.cy.ts
@@ -1,0 +1,242 @@
+import AddToGroupModal from './AddToGroupModal.vue'
+import { KongManagerConsumerGroupListConfig, KonnectConsumerGroupListConfig } from '../types'
+import { ConsumerGroup, consumerGroups5 } from '../../fixtures/mockData'
+import { KPrompt } from '@kong/kongponents'
+
+describe('<AddToGroupModal/>', () => {
+  describe('Konnect', () => {
+    const configGroupKonnect: KonnectConsumerGroupListConfig = {
+      app: 'konnect',
+      controlPlaneId: '1234-asdf-asdf-asdf',
+      apiBaseUrl: '/us/kong-api/konnect-api',
+      createRoute: 'create-consumer-group',
+      getViewRoute: () => 'view-consumer-group',
+      getEditRoute: () => 'edit-consumer-group',
+      consumerId: '5921d16a-3e1d-4936-b21f-e5cae587415c',
+      consumerUsername: 'Test Consumer',
+    }
+
+    const interceptFilters = (params?: {
+      mockData?: ConsumerGroup[];
+      alias?: string;
+    }): void => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${configGroupKonnect.apiBaseUrl}/api/runtime_groups/${configGroupKonnect.controlPlaneId}/consumer_groups*`,
+        },
+        {
+          statusCode: 200,
+          body: {
+            data: params?.mockData ?? [],
+            total: params?.mockData?.length ?? 0,
+          },
+        },
+      ).as(params?.alias ?? 'interceptFilters')
+    }
+
+    const interceptSubmission = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${configGroupKonnect.apiBaseUrl}/api/runtime_groups/${configGroupKonnect.controlPlaneId}/consumers/${configGroupKonnect.consumerId}/consumer_groups`,
+        },
+        {
+          statusCode: status,
+          body: {},
+        },
+      ).as('interceptSubmission')
+    }
+
+    it('should render correctly', () => {
+      interceptFilters()
+
+      cy.mount(AddToGroupModal, {
+        props: {
+          config: configGroupKonnect,
+          visible: true,
+        },
+      })
+
+      cy.wait('@interceptFilters')
+
+      cy.getTestId('add-to-group-modal').should('exist')
+      cy.get('.k-prompt-body .k-multiselect').should('exist')
+      cy.get('.k-prompt-action-buttons .k-prompt-cancel').should('exist')
+      cy.get('.k-prompt-action-buttons .k-prompt-proceed').should('exist')
+    })
+
+    it('should emit cancel event when KPrompt emits canceled event', () => {
+      interceptFilters()
+
+      cy.mount(AddToGroupModal, {
+        props: {
+          config: configGroupKonnect,
+          visible: true,
+          onCancel: cy.spy().as('cancelSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@interceptFilters')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(KPrompt)
+        .vm.$emit('canceled'))
+
+      cy.get('@cancelSpy').should('have.been.called')
+    })
+
+    it('should emit add:success event when KPrompt emits proceed event', () => {
+      interceptFilters({
+        mockData: consumerGroups5,
+      })
+      interceptSubmission()
+
+      cy.mount(AddToGroupModal, {
+        props: {
+          config: configGroupKonnect,
+          visible: true,
+          'onAdd:success': cy.spy().as('addSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@interceptFilters')
+
+      cy.getTestId('k-multiselect-trigger').should('be.visible')
+      cy.getTestId('k-multiselect-trigger').click()
+
+      cy.get('.k-popover-content .k-multiselect-list').should('be.visible')
+      cy.get('.k-popover-content .k-multiselect-list .k-multiselect-item').should('be.visible')
+      cy.get('.k-popover-content .k-multiselect-list .k-multiselect-item').should('have.length', 5)
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.getComponent('.k-multiselect')
+        .vm.$emit('update:modelValue', [consumerGroups5[0].id]))
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(KPrompt)
+        .vm.$emit('proceed'))
+
+      cy.wait('@interceptSubmission')
+
+      cy.get('@addSpy').should('have.been.called')
+    })
+  })
+
+  describe('Kong Manager', () => {
+    const configGroupKM: KongManagerConsumerGroupListConfig = {
+      app: 'kongManager',
+      workspace: 'default',
+      apiBaseUrl: '/kong-manager',
+      isExactMatch: false,
+      filterSchema: {},
+      createRoute: 'create-consumer-group',
+      getViewRoute: () => 'view-consumer-group',
+      getEditRoute: () => 'edit-consumer-group',
+      consumerId: '5921d16a-3e1d-4936-b21f-e5cae587415c',
+      consumerUsername: 'Test Consumer',
+    }
+
+    const interceptFilters = (params?: {
+      mockData?: ConsumerGroup[];
+      alias?: string;
+    }): void => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${configGroupKM.apiBaseUrl}/${configGroupKM.workspace}/consumer_groups*`,
+        },
+        {
+          statusCode: 200,
+          body: {
+            data: params?.mockData ?? [],
+            total: params?.mockData?.length ?? 0,
+          },
+        },
+      ).as(params?.alias ?? 'interceptFilters')
+    }
+
+    const interceptSubmission = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${configGroupKM.apiBaseUrl}/${configGroupKM.workspace}/consumers/${configGroupKM.consumerId}/consumer_groups`,
+        },
+        {
+          statusCode: status,
+          body: {},
+        },
+      ).as('interceptSubmission')
+    }
+
+    it('should render correctly', () => {
+      interceptFilters()
+
+      cy.mount(AddToGroupModal, {
+        props: {
+          config: configGroupKM,
+          visible: true,
+        },
+      })
+
+      cy.wait('@interceptFilters')
+
+      cy.getTestId('add-to-group-modal').should('exist')
+      cy.get('.k-prompt-body .k-multiselect').should('exist')
+      cy.get('.k-prompt-action-buttons .k-prompt-cancel').should('exist')
+      cy.get('.k-prompt-action-buttons .k-prompt-proceed').should('exist')
+    })
+
+    it('should emit cancel event when KPrompt emits canceled event', () => {
+      interceptFilters()
+
+      cy.mount(AddToGroupModal, {
+        props: {
+          config: configGroupKM,
+          visible: true,
+          onCancel: cy.spy().as('cancelSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@interceptFilters')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(KPrompt)
+        .vm.$emit('canceled'))
+
+      cy.get('@cancelSpy').should('have.been.called')
+    })
+
+    it('should emit add:success event when KPrompt emits proceed event', () => {
+      interceptFilters({
+        mockData: consumerGroups5,
+      })
+      interceptSubmission()
+
+      cy.mount(AddToGroupModal, {
+        props: {
+          config: configGroupKM,
+          visible: true,
+          'onAdd:success': cy.spy().as('addSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@interceptFilters')
+
+      cy.getTestId('k-multiselect-trigger').should('be.visible')
+      cy.getTestId('k-multiselect-trigger').click()
+
+      cy.get('.k-popover-content .k-multiselect-list').should('be.visible')
+      cy.get('.k-popover-content .k-multiselect-list .k-multiselect-item').should('be.visible')
+      cy.get('.k-popover-content .k-multiselect-list .k-multiselect-item').should('have.length', 5)
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.getComponent('.k-multiselect')
+        .vm.$emit('update:modelValue', [consumerGroups5[0].id]))
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(KPrompt)
+        .vm.$emit('proceed'))
+
+      cy.wait('@interceptSubmission')
+
+      cy.get('@addSpy').should('have.been.called')
+    })
+  })
+})

--- a/packages/entities/entities-consumer-groups/src/components/AddToGroupModal.vue
+++ b/packages/entities/entities-consumer-groups/src/components/AddToGroupModal.vue
@@ -1,0 +1,275 @@
+<template>
+  <KPrompt
+    :action-pending="isPending"
+    class="kong-ui-entities-add-to-groups-modal"
+    data-testid="add-to-group-modal"
+    :is-visible="visible"
+    :title="t('consumer_groups.consumers.add.title')"
+    @canceled="cancel"
+    @proceed="addToConsumerGroups"
+  >
+    <template #body-content>
+      <div class="add-to-group-form-container">
+        <p class="add-to-group-cta-text">
+          {{ t('consumer_groups.consumers.add.ctaText') }}
+        </p>
+        <KMultiselect
+          v-model="selectedConsumerGroups"
+          autosuggest
+          data-testid="add-to-groups-multiselect"
+          :dropdown-footer-text="additionalRecordsExist ? t('consumer_groups.consumers.add.footer') : undefined"
+          :items="availableConsumerGroups"
+          :label="t('consumer_groups.consumers.add.consumer_groups_label')"
+          :loading="loading"
+          :placeholder="t('consumer_groups.consumers.add.consumer_group_placeholder')"
+          :readonly="isPending"
+          required
+          width="100%"
+          @query-change="debouncedQueryChange"
+        />
+        <div
+          v-if="error || fetchErrorMessage || errorArray.length"
+          class="kong-ui-entity-add-to-groups-error"
+        >
+          <KAlert appearance="danger">
+            <template #alertMessage>
+              <p>{{ t('consumer_groups.errors.add') }}</p>
+              <ul v-if="errorArray.length">
+                <li
+                  v-for="(err, idx) in errorArray"
+                  :key="idx"
+                >
+                  {{ err }}
+                </li>
+              </ul>
+              <div>
+                {{ error || fetchErrorMessage }}
+              </div>
+            </template>
+          </KAlert>
+        </div>
+      </div>
+    </template>
+  </KPrompt>
+</template>
+
+<script setup lang="ts">
+import { computed, PropType, ref, watch, onBeforeMount } from 'vue'
+import type {
+  KongManagerConsumerGroupListConfig,
+  KonnectConsumerGroupListConfig,
+} from '../types'
+import { useDebouncedFilter, useAxios } from '@kong-ui-public/entities-shared'
+import composables from '../composables'
+import endpoints from '../consumer-groups-endpoints'
+import { MultiselectItem } from '@kong/kongponents'
+
+const { i18n: { t } } = composables.useI18n()
+
+const props = defineProps({
+  /** The base konnect or kongManger config. Pass additional config props in the shared entity component as needed. */
+  config: {
+    type: Object as PropType<KonnectConsumerGroupListConfig | KongManagerConsumerGroupListConfig>,
+    required: true,
+    validator: (config: KonnectConsumerGroupListConfig | KongManagerConsumerGroupListConfig): boolean => {
+      if (!config || !['konnect', 'kongManager'].includes(config?.app)) return false
+      if (!config.consumerId) return false
+      return true
+    },
+  },
+  visible: {
+    type: Boolean,
+    required: true,
+    default: false,
+  },
+})
+
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'add:success', consumers: string[]): void
+  (e: 'add:partial-success', consumers: string[]): void
+  (e: 'error', msg: string): void
+}>()
+
+const { axiosInstance } = useAxios({
+  headers: props.config?.requestHeaders,
+})
+
+/**
+ * ------------------------------
+ * Consumer Handling
+ * ------------------------------
+ */
+// Multiselect
+const selectedConsumerGroups = ref<string[]>([])
+const {
+  debouncedQueryChange,
+  loading,
+  allRecords,
+  error: fetchError,
+  loadItems,
+  results,
+} = useDebouncedFilter(
+  props.config,
+  endpoints.list[props.config.app].all,
+  '',
+  {
+    fetchedItemsKey: 'data',
+    searchKeys: ['name', 'id'],
+  },
+)
+
+const fetchErrorMessage = computed((): string => fetchError.value ? t('consumer_groups.errors.general') : '')
+const consumerGroupsSelectKey = ref<number>(0)
+// this will only be defined if we were able to initially fetch ALL available records
+const additionalRecordsExist = computed((): boolean => allRecords.value === undefined)
+
+const availableConsumerGroups = computed((): MultiselectItem[] => {
+  return results.value.map((record: Record<string, any>) => ({
+    label: record.name,
+    value: record.id,
+    selected: selectedConsumerGroups.value.includes(record.id),
+    data: record, // we need this to determine whether or not to show the description text
+  }))
+})
+
+const getConsumerGroupIdentifier = (consumerGroupId: string): string => {
+  const consumerGroup = additionalRecordsExist.value
+    ? results.value.find(con => con.id === consumerGroupId)
+    : allRecords.value?.find(con => con.id === consumerGroupId)
+
+  if (consumerGroup) {
+    return consumerGroup.name
+  }
+
+  return consumerGroupId
+}
+
+const cancel = () => {
+  error.value = ''
+  successArray.value = []
+  errorArray.value = []
+  emit('cancel')
+}
+
+// Add
+const successArray = ref<string[]>([])
+const isPending = ref(false)
+const error = ref('')
+const addToConsumerGroups = async (): Promise<void> => {
+  if (!selectedConsumerGroups.value.length) {
+    error.value = ''
+    errorArray.value = []
+    emit('cancel')
+    return
+  }
+
+  isPending.value = true
+  error.value = ''
+  successArray.value = []
+  errorArray.value = []
+
+  try {
+    const bulkOperation = selectedConsumerGroups.value.map(consumerGroupId => addConsumerToGroup(consumerGroupId))
+
+    const results = await Promise.allSettled(bulkOperation)
+
+    let allPass = true
+
+    results.forEach(result => {
+      if (result.status !== 'fulfilled') {
+        allPass = false
+      }
+    })
+
+    if (allPass) {
+      successArray.value = []
+      errorArray.value = []
+      // Emit the success event for the host app
+      emit('add:success', selectedConsumerGroups.value)
+      selectedConsumerGroups.value = []
+    } else {
+      if (successArray.value.length) {
+        emit('add:partial-success', successArray.value)
+      }
+
+      selectedConsumerGroups.value = []
+      handleBulkError(results)
+    }
+  } catch (_err: any) {
+    error.value = t('consumer_groups.errors.add')
+
+    // Emit the error event for the host app
+    emit('error', error.value)
+  } finally {
+    isPending.value = false
+  }
+}
+
+const submitUrl = computed((): string => {
+  let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app].forConsumer}`
+
+  if (props.config.app === 'konnect') {
+    url = url
+      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
+      .replace(/{consumerId}/gi, props.config?.consumerId || '')
+  } else if (props.config.app === 'kongManager') {
+    url = url
+      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+      .replace(/{consumerId}/gi, props.config?.consumerId || '')
+  }
+
+  return url
+})
+
+const addConsumerToGroup = async (consumerGroupId: string): Promise<any> => {
+  const payload = {
+    group: consumerGroupId,
+  }
+  try {
+    const res = await axiosInstance.post(submitUrl.value, payload)
+
+    successArray.value.push(consumerGroupId)
+
+    return res
+  } catch (error: any) {
+    let msg = `${getConsumerGroupIdentifier(consumerGroupId)} - ${error.message}`
+
+    if (error.response.status === 409) {
+      msg = `${getConsumerGroupIdentifier(consumerGroupId)} - ${t('consumer_groups.errors.already_added')}`
+    }
+
+    return Promise.reject(Error(msg))
+  }
+}
+
+const errorArray = ref<string[]>([])
+const handleBulkError = (array: any[]): void => {
+  errorArray.value = array.map(err => err.reason?.message).filter(Boolean)
+}
+
+watch(availableConsumerGroups, () => {
+  consumerGroupsSelectKey.value++
+}, { immediate: true, deep: true })
+
+onBeforeMount(async () => {
+  // load consumer groups
+  await loadItems()
+})
+</script>
+
+<style lang="scss" scoped>
+.kong-ui-entities-add-to-groups-modal {
+  .add-to-group-cta-text {
+    margin-top: 0;
+  }
+
+  .add-to-group-form-container {
+    margin-bottom: 20px;
+
+    .kong-ui-entity-add-to-groups-error {
+      margin-top: 16px;
+    }
+  }
+}
+</style>

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupConfigCard.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupConfigCard.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="kong-ui-consumer-group-entity-config-card">
+    <EntityBaseConfigCard
+      :config="config"
+      :config-schema="configSchema"
+      data-key="consumer_group"
+      :fetch-url="fetchUrl"
+      :hide-title="hideTitle"
+      @copy:success="(entity: any) => $emit('copy:success', entity)"
+      @fetch:error="(err: any) => $emit('fetch:error', err)"
+      @fetch:success="(entity: any) => $emit('fetch:success', entity)"
+      @loading="(val: boolean) => $emit('loading', val)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, PropType } from 'vue'
+import type { AxiosError } from 'axios'
+import type { KongManagerConsumerGroupEntityConfig, KonnectConsumerGroupEntityConfig, ConsumerGroupConfigurationSchema } from '../types'
+import { EntityBaseConfigCard } from '@kong-ui-public/entities-shared'
+import endpoints from '../consumer-groups-endpoints'
+import composables from '../composables'
+import '@kong-ui-public/entities-shared/dist/style.css'
+
+defineEmits<{
+  (e: 'loading', isLoading: boolean): void
+  (e: 'fetch:error', error: AxiosError): void,
+  (e: 'fetch:success', data: Record<string, any>): void,
+  (e: 'copy:success', data: Record<string, any>): void,
+}>()
+
+// Component props - This structure must exist in ALL entity components, with the exclusion of unneeded action props (e.g. if you don't need `canDelete`, just exclude it)
+const props = defineProps({
+  /** The base konnect or kongManger config. Pass additional config props in the shared entity component as needed. */
+  config: {
+    type: Object as PropType<KonnectConsumerGroupEntityConfig | KongManagerConsumerGroupEntityConfig>,
+    required: true,
+    validator: (config: KonnectConsumerGroupEntityConfig | KongManagerConsumerGroupEntityConfig): boolean => {
+      if (!config || !['konnect', 'kongManager'].includes(config?.app)) return false
+      if (config.app === 'konnect' && !config.controlPlaneId) return false
+      if (config.app === 'kongManager' && typeof config.workspace !== 'string') return false
+      if (!config.entityId) return false
+      return true
+    },
+  },
+  /**
+   * Control visibility of card title content
+   */
+  hideTitle: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const { i18n: { t } } = composables.useI18n()
+const fetchUrl = computed((): string => endpoints.form[props.config.app].edit)
+
+const configSchema = ref<ConsumerGroupConfigurationSchema>({
+  id: {},
+  name: {},
+  created_at: {},
+  updated_at: {},
+  tags: {
+    tooltip: t('consumer_groups.form.fields.tags.tooltip'),
+  },
+})
+</script>

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.cy.ts
@@ -1,0 +1,854 @@
+import ConsumerGroupForm from './ConsumerGroupForm.vue'
+import { Consumer, KongManagerConsumerGroupFormConfig, KonnectConsumerGroupFormConfig } from '../types'
+import {
+  consumersList5,
+  CreateConsumerGroupKMResponse,
+  CreateConsumerGroupKonnectResponse, KMGroup, KMGroup2,
+  konnectGroup,
+} from '../../fixtures/mockData'
+import { EntityBaseForm } from '@kong-ui-public/entities-shared'
+import { AxiosError } from 'axios'
+
+const cancelRoute = { name: 'consumer-group-list' }
+
+const konnectConfig: KonnectConsumerGroupFormConfig = {
+  app: 'konnect',
+  controlPlaneId: 'f0acb165-ff05-4788-aa06-6909b8d1694e',
+  apiBaseUrl: '/us/kong-api/konnect-api',
+  cancelRoute,
+}
+
+const KMConfig: KongManagerConsumerGroupFormConfig = {
+  app: 'kongManager',
+  workspace: 'default',
+  apiBaseUrl: '/kong-manager',
+  cancelRoute,
+}
+
+describe('<ConsumerGroupForm />', () => {
+  describe('Konnect', () => {
+    const interceptFetchingList = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${konnectConfig.apiBaseUrl}/api/runtime_groups/${konnectConfig.controlPlaneId}/consumers*`,
+        },
+        {
+          statusCode: status,
+          body: { data: consumersList5 },
+        },
+      ).as('fetchList')
+    }
+    const interceptCreate = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${konnectConfig.apiBaseUrl}/api/runtime_groups/${konnectConfig.controlPlaneId}/consumer_groups`,
+        },
+        {
+          statusCode: status,
+          body: CreateConsumerGroupKonnectResponse,
+        },
+      ).as('createGroup')
+    }
+    const interceptUpdate = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${konnectConfig.apiBaseUrl}/api/runtime_groups/${konnectConfig.controlPlaneId}/consumer_groups/*`,
+        },
+        {
+          statusCode: status,
+          body: CreateConsumerGroupKonnectResponse,
+        },
+      ).as('updateGroup')
+    }
+    const interceptFetchGroupData = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${konnectConfig.apiBaseUrl}/api/runtime_groups/${konnectConfig.controlPlaneId}/consumer_groups/*`,
+        },
+        {
+          statusCode: status,
+          body: konnectGroup,
+        },
+      ).as('fetchGroupData')
+    }
+    const interceptGetConsumers = (status = 200, response?: Consumer[]): void => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${konnectConfig.apiBaseUrl}/api/runtime_groups/${konnectConfig.controlPlaneId}/consumer_groups/*/consumers`,
+        },
+        {
+          statusCode: status,
+          body: { consumers: response || [consumersList5[0]] },
+        },
+      ).as('getConsumers')
+    }
+    const interceptAddConsumer = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${konnectConfig.apiBaseUrl}/api/runtime_groups/${konnectConfig.controlPlaneId}/consumer_groups/*/consumers`,
+        },
+        {
+          statusCode: status,
+          body: {},
+        },
+      ).as('addConsumer')
+    }
+    const interceptRemoveConsumer = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'DELETE',
+          url: `${konnectConfig.apiBaseUrl}/api/runtime_groups/${konnectConfig.controlPlaneId}/consumer_groups/*/consumers/*`,
+        },
+        {
+          statusCode: status,
+          body: {},
+        },
+      ).as('removeConsumer')
+    }
+
+    it('Create form should be rendered correctly', () => {
+      interceptFetchingList()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+        },
+      })
+
+      cy.wait('@fetchList')
+
+      cy.get('.kong-ui-entities-consumer-group-form').should('be.visible')
+      cy.get('.kong-ui-entities-consumer-group-form form').should('be.visible')
+
+      cy.getTestId('consumer-group-form-name').should('be.visible')
+      cy.getTestId('consumer-group-form-tags').should('be.visible')
+      cy.getTestId('k-multiselect-trigger').should('be.visible')
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get('.k-multiselect-popover').should('be.visible')
+      cy.get('.k-multiselect-popover .k-multiselect-item').should('have.length', 5)
+
+      cy.getTestId('form-cancel').should('be.visible')
+      cy.getTestId('form-cancel').should('be.enabled')
+      cy.getTestId('form-submit').should('be.visible')
+      cy.getTestId('form-submit').should('be.disabled')
+    })
+
+    it('Submit button should be enabled if name field is filled in correctly', () => {
+      interceptFetchingList()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+        },
+      })
+
+      cy.wait('@fetchList')
+
+      cy.getTestId('form-submit').should('be.visible')
+      cy.getTestId('form-submit').should('be.disabled')
+
+      cy.getTestId('consumer-group-form-name').type('test_name')
+
+      cy.getTestId('form-submit').should('be.enabled')
+    })
+
+    it('loading event should be emitted when EntityBaseForm emits loading event', () => {
+      interceptFetchingList()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          onLoading: cy.spy().as('onLoadingSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('loading', true))
+
+      cy.get('@onLoadingSpy').should('have.been.calledWith', true)
+    })
+
+    it('error event should be emitted when EntityBaseForm emits fetch:error event', () => {
+      interceptFetchingList()
+
+      const expectedError: AxiosError = {
+        isAxiosError: false,
+        toJSON(): object {
+          return {}
+        },
+        message: 'error',
+        name: 'error',
+      }
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          onError: cy.spy().as('onErrorSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('fetch:error', expectedError))
+
+      cy.get('@onErrorSpy').should('have.been.calledWith', expectedError)
+    })
+
+    it('Should emit update event after Customer Group with consumers was created', () => {
+      interceptFetchingList()
+      interceptCreate()
+      interceptAddConsumer()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.getTestId('consumer-group-form-name').type('test_name')
+      cy.getTestId('consumer-group-form-tags').type('test_tag')
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get('.k-multiselect-popover').should('be.visible')
+      cy.get('.k-multiselect-popover .k-multiselect-item').should('have.length', 5)
+      cy.get(`.k-multiselect-popover [data-testid="k-multiselect-item-${consumersList5[0].id}"] .select-item-label`).click()
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@createGroup')
+      cy.wait('@addConsumer')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith',
+        { name: 'test_name', tags: 'test_tag', consumers: ['1'], id: 'c0b7eac5-6b6d-48ad-bd0d-3253036cfebb' })
+    })
+
+    it('Should emit update event after Customer Group without consumers was created', () => {
+      interceptFetchingList()
+      interceptCreate()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.getTestId('consumer-group-form-name').type('test_name')
+      cy.getTestId('consumer-group-form-tags').type('test_tag')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@createGroup')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith',
+        { name: 'test_name', tags: 'test_tag', consumers: [], id: 'c0b7eac5-6b6d-48ad-bd0d-3253036cfebb' })
+    })
+
+    it('Error should be visible when creation fails', () => {
+      interceptFetchingList()
+      interceptCreate(400)
+      interceptAddConsumer()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@createGroup')
+
+      cy.get('@onUpdateSpy').should('not.have.been.called')
+      cy.getTestId('form-error').should('be.visible')
+    })
+
+    it('Error should be visible when adding Consumer fails', () => {
+      interceptFetchingList()
+      interceptCreate()
+      interceptAddConsumer(400)
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.getTestId('consumer-group-form-name').type('test_name')
+      cy.getTestId('consumer-group-form-tags').type('test_tag')
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get('.k-multiselect-popover').should('be.visible')
+      cy.get('.k-multiselect-popover .k-multiselect-item').should('have.length', 5)
+      cy.get(`.k-multiselect-popover [data-testid="k-multiselect-item-${consumersList5[0].id}"] .select-item-label`).click()
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@createGroup')
+      cy.wait('@addConsumer')
+
+      cy.get('@onUpdateSpy').should('not.have.been.called')
+      cy.getTestId('form-error').should('be.visible')
+    })
+
+    it('Should hydrate form correctly for Edit form type', () => {
+      interceptFetchingList()
+      interceptFetchGroupData()
+      interceptGetConsumers()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          consumerGroupId: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('fetch:success', konnectGroup))
+
+      cy.wait('@getConsumers')
+
+      cy.getTestId('consumer-group-form-name').should('have.value', konnectGroup.item.name)
+      cy.getTestId('consumer-group-form-tags').should('have.value', konnectGroup.item.tags?.join(', '))
+      cy.get('[data-testid="k-multiselect-trigger"] [data-testid="k-multiselect-selections"] .k-badge-text')
+        .should('contain.text', consumersList5[0].username)
+    })
+
+    it('update event should be emitted when Consumer Group was edited without changes in consumers', () => {
+      interceptFetchingList()
+      interceptFetchGroupData()
+      interceptGetConsumers()
+      interceptUpdate()
+
+      const expectedOutput = {
+        name: 'Another_test',
+        tags: 'tag1, tag5',
+        consumers: ['1'],
+        id: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+      }
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          consumerGroupId: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@getConsumers')
+
+      cy.getTestId('consumer-group-form-name').clear()
+      cy.getTestId('consumer-group-form-name').type(expectedOutput.name)
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@updateGroup')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith', expectedOutput)
+    })
+
+    it('update event should be emitted when Consumer Group was edited with added consumer', () => {
+      interceptFetchingList()
+      interceptFetchGroupData()
+      interceptGetConsumers()
+      interceptUpdate()
+      interceptAddConsumer()
+
+      const expectedOutput = {
+        name: 'Another_test',
+        tags: 'tag1, tag5',
+        consumers: ['1', '2'],
+        id: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+      }
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          consumerGroupId: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@getConsumers')
+
+      cy.getTestId('consumer-group-form-name').clear()
+      cy.getTestId('consumer-group-form-name').type(expectedOutput.name)
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get(`.k-multiselect-popover [data-testid="k-multiselect-item-${consumersList5[1].id}"] .select-item-label`).click()
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@updateGroup')
+      cy.wait('@addConsumer')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith', expectedOutput)
+    })
+
+    it('update event should be emitted when Consumer Group was edited with removed consumer', () => {
+      interceptFetchingList()
+      interceptFetchGroupData()
+      interceptGetConsumers(200, [consumersList5[0], consumersList5[1]])
+      interceptUpdate()
+      interceptRemoveConsumer()
+
+      const expectedOutput = {
+        name: 'Another_test',
+        tags: 'tag1, tag5',
+        consumers: ['1'],
+        id: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+      }
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: konnectConfig,
+          consumerGroupId: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@getConsumers')
+
+      cy.getTestId('consumer-group-form-name').clear()
+      cy.getTestId('consumer-group-form-name').type(expectedOutput.name)
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get(`.k-multiselect-popover [data-testid="k-multiselect-item-${consumersList5[1].id}"] .select-item-label`).click({ force: true })
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@updateGroup')
+      cy.wait('@removeConsumer')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith', expectedOutput)
+    })
+  })
+
+  describe('Kong manager', () => {
+    const interceptFetchingList = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${KMConfig.apiBaseUrl}/${KMConfig.workspace}/consumers*`,
+        },
+        {
+          statusCode: status,
+          body: { data: consumersList5 },
+        },
+      ).as('fetchList')
+    }
+    const interceptCreate = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${KMConfig.apiBaseUrl}/${KMConfig.workspace}/consumer_groups`,
+        },
+        {
+          statusCode: status,
+          body: CreateConsumerGroupKMResponse,
+        },
+      ).as('createGroup')
+    }
+    const interceptUpdate = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'PATCH',
+          url: `${KMConfig.apiBaseUrl}/${KMConfig.workspace}/consumer_groups/*`,
+        },
+        {
+          statusCode: status,
+          body: CreateConsumerGroupKMResponse,
+        },
+      ).as('updateGroup')
+    }
+    const interceptFetchGroupData = (status = 200, response?: Record<string, Record<string, any>>): void => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${KMConfig.apiBaseUrl}/${KMConfig.workspace}/consumer_groups/*`,
+        },
+        {
+          statusCode: status,
+          body: response || KMGroup,
+        },
+      ).as('fetchGroupData')
+    }
+    const interceptAddConsumer = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${KMConfig.apiBaseUrl}/${KMConfig.workspace}/consumer_groups/*/consumers`,
+        },
+        {
+          statusCode: status,
+          body: {},
+        },
+      ).as('addConsumer')
+    }
+    const interceptRemoveConsumer = (status = 200): void => {
+      cy.intercept(
+        {
+          method: 'DELETE',
+          url: `${KMConfig.apiBaseUrl}/${KMConfig.workspace}/consumer_groups/*/consumers/*`,
+        },
+        {
+          statusCode: status,
+          body: {},
+        },
+      ).as('removeConsumer')
+    }
+
+    it('Create form should be rendered correctly', () => {
+      interceptFetchingList()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+        },
+      })
+
+      cy.wait('@fetchList')
+
+      cy.get('.kong-ui-entities-consumer-group-form').should('be.visible')
+      cy.get('.kong-ui-entities-consumer-group-form form').should('be.visible')
+
+      cy.getTestId('consumer-group-form-name').should('be.visible')
+      cy.getTestId('consumer-group-form-tags').should('be.visible')
+      cy.getTestId('k-multiselect-trigger').should('be.visible')
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get('.k-multiselect-popover').should('be.visible')
+      cy.get('.k-multiselect-popover .k-multiselect-item').should('have.length', 5)
+
+      cy.getTestId('form-cancel').should('be.visible')
+      cy.getTestId('form-cancel').should('be.enabled')
+      cy.getTestId('form-submit').should('be.visible')
+      cy.getTestId('form-submit').should('be.disabled')
+    })
+
+    it('Submit button should be enabled if name field is filled in correctly', () => {
+      interceptFetchingList()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+        },
+      })
+
+      cy.wait('@fetchList')
+
+      cy.getTestId('form-submit').should('be.visible')
+      cy.getTestId('form-submit').should('be.disabled')
+
+      cy.getTestId('consumer-group-form-name').type('test_name')
+
+      cy.getTestId('form-submit').should('be.enabled')
+    })
+
+    it('loading event should be emitted when EntityBaseForm emits loading event', () => {
+      interceptFetchingList()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          onLoading: cy.spy().as('onLoadingSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('loading', true))
+
+      cy.get('@onLoadingSpy').should('have.been.calledWith', true)
+    })
+
+    it('error event should be emitted when EntityBaseForm emits fetch:error event', () => {
+      interceptFetchingList()
+
+      const expectedError: AxiosError = {
+        isAxiosError: false,
+        toJSON(): object {
+          return {}
+        },
+        message: 'error',
+        name: 'error',
+      }
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          onError: cy.spy().as('onErrorSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('fetch:error', expectedError))
+
+      cy.get('@onErrorSpy').should('have.been.calledWith', expectedError)
+    })
+
+    it('Should emit update event after Customer Group with consumers was created', () => {
+      interceptFetchingList()
+      interceptCreate()
+      interceptAddConsumer()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.getTestId('consumer-group-form-name').type('test_name')
+      cy.getTestId('consumer-group-form-tags').type('test_tag')
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get('.k-multiselect-popover').should('be.visible')
+      cy.get('.k-multiselect-popover .k-multiselect-item').should('have.length', 5)
+      cy.get(`.k-multiselect-popover [data-testid="k-multiselect-item-${consumersList5[0].id}"] .select-item-label`).click()
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@createGroup')
+      cy.wait('@addConsumer')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith',
+        { name: 'test_name', tags: 'test_tag', consumers: ['1'], id: 'c0b7eac5-6b6d-48ad-bd0d-3253036cfebb' })
+    })
+
+    it('Should emit update event after Customer Group without consumers was created', () => {
+      interceptFetchingList()
+      interceptCreate()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.getTestId('consumer-group-form-name').type('test_name')
+      cy.getTestId('consumer-group-form-tags').type('test_tag')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@createGroup')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith',
+        { name: 'test_name', tags: 'test_tag', consumers: [], id: 'c0b7eac5-6b6d-48ad-bd0d-3253036cfebb' })
+    })
+
+    it('Error should be visible when creation fails', () => {
+      interceptFetchingList()
+      interceptCreate(400)
+      interceptAddConsumer()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@createGroup')
+
+      cy.get('@onUpdateSpy').should('not.have.been.called')
+      cy.getTestId('form-error').should('be.visible')
+    })
+
+    it('Error should be visible when adding Consumer fails', () => {
+      interceptFetchingList()
+      interceptCreate()
+      interceptAddConsumer(400)
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.getTestId('consumer-group-form-name').type('test_name')
+      cy.getTestId('consumer-group-form-tags').type('test_tag')
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get('.k-multiselect-popover').should('be.visible')
+      cy.get('.k-multiselect-popover .k-multiselect-item').should('have.length', 5)
+      cy.get(`.k-multiselect-popover [data-testid="k-multiselect-item-${consumersList5[0].id}"] .select-item-label`).click()
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@createGroup')
+      cy.wait('@addConsumer')
+
+      cy.get('@onUpdateSpy').should('not.have.been.called')
+      cy.getTestId('form-error').should('be.visible')
+    })
+
+    it('Should hydrate form correctly for Edit form type', () => {
+      interceptFetchingList()
+      interceptFetchGroupData()
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          consumerGroupId: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('fetch:success', KMGroup))
+
+      cy.wait('@fetchGroupData')
+
+      cy.getTestId('consumer-group-form-name').should('have.value', KMGroup.consumer_group.name)
+      cy.getTestId('consumer-group-form-tags').should('have.value', KMGroup.consumer_group.tags?.join(', '))
+      cy.get('[data-testid="k-multiselect-trigger"] [data-testid="k-multiselect-selections"] .k-badge-text')
+        .should('contain.text', KMGroup.consumers[0].username)
+    })
+
+    it('update event should be emitted when Consumer Group was edited without changes in consumers', () => {
+      interceptFetchingList()
+      interceptFetchGroupData()
+      interceptUpdate()
+
+      const expectedOutput = {
+        name: 'Another_test',
+        tags: 'tag 1',
+        consumers: ['1'],
+        id: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+      }
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          consumerGroupId: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.getTestId('consumer-group-form-name').clear()
+      cy.getTestId('consumer-group-form-name').type(expectedOutput.name)
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@updateGroup')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith', expectedOutput)
+    })
+
+    it('update event should be emitted when Consumer Group was edited with added consumer', () => {
+      interceptFetchingList()
+      interceptFetchGroupData()
+      interceptUpdate()
+      interceptAddConsumer()
+
+      const expectedOutput = {
+        name: 'Another_test',
+        tags: 'tag 1',
+        consumers: ['1', '2'],
+        id: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+      }
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          consumerGroupId: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.getTestId('consumer-group-form-name').clear()
+      cy.getTestId('consumer-group-form-name').type(expectedOutput.name)
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get(`.k-multiselect-popover [data-testid="k-multiselect-item-${consumersList5[1].id}"] .select-item-label`).click()
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@updateGroup')
+      cy.wait('@addConsumer')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith', expectedOutput)
+    })
+
+    it('update event should be emitted when Consumer Group was edited with removed consumer', () => {
+      interceptFetchingList()
+      interceptFetchGroupData(200, KMGroup2)
+      interceptUpdate()
+      interceptRemoveConsumer()
+
+      const expectedOutput = {
+        name: 'Another_test',
+        tags: 'tag 1',
+        consumers: ['1'],
+        id: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+      }
+
+      cy.mount(ConsumerGroupForm, {
+        props: {
+          config: KMConfig,
+          consumerGroupId: '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5',
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.getTestId('consumer-group-form-name').clear()
+      cy.getTestId('consumer-group-form-name').type(expectedOutput.name)
+
+      cy.getTestId('k-multiselect-trigger').click()
+      cy.get(`.k-multiselect-popover [data-testid="k-multiselect-item-${consumersList5[1].id}"] .select-item-label`).click({ force: true })
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+        .vm.$emit('submit'))
+
+      cy.wait('@updateGroup')
+      cy.wait('@removeConsumer')
+
+      cy.get('@onUpdateSpy').should('have.been.calledWith', expectedOutput)
+    })
+  })
+})

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
@@ -1,0 +1,372 @@
+<template>
+  <div class="kong-ui-entities-consumer-group-form">
+    <EntityBaseForm
+      :can-submit="isFormValid && changesExist"
+      :config="config"
+      :edit-id="consumerGroupId"
+      :error-message="state.errorMessage || fetchError || preValidateErrorMessage"
+      :fetch-url="fetchUrl"
+      :is-readonly="state.readonly"
+      @cancel="cancelHandler"
+      @fetch:error="fetchErrorHandler($event)"
+      @fetch:success="updateFormValues"
+      @loading="loadingHandler($event)"
+      @submit="submitData"
+    >
+      <EntityFormSection
+        :description="t('consumer_groups.form.general_info.description')"
+        :title="t('consumer_groups.form.general_info.title')"
+      >
+        <KInput
+          v-model.trim="state.fields.name"
+          autocomplete="off"
+          data-testid="consumer-group-form-name"
+          :label="t('consumer_groups.form.fields.name.label')"
+          :placeholder="t('consumer_groups.form.fields.name.placeholder')"
+          required
+          type="text"
+        />
+
+        <KInput
+          v-model.trim="state.fields.tags"
+          autocomplete="off"
+          data-testid="consumer-group-form-tags"
+          :help="t('consumer_groups.form.fields.tags.help')"
+          :label="t('consumer_groups.form.fields.tags.label')"
+          :label-attributes="{
+            info: t('consumer_groups.form.fields.tags.tooltip'),
+            tooltipAttributes: { maxWidth: '300' } }"
+          :placeholder="t('consumer_groups.form.fields.tags.placeholder')"
+          type="text"
+        />
+      </EntityFormSection>
+
+      <EntityFormSection
+        :description="t('consumer_groups.form.consumers.description')"
+        has-divider
+        :title="t('consumer_groups.form.consumers.title')"
+      >
+        <KMultiselect
+          v-model="state.fields.consumers"
+          appearance="select"
+          autosuggest
+          expand-selected
+          :items="displayedConsumers"
+          :label="t('consumer_groups.form.fields.consumers.label')"
+          :loading="loading"
+          :placeholder="t('consumer_groups.form.fields.consumers.placeholder')"
+          width="auto"
+          @query-change="debouncedQueryChange"
+        >
+          <template #item-template="{ item }: { item: any }">
+            <div class="select-item-label">
+              {{ item.label }}
+            </div>
+            <div
+              v-if="item?.data?.username && item?.data?.custom_id"
+              class="select-item-desc"
+            >
+              {{ item?.data?.custom_id }}
+            </div>
+          </template>
+        </KMultiselect>
+      </EntityFormSection>
+    </EntityBaseForm>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import {
+  EntityBaseForm,
+  EntityBaseFormType,
+  EntityFormSection,
+  useAxios,
+  useDebouncedFilter, useErrors,
+} from '@kong-ui-public/entities-shared'
+import '@kong-ui-public/entities-shared/dist/style.css'
+import composables from '../composables'
+import { computed, onBeforeMount, PropType, reactive } from 'vue'
+import {
+  ConsumerGroupActions,
+  ConsumerGroupFields,
+  ConsumerGroupPayload,
+  ConsumerGroupState,
+  Consumer,
+  KongManagerConsumerGroupFormConfig,
+  KonnectConsumerGroupFormConfig, ConsumerGroupData,
+} from '../types'
+import endpoints from '../consumer-groups-endpoints'
+import { MultiselectItem } from '@kong/kongponents'
+import { useRouter } from 'vue-router'
+import { AxiosError } from 'axios'
+
+const props = defineProps({
+  /** The base konnect or kongManger config. Pass additional config props in the shared entity component as needed. */
+  config: {
+    type: Object as PropType<KonnectConsumerGroupFormConfig | KongManagerConsumerGroupFormConfig>,
+    required: true,
+    validator: (config: KonnectConsumerGroupFormConfig | KongManagerConsumerGroupFormConfig): boolean => {
+      if (!config || !['konnect', 'kongManager'].includes(config?.app)) return false
+      if (config?.app === 'konnect' && !config?.controlPlaneId) return false
+      if (config?.app === 'kongManager' && typeof config?.workspace !== 'string') return false
+      if (!config?.cancelRoute) return false
+      return true
+    },
+  },
+  /** If a valid consumerGroupId is provided, it will put the form in Edit mode instead of Create */
+  consumerGroupId: {
+    type: String,
+    required: false,
+    default: '',
+  },
+})
+
+const emit = defineEmits<{
+  (e: 'update', data: ConsumerGroupData): void,
+  (e: 'error', error: AxiosError): void,
+  (e: 'loading', isLoading: boolean): void,
+}>()
+
+const { i18n: { t } } = composables.useI18n()
+const router = useRouter()
+
+const state = reactive<ConsumerGroupState>({
+  fields: {
+    name: '',
+    tags: '',
+    consumers: [],
+  },
+  errorMessage: '',
+  readonly: false,
+})
+
+const originalFields = reactive<ConsumerGroupFields>({
+  name: '',
+  tags: '',
+  consumers: [],
+})
+
+const {
+  debouncedQueryChange,
+  loading,
+  error: fetchError,
+  loadItems,
+  results,
+} = useDebouncedFilter(props.config, endpoints.form[props.config?.app]?.consumersList, '', {
+  fetchedItemsKey: 'data',
+  searchKeys: ['username', 'custom_id'],
+})
+
+const { axiosInstance } = useAxios({
+  headers: props.config?.requestHeaders,
+})
+const { getMessageFromError } = useErrors()
+
+const displayedConsumers = computed((): MultiselectItem[] => {
+  return results.value.map((record: Record<string, any>) => ({
+    label: record.username || record.custom_id,
+    value: record.id,
+    selected: state.fields.consumers.includes(record.id),
+    data: record, // we need this to determine whether or not to show the description text
+  }))
+})
+
+const fetchUrl = computed<string>(() => endpoints.form[props.config?.app]?.edit)
+
+const formType = computed((): EntityBaseFormType => props.consumerGroupId
+  ? EntityBaseFormType.Edit
+  : EntityBaseFormType.Create)
+
+const isFormValid = computed((): boolean => !!state.fields.name && !preValidateErrorMessage.value)
+const changesExist = computed((): boolean => JSON.stringify(state.fields) !== JSON.stringify(originalFields))
+
+const getUrl = (action: ConsumerGroupActions, groupId = '', consumerId = ''): string => {
+  let url = `${props.config?.apiBaseUrl}${endpoints.form[props.config?.app][action]}`
+
+  if (props.config?.app === 'konnect') {
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
+  } else if (props.config?.app === 'kongManager') {
+    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+  }
+
+  url = url.replace(/{id}/gi, groupId || props.consumerGroupId)
+
+  if (action === 'addConsumer' || action === 'removeConsumer') {
+    url = url.replace(/{consumerId}/gi, consumerId)
+  }
+
+  return url
+}
+
+const cancelHandler = (): void => {
+  router.push(props.config?.cancelRoute || { name: 'consumer-group-list' })
+}
+
+const fetchErrorHandler = (err: AxiosError): void => {
+  emit('error', err)
+}
+
+const loadingHandler = (val: boolean): void => {
+  emit('loading', val)
+}
+
+const updateFormValues = async (data: Record<string, any>): Promise<void> => {
+  state.fields.name = data?.item?.name || data?.consumer_group?.name || data?.name || ''
+
+  const tags = data?.item?.tags || data?.consumer_group.tags || data?.tags || []
+  state.fields.tags = tags?.join(', ') || ''
+
+  if ('consumers' in data) {
+    state.fields.consumers = data?.consumers?.map((el: Consumer) => el.id) || []
+  } else {
+    try {
+      const { data: consumers } = await axiosInstance.get(getUrl('getConsumers'))
+
+      state.fields.consumers = ('consumers' in consumers)
+        ? consumers?.consumers?.map((el: Consumer) => el.id)
+        : []
+    } catch (e) {
+      emitError(e as AxiosError)
+    }
+  }
+
+  Object.assign(originalFields, state.fields)
+}
+
+const preValidateErrorMessage = computed(() => {
+  const namePattern = /^[0-9a-zA-Z.\-_~]*$/
+
+  return namePattern.test(state.fields.name) ? '' : t('consumer_groups.form.validation_errors.name')
+})
+
+const getPayload = (): ConsumerGroupPayload => ({
+  name: state.fields.name,
+  tags: state.fields.tags.split(',')?.map((tag: string) => String(tag || '')
+    .trim())?.filter((tag: string) => tag !== ''),
+})
+
+const addConsumer = async (consumerId: string, groupId = ''): Promise<void> => {
+  return await axiosInstance.post(getUrl('addConsumer', groupId, consumerId), { consumer: consumerId })
+}
+
+const removeConsumer = async (consumerId: string, groupId = ''): Promise<void> => {
+  return await axiosInstance.delete(getUrl('removeConsumer', groupId, consumerId))
+}
+
+const emitError = (e: AxiosError): void => {
+  state.errorMessage = getMessageFromError(e)
+  emit('error', e as AxiosError)
+}
+
+const emitUpdate = (id = props.consumerGroupId): void => {
+  Object.assign(originalFields, state.fields)
+
+  emit('update', { ...state.fields, id })
+}
+
+const handleConsumers = (results: any[] | undefined, message: string, groupId = props.consumerGroupId): void => {
+  const failed = results?.find(result => result.status !== 'fulfilled')
+  if (failed) {
+    emitError({
+      code: failed.status,
+      message,
+    } as AxiosError)
+  } else {
+    emitUpdate(groupId)
+  }
+}
+
+const createGroup = async (): Promise<void> => {
+  let newGroupId = ''
+  try {
+    const { data } = await axiosInstance.post(getUrl('create'), getPayload())
+
+    newGroupId = ('item' in data) ? data.item.id : data.id
+  } catch (e) {
+    emitError(e as AxiosError)
+  }
+
+  if (state.fields.consumers.length > 0 && newGroupId) {
+    try {
+      const bulkActions = state.fields.consumers.map(el => addConsumer(el, newGroupId))
+
+      const results = await Promise.allSettled(bulkActions)
+
+      handleConsumers(results, t('consumer_groups.errors.add_consumer'), newGroupId)
+    } catch (e) {
+      emitError(e as AxiosError)
+    }
+  } else if (state.fields.consumers.length === 0 && newGroupId) {
+    emitUpdate(newGroupId)
+  }
+}
+
+const updateGroup = async (): Promise<void> => {
+  try {
+    if (props.config?.app === 'konnect') {
+      await axiosInstance.put(getUrl('edit'), getPayload())
+    } else {
+      await axiosInstance.patch(getUrl('edit'), getPayload())
+    }
+  } catch (e) {
+    emitError(e as AxiosError)
+  }
+
+  const consumersToAdd = state.fields.consumers.filter(x => !originalFields.consumers.includes(x))
+  const consumersToRemove = originalFields.consumers.filter(x => !state.fields.consumers.includes(x))
+
+  if (consumersToRemove.length === 0 && consumersToAdd.length === 0) {
+    emitUpdate()
+  } else {
+    if (consumersToRemove.length > 0) {
+      try {
+        const bulkRemoveActions = consumersToRemove.map(el => removeConsumer(el))
+
+        const results = await Promise.allSettled(bulkRemoveActions)
+
+        handleConsumers(results, t('consumer_groups.errors.remove_consumer'))
+      } catch (e) {
+        emitError(e as AxiosError)
+      }
+    }
+
+    if (consumersToAdd.length > 0) {
+      try {
+        const bulkActions = consumersToAdd.map(el => addConsumer(el))
+
+        const results = await Promise.allSettled(bulkActions)
+
+        handleConsumers(results, t('consumer_groups.errors.add_consumer'))
+      } catch (e) {
+        emitError(e as AxiosError)
+      }
+    }
+  }
+}
+
+const submitData = async (): Promise<void> => {
+  try {
+    state.readonly = true
+
+    formType.value === EntityBaseFormType.Create ? await createGroup() : await updateGroup()
+  } finally {
+    state.readonly = false
+  }
+}
+
+onBeforeMount(async () => {
+  await loadItems()
+})
+</script>
+
+<style lang="scss" scoped>
+.kong-ui-entities-consumer-group-form {
+  width: 100%;
+
+  @media screen and (min-width: $kui-breakpoint-laptop) {
+    &:deep(.form-section-wrapper) {
+      column-gap: $kui-space-130;
+    }
+  }
+}
+</style>

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -1,0 +1,1268 @@
+// Cypress component test spec file
+import {
+  ConsumerGroup,
+  consumerGroups100,
+  consumerGroups5,
+  paginate,
+} from '../../fixtures/mockData'
+import {
+  KongManagerConsumerGroupListConfig,
+  KonnectConsumerGroupListConfig,
+} from '../types'
+import { v4 as uuidv4 } from 'uuid'
+import ConsumerGroupList from './ConsumerGroupList.vue'
+import AddToGroupModal from './AddToGroupModal.vue'
+
+describe('<ConsumerGroupList />', () => {
+  beforeEach(() => {
+    cy.on('uncaught:exception', err => !err.message.includes('ResizeObserver loop limit exceeded'))
+  })
+
+  describe('Kong Manager', () => {
+    const baseConfigKM: KongManagerConsumerGroupListConfig = {
+      app: 'kongManager',
+      workspace: 'default',
+      apiBaseUrl: '/kong-manager',
+      isExactMatch: false,
+      filterSchema: {},
+      createRoute: 'create-consumer-group',
+      getViewRoute: () => 'view-consumer-group',
+      getEditRoute: () => 'edit-consumer-group',
+    }
+    const configConsumerKM: KongManagerConsumerGroupListConfig = {
+      app: 'kongManager',
+      workspace: 'default',
+      apiBaseUrl: '/kong-manager',
+      isExactMatch: false,
+      filterSchema: {},
+      createRoute: 'create-consumer-group',
+      getViewRoute: () => 'view-consumer-group',
+      getEditRoute: () => 'edit-consumer-group',
+      consumerId: '5921d16a-3e1d-4936-b21f-e5cae587415c',
+      consumerUsername: 'Test Consumer',
+    }
+
+    const interceptKM = (params?: {
+      mockData?: ConsumerGroup[];
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumer_groups*`,
+        },
+        {
+          statusCode: 200,
+          body: {
+            data: params?.mockData ?? [],
+            total: params?.mockData?.length ?? 0,
+          },
+        },
+      ).as(params?.alias ?? 'getConsumerGroups')
+    }
+
+    const interceptConsumerKM = (params?: {
+      mockData?: ConsumerGroup[];
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKM.apiBaseUrl}/${configConsumerKM.workspace}/consumers/${configConsumerKM.consumerId}/consumer_groups*`,
+        },
+        {
+          statusCode: 200,
+          body: {
+            data: params?.mockData ?? [],
+            total: params?.mockData?.length ?? 0,
+          },
+        },
+      ).as(params?.alias ?? 'getGroups')
+    }
+
+    const interceptExitGroupKM = (params?: {
+      status?: number;
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'DELETE',
+          url: `${baseConfigKM.apiBaseUrl}/${configConsumerKM.workspace}/consumers/${configConsumerKM.consumerId}/consumer_groups/*`,
+        },
+        {
+          statusCode: params?.status || 200,
+          body: {},
+        },
+      ).as(params?.alias ?? 'exitGroup')
+    }
+
+    const interceptKMMultiPage = (params?: {
+      mockData?: ConsumerGroup[];
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumer_groups*`,
+        },
+        (req) => {
+          const size = req.query.size ? Number(req.query.size) : 30
+          const offset = req.query.offset ? Number(req.query.offset) : 0
+
+          req.reply({
+            statusCode: 200,
+            body: paginate(params?.mockData ?? [], size, offset),
+          })
+        },
+      ).as(params?.alias ?? 'getConsumerGroupsMultiPage')
+    }
+
+    const triggerQuery = '.kong-ui-entities-consumer-groups-list tbody tr [data-testid="k-dropdown-trigger"]'
+    const exitQuery = '.kong-ui-entities-consumer-groups-list tbody tr [data-testid="action-entity-delete"]'
+    const modalQuery = 'exit-group-modal'
+
+    it('should show empty state and create consumer group cta', () => {
+      interceptKM()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => true,
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroups')
+      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+      cy.get('.k-table-empty-state').should('be.visible')
+      cy.get('[data-testid="new-consumer-group"]').should('be.visible')
+    })
+
+    it('should hide empty state and create consumer group cta if user can not create', () => {
+      interceptKM()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => false,
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroups')
+      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+      cy.get('.k-table-empty-state').should('be.visible')
+      cy.get('[data-testid="new-consumer-group"]').should('not.exist')
+    })
+
+    it('should handle error state', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumer_groups*`,
+        },
+        {
+          statusCode: 500,
+          body: {},
+        },
+      ).as('getConsumerGroups')
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroups')
+      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+      cy.get('.k-table-error-state').should('be.visible')
+    })
+
+    it('should show consumer group items', () => {
+      interceptKM({
+        mockData: consumerGroups5,
+      })
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroups')
+      cy.get(
+        '.kong-ui-entities-consumer-groups-list tr [data-testid="consumerGroup.1"]',
+      ).should('exist')
+      cy.get(
+        '.kong-ui-entities-consumer-groups-list tr [data-testid="consumerGroup.2"]',
+      ).should('exist')
+    })
+
+    it('should allow switching between pages', () => {
+      interceptKMMultiPage({
+        mockData: consumerGroups100,
+      })
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      const l = '.kong-ui-entities-consumer-groups-list'
+      const p = '[data-testid="k-table-pagination"]'
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      // Page #1
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.29"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.30"]`).should('exist')
+
+      cy.get(`${l} ${p}`).should('exist')
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      // Page #2
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.31"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.32"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.59"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.60"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'not.have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      // Page #4
+      cy.get(`${l} tbody tr`).should('have.length', 10)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.91"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.92"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.99"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.100"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'not.have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`).should(
+        'have.class',
+        'disabled',
+      )
+    })
+
+    it('should allow picking different page sizes and persist the preference', () => {
+      interceptKMMultiPage({
+        mockData: consumerGroups100,
+      })
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+        .then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      const l = '.kong-ui-entities-consumer-groups-list'
+      const p = '[data-testid="k-table-pagination"]'
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.29"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.30"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '30 items per page',
+      )
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).click()
+      cy.get(
+        `${l} ${p} [data-testid="page-size-dropdown"] [value="15"]`,
+      ).click()
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 15)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.14"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.15"]`).should('exist')
+
+      // Unmount and mount
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.unmount())
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKM,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 15)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.14"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.15"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '15 items per page',
+      )
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).click()
+      cy.get(
+        `${l} ${p} [data-testid="page-size-dropdown"] [value="50"]`,
+      ).click()
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 50)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.49"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.50"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '50 items per page',
+      )
+    })
+
+    it('should render correct Add to Group button when consumerId is provided', () => {
+      interceptConsumerKM()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configConsumerKM,
+          canCreate: () => true,
+          canEdit: () => { },
+          canDelete: () => { },
+          canRetrieve: () => { },
+        },
+      })
+
+      cy.wait('@getGroups')
+
+      cy.getTestId('toolbar-add-consumer-group').should('exist')
+      cy.getTestId('toolbar-add-consumer-group').should('contain.text', 'Add to Consumer Group')
+    })
+
+    it('should render AddToGroupModal onclick Add to Group button when consumerId is provided', () => {
+      interceptConsumerKM()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configConsumerKM,
+          canCreate: () => true,
+          canEdit: () => { },
+          canDelete: () => { },
+          canRetrieve: () => { },
+        },
+      })
+
+      cy.wait('@getGroups')
+
+      cy.getTestId('toolbar-add-consumer-group').click()
+      cy.getTestId('add-to-group-modal').should('exist')
+    })
+
+    it('should hide AddToGroupModal when modal emits cancel event', () => {
+      interceptConsumerKM()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configConsumerKM,
+          canCreate: () => true,
+          canEdit: () => { },
+          canDelete: () => { },
+          canRetrieve: () => { },
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@getGroups')
+
+      cy.getTestId('toolbar-add-consumer-group').click()
+      cy.getTestId('add-to-group-modal').should('exist')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(AddToGroupModal).vm.$emit('cancel'))
+
+      cy.getTestId('add-to-group-modal').should('not.exist')
+    })
+
+    it('should hide AddToGroupModal and emit add:success event when modal emits add:success event', () => {
+      const expectedData = ['test 1', 'test 2']
+      interceptConsumerKM()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configConsumerKM,
+          canCreate: () => true,
+          canEdit: () => { },
+          canDelete: () => { },
+          canRetrieve: () => { },
+          'onAdd:success': cy.spy().as('addSuccess'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@getGroups')
+
+      cy.getTestId('toolbar-add-consumer-group').click()
+      cy.getTestId('add-to-group-modal').should('exist')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(AddToGroupModal).vm.$emit('add:success', expectedData))
+
+      cy.get('@addSuccess').should('have.been.calledOnceWith', expectedData)
+      cy.getTestId('add-to-group-modal').should('not.exist')
+    })
+
+    it('should not hide AddToGroupModal and emit add:success event when modal emits add:partial-success event',
+      () => {
+        const expectedData = ['test 1', 'test 2']
+        interceptConsumerKM()
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKM,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+            'onAdd:success': cy.spy().as('addSuccess'),
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+
+        cy.getTestId('toolbar-add-consumer-group').click()
+        cy.getTestId('add-to-group-modal').should('exist')
+
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(AddToGroupModal)
+          .vm.$emit('add:partial-success', expectedData))
+
+        cy.get('@addSuccess').should('have.been.calledOnceWith', expectedData)
+        cy.getTestId('add-to-group-modal').should('exist')
+      })
+
+    it('should render correct Exit item in action dropdown',
+      () => {
+        interceptConsumerKM({
+          mockData: consumerGroups5,
+        })
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKM,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => true,
+            canRetrieve: () => { },
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+        const popoverQuery = '.kong-ui-entities-consumer-groups-list tbody tr .k-popover'
+
+        cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+        cy.get(triggerQuery).should('be.visible')
+        cy.get(triggerQuery).click()
+        cy.get(popoverQuery).should('be.visible')
+        cy.get(exitQuery).should('be.visible')
+        cy.get(exitQuery).should('have.text', 'Exit')
+      })
+
+    it('should hide Exit Group modal when this modal emits canceled event',
+      () => {
+        interceptConsumerKM({
+          mockData: consumerGroups5,
+        })
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKM,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => true,
+            canRetrieve: () => { },
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+
+        cy.getTestId(modalQuery).should('not.exist')
+
+        cy.get(triggerQuery).click()
+        cy.get(exitQuery).should('be.visible').click()
+
+        cy.getTestId(modalQuery).should('exist')
+
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.getComponent(`[data-testid="${modalQuery}"]`)
+          .vm.$emit('canceled'))
+
+        cy.getTestId(modalQuery).should('not.exist')
+      })
+
+    it('should exit group and emit remove:success event when modal emits proceed event',
+      () => {
+        interceptConsumerKM({
+          mockData: consumerGroups5,
+        })
+        interceptExitGroupKM()
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKM,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => true,
+            canRetrieve: () => { },
+            'onRemove:success': cy.spy().as('removeSuccess'),
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+
+        cy.getTestId(modalQuery).should('not.exist')
+
+        cy.get(triggerQuery).click()
+        cy.get(exitQuery).should('be.visible').click()
+
+        cy.getTestId(modalQuery).should('exist')
+
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.getComponent(`[data-testid="${modalQuery}"]`)
+          .vm.$emit('proceed'))
+
+        cy.wait('@exitGroup')
+
+        cy.get('@removeSuccess').should('have.been.called')
+
+        cy.getTestId(modalQuery).should('not.exist')
+      })
+
+    it('should emit error event when exiting fails',
+      () => {
+        interceptConsumerKM({
+          mockData: consumerGroups5,
+        })
+        interceptExitGroupKM({ status: 500 })
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKM,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => true,
+            canRetrieve: () => { },
+            onError: cy.spy().as('errorSpy'),
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+
+        cy.getTestId(modalQuery).should('not.exist')
+
+        cy.get(triggerQuery).click()
+        cy.get(exitQuery).should('be.visible').click()
+
+        cy.getTestId(modalQuery).should('exist')
+
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.getComponent(`[data-testid="${modalQuery}"]`)
+          .vm.$emit('proceed'))
+
+        cy.wait('@exitGroup')
+
+        cy.get('@errorSpy').should('have.been.called')
+
+        cy.getTestId(modalQuery).should('exist')
+      })
+  })
+
+  describe('Konnect', () => {
+    const baseConfigKonnect: KonnectConsumerGroupListConfig = {
+      app: 'konnect',
+      controlPlaneId: '1234-abcd-ilove-cats',
+      apiBaseUrl: '/us/kong-api/konnect-api',
+      createRoute: 'create-consumer-group',
+      getViewRoute: () => 'view-consumer-group',
+      getEditRoute: () => 'edit-consumer-group',
+    }
+    const configConsumerKonnect: KonnectConsumerGroupListConfig = {
+      app: 'konnect',
+      controlPlaneId: '1234-abcd-ilove-cats',
+      apiBaseUrl: '/us/kong-api/konnect-api',
+      createRoute: 'create-consumer-group',
+      getViewRoute: () => 'view-consumer-group',
+      getEditRoute: () => 'edit-consumer-group',
+      consumerId: '5921d16a-3e1d-4936-b21f-e5cae587415c',
+      consumerUsername: 'Test Consumer',
+    }
+
+    const interceptKonnect = (params?: {
+      mockData?: ConsumerGroup[];
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumer_groups*`,
+        },
+        {
+          statusCode: 200,
+          body: {
+            data: params?.mockData ?? [],
+            total: params?.mockData?.length ?? 0,
+          },
+        },
+      ).as(params?.alias ?? 'getConsumerGroups')
+    }
+    const interceptConsumerKonnect = (params?: {
+      mockData?: ConsumerGroup[];
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${configConsumerKonnect.apiBaseUrl}/api/runtime_groups/${configConsumerKonnect.controlPlaneId}/consumers/${configConsumerKonnect.consumerId}/consumer_groups*`,
+        },
+        {
+          statusCode: 200,
+          body: {
+            data: params?.mockData ?? [],
+            total: params?.mockData?.length ?? 0,
+          },
+        },
+      ).as(params?.alias ?? 'getGroups')
+    }
+    const interceptExitGroupKonnect = (params?: {
+      status?: number;
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'DELETE',
+          url: `${configConsumerKonnect.apiBaseUrl}/api/runtime_groups/${configConsumerKonnect.controlPlaneId}/consumers/${configConsumerKonnect.consumerId}/consumer_groups/*`,
+        },
+        {
+          statusCode: params?.status || 200,
+          body: {},
+        },
+      ).as(params?.alias ?? 'exitGroup')
+    }
+
+    const interceptKonnectMultiPage = (params?: {
+      mockData?: ConsumerGroup[];
+      alias?: string;
+    }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumer_groups*`,
+        },
+        (req) => {
+          const size = req.query.size ? Number(req.query.size) : 30
+          const offset = req.query.offset ? Number(req.query.offset) : 0
+
+          req.reply({
+            statusCode: 200,
+            body: paginate(params?.mockData ?? [], size, offset),
+          })
+        },
+      ).as(params?.alias ?? 'getConsumerGroupsMultiPage')
+    }
+
+    const triggerQuery = '.kong-ui-entities-consumer-groups-list tbody tr [data-testid="k-dropdown-trigger"]'
+    const exitQuery = '.kong-ui-entities-consumer-groups-list tbody tr [data-testid="action-entity-delete"]'
+    const modalQuery = 'exit-group-modal'
+
+    it('should show empty state and create consumer group cta', () => {
+      interceptKonnect()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => true,
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroups')
+      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+      cy.get('.k-table-empty-state').should('be.visible')
+      cy.get('[data-testid="new-consumer-group"]').should('be.visible')
+    })
+
+    it('should hide empty state and create consumer group cta if user can not create', () => {
+      interceptKonnect()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroups')
+      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+      cy.get('.k-table-empty-state').should('be.visible')
+      cy.get('[data-testid="new-consumer-group"]').should('not.exist')
+    })
+
+    it('should handle error state', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumer_groups*`,
+        },
+        {
+          statusCode: 500,
+          body: {},
+        },
+      ).as('getConsumerGroups')
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroups')
+      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+      cy.get('.k-table-error-state').should('be.visible')
+    })
+
+    it('should show consumer group items', () => {
+      interceptKonnect({
+        mockData: consumerGroups5,
+      })
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroups')
+      cy.get(
+        '.kong-ui-entities-consumer-groups-list tr [data-testid="consumerGroup.1"]',
+      ).should('exist')
+      cy.get(
+        '.kong-ui-entities-consumer-groups-list tr [data-testid="consumerGroup.2"]',
+      ).should('exist')
+    })
+
+    it('should allow switching between pages', () => {
+      interceptKonnectMultiPage({
+        mockData: consumerGroups100,
+      })
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      const l = '.kong-ui-entities-consumer-groups-list'
+      const p = '[data-testid="k-table-pagination"]'
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      // Page #1
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.29"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.30"]`).should('exist')
+
+      cy.get(`${l} ${p}`).should('exist')
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      // Page #2
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.31"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.32"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.59"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.60"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'not.have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} ${p} [data-testid="next-btn"]`)
+        .should('not.have.class', 'disabled')
+        .click() // next page
+
+      // Page #4
+      cy.get(`${l} tbody tr`).should('have.length', 10)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.91"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.92"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.99"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.100"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="prev-btn"]`).should(
+        'not.have.class',
+        'disabled',
+      )
+      cy.get(`${l} ${p} [data-testid="next-btn"]`).should(
+        'have.class',
+        'disabled',
+      )
+    })
+
+    it('should allow picking different page sizes and persist the preference', () => {
+      interceptKonnectMultiPage({
+        mockData: consumerGroups100,
+      })
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+        .then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      const l = '.kong-ui-entities-consumer-groups-list'
+      const p = '[data-testid="k-table-pagination"]'
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 30)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.29"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.30"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '30 items per page',
+      )
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).click()
+      cy.get(
+        `${l} ${p} [data-testid="page-size-dropdown"] [value="15"]`,
+      ).click()
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 15)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.14"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.15"]`).should('exist')
+
+      // Unmount and mount
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.unmount())
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => {},
+          canEdit: () => {},
+          canDelete: () => {},
+          canRetrieve: () => {},
+        },
+      })
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 15)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.14"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.15"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '15 items per page',
+      )
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).click()
+      cy.get(
+        `${l} ${p} [data-testid="page-size-dropdown"] [value="50"]`,
+      ).click()
+
+      cy.wait('@getConsumerGroupsMultiPage')
+
+      cy.get(`${l} tbody tr`).should('have.length', 50)
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.1"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.2"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.49"]`).should('exist')
+      cy.get(`${l} tbody tr [data-testid="consumerGroup.50"]`).should('exist')
+
+      cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).should(
+        'contain.text',
+        '50 items per page',
+      )
+    })
+
+    it('should render correct Add to Group button when consumerId is provided', () => {
+      interceptConsumerKonnect()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configConsumerKonnect,
+          canCreate: () => true,
+          canEdit: () => { },
+          canDelete: () => { },
+          canRetrieve: () => { },
+        },
+      })
+
+      cy.wait('@getGroups')
+
+      cy.getTestId('toolbar-add-consumer-group').should('exist')
+      cy.getTestId('toolbar-add-consumer-group').should('contain.text', 'Add to Consumer Group')
+    })
+
+    it('should render AddToGroupModal onclick Add to Group button when consumerId is provided', () => {
+      interceptConsumerKonnect()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configConsumerKonnect,
+          canCreate: () => true,
+          canEdit: () => { },
+          canDelete: () => { },
+          canRetrieve: () => { },
+        },
+      })
+
+      cy.wait('@getGroups')
+
+      cy.getTestId('toolbar-add-consumer-group').click()
+      cy.getTestId('add-to-group-modal').should('exist')
+    })
+
+    it('should hide AddToGroupModal when modal emits cancel event', () => {
+      interceptConsumerKonnect()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configConsumerKonnect,
+          canCreate: () => true,
+          canEdit: () => { },
+          canDelete: () => { },
+          canRetrieve: () => { },
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@getGroups')
+
+      cy.getTestId('toolbar-add-consumer-group').click()
+      cy.getTestId('add-to-group-modal').should('exist')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(AddToGroupModal).vm.$emit('cancel'))
+
+      cy.getTestId('add-to-group-modal').should('not.exist')
+    })
+
+    it('should hide AddToGroupModal and emit add:success event when modal emits add:success event', () => {
+      const expectedData = ['test 1', 'test 2']
+      interceptConsumerKonnect()
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configConsumerKonnect,
+          canCreate: () => true,
+          canEdit: () => { },
+          canDelete: () => { },
+          canRetrieve: () => { },
+          'onAdd:success': cy.spy().as('addSuccess'),
+        },
+      }).then(({ wrapper }) => wrapper)
+        .as('vueWrapper')
+
+      cy.wait('@getGroups')
+
+      cy.getTestId('toolbar-add-consumer-group').click()
+      cy.getTestId('add-to-group-modal').should('exist')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(AddToGroupModal).vm.$emit('add:success', expectedData))
+
+      cy.get('@addSuccess').should('have.been.calledOnceWith', expectedData)
+      cy.getTestId('add-to-group-modal').should('not.exist')
+    })
+
+    it('should not hide AddToGroupModal and emit add:success event when modal emits add:partial-success event',
+      () => {
+        const expectedData = ['test 1', 'test 2']
+        interceptConsumerKonnect()
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKonnect,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+            'onAdd:success': cy.spy().as('addSuccess'),
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+
+        cy.getTestId('toolbar-add-consumer-group').click()
+        cy.getTestId('add-to-group-modal').should('exist')
+
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(AddToGroupModal)
+          .vm.$emit('add:partial-success', expectedData))
+
+        cy.get('@addSuccess').should('have.been.calledOnceWith', expectedData)
+        cy.getTestId('add-to-group-modal').should('exist')
+      })
+
+    it('should render correct Exit item in action dropdown',
+      () => {
+        interceptConsumerKonnect({
+          mockData: consumerGroups5,
+        })
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKonnect,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => true,
+            canRetrieve: () => { },
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+        const popoverQuery = '.kong-ui-entities-consumer-groups-list tbody tr .k-popover'
+
+        cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+        cy.get(triggerQuery).should('be.visible')
+        cy.get(triggerQuery).click()
+        cy.get(popoverQuery).should('be.visible')
+        cy.get(exitQuery).should('be.visible')
+        cy.get(exitQuery).should('have.text', 'Exit')
+      })
+
+    it('should hide Exit Group modal when this modal emits canceled event',
+      () => {
+        interceptConsumerKonnect({
+          mockData: consumerGroups5,
+        })
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKonnect,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => true,
+            canRetrieve: () => { },
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+
+        cy.getTestId(modalQuery).should('not.exist')
+
+        cy.get(triggerQuery).click()
+        cy.get(exitQuery).should('be.visible').click()
+
+        cy.getTestId(modalQuery).should('exist')
+
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.getComponent(`[data-testid="${modalQuery}"]`)
+          .vm.$emit('canceled'))
+
+        cy.getTestId(modalQuery).should('not.exist')
+      })
+
+    it('should exit group and emit remove:success event when modal emits proceed event',
+      () => {
+        interceptConsumerKonnect({
+          mockData: consumerGroups5,
+        })
+        interceptExitGroupKonnect()
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKonnect,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => true,
+            canRetrieve: () => { },
+            'onRemove:success': cy.spy().as('removeSuccess'),
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+
+        cy.getTestId(modalQuery).should('not.exist')
+
+        cy.get(triggerQuery).click()
+        cy.get(exitQuery).should('be.visible').click()
+
+        cy.getTestId(modalQuery).should('exist')
+
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.getComponent(`[data-testid="${modalQuery}"]`)
+          .vm.$emit('proceed'))
+
+        cy.wait('@exitGroup')
+
+        cy.get('@removeSuccess').should('have.been.called')
+
+        cy.getTestId(modalQuery).should('not.exist')
+      })
+
+    it('should emit error event when exiting fails',
+      () => {
+        interceptConsumerKonnect({
+          mockData: consumerGroups5,
+        })
+        interceptExitGroupKonnect({ status: 500 })
+
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: configConsumerKonnect,
+            canCreate: () => true,
+            canEdit: () => { },
+            canDelete: () => true,
+            canRetrieve: () => { },
+            onError: cy.spy().as('errorSpy'),
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
+
+        cy.wait('@getGroups')
+
+        cy.getTestId(modalQuery).should('not.exist')
+
+        cy.get(triggerQuery).click()
+        cy.get(exitQuery).should('be.visible').click()
+
+        cy.getTestId(modalQuery).should('exist')
+
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.getComponent(`[data-testid="${modalQuery}"]`)
+          .vm.$emit('proceed'))
+
+        cy.wait('@exitGroup')
+
+        cy.get('@errorSpy').should('have.been.called')
+
+        cy.getTestId(modalQuery).should('exist')
+      })
+  })
+})

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -1,0 +1,592 @@
+<template>
+  <div class="kong-ui-entities-consumer-groups-list">
+    <EntityBaseTable
+      :cache-identifier="cacheIdentifier"
+      :disable-pagination="isConsumerPage"
+      disable-pagination-page-jump
+      :disable-sorting="disableSorting"
+      :empty-state-options="emptyStateOptions"
+      enable-entity-actions
+      :error-message="errorMessage"
+      :fetcher="fetcher"
+      :fetcher-cache-key="fetcherCacheKey"
+      pagination-type="offset"
+      preferences-storage-key="kong-ui-entities-consumer-groups-list"
+      :query="filterQuery"
+      :row-attributes="rowAttributes"
+      :table-headers="tableHeaders"
+      @clear-search-input="clearFilter"
+      @click:row="(row: any) => rowClick(row as EntityRow)"
+      @empty-state-cta-clicked="handleEmptyStateCtaClicked"
+      @sort="resetPagination"
+    >
+      <!-- Filter -->
+      <template #toolbar-filter>
+        <EntityFilter
+          v-if="!isConsumerPage"
+          v-model="filterQuery"
+          :config="filterConfig"
+        />
+      </template>
+      <!-- Create action -->
+      <template #toolbar-button>
+        <PermissionsWrapper :auth-function="() => canCreate()">
+          <KButton
+            appearance="primary"
+            data-testid="toolbar-add-consumer-group"
+            icon="plus"
+            :to="config.consumerId ? undefined : config.createRoute"
+            @click="() => config.consumerId ? handleAddToGroupClick() : undefined"
+          >
+            {{ config.consumerId ? t('consumer_groups.actions.add_to_group') : t('consumer_groups.list.toolbar_actions.new_consumer_group') }}
+          </KButton>
+        </PermissionsWrapper>
+      </template>
+
+      <!-- Column Formatting -->
+      <template #name="{ rowValue }">
+        <b>{{ rowValue ?? '-' }}</b>
+      </template>
+      <template #consumers_count="{ rowValue }">
+        {{ rowValue ?? '-' }}
+      </template>
+      <template #tags="{ rowValue }">
+        <KTruncate v-if="rowValue?.length > 0">
+          <KBadge
+            v-for="tag in rowValue"
+            :key="tag"
+            @click.stop
+          >
+            {{ tag }}
+          </KBadge>
+        </KTruncate>
+        <span v-else>-</span>
+      </template>
+
+      <!-- Row actions -->
+      <template #actions="{ row }">
+        <KClipboardProvider v-slot="{ copyToClipboard }">
+          <KDropdownItem
+            data-testid="action-entity-copy-id"
+            @click="copyId(row, copyToClipboard)"
+          >
+            {{ t('consumer_groups.actions.copy_id') }}
+          </KDropdownItem>
+        </KClipboardProvider>
+        <KClipboardProvider v-slot="{ copyToClipboard }">
+          <KDropdownItem
+            data-testid="action-entity-copy-json"
+            @click="copyJson(row, copyToClipboard)"
+          >
+            {{ t('consumer_groups.actions.copy_json') }}
+          </KDropdownItem>
+        </KClipboardProvider>
+        <PermissionsWrapper :auth-function="() => canRetrieve(row)">
+          <KDropdownItem
+            data-testid="action-entity-view"
+            has-divider
+            :item="getViewDropdownItem(row.id)"
+          />
+        </PermissionsWrapper>
+        <PermissionsWrapper :auth-function="() => canEdit(row)">
+          <KDropdownItem
+            data-testid="action-entity-edit"
+            :item="getEditDropdownItem(row.id)"
+          />
+        </PermissionsWrapper>
+        <PermissionsWrapper :auth-function="() => canDelete(row)">
+          <KDropdownItem
+            data-testid="action-entity-delete"
+            has-divider
+            is-dangerous
+            @click="() => config.consumerId ? handleExitGroupClick(row) : deleteRow(row)"
+          >
+            {{ config.consumerId ? t('consumer_groups.actions.exit') : t('consumer_groups.actions.delete') }}
+          </KDropdownItem>
+        </PermissionsWrapper>
+      </template>
+    </EntityBaseTable>
+
+    <EntityDeleteModal
+      :action-pending="isDeletePending"
+      data-testid="delete-consumer-group-modal"
+      :description="t('consumer_groups.delete.description')"
+      :entity-name="consumerGroupToBeDeleted && (consumerGroupToBeDeleted.name || consumerGroupToBeDeleted.id)"
+      :entity-type="EntityTypes.ConsumerGroup"
+      :error="deleteModalError"
+      :title="t('consumer_groups.delete.title')"
+      :visible="isDeleteModalVisible"
+      @cancel="hideDeleteModal"
+      @proceed="confirmDelete"
+    />
+
+    <AddToGroupModal
+      v-if="config.consumerId"
+      :config="config"
+      data-testid="add-to-group-modal"
+      :visible="isAddModalVisible"
+      @add:partial-success="(data: any) => handleAddSuccess(data, true)"
+      @add:success="(data: any) => handleAddSuccess(data)"
+      @cancel="hideAddToGroupModal"
+    />
+
+    <KPrompt
+      v-if="config.consumerId && groupToExit"
+      data-testid="exit-group-modal"
+      :is-visible="isExitModalVisible"
+      :title="t('consumer_groups.consumers.exit.title')"
+      type="danger"
+      @canceled="hideExitGroupModal"
+      @proceed="exitGroups"
+    >
+      <template #body-content>
+        <i18n-t
+          class="exit-modal-message"
+          :keypath="config.consumerUsername ? 'consumer_groups.consumers.exit.confirmation' : 'consumer_groups.consumers.exit.confirmationNoUsername'"
+          tag="p"
+        >
+          <template #consumerGroup>
+            <strong>
+              {{ groupToExit.name || groupToExit.id }}
+            </strong>
+          </template>
+          <template
+            v-if="config.consumerUsername"
+            #consumer
+          >
+            <strong>
+              {{ config.consumerUsername }}
+            </strong>
+          </template>
+        </i18n-t>
+        <p>
+          {{ t('consumer_groups.consumers.exit.description') }}
+        </p>
+      </template>
+    </KPrompt>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, PropType, ref, watch, onBeforeMount } from 'vue'
+import type { AxiosError } from 'axios'
+import { useRouter } from 'vue-router'
+import composables from '../composables'
+import endpoints from '../consumer-groups-endpoints'
+import {
+  EntityBaseTable,
+  EntityDeleteModal,
+  EntityFilter,
+  EntityTypes,
+  FetcherStatus,
+  PermissionsWrapper,
+  useAxios,
+  useFetcher,
+  useDeleteUrlBuilder,
+} from '@kong-ui-public/entities-shared'
+import type {
+  KongManagerConsumerGroupListConfig,
+  KonnectConsumerGroupListConfig,
+  EntityRow,
+  CopyEventPayload,
+} from '../types'
+import type {
+  BaseTableHeaders,
+  EmptyStateOptions,
+  ExactMatchFilterConfig,
+  FuzzyMatchFilterConfig,
+} from '@kong-ui-public/entities-shared'
+import '@kong-ui-public/entities-shared/dist/style.css'
+import AddToGroupModal from './AddToGroupModal.vue'
+
+const emit = defineEmits<{
+  (e: 'error', error: AxiosError): void,
+  (e: 'copy:success', payload: CopyEventPayload): void,
+  (e: 'copy:error', payload: CopyEventPayload): void,
+  (e: 'delete:success', consumerGroup: EntityRow): void,
+  (e: 'add:success', consumers: string[]): void,
+  (e: 'remove:success', consumer: EntityRow): void,
+}>()
+
+// Component props - This structure must exist in ALL entity components, with the exclusion of unneeded action props (e.g. if you don't need `canDelete`, just exclude it)
+const props = defineProps({
+  /** The base konnect or kongManger config. Pass additional config props in the shared entity component as needed. */
+  config: {
+    type: Object as PropType<KonnectConsumerGroupListConfig | KongManagerConsumerGroupListConfig>,
+    required: true,
+    validator: (config: KonnectConsumerGroupListConfig | KongManagerConsumerGroupListConfig): boolean => {
+      if (!config || !['konnect', 'kongManager'].includes(config?.app)) return false
+      if (!config.createRoute || !config.getViewRoute || !config.getEditRoute) return false
+      if (config.app === 'kongManager' && !config.isExactMatch && !config.filterSchema) return false
+      return true
+    },
+  },
+  // used to override the default identifier for the cache entry
+  cacheIdentifier: {
+    type: String,
+    default: '',
+  },
+  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  canCreate: {
+    type: Function as PropType<() => Promise<boolean>>,
+    required: false,
+    default: async () => true,
+  },
+  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  canDelete: {
+    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    required: false,
+    default: async () => true,
+  },
+  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  canEdit: {
+    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    required: false,
+    default: async () => true,
+  },
+  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  canRetrieve: {
+    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    required: false,
+    default: async () => true,
+  },
+})
+
+const { i18nT, i18n: { t } } = composables.useI18n()
+const router = useRouter()
+
+const { axiosInstance } = useAxios({
+  headers: props.config?.requestHeaders,
+})
+const fetcherCacheKey = ref<number>(1)
+const isConsumerPage = computed<boolean>(() => !!props.config.consumerId)
+
+/**
+ * Table Headers
+ */
+const disableSorting = computed((): boolean => props.config.app !== 'kongManager' || !!props.config.disableSorting)
+const fields: BaseTableHeaders = {
+  name: { label: t('consumer_groups.list.table_headers.name'), searchable: true, sortable: true },
+}
+// TODO: when koko supports `?count=true` this conditional can be removed
+if (props.config.app === 'kongManager') {
+  fields.consumers_count = { label: t('consumer_groups.list.table_headers.consumers_count'), searchable: false, sortable: false }
+}
+fields.tags = { label: t('consumer_groups.list.table_headers.tags'), sortable: false }
+
+const tableHeaders: BaseTableHeaders = fields
+
+const rowAttributes = (row: Record<string, any>) => ({
+  'data-testid': row.username ?? row.custom_id ?? row.id,
+})
+
+/**
+ * Fetcher & Filtering
+ */
+const fetcherBaseUrl = computed<string>(() => {
+  let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app][isConsumerPage.value ? 'forConsumer' : 'all']}`
+
+  if (props.config.app === 'konnect') {
+    url = url
+      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
+      .replace(/{consumerId}/gi, props.config?.consumerId || '')
+  } else if (props.config.app === 'kongManager') {
+    url = url
+      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+      .replace(/{consumerId}/gi, props.config?.consumerId || '')
+  }
+
+  return url
+})
+
+const filterQuery = ref<string>('')
+const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
+  const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
+
+  if (isExactMatch) {
+    return {
+      isExactMatch,
+      fields: {
+        username: fields.name,
+        id: { label: t('consumer_groups.list.table_headers.id') },
+      },
+      placeholder: t('consumer_groups.search.placeholder'),
+    } as ExactMatchFilterConfig
+  }
+
+  return {
+    isExactMatch,
+    fields: {
+      name: fields.name,
+    },
+    schema: props.config.filterSchema,
+  } as FuzzyMatchFilterConfig
+})
+
+const dataKeyName = computed((): string | undefined => isConsumerPage.value ? 'consumer_groups' : undefined)
+const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value, dataKeyName.value)
+
+const clearFilter = (): void => {
+  filterQuery.value = ''
+}
+
+const resetPagination = (): void => {
+  // Increment the cache key on sort
+  fetcherCacheKey.value++
+}
+
+/**
+ * loading, Error, Empty state
+ */
+const errorMessage = ref('')
+
+/**
+ * Copy ID action
+ */
+const copyId = (row: EntityRow, copyToClipboard: (val: string) => boolean): void => {
+  const id = row.id as string
+
+  if (!copyToClipboard(id)) {
+    // Emit the error event for the host app
+    emit('copy:error', {
+      entity: row,
+      field: 'id',
+      message: t('consumer_groups.errors.copy'),
+    })
+
+    return
+  }
+
+  // Emit the success event for the host app
+  emit('copy:success', {
+    entity: row,
+    field: 'id',
+    message: t('consumer_groups.copy.success', { val: id }),
+  })
+}
+
+/**
+ * Copy JSON action
+ */
+const copyJson = (row: EntityRow, copyToClipboard: (val: string) => boolean): void => {
+  const val = JSON.stringify(row)
+
+  if (!copyToClipboard(val)) {
+    // Emit the error event for the host app
+    emit('copy:error', {
+      entity: row,
+      message: t('consumer_groups.errors.copy'),
+    })
+
+    return
+  }
+
+  // Emit the success event for the host app
+  emit('copy:success', {
+    entity: row,
+    message: t('consumer_groups.copy.success_brief'),
+  })
+}
+
+/**
+ * Row Click + View Details action
+ */
+const rowClick = async (row: EntityRow): Promise<void> => {
+  const isAllowed = await props.canRetrieve?.(row)
+
+  if (!isAllowed) {
+    return
+  }
+
+  router.push(props.config.getViewRoute(row.id as string))
+}
+
+// Render the view dropdown item as a router-link
+const getViewDropdownItem = (id: string) => {
+  return {
+    label: t('consumer_groups.actions.view'),
+    to: props.config.getViewRoute(id),
+  }
+}
+
+/**
+ * Edit action
+ */
+// Render the edit dropdown item as a router-link
+const getEditDropdownItem = (id: string) => {
+  return {
+    label: t('consumer_groups.actions.edit'),
+    to: props.config.getEditRoute(id),
+  }
+}
+
+/**
+ * Delete action
+ */
+const consumerGroupToBeDeleted = ref<EntityRow | undefined>(undefined)
+const isDeleteModalVisible = ref<boolean>(false)
+const isDeletePending = ref<boolean>(false)
+const deleteModalError = ref<string>('')
+
+const buildDeleteUrl = useDeleteUrlBuilder(props.config, fetcherBaseUrl.value)
+
+const deleteRow = (row: EntityRow): void => {
+  consumerGroupToBeDeleted.value = row
+  isDeleteModalVisible.value = true
+}
+
+const hideDeleteModal = (): void => {
+  isDeleteModalVisible.value = false
+}
+
+const confirmDelete = async (): Promise<void> => {
+  if (!consumerGroupToBeDeleted.value?.id) {
+    return
+  }
+
+  isDeletePending.value = true
+
+  try {
+    await axiosInstance.delete(buildDeleteUrl(consumerGroupToBeDeleted.value.id))
+
+    isDeletePending.value = false
+    isDeleteModalVisible.value = false
+    fetcherCacheKey.value++
+
+    // Emit the success event for the host app
+    emit('delete:success', consumerGroupToBeDeleted.value)
+  } catch (error: any) {
+    deleteModalError.value = error.response?.data?.message ||
+      error.message ||
+      t('consumer_groups.errors.delete')
+
+    // Emit the error event for the host app
+    emit('error', error)
+  } finally {
+    isDeletePending.value = false
+  }
+}
+
+/**
+ * ------------------------------
+ * Consumer Actions
+ * ------------------------------
+ */
+// Add
+const isAddModalVisible = ref<boolean>(false)
+const handleAddToGroupClick = (): void => {
+  isAddModalVisible.value = true
+}
+const hideAddToGroupModal = (): void => {
+  isAddModalVisible.value = false
+}
+const handleAddSuccess = (data: Array<string>, partialSuccess?: boolean) => {
+  // if only partially successful leave the modal open
+  if (!partialSuccess) {
+    hideAddToGroupModal()
+  }
+  fetcherCacheKey.value++
+  emit('add:success', data)
+}
+
+const handleEmptyStateCtaClicked = () => {
+  if (isConsumerPage.value) {
+    handleAddToGroupClick()
+  }
+}
+
+// Remove
+const groupToExit = ref<EntityRow | undefined>(undefined)
+const isExitModalVisible = ref<boolean>(false)
+const consumerRemoveError = ref('')
+const handleExitGroupClick = (row: EntityRow): void => {
+  groupToExit.value = row
+  isExitModalVisible.value = true
+}
+const hideExitGroupModal = (): void => {
+  isExitModalVisible.value = false
+  groupToExit.value = undefined
+}
+const removeUrl = computed<string>(() => {
+  let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app].oneForConsumer}`
+  if (props.config.app === 'konnect') {
+    url = url
+      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
+      .replace(/{consumerId}/gi, props.config?.consumerId || '')
+  } else if (props.config.app === 'kongManager') {
+    url = url
+      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+      .replace(/{consumerId}/gi, props.config?.consumerId || '')
+  }
+  return url
+})
+const isRemovePending = ref(false)
+const exitGroups = async (): Promise<void> => {
+  if (!groupToExit.value) {
+    return
+  }
+  isRemovePending.value = true
+  try {
+    const url = removeUrl.value.replace(/{consumerGroupId}/gi, groupToExit.value.id)
+    await axiosInstance.delete(url)
+    emit('remove:success', groupToExit.value)
+    hideExitGroupModal()
+    fetcherCacheKey.value++
+  } catch (err: any) {
+    consumerRemoveError.value = err.message || t('consumer_groups.errors.delete')
+    // Emit the error event for the host app
+    emit('error', err)
+  } finally {
+    isRemovePending.value = false
+  }
+}
+
+/**
+ * Watchers
+ */
+watch(fetcherState, (state) => {
+  if (state.status === FetcherStatus.Error) {
+    errorMessage.value = t('consumer_groups.errors.general')
+    // Emit the error for the host app
+    emit('error', state.error)
+
+    return
+  }
+
+  errorMessage.value = ''
+})
+
+// Initialize the empty state options assuming a user does not have create permissions
+// IMPORTANT: you must initialize this object assuming the user does **NOT** have create permissions so that the onBeforeMount hook can properly evaluate the props.canCreate function.
+const emptyStateOptions = ref<EmptyStateOptions>({
+  ctaPath: isConsumerPage.value ? undefined : props.config.createRoute,
+  ctaText: undefined,
+  message: t('consumer_groups.list.empty_state.description'),
+  title: t('consumer_groups.title'),
+})
+
+onBeforeMount(async () => {
+  // Evaluate if the user has create permissions
+  const userCanCreate = await props.canCreate()
+
+  // If a user can create consumer groups, we need to modify the empty state actions/messaging
+  if (userCanCreate) {
+    emptyStateOptions.value.title = isConsumerPage.value ? t('consumer_groups.list.empty_state.title_for_consumer') : t('consumer_groups.list.empty_state.title')
+    emptyStateOptions.value.ctaText = isConsumerPage.value ? t('consumer_groups.actions.add_to_group') : t('consumer_groups.actions.create')
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.kong-ui-entities-consumer-groups-list {
+  width: 100%;
+
+  .kong-ui-entity-filter-input {
+    width: 300px;
+  }
+
+  .exit-modal-message {
+    margin-top: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-consumer-groups/src/composables/index.ts
+++ b/packages/entities/entities-consumer-groups/src/composables/index.ts
@@ -1,0 +1,6 @@
+import useI18n from './useI18n'
+
+// All composables must be exported as part of the default object for Cypress test stubs
+export default {
+  useI18n,
+}

--- a/packages/entities/entities-consumer-groups/src/composables/useI18n.ts
+++ b/packages/entities/entities-consumer-groups/src/composables/useI18n.ts
@@ -1,0 +1,11 @@
+import { createI18n, i18nTComponent } from '@kong-ui-public/i18n'
+import english from '../locales/en.json'
+
+export default function useI18n() {
+  const i18n = createI18n<typeof english>('en-us', english)
+
+  return {
+    i18n,
+    i18nT: i18nTComponent<typeof english>(i18n), // Translation component <i18n-t>
+  }
+}

--- a/packages/entities/entities-consumer-groups/src/consumer-groups-endpoints.ts
+++ b/packages/entities/entities-consumer-groups/src/consumer-groups-endpoints.ts
@@ -1,0 +1,35 @@
+const konnectBaseApiUrl = '/api/runtime_groups/{controlPlaneId}'
+const KMBaseApiUrl = '/{workspace}'
+
+export default {
+  list: {
+    konnect: {
+      all: `${konnectBaseApiUrl}/consumer_groups`,
+      forConsumer: `${konnectBaseApiUrl}/consumers/{consumerId}/consumer_groups`,
+      oneForConsumer: `${konnectBaseApiUrl}/consumers/{consumerId}/consumer_groups/{consumerGroupId}`,
+    },
+    kongManager: {
+      all: `${KMBaseApiUrl}/consumer_groups?counter=true`,
+      forConsumer: `${KMBaseApiUrl}/consumers/{consumerId}/consumer_groups`,
+      oneForConsumer: `${KMBaseApiUrl}/consumers/{consumerId}/consumer_groups/{consumerGroupId}`,
+    },
+  },
+  form: {
+    konnect: {
+      consumersList: `${konnectBaseApiUrl}/consumers`,
+      create: `${konnectBaseApiUrl}/consumer_groups`,
+      edit: `${konnectBaseApiUrl}/consumer_groups/{id}`,
+      addConsumer: `${konnectBaseApiUrl}/consumer_groups/{id}/consumers`,
+      removeConsumer: `${konnectBaseApiUrl}/consumer_groups/{id}/consumers/{consumerId}`,
+      getConsumers: `${konnectBaseApiUrl}/consumer_groups/{id}/consumers`,
+    },
+    kongManager: {
+      consumersList: `${KMBaseApiUrl}/consumers`,
+      create: `${KMBaseApiUrl}/consumer_groups`,
+      edit: `${KMBaseApiUrl}/consumer_groups/{id}`,
+      addConsumer: `${KMBaseApiUrl}/consumer_groups/{id}/consumers`,
+      removeConsumer: `${KMBaseApiUrl}/consumer_groups/{id}/consumers/{consumerId}`,
+      getConsumers: `${KMBaseApiUrl}/consumer_groups/{id}/consumers`,
+    },
+  },
+}

--- a/packages/entities/entities-consumer-groups/src/global-components.d.ts
+++ b/packages/entities/entities-consumer-groups/src/global-components.d.ts
@@ -1,0 +1,2 @@
+// Import globally available components
+import '@kong/kongponents/dist/types/global-components'

--- a/packages/entities/entities-consumer-groups/src/index.ts
+++ b/packages/entities/entities-consumer-groups/src/index.ts
@@ -1,0 +1,7 @@
+import ConsumerGroupList from './components/ConsumerGroupList.vue'
+import ConsumerGroupForm from './components/ConsumerGroupForm.vue'
+import ConsumerGroupConfigCard from './components/ConsumerGroupConfigCard.vue'
+
+export { ConsumerGroupList, ConsumerGroupForm, ConsumerGroupConfigCard }
+
+export * from './types'

--- a/packages/entities/entities-consumer-groups/src/locales/en.json
+++ b/packages/entities/entities-consumer-groups/src/locales/en.json
@@ -1,0 +1,95 @@
+{
+  "consumer_groups": {
+    "list": {
+      "table_headers": {
+        "name": "Name",
+        "consumers_count": "Consumers",
+        "tags": "Tags",
+        "id": "ID"
+      },
+      "empty_state": {
+        "title": "Configure a New Consumer Group",
+        "description": "Use consumer groups to manage custom rate limiting configuration for subsets of consumers.",
+        "title_for_consumer": "Add to a Consumer Group"
+      },
+      "toolbar_actions": {
+        "new_consumer_group": "New Consumer Group"
+      }
+    },
+    "title": "Consumer Groups",
+    "search": {
+      "placeholder": "Filter by exact name or ID"
+    },
+    "actions": {
+      "add_to_group": "Add to Consumer Group",
+      "create": "New Consumer Group",
+      "copy_id": "Copy ID",
+      "copy_json": "Copy JSON",
+      "edit": "Edit",
+      "delete": "Delete",
+      "exit": "Exit",
+      "view": "View Details"
+    },
+    "delete": {
+      "title": "Delete a Consumer Group",
+      "description": "Deleting this group will remove this group from all plugins and its rate limit configuration. This action cannot be reversed."
+    },
+    "consumers": {
+      "add": {
+        "title": "Add To Consumer Groups",
+        "ctaText": "Add this consumer to consumer groups",
+        "consumer_groups_label": "Consumer Groups",
+        "consumer_group_placeholder": "Add to consumer groups",
+        "footer": "Search by exact name or ID to find consumer groups not included in the list"
+      },
+      "exit": {
+        "title": "Exit from a Consumer Group",
+        "confirmation": "Are you sure you want to remove consumer {consumer} from consumer group {consumerGroup}?",
+        "confirmationNoUsername": "Are you sure you want this consumer to exit from consumer group {consumerGroup}?",
+        "description": "Exiting from the group could change the rate limit policy applied to this consumer."
+      }
+    },
+    "errors": {
+      "general": "Consumer Groups could not be retrieved",
+      "delete": "The consumer group could not be deleted at this time.",
+      "copy": "Failed to copy to clipboard",
+      "add": "The consumer could not be added to some groups at this time.",
+      "already_added": "The consumer is already in this consumer group",
+      "add_consumer": "An unexpected error occurred while adding consumers. Please try again.",
+      "remove_consumer": "An unexpected error occurred while removing consumers. Please try again."
+    },
+    "copy": {
+      "success": "Copied {val} to clipboard",
+      "success_brief": "Successfully copied to clipboard"
+    },
+    "form": {
+      "general_info": {
+        "title": "General Information",
+        "description": "General information will help identify and manage this consumer group."
+      },
+      "consumers": {
+        "title": "Consumers",
+        "description": "Add or remove consumers from this group"
+      },
+      "fields": {
+        "name": {
+          "label": "Name",
+          "placeholder": "Enter a unique name for this consumer group "
+        },
+        "tags": {
+          "label": "Tags",
+          "placeholder": "Enter a list of tags seperated by comma",
+          "help": "e.g. tag1, tag2, tag3",
+          "tooltip": "An optional set of strings for grouping and filtering, separated by commas."
+        },
+        "consumers": {
+          "label": "Consumers",
+          "placeholder": "Select one or more consumers"
+        }
+      },
+      "validation_errors": {
+        "name": "The name can be any string containing letters, numbers, or the following characters: ., -, _, or ~. Do not use spaces."
+      }
+    }
+  }
+}

--- a/packages/entities/entities-consumer-groups/src/types/consumer-group-config-card.ts
+++ b/packages/entities/entities-consumer-groups/src/types/consumer-group-config-card.ts
@@ -1,0 +1,16 @@
+import type { KonnectBaseEntityConfig, KongManagerBaseEntityConfig, ConfigurationSchemaItem } from '@kong-ui-public/entities-shared'
+
+/** Konnect ConsumerGroup entity config */
+export interface KonnectConsumerGroupEntityConfig extends KonnectBaseEntityConfig {}
+
+/** Kong Manager ConsumerGroup entity config */
+export interface KongManagerConsumerGroupEntityConfig extends KongManagerBaseEntityConfig {}
+
+export interface ConsumerGroupConfigurationSchema {
+  // basic fields
+  id: ConfigurationSchemaItem
+  name: ConfigurationSchemaItem
+  updated_at: ConfigurationSchemaItem
+  created_at: ConfigurationSchemaItem
+  tags: ConfigurationSchemaItem
+}

--- a/packages/entities/entities-consumer-groups/src/types/consumer-group-form.ts
+++ b/packages/entities/entities-consumer-groups/src/types/consumer-group-form.ts
@@ -1,0 +1,42 @@
+import { RouteLocationRaw } from 'vue-router'
+import { BaseFormConfig, KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
+
+export interface BaseConsumerGroupFormConfig extends Omit<BaseFormConfig, 'cancelRoute'>{
+  /** Route to return to if canceling create/edit a Consumer form */
+  cancelRoute: RouteLocationRaw
+}
+
+/** Konnect Consumer form config */
+export interface KonnectConsumerGroupFormConfig extends Omit<KonnectBaseFormConfig, 'cancelRoute'>, BaseConsumerGroupFormConfig {}
+
+/** Kong Manager Consumer form config */
+export interface KongManagerConsumerGroupFormConfig extends Omit<KongManagerBaseFormConfig, 'cancelRoute'>, BaseConsumerGroupFormConfig {}
+
+export interface ConsumerGroupFields {
+  name: string,
+  tags: string,
+  consumers: string[]
+}
+
+export interface ConsumerGroupPayload extends Omit<ConsumerGroupFields, 'consumers' | 'tags'> {
+  tags: string[]
+}
+export interface ConsumerGroupData extends ConsumerGroupFields {
+  id: string
+}
+
+export interface ConsumerGroupState {
+  fields: ConsumerGroupFields
+  errorMessage: string
+  readonly: boolean
+}
+
+export interface Consumer {
+  created_at: number
+  id: string
+  tags: string[]
+  updated_at: number
+  username: string
+}
+
+export type ConsumerGroupActions = 'getConsumers' | 'create' | 'edit' | 'addConsumer' | 'removeConsumer'

--- a/packages/entities/entities-consumer-groups/src/types/consumer-group-list.ts
+++ b/packages/entities/entities-consumer-groups/src/types/consumer-group-list.ts
@@ -1,0 +1,46 @@
+import type { RouteLocationRaw } from 'vue-router'
+import {
+  FilterSchema,
+  KongManagerBaseTableConfig,
+  KonnectBaseTableConfig,
+} from '@kong-ui-public/entities-shared'
+
+export interface BaseConsumerGroupListConfig {
+  /** Current consumer id if the ConsumerGroupList in nested in the groups tab on a consumer detail page */
+  consumerId?: string
+  /** Current consumer username if the ConsumerGroupList in nested in the groups tab on a consumer detail page */
+  consumerUsername?: string
+  /** Route for creating a consumer group */
+  createRoute: RouteLocationRaw
+  /** A function that returns the route for viewing a consumer group */
+  getViewRoute: (id: string) => RouteLocationRaw
+  /** A function that returns the route for editing a consumer group */
+  getEditRoute: (id: string) => RouteLocationRaw
+}
+
+/** Konnect route list config */
+export interface KonnectConsumerGroupListConfig extends KonnectBaseTableConfig, BaseConsumerGroupListConfig {}
+
+/** Kong Manager route list config */
+export interface KongManagerConsumerGroupListConfig
+  extends KongManagerBaseTableConfig,
+  BaseConsumerGroupListConfig {
+  /** FilterSchema for fuzzy match */
+  filterSchema?: FilterSchema
+}
+
+export interface EntityRow extends Record<string, any> {
+  id: string
+  name: string
+  consumers: number
+}
+
+/** Copy field event payload */
+export interface CopyEventPayload {
+  /** The entity row */
+  entity: EntityRow
+  /** The field being copied. If omitted, the entity JSON is being copied. */
+  field?: string
+  /** The toaster message */
+  message: string
+}

--- a/packages/entities/entities-consumer-groups/src/types/index.ts
+++ b/packages/entities/entities-consumer-groups/src/types/index.ts
@@ -1,0 +1,6 @@
+// Export all types and interfaces from this index.ts
+// The actual types and interfaces should be contained in separate files within this folder.
+
+export * from './consumer-group-list'
+export * from './consumer-group-form'
+export * from './consumer-group-config-card'

--- a/packages/entities/entities-consumer-groups/tsconfig.build.json
+++ b/packages/entities/entities-consumer-groups/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.cy.ts",
+    "src/**/*.spec.ts",
+    "sandbox",
+    "dist"
+  ]
+}

--- a/packages/entities/entities-consumer-groups/tsconfig.json
+++ b/packages/entities/entities-consumer-groups/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "declarationDir": "dist/types",
+    "types": [
+      "node",
+      "vite/client",
+      "cypress",
+      "cypress/vue",
+      "../../../cypress/support"
+    ]
+  },
+  "include": [
+    "src/**/*",
+    "sandbox/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/entities/entities-consumer-groups/vite.config.ts
+++ b/packages/entities/entities-consumer-groups/vite.config.ts
@@ -1,0 +1,35 @@
+import sharedViteConfig, { getApiProxies, sanitizePackageName } from '../../../vite.config.shared'
+import { resolve } from 'path'
+import { defineConfig, mergeConfig } from 'vite'
+
+// Package name MUST always match the kebab-case package name inside the component's package.json file and the name of your `/packages/{package-name}` directory
+const packageName = 'entities-consumer-groups'
+const sanitizedPackageName = sanitizePackageName(packageName)
+
+// Merge the shared Vite config with the local one defined below
+const config = mergeConfig(sharedViteConfig, defineConfig({
+  build: {
+    lib: {
+      // The kebab-case name of the exposed global variable. MUST be in the format `kong-ui-public-{package-name}`
+      // Example: name: 'kong-ui-public-demo-component'
+      name: `kong-ui-public-${sanitizedPackageName}`,
+      entry: resolve(__dirname, './src/index.ts'),
+      fileName: (format) => `${sanitizedPackageName}.${format}.js`,
+    },
+  },
+  server: {
+    proxy: {
+      // Add the API proxies to inject the Authorization header
+      ...getApiProxies(),
+    },
+  },
+}))
+
+// If we are trying to preview a build of the local `package/entities-consumer-groups/sandbox` directory,
+// unset the external and lib properties
+if (process.env.PREVIEW_SANDBOX) {
+  config.build.rollupOptions.external = undefined
+  config.build.lib = undefined
+}
+
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -28,7 +24,7 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@rushstack/eslint-patch':
         specifier: ^1.3.2
         version: 1.3.2
@@ -233,7 +229,7 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@types/uuid':
         specifier: ^9.0.2
         version: 9.0.2
@@ -248,16 +244,16 @@ importers:
         version: 0.4.3
       '@kong-ui-public/core':
         specifier: 1.1.0
-        version: 1.1.0(axios@1.4.0)(swrv@1.0.4)
+        version: 1.1.0(axios@1.4.0)(swrv@1.0.4)(vue@3.3.4)
       '@kong-ui-public/metric-cards':
         specifier: 0.2.14
-        version: 0.2.14
+        version: 0.2.14(@kong/kongponents@8.116.2)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
       swrv:
         specifier: ^1.0.4
-        version: 1.0.4
+        version: 1.0.4(vue@3.3.4)
     devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
@@ -284,7 +280,7 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -306,7 +302,7 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@types/lodash.clonedeep':
         specifier: ^4.5.7
         version: 4.5.7
@@ -348,7 +344,7 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -367,13 +363,13 @@ importers:
         version: 1.4.0
       swrv:
         specifier: ^1.0.4
-        version: 1.0.4
+        version: 1.0.4(vue@3.3.4)
 
   packages/core/i18n:
     dependencies:
       '@formatjs/intl':
         specifier: ^2.9.0
-        version: 2.9.0
+        version: 2.9.0(typescript@5.1.6)
       flat:
         specifier: ^5.0.2
         version: 5.0.2
@@ -388,10 +384,35 @@ importers:
         version: link:../i18n
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
+
+  packages/entities/entities-consumer-groups:
+    dependencies:
+      '@kong-ui-public/entities-shared':
+        specifier: workspace:^
+        version: link:../entities-shared
+    devDependencies:
+      '@kong-ui-public/i18n':
+        specifier: workspace:^
+        version: link:../../core/i18n
+      '@kong/design-tokens':
+        specifier: ^1.8.0
+        version: 1.8.0
+      '@kong/kongponents':
+        specifier: ^8.116.2
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
+      axios:
+        specifier: ^1.4.0
+        version: 1.4.0
+      vue:
+        specifier: ^3.3.4
+        version: 3.3.4
+      vue-router:
+        specifier: ^4.2.4
+        version: 4.2.4(vue@3.3.4)
 
   packages/entities/entities-consumers:
     dependencies:
@@ -407,7 +428,7 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -432,7 +453,7 @@ importers:
         version: link:../../core/i18n
       '@kong/kongponents':
         specifier: ^8.106.0
-        version: 8.116.2(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -460,7 +481,7 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.106.0
-        version: 8.116.2(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -491,7 +512,7 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -516,7 +537,7 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -541,13 +562,13 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@types/prismjs':
         specifier: ^1.26.0
         version: 1.26.0
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.0.1
-        version: 3.0.1(vue@3.3.4)
+        version: 3.0.1(vite@4.4.7)(vue@3.3.4)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -572,10 +593,10 @@ importers:
         version: 1.8.0
       '@kong/kongponents':
         specifier: ^8.116.2
-        version: 8.116.2(vue@3.3.4)
+        version: 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.0.4
-        version: 1.0.4
+        version: 1.0.4(vite@4.4.7)
       '@types/lodash.clonedeep':
         specifier: ^4.5.7
         version: 4.5.7
@@ -593,7 +614,7 @@ importers:
     dependencies:
       '@kong/swagger-ui-kong-theme-universal':
         specifier: ^4.2.6
-        version: 4.2.6(react-dom@17.0.2)(react@17.0.2)
+        version: 4.2.6(react-dom@17.0.2)(react@17.0.2)(vue-router@4.2.4)(vue@3.3.4)
       react:
         specifier: 17.0.2
         version: 17.0.2
@@ -674,7 +695,7 @@ packages:
       '@babel/traverse': 7.22.5
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -939,7 +960,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.5
       '@babel/parser': 7.22.5
       '@babel/types': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1491,7 +1512,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -1566,7 +1587,7 @@ packages:
       tslib: 2.6.1
     dev: false
 
-  /@formatjs/intl@2.9.0:
+  /@formatjs/intl@2.9.0(typescript@5.1.6):
     resolution: {integrity: sha512-Ym0trUoC/VO6wQu4YHa0H1VR2tEixFRmwZgADkDLm7nD+vv1Ob+/88mUAoT0pwvirFqYKgUKEwp1tFepqyqvVA==}
     peerDependencies:
       typescript: ^4.7 || 5
@@ -1581,6 +1602,7 @@ packages:
       '@formatjs/intl-listformat': 7.4.0
       intl-messageformat: 10.5.0
       tslib: 2.6.1
+      typescript: 5.1.6
     dev: false
 
   /@gar/promisify@1.1.3:
@@ -1592,7 +1614,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1698,7 +1720,7 @@ packages:
       date-fns: 2.30.0
     dev: false
 
-  /@kong-ui-public/core@1.1.0(axios@1.4.0)(swrv@1.0.4):
+  /@kong-ui-public/core@1.1.0(axios@1.4.0)(swrv@1.0.4)(vue@3.3.4):
     resolution: {integrity: sha512-j1kK07/zDyxwePi1EX1rZ+3iL955VdhZiodzeT5ift7iVQTiPt9VNUFu9+IXJ/AxHfuYu/gaL+gily9TsJTX3w==}
     peerDependencies:
       axios: ^1.4.0
@@ -1707,53 +1729,34 @@ packages:
     dependencies:
       axios: 1.4.0
       date-fns: 2.30.0
-      swrv: 1.0.4
+      swrv: 1.0.4(vue@3.3.4)
+      vue: 3.3.4
     dev: false
 
-  /@kong-ui-public/metric-cards@0.2.14:
+  /@kong-ui-public/metric-cards@0.2.14(@kong/kongponents@8.116.2)(vue@3.3.4):
     resolution: {integrity: sha512-3z7aKeRox1VgxjQG6a0g1W+ME8u+62n+VvIb1HUH00rdacIBIKXGPBJTdIAFbodNtDa+s9oeV/OdjEUS5j+YbQ==}
     peerDependencies:
       '@kong/kongponents': ^8.83.5
       vue: ^3.2.47
     dependencies:
+      '@kong/kongponents': 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       approximate-number: 2.1.1
+      vue: 3.3.4
     dev: false
 
   /@kong/design-tokens@1.8.0:
     resolution: {integrity: sha512-al+FQaLcNaEr6SNxQfaWKt8VB4AEjJHQLYjiZUjw/YrUb1M2ERA5PV0fBkB3lDz+sh8O2BhoQo7cFrR7StEepw==}
     dev: true
 
-  /@kong/kongponents@8.116.2:
+  /@kong/kongponents@8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4):
     resolution: {integrity: sha512-p+08/xu8PA8P/+eaaXKH+lBVG0irNCFH2BF24gXagyi/VKqNsVy1z+YYUe065MYnalsUgifCFp/xTW2XTLi6Lg==}
     engines: {node: '>=16.19.0'}
     peerDependencies:
+      axios: ^0.27.2
       vue: '>= 3.3.0'
       vue-router: ^4.1.6
     dependencies:
-      axios: 0.27.2
-      date-fns: 2.30.0
-      date-fns-tz: 1.3.8(date-fns@2.30.0)
-      focus-trap: 7.5.2
-      focus-trap-vue: 3.4.0(focus-trap@7.5.2)
-      popper.js: 1.16.1
-      sortablejs: 1.15.0
-      swrv: 1.0.4
-      uuid: 8.3.2
-      v-calendar: 3.0.3
-      vue-draggable-next: 2.2.0(sortablejs@1.15.0)
-    transitivePeerDependencies:
-      - '@popperjs/core'
-      - debug
-    dev: false
-
-  /@kong/kongponents@8.116.2(vue-router@4.2.4)(vue@3.3.4):
-    resolution: {integrity: sha512-p+08/xu8PA8P/+eaaXKH+lBVG0irNCFH2BF24gXagyi/VKqNsVy1z+YYUe065MYnalsUgifCFp/xTW2XTLi6Lg==}
-    engines: {node: '>=16.19.0'}
-    peerDependencies:
-      vue: '>= 3.3.0'
-      vue-router: ^4.1.6
-    dependencies:
-      axios: 0.27.2
+      axios: 1.4.0
       date-fns: 2.30.0
       date-fns-tz: 1.3.8(date-fns@2.30.0)
       focus-trap: 7.5.2
@@ -1768,40 +1771,14 @@ packages:
       vue-router: 4.2.4(vue@3.3.4)
     transitivePeerDependencies:
       - '@popperjs/core'
-      - debug
-    dev: true
 
-  /@kong/kongponents@8.116.2(vue@3.3.4):
-    resolution: {integrity: sha512-p+08/xu8PA8P/+eaaXKH+lBVG0irNCFH2BF24gXagyi/VKqNsVy1z+YYUe065MYnalsUgifCFp/xTW2XTLi6Lg==}
-    engines: {node: '>=16.19.0'}
-    peerDependencies:
-      vue: '>= 3.3.0'
-      vue-router: ^4.1.6
-    dependencies:
-      axios: 0.27.2
-      date-fns: 2.30.0
-      date-fns-tz: 1.3.8(date-fns@2.30.0)
-      focus-trap: 7.5.2
-      focus-trap-vue: 3.4.0(focus-trap@7.5.2)(vue@3.3.4)
-      popper.js: 1.16.1
-      sortablejs: 1.15.0
-      swrv: 1.0.4(vue@3.3.4)
-      uuid: 8.3.2
-      v-calendar: 3.0.3(vue@3.3.4)
-      vue: 3.3.4
-      vue-draggable-next: 2.2.0(sortablejs@1.15.0)(vue@3.3.4)
-    transitivePeerDependencies:
-      - '@popperjs/core'
-      - debug
-    dev: true
-
-  /@kong/swagger-ui-kong-theme-universal@4.2.6(react-dom@17.0.2)(react@17.0.2):
+  /@kong/swagger-ui-kong-theme-universal@4.2.6(react-dom@17.0.2)(react@17.0.2)(vue-router@4.2.4)(vue@3.3.4):
     resolution: {integrity: sha512-ZZtnsER3yHFnzjy5OO3jYgeY3ZCuhQP6IFqwq2vUj9HntyJUBOBUxvTJ9YJoQHz2wMVuatdUJHadQcUVS/Cktw==}
     peerDependencies:
       react: 17.0.2
     dependencies:
       '@braintree/sanitize-url': 2.1.0
-      '@kong/kongponents': 8.116.2
+      '@kong/kongponents': 8.116.2(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@kyleshockey/xml': 1.0.2
       classnames: 2.3.2
       curl-to-har: 1.0.1
@@ -1818,7 +1795,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - '@popperjs/core'
-      - debug
+      - axios
       - mkdirp
       - prop-types
       - react-dom
@@ -1951,7 +1928,7 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /@modyfi/vite-plugin-yaml@1.0.4:
+  /@modyfi/vite-plugin-yaml@1.0.4(vite@4.4.7):
     resolution: {integrity: sha512-qkT0KiR3AQQRfUvDzLv4+1rYAzXj+QmGhAbyUd0Ordf9xynK76i758lk5GiEfxuQxbvdqDaJ9oXkH/KacbSjQQ==}
     peerDependencies:
       vite: ^2.6.0 || ^3.0.0 || ^4.0.0
@@ -1959,6 +1936,7 @@ packages:
       '@rollup/pluginutils': 5.0.2
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
+      vite: 4.4.7(@types/node@18.17.1)(sass@1.64.1)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -3131,7 +3109,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.46.0)(typescript@5.1.6)
       '@typescript-eslint/utils': 5.62.0(eslint@8.46.0)(typescript@5.1.6)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.46.0
       graphemer: 1.4.0
       ignore: 5.2.4
@@ -3160,7 +3138,7 @@ packages:
       '@typescript-eslint/type-utils': 6.2.0(eslint@8.46.0)(typescript@5.1.6)
       '@typescript-eslint/utils': 6.2.0(eslint@8.46.0)(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.2.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.46.0
       graphemer: 1.4.0
       ignore: 5.2.4
@@ -3186,7 +3164,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.46.0
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -3207,7 +3185,7 @@ packages:
       '@typescript-eslint/types': 6.2.0
       '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.2.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.46.0
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -3242,7 +3220,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
       '@typescript-eslint/utils': 5.62.0(eslint@8.46.0)(typescript@5.1.6)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.46.0
       tsutils: 3.21.0(typescript@5.1.6)
       typescript: 5.1.6
@@ -3262,7 +3240,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.2.0(typescript@5.1.6)
       '@typescript-eslint/utils': 6.2.0(eslint@8.46.0)(typescript@5.1.6)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.46.0
       ts-api-utils: 1.0.1(typescript@5.1.6)
       typescript: 5.1.6
@@ -3291,7 +3269,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -3312,7 +3290,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.2.0
       '@typescript-eslint/visitor-keys': 6.2.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -3388,21 +3366,6 @@ packages:
       '@babel/plugin-transform-typescript': 7.22.5(@babel/core@7.22.5)
       '@vue/babel-plugin-jsx': 1.1.1(@babel/core@7.22.5)
       vite: 4.4.7(@types/node@18.17.1)(sass@1.64.1)
-      vue: 3.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@vitejs/plugin-vue-jsx@3.0.1(vue@3.3.4):
-    resolution: {integrity: sha512-+Jb7ggL48FSPS1uhPnJbJwWa9Sr90vQ+d0InW+AhBM22n+cfuYqJZDckBc+W3QSHe1WDvewMZfa4wZOtk5pRgw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^4.0.0
-      vue: ^3.0.0
-    dependencies:
-      '@babel/core': 7.22.5
-      '@babel/plugin-transform-typescript': 7.22.5(@babel/core@7.22.5)
-      '@vue/babel-plugin-jsx': 1.1.1(@babel/core@7.22.5)
       vue: 3.3.4
     transitivePeerDependencies:
       - supports-color
@@ -3535,7 +3498,7 @@ packages:
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.0
+      magic-string: 0.30.1
       postcss: 8.4.27
       source-map-js: 1.0.2
 
@@ -3547,7 +3510,6 @@ packages:
 
   /@vue/devtools-api@6.5.0:
     resolution: {integrity: sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==}
-    dev: true
 
   /@vue/eslint-config-standard@8.0.1(@typescript-eslint/parser@6.2.0)(eslint-plugin-vue@9.17.0)(eslint@8.46.0):
     resolution: {integrity: sha512-+FsTb8kOf2GSbXXTwbigRBRRur/byMbwL6Ijii2JoXW4hsLB4arl9lbgV54OUOV5o20INLHDmBVONO16rP/a1g==}
@@ -3617,7 +3579,7 @@ packages:
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.0
+      magic-string: 0.30.1
 
   /@vue/reactivity@3.3.4:
     resolution: {integrity: sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==}
@@ -3923,7 +3885,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3932,7 +3894,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -4238,14 +4200,6 @@ packages:
   /aws4@1.12.0:
     resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
     dev: true
-
-  /axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-    dependencies:
-      follow-redirects: 1.15.2
-      form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
 
   /axios@1.4.0:
     resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
@@ -5546,17 +5500,6 @@ packages:
     dependencies:
       ms: 2.0.0
 
-  /debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-    dev: true
-
   /debug@3.2.7(supports-color@8.1.1):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -5567,18 +5510,6 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 8.1.1
-    dev: true
-
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
     dev: true
 
   /debug@4.3.4(supports-color@8.1.1):
@@ -6155,7 +6086,7 @@ packages:
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.12.1
       resolve: 1.22.4
     transitivePeerDependencies:
@@ -6184,7 +6115,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 6.2.0(eslint@8.46.0)(typescript@5.1.6)
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
@@ -6237,7 +6168,7 @@ packages:
       array.prototype.findlastindex: 1.2.2
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
@@ -6393,7 +6324,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -6875,15 +6806,6 @@ packages:
       tabbable: 6.2.0
     dev: false
 
-  /focus-trap-vue@3.4.0(focus-trap@7.5.2):
-    resolution: {integrity: sha512-VAI4gJgsjC8KcjDH+h4j2SxFY2XrXmm47a1EXti8gx311abybzqVhkS32Um7i+00J8RQD7hqL1Kfc26WpsMx0w==}
-    peerDependencies:
-      focus-trap: ^6.7.0
-      vue: ^3.0.0-rc.13
-    dependencies:
-      focus-trap: 7.5.2
-    dev: false
-
   /focus-trap-vue@3.4.0(focus-trap@7.5.2)(vue@3.3.4):
     resolution: {integrity: sha512-VAI4gJgsjC8KcjDH+h4j2SxFY2XrXmm47a1EXti8gx311abybzqVhkS32Um7i+00J8RQD7hqL1Kfc26WpsMx0w==}
     peerDependencies:
@@ -6892,7 +6814,6 @@ packages:
     dependencies:
       focus-trap: 7.5.2
       vue: 3.3.4
-    dev: true
 
   /focus-trap-vue@4.0.2(focus-trap@7.5.2)(vue@3.3.4):
     resolution: {integrity: sha512-2iQN2xKCSCzyhcD90VpueQcTIAhaCRxxo67fkz7RSqLmEd16QKjfGslCr3KxvBx0LfpVN9j0IAyKKuJKw3Intg==}
@@ -7670,7 +7591,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7719,7 +7640,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8939,18 +8860,11 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /magic-string@0.30.0:
-    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-
   /magic-string@0.30.1:
     resolution: {integrity: sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -11765,7 +11679,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -11844,7 +11758,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -11858,7 +11772,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -12204,7 +12118,7 @@ packages:
       cosmiconfig: 8.2.0
       css-functions-list: 3.2.0
       css-tree: 2.3.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.3.0
       fastest-levenshtein: 1.0.16
       file-entry-cache: 6.0.1
@@ -12365,18 +12279,12 @@ packages:
       - rollup
     dev: false
 
-  /swrv@1.0.4:
-    resolution: {integrity: sha512-zjEkcP8Ywmj+xOJW3lIT65ciY/4AL4e/Or7Gj0MzU3zBJNMdJiT8geVZhINavnlHRMMCcJLHhraLTAiDOTmQ9g==}
-    peerDependencies:
-      vue: '>=3.2.26 < 4'
-
   /swrv@1.0.4(vue@3.3.4):
     resolution: {integrity: sha512-zjEkcP8Ywmj+xOJW3lIT65ciY/4AL4e/Or7Gj0MzU3zBJNMdJiT8geVZhINavnlHRMMCcJLHhraLTAiDOTmQ9g==}
     peerDependencies:
       vue: '>=3.2.26 < 4'
     dependencies:
       vue: 3.3.4
-    dev: true
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -12783,7 +12691,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 1.0.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       make-fetch-happen: 11.1.1
     transitivePeerDependencies:
       - supports-color
@@ -12921,7 +12829,6 @@ packages:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /ufo@1.1.2:
     resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
@@ -13090,20 +12997,6 @@ packages:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
 
-  /v-calendar@3.0.3:
-    resolution: {integrity: sha512-Skpp/nMoFqFadm94aWj0oOfazoux5T5Ug3/pbRbdolkoDrnVcL7Ronw1/SGFRUPGOwnLdYwhKPhrhSE1segW6w==}
-    peerDependencies:
-      '@popperjs/core': ^2.0.0
-      vue: ^3.2.0
-    dependencies:
-      '@types/lodash': 4.14.195
-      '@types/resize-observer-browser': 0.1.7
-      date-fns: 2.30.0
-      date-fns-tz: 1.3.8(date-fns@2.30.0)
-      lodash: 4.17.21
-      vue-screen-utils: 1.0.0-beta.13
-    dev: false
-
   /v-calendar@3.0.3(vue@3.3.4):
     resolution: {integrity: sha512-Skpp/nMoFqFadm94aWj0oOfazoux5T5Ug3/pbRbdolkoDrnVcL7Ronw1/SGFRUPGOwnLdYwhKPhrhSE1segW6w==}
     peerDependencies:
@@ -13117,7 +13010,6 @@ packages:
       lodash: 4.17.21
       vue: 3.3.4
       vue-screen-utils: 1.0.0-beta.13(vue@3.3.4)
-    dev: true
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -13183,7 +13075,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
@@ -13293,7 +13185,7 @@ packages:
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       jsdom: 22.1.0
       local-pkg: 0.4.3
       magic-string: 0.30.1
@@ -13338,15 +13230,6 @@ packages:
     resolution: {integrity: sha512-6bnLkn8O0JJyiFSIF0EfCogzeqNXpnjJ0vW/SZzNHfe6sPx30lTtTXlE5TFs2qhJlAtDFybStVNpL73cPe3OMQ==}
     dev: true
 
-  /vue-draggable-next@2.2.0(sortablejs@1.15.0):
-    resolution: {integrity: sha512-JQ7Ac4knnpsA47/acUhRR7negDHNZDLdpbXRR+n89f516rJDt+eHh48tfqTe80q2UfnLymQ46zi81gCMKFU4DQ==}
-    peerDependencies:
-      sortablejs: ^1.14.0
-      vue: ^3.2.2
-    dependencies:
-      sortablejs: 1.15.0
-    dev: false
-
   /vue-draggable-next@2.2.0(sortablejs@1.15.0)(vue@3.3.4):
     resolution: {integrity: sha512-JQ7Ac4knnpsA47/acUhRR7negDHNZDLdpbXRR+n89f516rJDt+eHh48tfqTe80q2UfnLymQ46zi81gCMKFU4DQ==}
     peerDependencies:
@@ -13355,7 +13238,6 @@ packages:
     dependencies:
       sortablejs: 1.15.0
       vue: 3.3.4
-    dev: true
 
   /vue-eslint-parser@9.3.1(eslint@8.46.0):
     resolution: {integrity: sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==}
@@ -13363,7 +13245,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.46.0
       eslint-scope: 7.2.0
       eslint-visitor-keys: 3.4.1
@@ -13382,13 +13264,6 @@ packages:
     dependencies:
       '@vue/devtools-api': 6.5.0
       vue: 3.3.4
-    dev: true
-
-  /vue-screen-utils@1.0.0-beta.13:
-    resolution: {integrity: sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==}
-    peerDependencies:
-      vue: ^3.2.0
-    dev: false
 
   /vue-screen-utils@1.0.0-beta.13(vue@3.3.4):
     resolution: {integrity: sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==}
@@ -13396,7 +13271,6 @@ packages:
       vue: ^3.2.0
     dependencies:
       vue: 3.3.4
-    dev: true
 
   /vue-template-compiler@2.7.14:
     resolution: {integrity: sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==}
@@ -13982,3 +13856,7 @@ packages:
   /zenscroll@4.0.2:
     resolution: {integrity: sha512-jEA1znR7b4C/NnaycInCU6h/d15ZzCd1jmsruqOKnZP6WXQSMH3W2GL+OXbkruslU4h+Tzuos0HdswzRUk/Vgg==}
     dev: false
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Adds the `consumer-groups` package. Verified [here](https://github.com/Kong/kong-admin/actions/runs/5818613046?pr=2845).

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
