### PR TITLE
fix(swagger-ui-web-component): open section if collapsed for side nav (TDX-3313)

### DIFF
--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -223,17 +223,17 @@ export class SwaggerUIElement extends HTMLElement {
     }
 
     const operationElementId = operationToSwaggerThingId(operation)
-    let element = this.shadowRoot.getElementById(operationElementId)
-    if (!element) {
+    let scrollElement = this.shadowRoot.getElementById(operationElementId)
+    if (!scrollElement) {
       // we are going to see if the parent div element exists and then try and find the 
       // element again
       const parentDiv = this.shadowRoot.querySelector(`[data-tag='${operation.tag}']`)
 
       if (parentDiv) {
         parentDiv.click()
-        element = this.shadowRoot.getElementById(operationElementId)
+        scrollElement = this.shadowRoot.getElementById(operationElementId)
 
-        if (!element) {
+        if (!scrollElement) {
           return false
         }
       } else {
@@ -248,7 +248,7 @@ export class SwaggerUIElement extends HTMLElement {
       behavior = 'smooth'
     }
 
-    element.scrollIntoView({ behavior })
+    scrollElement.scrollIntoView({ behavior })
   }
 
   get autoInit() {

--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -223,9 +223,22 @@ export class SwaggerUIElement extends HTMLElement {
     }
 
     const operationElementId = operationToSwaggerThingId(operation)
-    const element = this.shadowRoot.getElementById(operationElementId)
+    let element = this.shadowRoot.getElementById(operationElementId)
     if (!element) {
-      return false
+      // we are going to see if the parent div element exists and then try and find the 
+      // element again
+      const parentDiv = this.shadowRoot.querySelector(`[data-tag='${operation.tag}']`)
+
+      if (parentDiv) {
+        parentDiv.click()
+        element = this.shadowRoot.getElementById(operationElementId)
+
+        if (!element) {
+          return false
+        }
+      } else {
+        return false
+      }
     }
 
     // respect reduced motion settings


### PR DESCRIPTION
# Summary
The bug was because the div is not visible if the parent container is not open. This bug fix opens the parent container, which then allows us to select the operation that we want to find, and then scrolls to it.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
