### PR TITLE
feat(plugins): support scoping for consumer groups

### DIFF
--- a/packages/core/forms/src/generator/fields/advanced/FieldAutoSuggest.vue
+++ b/packages/core/forms/src/generator/fields/advanced/FieldAutoSuggest.vue
@@ -108,6 +108,7 @@ export default {
   async created() {
     await this.$nextTick()
     let presetEntity
+    let entityData
 
     switch (this.fieldState) {
       case fieldStates.UPDATE_ENTITY:
@@ -115,7 +116,12 @@ export default {
           console.warn('[@kong-ui-public/forms] No API service provided')
           break
         }
-        presetEntity = await this.getItem((await this[FORMS_API_KEY].getOne(this.entity, this.model[this.schema.model])).data)
+
+        // Get entity data from API. In most cases the data is stored in the `data` key of the response directly
+        // but sometimes it is stored in a nested key inside the `data` key, so we allow the user to specify it in the schema
+        // e.g. entity data returned from `consumer_groups/:id` is stored in `data.consumer_group`
+        entityData = (await this[FORMS_API_KEY].getOne(this.entity, this.model[this.schema.model])).data
+        presetEntity = this.getItem(this.schema.entityDataKey ? entityData[this.schema.entityDataKey] : entityData)
         this.idValue = presetEntity.id
         break
       case fieldStates.CREATE_FROM_ENTITY:

--- a/packages/entities/entities-plugins/docs/plugin-config-card.md
+++ b/packages/entities/entities-plugins/docs/plugin-config-card.md
@@ -89,7 +89,7 @@ Set this value to `true` to hide the card title.
 - required: `false`
 - default: `''`
 
-The type of the entity with which the plugin is associated. Can be one of `'services'`, `'routes'` or `'consumers'`.
+The type of the entity with which the plugin is associated. Can be one of `'services'`, `'routes'`, `'consumers'` or `consumer_groups`.
 
 #### `scopedEntityId`
 

--- a/packages/entities/entities-plugins/docs/plugin-list.md
+++ b/packages/entities/entities-plugins/docs/plugin-list.md
@@ -117,13 +117,13 @@ A table component for plugins.
     - type: `string`
     - required: `false`
     - default: `null`
-    - Current entity id if the PluginList is nested in the plugins tab on a consumer, gateway service, or route detail page.
+    - Current entity id if the PluginList is nested in the plugins tab on a consumer, consumer group, gateway service, or route detail page.
 
   - `entityType`:
-    - type: `'consumers' | 'services' | 'routes'`
+    - type: `'consumers' | 'consumer_groups' | 'services' | 'routes'`
     - required: `false`
     - default: `null`
-    - Current entity type if the PluginList is nested in the plugins tab on a consumer, gateway service, or route detail page.
+    - Current entity type if the PluginList is nested in the plugins tab on a consumer, consumer group, gateway service, or route detail page.
 
 The base konnect or kongManger config.
 
@@ -178,7 +178,7 @@ A synchronous or asynchronous function, that returns a boolean, that evaluates i
 
 #### `canRetrieveScopedEntity`
 
-- type: `Function as PropType<(entityType: 'service' | 'route' | 'consumer', entityId: string) => boolean | Promise<boolean>>`
+- type: `Function as PropType<(entityType: 'service' | 'route' | 'consumer' | 'consumer_group', entityId: string) => boolean | Promise<boolean>>`
 - required: `false`
 - default: `async () => true`
 

--- a/packages/entities/entities-plugins/fixtures/mockData.ts
+++ b/packages/entities/entities-plugins/fixtures/mockData.ts
@@ -19,7 +19,7 @@ export const plugins: FetcherRawResponse = {
       ordering: {},
       instance_name: 'instance-1',
       created_at: 1610617600,
-
+      consumer_group: { id: 'consumer-group-1' },
       consumer: { id: 'consumer-1' },
       route: { id: 'route-1' },
       service: null,
@@ -32,7 +32,6 @@ export const plugins: FetcherRawResponse = {
       protocols: ['http', 'https'],
       tags: ['tag2'],
       created_at: 1610617601,
-
       consumer: null,
       route: null,
       service: null,

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@kong-ui-public/copy-uuid": "workspace:^",
+    "@kong-ui-public/entities-consumer-groups": "workspace:^",
     "@kong-ui-public/entities-consumers": "workspace:^",
     "@kong-ui-public/entities-gateway-services": "workspace:^",
     "@kong-ui-public/entities-routes": "workspace:^",

--- a/packages/entities/entities-plugins/sandbox/index.ts
+++ b/packages/entities/entities-plugins/sandbox/index.ts
@@ -47,6 +47,11 @@ const init = async () => {
         component: () => import('./pages/FallbackPage.vue'),
       },
       {
+        path: '/consumer_group/:id',
+        name: 'view-consumer_group',
+        component: () => import('./pages/FallbackPage.vue'),
+      },
+      {
         path: '/plugin/:id/configure-dynamic-ordering',
         name: 'configure-dynamic-ordering',
         component: () => import('./pages/FallbackPage.vue'),

--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
@@ -82,6 +82,18 @@
           :uuid="rowValue.id"
         />
       </template>
+      <template #consumer_group="{ rowValue, row }">
+        <span v-if="!rowValue">–</span>
+        <CopyUuid
+          v-else
+          data-testid="consumer-group-copy-uuid"
+          :notify="() => { }"
+          :success-tooltip="t('copy.success_tooltip')"
+          :tooltip="t('copy.tooltip', { label: row.label })"
+          :truncated="false"
+          :uuid="rowValue.id"
+        />
+      </template>
     </EntityBaseConfigCard>
   </div>
 </template>
@@ -194,6 +206,11 @@ const configSchema = computed((): ConfigurationSchema => {
     },
     service: {
       label: t('plugins.fields.service'),
+      section: ConfigurationSchemaSection.Basic,
+      order: 6,
+    },
+    consumer_group: {
+      label: t('plugins.fields.consumer_group'),
       section: ConfigurationSchemaSection.Basic,
       order: 6,
     },

--- a/packages/entities/entities-plugins/src/components/PluginList.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginList.cy.ts
@@ -146,7 +146,8 @@ describe('<PluginList />', () => {
         .should('not.contain.text', 'Global')
         .should('contain.text', 'Route')
         .should('contain.text', 'Consumer')
-        .should('have.lengthOf', 2)
+        .should('contain.text', 'Consumer Group')
+        .should('have.lengthOf', 3)
 
       cy.getTestId('acl').find('[data-testid="appliedTo"] .k-badge')
         .should('have.lengthOf', 1)

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -456,6 +456,9 @@ const aggregateAppliedTo = (row: EntityRow): ({ type: ViewRouteType | null, badg
   if (row.consumer?.id) {
     badges.push({ type: 'consumer', badgeText: t('plugins.list.table_headers.applied_to_badges.consumer') })
   }
+  if (row.consumer_group?.id) {
+    badges.push({ type: 'consumer_group', badgeText: t('plugins.list.table_headers.applied_to_badges.consumer_group') })
+  }
   if (badges.length) {
     return badges
   }
@@ -481,6 +484,9 @@ const handleAppliedToClick = (type: ViewRouteType, row: EntityRow) => {
       break
     case 'consumer':
       id = row.consumer?.id
+      break
+    case 'consumer_group':
+      id = row.consumer_group?.id
       break
     default:
       break

--- a/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
+++ b/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
@@ -193,7 +193,7 @@ export const usePluginMetaData = () => {
       group: PluginGroup.TRAFFIC_CONTROL,
       isEnterprise: true,
       name: t('plugins.meta.rate-limiting-advanced.name'),
-      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER],
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER, PluginScope.CONSUMER_GROUP],
     },
     'rate-limiting': {
       description: t('plugins.meta.rate-limiting.description'),
@@ -317,7 +317,7 @@ export const usePluginMetaData = () => {
       group: PluginGroup.TRANSFORMATIONS,
       isEnterprise: false,
       name: t('plugins.meta.response-transformer-advanced.name'),
-      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER],
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER, PluginScope.CONSUMER_GROUP],
     },
     'correlation-id': {
       description: t('plugins.meta.correlation-id.description'),
@@ -331,21 +331,21 @@ export const usePluginMetaData = () => {
       group: PluginGroup.TRANSFORMATIONS,
       isEnterprise: true,
       name: t('plugins.meta.request-transformer-advanced.name'),
-      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER],
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER, PluginScope.CONSUMER_GROUP],
     },
     'request-transformer': {
       description: t('plugins.meta.request-transformer.description'),
       group: PluginGroup.TRANSFORMATIONS,
       isEnterprise: false,
       name: t('plugins.meta.request-transformer.name'),
-      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER],
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER, PluginScope.CONSUMER_GROUP],
     },
     'response-transformer': {
       description: t('plugins.meta.response-transformer.description'),
       group: PluginGroup.TRANSFORMATIONS,
       isEnterprise: false,
       name: t('plugins.meta.response-transformer.name'),
-      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER],
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER, PluginScope.CONSUMER_GROUP],
     },
     'route-transformer-advanced': {
       description: t('plugins.meta.route-transformer-advanced.description'),

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -45,7 +45,8 @@
           "consumer": "Consumer",
           "global": "Global",
           "route": "Route",
-          "service": "Service"
+          "service": "Service",
+          "consumer_group": "Consumer Group"
         },
         "id": "ID",
         "name": "Name",
@@ -388,7 +389,8 @@
     "fields": {
       "service": "Service ID",
       "route": "Route ID",
-      "consumer": "Consumer ID"
+      "consumer": "Consumer ID",
+      "consumer_group": "Consumer Group ID"
     }
   },
   "glossary": {

--- a/packages/entities/entities-plugins/src/types/plugin-list.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-list.ts
@@ -4,9 +4,10 @@ import type { FilterSchema, KongManagerBaseTableConfig, KonnectBaseTableConfig }
 import type { EntityRow as ServiceEntity } from '@kong-ui-public/entities-gateway-services'
 import type { EntityRow as ConsumerEntity } from '@kong-ui-public/entities-consumers'
 import type { EntityRow as RouteEntity } from '@kong-ui-public/entities-routes'
+import type { EntityRow as ConsumerGroupEntity } from '@kong-ui-public/entities-consumer-groups'
 
-export type ViewRouteType = 'consumer' | 'route' | 'service'
-export type EntityType = 'consumers' | 'routes' | 'services'
+export type ViewRouteType = 'consumer' | 'route' | 'service' | 'consumer_group'
+export type EntityType = 'consumers' | 'routes' | 'services' | 'consumer_groups'
 
 export interface EntityRow extends Record<string, any> {
   config: any
@@ -22,6 +23,7 @@ export interface EntityRow extends Record<string, any> {
   consumer?: Pick<ConsumerEntity, 'id'> | null
   route?: Pick<RouteEntity, 'id'> | null
   service?: Pick<ServiceEntity, 'id'> | null
+  consumer_group?: Pick<ConsumerGroupEntity, 'id'> | null
 }
 
 export interface BasePluginListConfig {

--- a/packages/entities/entities-plugins/src/types/plugin.ts
+++ b/packages/entities/entities-plugins/src/types/plugin.ts
@@ -16,6 +16,7 @@ export enum PluginScope {
   SERVICE = 'service',
   ROUTE = 'route',
   CONSUMER = 'consumer',
+  CONSUMER_GROUP = 'consumer_group',
 }
 
 export type PluginMetaData = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@rushstack/eslint-patch':
         specifier: ^1.3.3
         version: 1.3.3
@@ -233,7 +233,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@types/uuid':
         specifier: ^9.0.2
         version: 9.0.2
@@ -287,7 +287,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -309,7 +309,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@types/lodash.clonedeep':
         specifier: ^4.5.7
         version: 4.5.7
@@ -351,7 +351,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -389,7 +389,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@types/lodash':
         specifier: ^4.14.197
         version: 4.14.197
@@ -416,7 +416,7 @@ importers:
         version: link:../i18n
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -441,7 +441,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -469,7 +469,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -494,7 +494,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -519,7 +519,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -544,7 +544,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -569,7 +569,7 @@ importers:
         version: link:../../core/i18n
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -597,7 +597,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -613,6 +613,9 @@ importers:
       '@kong-ui-public/copy-uuid':
         specifier: workspace:^
         version: link:../../core/copy-uuid
+      '@kong-ui-public/entities-consumer-groups':
+        specifier: workspace:^
+        version: link:../entities-consumer-groups
       '@kong-ui-public/entities-consumers':
         specifier: workspace:^
         version: link:../entities-consumers
@@ -634,7 +637,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -659,7 +662,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -690,7 +693,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -718,7 +721,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -743,7 +746,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -768,7 +771,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       axios:
         specifier: ^1.4.0
         version: 1.4.0
@@ -793,7 +796,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@types/prismjs':
         specifier: ^1.26.0
         version: 1.26.0
@@ -824,7 +827,7 @@ importers:
         version: 1.9.1
       '@kong/kongponents':
         specifier: ^8.122.6
-        version: 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+        version: 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.0.4
         version: 1.0.4(vite@4.4.9)
@@ -1979,7 +1982,7 @@ packages:
       '@kong/kongponents': ^8.83.5
       vue: ^3.2.47
     dependencies:
-      '@kong/kongponents': 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+      '@kong/kongponents': 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       approximate-number: 2.1.1
       vue: 3.3.4
     dev: false
@@ -1988,14 +1991,15 @@ packages:
     resolution: {integrity: sha512-r+0m5g31ZcI95inz+WRqM2V3XZ9rC1uEIh9mCMi5VAVhO5CypYhEoDp3UZZdctfAt8hVc+4boWnEIeuQQrDkqg==}
     dev: true
 
-  /@kong/kongponents@8.122.6(vue-router@4.2.4)(vue@3.3.4):
+  /@kong/kongponents@8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4):
     resolution: {integrity: sha512-J9sw8lVc/uF/4r7XzdFnehB9VpUjt4gCmMT5q36B2k+J1EmAun0Wv4oNArK/66189V4VXAwBZII2Bq1sIo04Ww==}
     engines: {node: '>=16.19.0'}
     peerDependencies:
+      axios: ^0.27.2
       vue: '>= 3.3.0'
       vue-router: ^4.1.6
     dependencies:
-      axios: 0.27.2
+      axios: 1.4.0
       date-fns: 2.30.0
       date-fns-tz: 1.3.8(date-fns@2.30.0)
       focus-trap: 7.5.2
@@ -2010,7 +2014,6 @@ packages:
       vue-router: 4.2.4(vue@3.3.4)
     transitivePeerDependencies:
       - '@popperjs/core'
-      - debug
 
   /@kong/swagger-ui-kong-theme-universal@4.2.6(react-dom@17.0.2)(react@17.0.2)(vue-router@4.2.4)(vue@3.3.4):
     resolution: {integrity: sha512-ZZtnsER3yHFnzjy5OO3jYgeY3ZCuhQP6IFqwq2vUj9HntyJUBOBUxvTJ9YJoQHz2wMVuatdUJHadQcUVS/Cktw==}
@@ -2018,7 +2021,7 @@ packages:
       react: 17.0.2
     dependencies:
       '@braintree/sanitize-url': 2.1.0
-      '@kong/kongponents': 8.122.6(vue-router@4.2.4)(vue@3.3.4)
+      '@kong/kongponents': 8.122.6(axios@1.4.0)(vue-router@4.2.4)(vue@3.3.4)
       '@kyleshockey/xml': 1.0.2
       classnames: 2.3.2
       curl-to-har: 1.0.1
@@ -2035,7 +2038,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - '@popperjs/core'
-      - debug
+      - axios
       - mkdirp
       - prop-types
       - react-dom
@@ -4583,14 +4586,6 @@ packages:
   /aws4@1.12.0:
     resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
     dev: true
-
-  /axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-    dependencies:
-      follow-redirects: 1.15.2
-      form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
 
   /axios@1.4.0:
     resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR enables `entities-plugins` to:
- display `Consumer Group` in the plugin list if a plugin is scoped to a consumer group
<p align=center><img width="700" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/8baff5c3-2812-4337-bcbf-522c5b2c1689"></p>

- show `Consumer Group ID` in the plugin config card if the plugin is scoped to a consumer group
<p align=center><img width="700" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/5db0bb9d-3f25-46ae-85ce-71f7fdb4db08"></p>

Also updates `FieldAutoSuggest` so that the plugin form can handle consumer group selection correctly. Note that consumer group selection needs to be handled in the host app.


## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
