### PR TITLE
feat(queryTime): support doing calculations in a specific TZ [MA-1916]

### DIFF
--- a/packages/analytics/analytics-utilities/package.json
+++ b/packages/analytics/analytics-utilities/package.json
@@ -56,7 +56,8 @@
     "errorLimit": "500KB"
   },
   "dependencies": {
-    "date-fns": "^2.30.0"
+    "date-fns": "^2.30.0",
+    "date-fns-tz": "^2.0.0"
   },
   "devDependencies": {
     "@kong/design-tokens": "^1.9.0"

--- a/packages/analytics/analytics-utilities/src/queryTime.spec.tz.ts
+++ b/packages/analytics/analytics-utilities/src/queryTime.spec.tz.ts
@@ -602,12 +602,12 @@ runUtcTest('UTC: timezone handling', () => {
 
   it('calculates relative dates in a local, positive-offset timezone', () => {
     // Sanity check
-    expect(formatInTimeZone(new Date(), 'Africa/Cairo', 'yyyy-MM-dd HH:mm:ssXXX')).toBe('2023-11-09 03:00:00+02:00')
+    expect(formatInTimeZone(new Date(), 'Europe/Sofia', 'yyyy-MM-dd HH:mm:ssXXX')).toBe('2023-11-09 03:00:00+02:00')
 
-    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.SEVEN_DAY), 'Africa/Cairo')
-    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.SEVEN_DAY), 'Africa/Cairo')
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.SEVEN_DAY), 'Europe/Sofia')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.SEVEN_DAY), 'Europe/Sofia')
 
-    // Unary and delta end times should be the start of the _next_ day in Cairo time.
+    // Unary and delta end times should be the start of the _next_ day in Bulgarian time.
     expect(unaryQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
     expect(deltaQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
 
@@ -620,14 +620,14 @@ runUtcTest('UTC: timezone handling', () => {
   })
 
   it('calculates current week in a local, positive-offset timezone', () => {
-    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.CURRENT_WEEK), 'Africa/Cairo')
-    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_WEEK), 'Africa/Cairo')
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.CURRENT_WEEK), 'Europe/Sofia')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_WEEK), 'Europe/Sofia')
 
     // Unary and delta end times should be rounded up to the nearest day.
     expect(unaryQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
     expect(deltaQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
 
-    // Unary start times should be the start of the first day of the current week in Cairo time.
+    // Unary start times should be the start of the first day of the current week in Bulgarian time.
     expect(unaryQuery.startDate()).toEqual(new Date('2023-11-05T22:00:00.000Z'))
 
     // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
@@ -637,53 +637,58 @@ runUtcTest('UTC: timezone handling', () => {
   })
 
   it('calculates previous week in a local, positive-offset timezone', () => {
-    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_WEEK), 'Africa/Cairo')
-    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_WEEK), 'Africa/Cairo')
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_WEEK), 'Europe/Sofia')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_WEEK), 'Europe/Sofia')
 
     // Unary and delta end times should be the start of the current week.
     expect(unaryQuery.endDate()).toEqual(new Date('2023-11-05T22:00:00.000Z'))
     expect(deltaQuery.endDate()).toEqual(new Date('2023-11-05T22:00:00.000Z'))
 
-    // Unary start times should be the start of the first day of the previous week in Cairo time.
+    // Unary start times should be the start of the first day of the previous week in Bulgarian time.
     expect(unaryQuery.startDate()).toEqual(new Date('2023-10-29T22:00:00.000Z'))
 
     // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
     // actually comparing to the full previous week.
-    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-22T22:00:00.000Z'))
+    // This is extended to the nearest day, which in this case results in a different hour offset due to DST.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-22T21:00:00.000Z'))
     expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
   })
 
   it('calculates current month in a local, positive-offset timezone', () => {
-    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'Africa/Cairo')
-    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'Africa/Cairo')
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'Europe/Sofia')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'Europe/Sofia')
 
     // Unary and delta end times should be rounded up to the nearest day.
     expect(unaryQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
     expect(deltaQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
 
-    // Unary start times should be the start of the first day of the current month in Cairo time.
+    // Unary start times should be the start of the first day of the current month in Bulgarian time.
     expect(unaryQuery.startDate()).toEqual(new Date('2023-10-31T22:00:00.000Z'))
 
     // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
     // actually comparing to the full previous month.
-    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-22T22:00:00.000Z'))
+    // This is extended to the nearest day, which in this case results in a different hour offset due to DST.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-22T21:00:00.000Z'))
     expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
   })
 
   it('calculates previous month in a local, positive-offset timezone', () => {
-    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'Africa/Cairo')
-    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'Africa/Cairo')
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'Europe/Sofia')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'Europe/Sofia')
 
     // Unary and delta end times should be the start of the current month.
     expect(unaryQuery.endDate()).toEqual(new Date('2023-10-31T22:00:00.000Z'))
     expect(deltaQuery.endDate()).toEqual(new Date('2023-10-31T22:00:00.000Z'))
 
-    // Unary start times should be the start of the first day of the previous month in Cairo time.
-    expect(unaryQuery.startDate()).toEqual(new Date('2023-09-30T22:00:00.000Z'))
+    // Unary start times should be the start of the first day of the previous month in Bulgarian time.
+    // Bulgaria has a DST transition on 10/28, so this is now a different hour offset.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-09-30T21:00:00.000Z'))
 
     // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
     // actually comparing to the full previous month.
-    expect(deltaQuery.startDate()).toEqual(new Date('2023-08-30T22:00:00.000Z'))
+    // DST introduces an odd edge case where the timeframe length is N days + 1 hour.  We basically round the timeframe
+    // up to the nearest day, so we end up with N+1 days.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-08-29T21:00:00.000Z'))
 
     expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
   })

--- a/packages/analytics/analytics-utilities/src/queryTime.spec.tz.ts
+++ b/packages/analytics/analytics-utilities/src/queryTime.spec.tz.ts
@@ -4,6 +4,7 @@ import { add, setDate, startOfDay, startOfMonth, startOfWeek, subMilliseconds } 
 import { GranularityKeys, TimeframeKeys } from './types'
 import { DeltaQueryTime, TimeseriesQueryTime, UnaryQueryTime } from './queryTime'
 import { datePickerSelectionToTimeframe, Timeframe, TimePeriods } from './timeframes'
+import { formatInTimeZone } from 'date-fns-tz'
 
 const standardizeTimezone = (d: Date) => {
   // Adjust according to the test runner's timezone for consistent results.
@@ -492,5 +493,269 @@ runDstTest('daylight savings time: fall', () => {
     expect(unaryQuery.endSeconds() - unaryQuery.startSeconds()).toBe(60 * 60 * 24 * 7)
     expect(deltaQuery.endSeconds() - deltaQuery.startSeconds()).toBe(60 * 60 * 24 * 7 * 2)
     expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+})
+
+const supportsUtc = Intl.DateTimeFormat().resolvedOptions().timeZone === 'UTC'
+
+const runUtcTest = supportsUtc ? describe : describe.skip
+
+runUtcTest('UTC: timezone handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    const fakeNow = new Date('2023-11-09T01:00:00Z') // This is 2023-11-08T20:00:00 Eastern.
+    standardizeTimezone(fakeNow)
+    vi.setSystemTime(fakeNow)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('calculates relative dates in a local, negative-offset timezone', () => {
+    // Sanity check
+    expect(formatInTimeZone(new Date(), 'America/New_York', 'yyyy-MM-dd HH:mm:ssXXX')).toBe('2023-11-08 20:00:00-05:00')
+
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.SEVEN_DAY), 'US/Eastern')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.SEVEN_DAY), 'US/Eastern')
+
+    // Unary and delta end times should be the start of the _next_ day in Eastern time.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-09T05:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-11-09T05:00:00.000Z'))
+
+    // The Eastern timezone gains an hour in the fall.  UTC does not, so this should be the same hour as before.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-11-02T05:00:00.000Z'))
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-26T05:00:00.000Z'))
+    expect(unaryQuery.endSeconds() - unaryQuery.startSeconds()).toBe(60 * 60 * 24 * 7)
+    expect(deltaQuery.endSeconds() - deltaQuery.startSeconds()).toBe(60 * 60 * 24 * 7 * 2)
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+
+  it('calculates current week in a local, negative-offset timezone', () => {
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.CURRENT_WEEK), 'US/Eastern')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_WEEK), 'US/Eastern')
+
+    // Unary and delta end times should be rounded up to the nearest day.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-09T05:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-11-09T05:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the current week in Eastern time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-11-06T05:00:00.000Z'))
+
+    // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
+    // actually comparing to the full previous week.
+    // Because we're dealing with absolute timeframes, this rounds to the nearest day and therefore tracks DST.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-11-03T04:00:00.000Z'))
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+
+  it('calculates previous week in a local, negative-offset timezone', () => {
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_WEEK), 'US/Eastern')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_WEEK), 'US/Eastern')
+
+    // Unary and delta end times should be the start of the current week.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-06T05:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-11-06T05:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the previous week in Eastern time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-10-30T04:00:00.000Z'))
+
+    // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
+    // actually comparing to the full previous week.
+    // DST introduces an odd edge case where the timeframe length is N days + 1 hour.  We basically round the timeframe
+    // up to the nearest day, so we end up with N+1 days.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-22T04:00:00.000Z'))
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+
+  it('calculates current month in a local, negative-offset timezone', () => {
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'US/Eastern')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'US/Eastern')
+
+    // Unary and delta end times should be rounded up to the nearest day.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-09T05:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-11-09T05:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the current month in Eastern time.
+    // Unlike "last 7 days", this one tracks the DST change; it's based on days rather than hours.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-11-01T04:00:00.000Z'))
+
+    // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
+    // actually comparing to the full previous month.
+    // The timeframe gets rounded up to the nearest day, so this tracks the DST change.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-23T04:00:00.000Z'))
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+
+  it('calculates previous month in a local, negative-offset timezone', () => {
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'US/Eastern')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'US/Eastern')
+
+    // Unary and delta end times should be the start of the current month.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-01T04:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-11-01T04:00:00.000Z'))
+
+    // Unary and delta start times should be the start of the first day of the previous month in Eastern time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-10-01T04:00:00.000Z'))
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-08-31T04:00:00.000Z'))
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+
+  it('calculates relative dates in a local, positive-offset timezone', () => {
+    // Sanity check
+    expect(formatInTimeZone(new Date(), 'Africa/Cairo', 'yyyy-MM-dd HH:mm:ssXXX')).toBe('2023-11-09 03:00:00+02:00')
+
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.SEVEN_DAY), 'Africa/Cairo')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.SEVEN_DAY), 'Africa/Cairo')
+
+    // Unary and delta end times should be the start of the _next_ day in Cairo time.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
+
+    // This timezone doesn't have a DST transition within this date range.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-11-02T22:00:00.000Z'))
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-26T22:00:00.000Z'))
+    expect(unaryQuery.endSeconds() - unaryQuery.startSeconds()).toBe(60 * 60 * 24 * 7)
+    expect(deltaQuery.endSeconds() - deltaQuery.startSeconds()).toBe(60 * 60 * 24 * 7 * 2)
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+
+  it('calculates current week in a local, positive-offset timezone', () => {
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.CURRENT_WEEK), 'Africa/Cairo')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_WEEK), 'Africa/Cairo')
+
+    // Unary and delta end times should be rounded up to the nearest day.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the current week in Cairo time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-11-05T22:00:00.000Z'))
+
+    // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
+    // actually comparing to the full previous week.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-11-01T22:00:00.000Z'))
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+
+  it('calculates previous week in a local, positive-offset timezone', () => {
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_WEEK), 'Africa/Cairo')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_WEEK), 'Africa/Cairo')
+
+    // Unary and delta end times should be the start of the current week.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-05T22:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-11-05T22:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the previous week in Cairo time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-10-29T22:00:00.000Z'))
+
+    // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
+    // actually comparing to the full previous week.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-22T22:00:00.000Z'))
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+
+  it('calculates current month in a local, positive-offset timezone', () => {
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'Africa/Cairo')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'Africa/Cairo')
+
+    // Unary and delta end times should be rounded up to the nearest day.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-11-09T22:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the current month in Cairo time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-10-31T22:00:00.000Z'))
+
+    // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
+    // actually comparing to the full previous month.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-10-22T22:00:00.000Z'))
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+
+  it('calculates previous month in a local, positive-offset timezone', () => {
+    const deltaQuery = new DeltaQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'Africa/Cairo')
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'Africa/Cairo')
+
+    // Unary and delta end times should be the start of the current month.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-10-31T22:00:00.000Z'))
+    expect(deltaQuery.endDate()).toEqual(new Date('2023-10-31T22:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the previous month in Cairo time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-09-30T22:00:00.000Z'))
+
+    // Delta start times are tricky; the existing behavior is to just match the length of the timeframe rather than
+    // actually comparing to the full previous month.
+    expect(deltaQuery.startDate()).toEqual(new Date('2023-08-30T22:00:00.000Z'))
+
+    expect(deltaQuery.granularitySeconds()).toBe(unaryQuery.granularitySeconds())
+  })
+})
+
+runUtcTest('UTC: month boundary edge cases, negative offset', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    const fakeNow = new Date('2023-11-01T01:00:00Z')
+    standardizeTimezone(fakeNow)
+    vi.setSystemTime(fakeNow)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('handles current month correctly', () => {
+    // Sanity check
+    expect(formatInTimeZone(new Date(), 'America/New_York', 'yyyy-MM-dd HH:mm:ssXXX')).toBe('2023-10-31 21:00:00-04:00')
+
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'US/Eastern')
+
+    // Unary and delta end times should be rounded up to the nearest day, which happens to be the end of the month.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-11-01T04:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the current month in Eastern time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-10-01T04:00:00.000Z'))
+  })
+
+  it('handles previous month correctly', () => {
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'US/Eastern')
+
+    // Unary and delta end times should be the first day of this month.
+    expect(unaryQuery.endDate()).toEqual(new Date('2023-10-01T04:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the previous month in Eastern time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2023-09-01T04:00:00.000Z'))
+  })
+})
+
+runUtcTest('UTC: month boundary edge cases, positive offset', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Egypt did not observe DST for a few years around 2020.
+    const fakeNow = new Date('2020-11-30T23:00:00Z')
+    standardizeTimezone(fakeNow)
+    vi.setSystemTime(fakeNow)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('handles current month correctly', () => {
+    // Sanity check
+    expect(formatInTimeZone(new Date(), 'Africa/Cairo', 'yyyy-MM-dd HH:mm:ssXXX')).toBe('2020-12-01 01:00:00+02:00')
+
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.CURRENT_MONTH), 'Africa/Cairo')
+
+    // Unary and delta end times should be rounded up to the nearest day.
+    expect(unaryQuery.endDate()).toEqual(new Date('2020-12-01T22:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the current month in Cairo time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2020-11-30T22:00:00.000Z'))
+  })
+
+  it('handles previous month correctly', () => {
+    const unaryQuery = new UnaryQueryTime(getTimePeriod(TimeframeKeys.PREVIOUS_MONTH), 'Africa/Cairo')
+
+    // Unary and delta end times should be the first day of this month.
+    expect(unaryQuery.endDate()).toEqual(new Date('2020-11-30T22:00:00.000Z'))
+
+    // Unary start times should be the start of the first day of the previous month in Cairo time.
+    expect(unaryQuery.startDate()).toEqual(new Date('2020-10-31T22:00:00.000Z'))
   })
 })

--- a/packages/analytics/analytics-utilities/src/timeframes.ts
+++ b/packages/analytics/analytics-utilities/src/timeframes.ts
@@ -69,13 +69,13 @@ export class Timeframe {
 
   // rawEnd does not consider granularity and should not be used directly in queries.
   // Use `new QueryTime(timeframe, granularity?).queryEndSeconds()` instead.
-  rawEnd(_tz?: string): Date {
+  rawEnd(): Date {
     return this._endCustom || new Date()
   }
 
   // rawStart does not consider granularity and should not be used directly in queries.
   // Use `new QueryTime(timeframe, granularity?).queryStartSeconds()` instead.
-  rawStart(_tz?: string): Date {
+  rawStart(): Date {
     return this._startCustom || new Date(this.rawEnd().getTime() - this.timeframeLengthMs())
   }
 

--- a/packages/analytics/analytics-utilities/src/timeframes.ts
+++ b/packages/analytics/analytics-utilities/src/timeframes.ts
@@ -69,13 +69,15 @@ export class Timeframe {
 
   // rawEnd does not consider granularity and should not be used directly in queries.
   // Use `new QueryTime(timeframe, granularity?).queryEndSeconds()` instead.
-  rawEnd(): Date {
+  // eslint-disable-next-line -- `tz` is required because it's used in subclasses.
+  rawEnd(_tz?: string): Date {
     return this._endCustom || new Date()
   }
 
   // rawStart does not consider granularity and should not be used directly in queries.
   // Use `new QueryTime(timeframe, granularity?).queryStartSeconds()` instead.
-  rawStart(): Date {
+  // eslint-disable-next-line -- `tz` is required because it's used in subclasses.
+  rawStart(_tz?: string): Date {
     return this._startCustom || new Date(this.rawEnd().getTime() - this.timeframeLengthMs())
   }
 

--- a/packages/analytics/analytics-utilities/src/timeframes.ts
+++ b/packages/analytics/analytics-utilities/src/timeframes.ts
@@ -16,6 +16,12 @@ import {
   TimeframeOptions,
   TimePeriod,
 } from './types'
+import { getTimezoneOffset, utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz'
+
+const adjustForTz = (d: Date, tz: string) => {
+  // Adjust the given date by the given TZ offset.
+  return new Date(d.getTime() - getTimezoneOffset(tz, d))
+}
 
 export class Timeframe {
   readonly timeframeText: string
@@ -63,13 +69,13 @@ export class Timeframe {
 
   // rawEnd does not consider granularity and should not be used directly in queries.
   // Use `new QueryTime(timeframe, granularity?).queryEndSeconds()` instead.
-  rawEnd(): Date {
+  rawEnd(_tz?: string): Date {
     return this._endCustom || new Date()
   }
 
   // rawStart does not consider granularity and should not be used directly in queries.
   // Use `new QueryTime(timeframe, granularity?).queryStartSeconds()` instead.
-  rawStart(): Date {
+  rawStart(_tz?: string): Date {
     return this._startCustom || new Date(this.rawEnd().getTime() - this.timeframeLengthMs())
   }
 
@@ -108,11 +114,27 @@ export class Timeframe {
 
     return allowedValues
   }
+
+  protected tzAdjustedDate(tz?: string): Date {
+    if (!tz) {
+      return new Date()
+    }
+
+    // Take `new Date()` and adjust it so that it's within the given TZ
+    // instead of the current environment's TZ.
+    const tzNeutral = zonedTimeToUtc(new Date(), (new Intl.DateTimeFormat()).resolvedOptions().timeZone)
+    return utcToZonedTime(tzNeutral, tz)
+  }
 }
 
 class CurrentWeek extends Timeframe {
-  rawStart(): Date {
-    const thisMonday = startOfWeek(new Date(), { weekStartsOn: 1 })
+  rawStart(tz?: string): Date {
+    // `startOfWeek` isn't aware of timezones, so the resulting "start of month" time is in the local timezone.
+    let thisMonday = startOfWeek(this.tzAdjustedDate(tz), { weekStartsOn: 1 })
+
+    if (tz) {
+      thisMonday = adjustForTz(thisMonday, tz)
+    }
 
     return thisMonday
   }
@@ -123,8 +145,13 @@ class CurrentWeek extends Timeframe {
 }
 
 class CurrentMonth extends Timeframe {
-  rawStart(): Date {
-    const firstOfTheMonth = startOfMonth(new Date())
+  rawStart(tz?: string): Date {
+    // `startOfMonth` isn't aware of timezones, so the resulting "start of month" time is in the local timezone.
+    let firstOfTheMonth = startOfMonth(this.tzAdjustedDate(tz))
+
+    if (tz) {
+      firstOfTheMonth = adjustForTz(firstOfTheMonth, tz)
+    }
 
     return firstOfTheMonth
   }
@@ -135,30 +162,52 @@ class CurrentMonth extends Timeframe {
 }
 
 class PreviousWeek extends Timeframe {
-  rawEnd(): Date {
-    const thisMonday = startOfWeek(new Date(), { weekStartsOn: 1 })
+  rawEnd(tz?: string): Date {
+    // `startOfWeek` isn't aware of timezones, so the resulting "start of month" time is in the local timezone.
+    let thisMonday = startOfWeek(this.tzAdjustedDate(tz), { weekStartsOn: 1 })
+
+    if (tz) {
+      thisMonday = adjustForTz(thisMonday, tz)
+    }
 
     return thisMonday
   }
 
-  rawStart(): Date {
-    const lastMonday = startOfWeek(new Date().setDate(new Date().getDate() - 7), {
+  rawStart(tz?: string): Date {
+    const date = this.tzAdjustedDate(tz)
+
+    // `startOfWeek` isn't aware of timezones, so the resulting "start of month" time is in the local timezone.
+    let lastMonday = startOfWeek(date.setDate(date.getDate() - 7), {
       weekStartsOn: 1,
     })
+
+    if (tz) {
+      lastMonday = adjustForTz(lastMonday, tz)
+    }
 
     return lastMonday
   }
 }
 
 class PreviousMonth extends Timeframe {
-  rawEnd(): Date {
-    const thisMonth = startOfMonth(new Date())
+  rawEnd(tz?: string): Date {
+    // `startOfMonth` isn't aware of timezones, so the resulting "start of month" time is in the local timezone.
+    let thisMonth = startOfMonth(this.tzAdjustedDate(tz))
+
+    if (tz) {
+      thisMonth = adjustForTz(thisMonth, tz)
+    }
 
     return thisMonth
   }
 
-  rawStart(): Date {
-    const lastMonth = startOfMonth(subMonths(new Date(), 1))
+  rawStart(tz?: string): Date {
+    // `startOfMonth` isn't aware of timezones, so the resulting "start of month" time is in the local timezone.
+    let lastMonth = startOfMonth(subMonths(this.tzAdjustedDate(tz), 1))
+
+    if (tz) {
+      lastMonth = adjustForTz(lastMonth, tz)
+    }
 
     return lastMonth
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
+      date-fns-tz:
+        specifier: ^2.0.0
+        version: 2.0.0(date-fns@2.30.0)
     devDependencies:
       '@kong/design-tokens':
         specifier: ^1.9.0


### PR DESCRIPTION
- Avoid breaking the API; `tz` is an optional param.
- Add many test cases.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
