### PR TITLE
fix: correct entity lists' permission prop type

### DIFF
--- a/packages/entities/entities-certificates/docs/ca-certificate-list.md
+++ b/packages/entities/entities-certificates/docs/ca-certificate-list.md
@@ -110,35 +110,35 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 ### Events
 

--- a/packages/entities/entities-certificates/docs/certificate-list.md
+++ b/packages/entities/entities-certificates/docs/certificate-list.md
@@ -116,43 +116,43 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canCreateSni`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new SNI entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new SNI entity.
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 ### Events
 

--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -190,27 +190,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -218,33 +218,33 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new SNI entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new SNI entity */
   canCreateSni: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-consumer-credentials/docs/consumer-credential-list.md
+++ b/packages/entities/entities-consumer-credentials/docs/consumer-credential-list.md
@@ -99,27 +99,27 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 ### Events
 

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -231,21 +231,21 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
@@ -122,37 +122,37 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 Note: When ConsumerGroupList config specifies a `consumerId` the `canCreate` permission is applied to the action of adding the consumer to another consumer group instead of creating a new consumer group.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 Note: When ConsumerGroupList config specifies a `consumerId` the `canDelete` permission is applied to the action of exiting from a consumer group instead of deleting a consumer group.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 ### Events
 

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -227,27 +227,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-consumers/docs/consumer-list.md
+++ b/packages/entities/entities-consumers/docs/consumer-list.md
@@ -122,37 +122,37 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 Note: When ConsumerList config specifies a `consumerGroupId` the `canCreate` permission is applied to the action of adding a consumer to a consumer group instead of creating a new consumer.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 Note: When ConsumerList config specifies a `consumerGroupId` the `canDelete` permission is applied to the action of removing a consumer from a consumer group instead of deleting a consumer.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 ### Events
 

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -227,27 +227,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-gateway-services/docs/gateway-service-list.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-list.md
@@ -110,35 +110,35 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 ### Events
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -201,27 +201,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-key-sets/docs/key-set-list.md
+++ b/packages/entities/entities-key-sets/docs/key-set-list.md
@@ -105,27 +105,35 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+
+#### `canRetrieve`
+
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
+- required: `false`
+- default: `async () => true`
+
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity
 
 ### Events
 

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -179,27 +179,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-keys/docs/key-list.md
+++ b/packages/entities/entities-keys/docs/key-list.md
@@ -111,27 +111,35 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+
+#### `canRetrieve`
+
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
+- required: `false`
+- default: `async () => true`
+
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity
 
 ### Events
 

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -185,27 +185,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-plugins/docs/plugin-list.md
+++ b/packages/entities/entities-plugins/docs/plugin-list.md
@@ -138,59 +138,59 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canToggle`
 
-- type: `Function as PropType<(row: EntityRow) => Promise<boolean>>`
+- type: `Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can toggle (enable/disable) a given entity
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can toggle (enable/disable) a given entity
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 #### `canRetrieveScopedEntity`
 
-- type: `Function as PropType<(entityType: 'service' | 'route' | 'consumer', entityId: string) => Promise<boolean>>`
+- type: `Function as PropType<(entityType: 'service' | 'route' | 'consumer', entityId: string) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given scoped entity (e.g. route linked with the plugin)
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given scoped entity (e.g. route linked with the plugin)
 
 #### `canConfigureDynamicOrdering`
 
-- type: `Function as PropType<(row: EntityRow) => Promise<boolean>>`
+- type: `Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can configure dynamic ordering for a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can configure dynamic ordering for a given entity.
 
 #### `title`
 

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -289,45 +289,45 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can toggle (enable/disable) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can toggle (enable/disable) a given entity */
   canToggle: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given scoped entity (e.g. route linked with the plugin) */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given scoped entity (e.g. route linked with the plugin) */
   canRetrieveScopedEntity: {
-    type: Function as PropType<(entityType: string, entityId: string) => Promise<boolean>>,
+    type: Function as PropType<(entityType: string, entityId: string) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can configure dynamic ordering for a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can configure dynamic ordering for a given entity */
   canConfigureDynamicOrdering: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-routes/docs/route-list.md
+++ b/packages/entities/entities-routes/docs/route-list.md
@@ -120,35 +120,35 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 #### `title`
 

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -235,27 +235,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-shared/docs/permissions-wrapper.md
+++ b/packages/entities/entities-shared/docs/permissions-wrapper.md
@@ -23,11 +23,11 @@ A composable that exports a shared Axios instance.
 
 #### `authFunction`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `true`
-- default: `async (): Promise<boolean> => true`
+- default: `async () => true`
 
-An async function that returns a boolean to determine whether the wrapper should hide or show the default slot content.
+A sync or async function that returns a boolean to determine whether the wrapper should hide or show the default slot content.
 
 #### `forceShow`
 

--- a/packages/entities/entities-snis/docs/sni-list.md
+++ b/packages/entities/entities-snis/docs/sni-list.md
@@ -110,35 +110,35 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 ### Events
 

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -178,27 +178,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-upstreams-targets/docs/targets-list.md
+++ b/packages/entities/entities-upstreams-targets/docs/targets-list.md
@@ -107,27 +107,27 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 ### Slots
 

--- a/packages/entities/entities-upstreams-targets/docs/upstreams-list.md
+++ b/packages/entities/entities-upstreams-targets/docs/upstreams-list.md
@@ -111,35 +111,35 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 ### Events
 

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -191,21 +191,21 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -171,27 +171,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },

--- a/packages/entities/entities-vaults/docs/vault-list.md
+++ b/packages/entities/entities-vaults/docs/vault-list.md
@@ -108,35 +108,35 @@ Note: the default value is usually sufficient unless the app needs to support mu
 
 #### `canCreate`
 
-- type: `Function as PropType<() => Promise<boolean>>`
+- type: `Function as PropType<() => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity.
 
 #### `canDelete`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity.
 
 #### `canEdit`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity.
 
 #### `canRetrieve`
 
-- type: `Function as PropType<(row: object) => Promise<boolean>>`
+- type: `Function as PropType<(row: object) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 
-An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
 ### Events
 

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -186,27 +186,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can create a new entity */
   canCreate: {
-    type: Function as PropType<() => Promise<boolean>>,
+    type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete a given entity */
   canDelete: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit a given entity */
   canEdit: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },
-  /** An asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity */
   canRetrieve: {
-    type: Function as PropType<(row: EntityRow) => Promise<boolean>>,
+    type: Function as PropType<(row: EntityRow) => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
   },


### PR DESCRIPTION
All `can***` props in entity list component should accept the permission check functions in synchronous version

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
