### PR TITLE
fix(analytics-chart): better legend label truncation [MA-2048]

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/App.vue
+++ b/packages/analytics/analytics-chart/sandbox/App.vue
@@ -353,7 +353,7 @@ const metricItems = [{
 }]
 
 const statusCodeLabels = [
-  '200', '300', '400', '500', '501', '502', '503', '404', '401', '202', '201', '203', '204', 'This is a really long chart label to test long labels',
+  '200', '300', '400', '500', 'This is a really long chart label to test long labels',
 ]
 const statusCodeDimensionValues = ref(new Set(statusCodeLabels))
 

--- a/packages/analytics/analytics-chart/sandbox/App.vue
+++ b/packages/analytics/analytics-chart/sandbox/App.vue
@@ -353,7 +353,7 @@ const metricItems = [{
 }]
 
 const statusCodeLabels = [
-  '200', '300', '400', '500', 'This is a really long chart label to test long labels',
+  '200', '300', '400', '500', '501', '502', '503', '404', '401', '202', '201', '203', '204', 'This is a really long chart label to test long labels',
 ]
 const statusCodeDimensionValues = ref(new Set(statusCodeLabels))
 

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -196,7 +196,7 @@ const position = inject('legendPosition', ref(ChartLegendPosition.Right))
     }
 
     .label {
-      width: 14ch;
+      width: 12ch;
     }
     .truncate-label {
       max-width: 10ch;

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -40,7 +40,7 @@
 <script setup lang="ts">
 import { ChartLegendPosition } from '../../enums'
 import { Chart } from 'chart.js'
-import { computed, inject, ref, watch } from 'vue'
+import { inject, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 const props = defineProps({
   id: {
@@ -63,7 +63,7 @@ const shouldTruncate = ref(false)
 
 // Return the number of rows for a grid layout
 // by cmparing the top position of each item.
-const numberOfRows = computed(() => {
+const numberOfRows = () => {
   const element = legendContainerRef.value
   if (!element || !legendItemsRef.value || element.children.length === 0) {
     return 0
@@ -83,11 +83,11 @@ const numberOfRows = computed(() => {
   }
 
   return numberOfRows
-})
+}
 
 const checkForWrap = () => {
   if (legendContainerRef.value && position.value === ChartLegendPosition.Bottom) {
-    if (numberOfRows.value > 1) {
+    if (numberOfRows() > 1) {
       shouldTruncate.value = true
     } else {
       shouldTruncate.value = false
@@ -96,6 +96,14 @@ const checkForWrap = () => {
 }
 
 watch(() => props.items, checkForWrap, { immediate: true, flush: 'post' })
+
+onMounted(() => {
+  window.addEventListener('resize', checkForWrap)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', checkForWrap)
+})
 
 const handleLegendItemClick = (datasetIndex: number = 0, segmentIndex: number): void => {
   if (props.chartInstance === null) {


### PR DESCRIPTION
https://konghq.atlassian.net/browse/MA-2048

# Summary

Only truncate the label when the legend grows such that it begins to wrap to multiple rows.

calculate the number of row in the grid layout, representing
the legend by comparing the "top" position of each item
incrementing the numberOfRows each time there is a difference.

Use the number of rows to determine if a label should be
truncated or not.

## Truncate when list grows and wraps to a new row.
https://www.loom.com/share/c338d6643f9d4f46baf49de6245e468a

## Truncate on window resize if legend is forced into a new row.
https://www.loom.com/share/bf2b6c0d7a03428ea290f3059fe6d01d

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
