### PR TITLE
fix(timeframes): fix bug in previous month calculation [MA-1583]

### DIFF
--- a/packages/analytics/analytics-utilities/src/queryTime.spec.tz.ts
+++ b/packages/analytics/analytics-utilities/src/queryTime.spec.tz.ts
@@ -268,6 +268,31 @@ describe('pseudo-absolute periods', () => {
   })
 })
 
+describe('edge cases around pseudo-absolute periods', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+
+    const fakeNow = new Date('2023-03-31T12:00:00Z')
+
+    standardizeTimezone(fakeNow)
+    vi.setSystemTime(fakeNow)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('handles February in previous month calculations', () => {
+    const timeQuery = new TimeseriesQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH))
+
+    const expectedStart = startOfDay(new Date('2023-02-01T12:00:00Z'))
+    const expectedEnd = startOfDay(new Date('2023-03-01T12:00:00Z'))
+
+    expect(timeQuery.startDate()).toEqual(expectedStart)
+    expect(timeQuery.endDate()).toEqual(expectedEnd)
+  })
+})
+
 describe('queries with mocked dates', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/packages/analytics/analytics-utilities/src/timeframes.ts
+++ b/packages/analytics/analytics-utilities/src/timeframes.ts
@@ -158,7 +158,7 @@ class PreviousMonth extends Timeframe {
   }
 
   rawStart(): Date {
-    const lastMonth = startOfMonth(new Date().setMonth(new Date().getMonth() - 1))
+    const lastMonth = startOfMonth(subMonths(new Date(), 1))
 
     return lastMonth
   }


### PR DESCRIPTION
In the last few days of March, subtracting 1 from `Date.getMonth` will result in a March date rather than a February date.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
