### PR TITLE
fix(entities-shared): add missing watcher to permissions-wrapper

### DIFF
--- a/packages/entities/entities-shared/src/components/permissions-wrapper/PermissionsWrapper.vue
+++ b/packages/entities/entities-shared/src/components/permissions-wrapper/PermissionsWrapper.vue
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { ref, computed, onBeforeMount } from 'vue'
+import { ref, computed, onBeforeMount, watch } from 'vue'
 
 const props = defineProps({
   /**
@@ -35,6 +35,10 @@ const isAllowed = ref<boolean | undefined>(undefined)
 const showSlotContent = computed((): boolean => isAllowed.value === true || (isAllowed.value !== undefined && props.forceShow === true))
 
 onBeforeMount(async (): Promise<void> => {
+  isAllowed.value = await props.authFunction()
+})
+
+watch(() => props.authFunction, async () => {
   isAllowed.value = await props.authFunction()
 })
 </script>

--- a/packages/entities/entities-shared/src/components/permissions-wrapper/PermissionsWrapper.vue
+++ b/packages/entities/entities-shared/src/components/permissions-wrapper/PermissionsWrapper.vue
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { ref, computed, onBeforeMount, watch } from 'vue'
+import { ref, computed, watch } from 'vue'
 
 const props = defineProps({
   /**

--- a/packages/entities/entities-shared/src/components/permissions-wrapper/PermissionsWrapper.vue
+++ b/packages/entities/entities-shared/src/components/permissions-wrapper/PermissionsWrapper.vue
@@ -34,11 +34,7 @@ const props = defineProps({
 const isAllowed = ref<boolean | undefined>(undefined)
 const showSlotContent = computed((): boolean => isAllowed.value === true || (isAllowed.value !== undefined && props.forceShow === true))
 
-onBeforeMount(async (): Promise<void> => {
-  isAllowed.value = await props.authFunction()
-})
-
 watch(() => props.authFunction, async () => {
   isAllowed.value = await props.authFunction()
-})
+}, { immediate: true })
 </script>


### PR DESCRIPTION
# Summary

Fixes an issue where `isAllowed` in `PermissionsWrapper` was not updated while the `auth-function` property was updated.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
