### PR TITLE
fix: renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,9 @@
       "minimumReleaseAge": "10 days"
     },
     {
+      "automerge": true,
+      "groupName": "all kong scoped dependencies",
+      "groupSlug": "all-kong-scopes",
       "matchPackagePatterns": [
         "^@kong\/",
         "^@kong-ui\/",

--- a/renovate.json
+++ b/renovate.json
@@ -24,16 +24,8 @@
   "automergeSchedule": [
     "every weekday"
   ],
-  "stabilityDays": 14,
+  "minimumReleaseAge": "14 days",
   "packageRules": [
-    {
-      "matchPackagePatterns": [
-        "^@kong\/",
-        "^@kong-ui\/",
-        "^@kong-ui-public\/"
-      ],
-      "stabilityDays": 0
-    },
     {
       "automerge": true,
       "groupName": "all non-major dependencies with stable version",
@@ -46,7 +38,15 @@
         "minor",
         "patch"
       ],
-      "stabilityDays": 10
+      "minimumReleaseAge": "10 days"
+    },
+    {
+      "matchPackagePatterns": [
+        "^@kong\/",
+        "^@kong-ui\/",
+        "^@kong-ui-public\/"
+      ],
+      "minimumReleaseAge": "1 day"
     }
   ],
   "npmrcMerge": true,

--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
         "^@kong-ui\/",
         "^@kong-ui-public\/"
       ],
-      "minimumReleaseAge": "1 day"
+      "minimumReleaseAge": "2 hours"
     }
   ],
   "npmrcMerge": true,


### PR DESCRIPTION
# Summary

Modify the `renovate.json` config so that the package rules are ordered from least important to most important.

> Renovate evaluates all `packageRules` and does not stop after the first match. Order your `packageRules` so the **least important rules are at the top**, and the **most important rules at the bottom**. This way important rules override settings from earlier rules if needed.

Also updates `stabilityDays` (deprecated) to the [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) property.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
