### PR TITLE
fix: adjust column width to prevent legend items from overlapping

### DIFF
--- a/packages/analytics/analytics-chart/README.md
+++ b/packages/analytics/analytics-chart/README.md
@@ -94,7 +94,7 @@ yarn add @kong-ui-public/analytics-chart
 
 - type: `string`
 - required: `false`
-- default: `'400px'`
+- default: `'500px'`
 - set the chart height using css height values (px, %, etc...)
 
 #### `width`

--- a/packages/analytics/analytics-chart/sandbox/App.vue
+++ b/packages/analytics/analytics-chart/sandbox/App.vue
@@ -360,9 +360,15 @@ const metricItems = [{
   unit: 'bytes',
 }]
 
+// Short labels
 const statusCodeLabels = [
-  '200', '300', '400', '500', 'This is a really long chart label to test long labels',
+  '200', '300', '400', '500',
 ]
+
+// Long labels
+// const statusCodeLabels = [
+//   'getmeakong123', 'getmeakong123123', 'testservice1233', 'testtesttest123123', 'This is a really long chart label to test long labels',
+// ]
 const statusCodeDimensionValues = ref(new Set(statusCodeLabels))
 
 const serviceDimensionValues = ref(new Set([

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -48,6 +48,7 @@
     <div
       v-else
       class="analytics-chart-parent"
+      :style="{ height: heightRef, width }"
     >
       <TimeSeriesChart
         v-if="isTimeSeriesChart"
@@ -56,7 +57,6 @@
         :dimension-axes-title="timestampAxisTitle"
         :fill="chartOptions.fill"
         :granularity="timeSeriesGranularity"
-        :height="height"
         :legend-values="legendValues"
         :metric-axes-title="metricAxesTitle"
         :metric-unit="computedMetricUnit"
@@ -66,7 +66,6 @@
         :time-range-sec="timeRangeSec"
         :tooltip-title="tooltipTitle"
         :type="(chartOptions.type as (ChartTypes.TIMESERIES_LINE | ChartTypes.TIMESERIES_BAR))"
-        :width="width"
       />
       <StackedBarChart
         v-else-if="isBarChart"
@@ -80,6 +79,7 @@
         :orientation="barChartOrientation"
         :synthetics-data-key="syntheticsDataKey"
         :tooltip-title="tooltipTitle"
+        @height-update="handleHeightUpdate"
       />
       <DoughnutChart
         v-else-if="isDoughnutChart"
@@ -91,7 +91,6 @@
         :metric-unit="computedMetricUnit"
         :synthetics-data-key="syntheticsDataKey"
         :tooltip-title="tooltipTitle"
-        :width="width"
       />
     </div>
   </div>
@@ -104,7 +103,7 @@ import { ChartTypes, ChartLegendPosition } from '../enums'
 import StackedBarChart from './chart-types/StackedBarChart.vue'
 import DoughnutChart from './chart-types/DoughnutChart.vue'
 import type { PropType } from 'vue'
-import { computed, provide, toRef } from 'vue'
+import { computed, provide, ref, toRef } from 'vue'
 import { GranularityKeys, msToGranularity } from '@kong-ui-public/analytics-utilities'
 import type { AnalyticsExploreResult, AnalyticsExploreV2Result, GranularityFullObj } from '@kong-ui-public/analytics-utilities'
 import { datavisPalette, hasMillisecondTimestamps } from '../utils'
@@ -151,7 +150,7 @@ const props = defineProps({
   height: {
     type: String,
     required: false,
-    default: '400px',
+    default: '500px',
     validator: (value: string): boolean => {
       return /(\d *)(px|%)/.test(value)
     },
@@ -177,6 +176,11 @@ const props = defineProps({
 })
 
 const { i18n } = composables.useI18n()
+const heightRef = ref<string>(props.height)
+
+const handleHeightUpdate = (height: number) => {
+  heightRef.value = `${height}px`
+}
 
 const computedChartData = computed(() => {
   return isTimeSeriesChart.value
@@ -314,6 +318,10 @@ provide('legendPosition', toRef(props, 'legendPosition'))
   border: $kui-border-width-10 solid $kui-color-border;
   margin: $kui-space-60;
   padding: $kui-space-60;
+
+  .analytics-chart-parent {
+    overflow: hidden;
+  }
 
   .chart-empty-state {
     padding: $kui-space-70 $kui-space-0 $kui-space-60 $kui-space-0;

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -17,6 +17,7 @@
         :style="{ background: fillStyle, 'border-color': strokeStyle }"
       />
       <div
+        class="label-container"
         :class="{ 'strike-through': !isDatasetVisible(datasetIndex, index) }"
       >
         <div
@@ -39,8 +40,9 @@
 
 <script setup lang="ts">
 import { ChartLegendPosition } from '../../enums'
-import { Chart } from 'chart.js'
-import { inject, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { Chart, type LegendItem } from 'chart.js'
+import { inject, onBeforeUnmount, onMounted, ref, watch, type PropType } from 'vue'
+import { KUI_SPACE_100 } from '@kong/design-tokens'
 
 const props = defineProps({
   id: {
@@ -48,7 +50,7 @@ const props = defineProps({
     required: true,
   },
   items: {
-    type: Array,
+    type: Object as PropType<LegendItem[]>,
     required: true,
   },
   chartInstance: {
@@ -57,9 +59,13 @@ const props = defineProps({
     default: () => null,
   },
 })
+
 const legendContainerRef = ref<HTMLElement>()
 const legendItemsRef = ref<HTMLElement[]>([])
 const shouldTruncate = ref(false)
+const showValues = inject('showLegendValues', true)
+const position = inject('legendPosition', ref(ChartLegendPosition.Right))
+const legendItemsTracker = ref<LegendItem[]>([])
 
 // Return the number of rows for a grid layout
 // by cmparing the top position of each item.
@@ -95,9 +101,55 @@ const checkForWrap = () => {
   }
 }
 
-watch(() => props.items, checkForWrap, { immediate: true, flush: 'post' })
+// Set the grid-template-columns style based on the width of the widest item
+const formatGrid = () => {
+  if (legendContainerRef.value && position.value === ChartLegendPosition.Bottom) {
+    let maxWidth = 0
+
+    legendItemsRef.value.forEach(item => {
+      // Each <li> has two elements: the legend and the label.
+      // Sum the width of each element to get the total width of the item.
+      const width = Array.from(item.children).reduce((total, element) => {
+        return total + (element as HTMLElement).offsetWidth
+      }, 0)
+      if (width > maxWidth) {
+        maxWidth = width
+      }
+    })
+    const padding = parseInt(KUI_SPACE_100, 10)
+    legendContainerRef.value.style.gridTemplateColumns = `repeat(auto-fit, ${maxWidth + padding}px)`
+  }
+}
+
+const legendItemsChanged = () => {
+  if (props.items.length !== legendItemsTracker.value.length) {
+    legendItemsTracker.value = props.items
+    return true
+  }
+
+  for (let i = 0; i < props.items.length; i++) {
+    if (props.items[i].text !== legendItemsTracker.value[i].text) {
+      legendItemsTracker.value = props.items
+      return true
+    }
+  }
+
+  return false
+}
+
+watch(() => props.items, () => {
+  checkForWrap()
+  if (legendItemsChanged()) {
+    formatGrid()
+  }
+}, { immediate: true, flush: 'post' })
+
+watch(() => position.value, () => {
+  formatGrid()
+})
 
 onMounted(() => {
+  legendItemsTracker.value = props.items
   window.addEventListener('resize', checkForWrap)
 })
 
@@ -149,16 +201,12 @@ const positionToClass = (position: `${ChartLegendPosition}`) => {
   }[position]
 }
 
-const showValues = inject('showLegendValues', true)
-const position = inject('legendPosition', ref(ChartLegendPosition.Right))
-
 </script>
 
 <style lang="scss" scoped>
 .legend-container {
   display: flex;
   max-height: inherit;
-  min-width: 10%;
   -ms-overflow-style: thin;
   overflow-x: hidden;
   overflow-y: scroll;
@@ -168,17 +216,14 @@ const position = inject('legendPosition', ref(ChartLegendPosition.Right))
   &.vertical {
     flex-direction: column;
     max-height: 400px;
-    max-width: 200px;
-
-    .legend {
-      margin-top: $kui-space-30;
-    }
+    max-width: 15%;
+    word-break: break-word;
 
     // Allow legend to expand horizontally at lower resolutions
     @media (max-width: ($kui-breakpoint-phablet - 1px)) {
       flex-direction: row;
+      height: 20%;
       max-width: 100%;
-      padding-top: $kui-space-50;
       width: 100%;
     }
   }
@@ -186,28 +231,14 @@ const position = inject('legendPosition', ref(ChartLegendPosition.Right))
   &.horizontal {
     column-gap: $kui-space-10;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(12ch, max-content));
     justify-content: center;
-    max-height: $kui-space-150;
+    max-height: 15%;
     width: 100%;
-
-    .legend {
-      margin-top: $kui-space-30;
-    }
-
-    .label {
-      width: 12ch;
-    }
     .truncate-label {
-      max-width: 10ch;
+      max-width: 15ch;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-    }
-
-    li {
-      display: flex;
-      justify-content: start;
     }
   }
 
@@ -227,23 +258,26 @@ const position = inject('legendPosition', ref(ChartLegendPosition.Right))
 
   // Individual legend item
   li {
+    align-items: start;
+    cursor: pointer;
+    display: flex;
+    margin-top: $kui-space-60;
+
     .legend {
       flex: 0 0 14px;
       height: 3px;
       margin-right: $kui-space-50;
+      margin-top: $kui-space-30;
     }
-
-    cursor: pointer;
-    display: flex;
-    height: fit-content;
-    margin: $kui-space-50;
 
     .label {
       font-size: $kui-font-size-30;
+      line-height: $kui-font-size-50;
     }
 
     .sub-label {
       font-size: $kui-font-size-20;
+      line-height: $kui-font-size-30;
       word-break: none;
     }
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/DoughnutChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DoughnutChart.vue
@@ -6,7 +6,6 @@
   >
     <div
       class="chart-container"
-      :style="{ height, width }"
     >
       <Doughnut
         ref="chartInstance"
@@ -92,22 +91,6 @@ const props = defineProps({
     type: Object as PropType<AnalyticsChartColors | string[]>,
     required: false,
     default: datavisPalette,
-  },
-  height: {
-    type: String,
-    required: false,
-    default: '400px',
-    validator: (value: string): boolean => {
-      return /(\d *)(px|%)/.test(value)
-    },
-  },
-  width: {
-    type: String,
-    required: false,
-    default: '100%',
-    validator: (value: string): boolean => {
-      return /(\d *)(px|%)/.test(value)
-    },
   },
 })
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -6,7 +6,6 @@
   >
     <div
       class="chart-container"
-      :style="{height, width}"
       @click="handleChartClick()"
     >
       <Line
@@ -72,7 +71,7 @@ import { Line, Bar } from 'vue-chartjs'
 import composables from '../../composables'
 import type { AnalyticsChartColors, KChartData, LegendValues, TooltipState } from '../../types'
 import { GranularityKeys } from '@kong-ui-public/analytics-utilities'
-import type { Chart } from 'chart.js'
+import type { Chart, LegendItem } from 'chart.js'
 import { ChartLegendPosition, ChartTypes } from '../../enums'
 
 const props = defineProps({
@@ -145,29 +144,13 @@ const props = defineProps({
     default: datavisPalette,
 
   },
-  height: {
-    type: String,
-    required: false,
-    default: '400px',
-    validator: (value: string): boolean => {
-      return /(\d *)(px|%)/.test(value)
-    },
-  },
-  width: {
-    type: String,
-    required: false,
-    default: '100%',
-    validator: (value: string): boolean => {
-      return /(\d *)(px|%)/.test(value)
-    },
-  },
 })
 
 const { i18n } = composables.useI18n()
 const chartInstance = ref<{chart: Chart}>()
 const legendID = ref(uuidv4())
 const chartID = ref(uuidv4())
-const legendItems = ref([])
+const legendItems = ref<LegendItem[]>([])
 const tooltipElement = ref()
 const legendPosition = ref(inject('legendPosition', ChartLegendPosition.Right))
 

--- a/packages/analytics/analytics-chart/src/styles/chart.scss
+++ b/packages/analytics/analytics-chart/src/styles/chart.scss
@@ -1,12 +1,15 @@
 .chart-parent {
   align-items: center;
   display: flex;
+  height: inherit ;
   position: relative;
+  width: inherit;
 
   &.column {
     flex-direction: column;
 
     .chart-container {
+      height: 80%;
       width: 100%;
     }
   }
@@ -16,27 +19,25 @@
 
     .chart-container {
       flex-grow: 1;
-      width: 85% !important;
-    }
-  }
+      height: 100%;
+      width: 85%;
 
-  &:not(.show-total) {
-    // Always stack legend below chart below mobile breakpoint
+      // Allow chart to expand full width on mobile
+      @media (max-width: ($kui-breakpoint-phablet - 1px)) {
+        height: 80% !important;
+        width: 100% !important;
+      }
+    }
     @media (max-width: ($kui-breakpoint-phablet - 1px)) {
       display: flex;
       flex-wrap: wrap;
     }
   }
 
+
   .chart-container {
-    margin-bottom: $kui-space-50;
     // Per ChartJS docs, the chart container needs to be position: relative and _only_ contain the chart canvas.
     // https://www.chartjs.org/docs/latest/configuration/responsive.html
     position: relative;
-
-    // Allow chart to expand full width on mobile
-    @media (max-width: ($kui-breakpoint-phablet - 1px)) {
-      width: 100% !important;
-    }
   }
 }


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-2055

- set the grid-column-template width based on the widest item
- implement a grid formatting function in order to better handle
   dynamic sized legend items. Pure CSS was not enough to handle
   both short as well as long legend labels.
- To avoid unecesarry calls to a potentially DOM-modifying function
   only execute formatGrid() if the legend items have changed.
- Fixes and tweaks to styles for better readability and consistency
  - Fix how chart width/height and legend/width height are set and maintained across all sub-components

![image](https://github.com/Kong/public-ui-components/assets/6026470/7568e9fc-fe4b-44d1-b26b-8eafbe8efec3)
![image](https://github.com/Kong/public-ui-components/assets/6026470/68dd28f1-7982-47e6-9466-9efe9bb08372)
![image](https://github.com/Kong/public-ui-components/assets/6026470/0571f861-bb0d-4ef3-99a9-4c353f7b985d)
![image](https://github.com/Kong/public-ui-components/assets/6026470/1dec4394-3ca2-4d23-9b13-2856438fb152)
![image](https://github.com/Kong/public-ui-components/assets/6026470/58ac70f7-d09f-4522-bd9b-0fa402535d24)
![image](https://github.com/Kong/public-ui-components/assets/6026470/2b87d5f9-4012-4e41-be39-bc18ae0ac381)
![image](https://github.com/Kong/public-ui-components/assets/6026470/1620b6e1-00e4-4fb2-b434-a04c43eac46d)
![image](https://github.com/Kong/public-ui-components/assets/6026470/c6541e70-1c84-4aeb-8848-a1b9bc295955)
![image](https://github.com/Kong/public-ui-components/assets/6026470/52265c20-ccf0-4477-9736-9a233e610313)
![image](https://github.com/Kong/public-ui-components/assets/6026470/f3819026-de9e-470c-bcdb-6c5fb400b8f3)
![image](https://github.com/Kong/public-ui-components/assets/6026470/3f951d67-6aaa-45e5-b5ca-ff339cace0cf)


<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
