### PR TITLE
fix(deps): bump version of `analytics-utilities`

### DIFF
--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -48,7 +48,7 @@
     "extends": "../../../package.json"
   },
   "dependencies": {
-    "@kong-ui-public/analytics-utilities": "^0.4.3",
+    "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/core": "1.1.0",
     "@kong-ui-public/metric-cards": "0.2.14",
     "axios": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,8 +244,8 @@ importers:
   packages/analytics/analytics-metric-provider:
     dependencies:
       '@kong-ui-public/analytics-utilities':
-        specifier: ^0.4.3
-        version: 0.4.3
+        specifier: workspace:^
+        version: link:../analytics-utilities
       '@kong-ui-public/core':
         specifier: 1.1.0
         version: 1.1.0(axios@1.4.0)(swrv@1.0.4)(vue@3.3.4)
@@ -1815,12 +1815,6 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
-
-  /@kong-ui-public/analytics-utilities@0.4.3:
-    resolution: {integrity: sha512-2mlYatUIRRFq5m6cVhALv34BExF6/TpC9X9Y3uPdiYZso8HoKagB+MnSwTbkUIdxU0oUHgfxoIPBa8OwttzKxg==}
-    dependencies:
-      date-fns: 2.30.0
-    dev: false
 
   /@kong-ui-public/core@1.1.0(axios@1.4.0)(swrv@1.0.4)(vue@3.3.4):
     resolution: {integrity: sha512-j1kK07/zDyxwePi1EX1rZ+3iL955VdhZiodzeT5ift7iVQTiPt9VNUFu9+IXJ/AxHfuYu/gaL+gily9TsJTX3w==}


### PR DESCRIPTION
Make the link between `analytics-utilities` and `analytics-metric-provider` a workspace dep to help avoid type issues when the packages are used together.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
