### PR TITLE
test(entities-upstreams-targets): fix flaky tests and test results upload workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,12 +312,21 @@ jobs:
           install: false
           command: pnpm run test:component:ci --spec ${{ matrix.container }}
 
+      - name: Normalize test results artifact name
+        continue-on-error: true
+        if: failure()
+        id: normalize-name
+        shell: bash
+        run: |
+          packageName=$(echo ${{ matrix.container }} | sed 's/\//-/g')
+          echo "artifactName=component-test-failures-${packageName}" >> $GITHUB_OUTPUT
+
       - name: Upload Component Test Results
         uses: actions/upload-artifact@v3
         continue-on-error: true
         if: failure()
         with:
-          name: component-test-failures-${{ matrix.container }}
+          name: ${{ steps.normalize-name.outputs.artifactName }}
           path: |
             cypress/videos/
             cypress/screenshots/

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.cy.ts
@@ -266,7 +266,7 @@ describe('<UpstreamsForm/>', () => {
         },
       })
 
-      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'])
+      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'], { timeout: 10000 })
 
       cy.get('.certificate-select input').should('have.value', upstreamsResponseFull.client_certificate?.id)
       cy.get('.name-select input').should('have.value', upstreamsResponseFull.name)
@@ -325,7 +325,7 @@ describe('<UpstreamsForm/>', () => {
       }).then(({ wrapper }) => wrapper)
         .as('vueWrapper')
 
-      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'])
+      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'], { timeout: 10000 })
 
       cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
         .vm.$emit('submit'))
@@ -596,7 +596,7 @@ describe('<UpstreamsForm/>', () => {
         },
       })
 
-      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'])
+      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'], { timeout: 10000 })
 
       cy.get('.certificate-select input').should('have.value', upstreamsResponseFull.client_certificate?.id)
       cy.get('.name-select input').should('have.value', upstreamsResponseFull.name)
@@ -657,7 +657,7 @@ describe('<UpstreamsForm/>', () => {
       }).then(({ wrapper }) => wrapper)
         .as('vueWrapper')
 
-      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'])
+      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'], { timeout: 10000 })
 
       cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
         .vm.$emit('submit'))
@@ -684,7 +684,7 @@ describe('<UpstreamsForm/>', () => {
       }).then(({ wrapper }) => wrapper)
         .as('vueWrapper')
 
-      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'])
+      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'], { timeout: 10000 })
 
       cy.getTestId('active-health-switch').should('be.checked')
       cy.get('[data-testid="active-health-switch"] + .switch-control').click({ force: true })
@@ -714,7 +714,7 @@ describe('<UpstreamsForm/>', () => {
       }).then(({ wrapper }) => wrapper)
         .as('vueWrapper')
 
-      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'])
+      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'], { timeout: 10000 })
 
       cy.getTestId('passive-health-switch').should('be.checked')
       cy.get('[data-testid="passive-health-switch"] + .switch-control').click({ force: true })


### PR DESCRIPTION
The `cy.wait()` will wait intercepted network events for 5 seconds by default. But in the CI environment, the
`['@getUpstream', '@fetchServices', '@fetchCertificates']` combination will took more than 4 seconds so the test will be flaky if it occasionally execeeds the 5 seconds limitation.

The slow part seems caused by the Cypress's vm hooks. It does not affect the component in development/production mode. So it's safe to loose the timeout to 10 seconds

This commit also fix the test results upload failure. The artifact name could not contains some special characters like `/`, which will occur in `matrix.container`. A new step is added to normalize the artifact name to make sure it can be uploaded successfully. (Verified [here](https://github.com/Kong/public-ui-components/actions/runs/5893716306))

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
