### PR TITLE
feat: add support for multiple metrics

### DIFF
--- a/packages/analytics/analytics-chart/README.md
+++ b/packages/analytics/analytics-chart/README.md
@@ -39,7 +39,7 @@ yarn add @kong-ui-public/analytics-chart
 
 - type: [AnalyticsChartOptions](https://github.com/Kong/public-ui-components/blob/main/packages/analytics/analytics-chart/src/types/chart-data.ts)
 - required: `true`
-- `stacked` option only apply to time series charts
+- `stacked` option applies to timeseries charts as well as vertical/horizontal bar charts.
 - `fill` only applies to time series line chart
 - `chartTypes` defined [here](https://github.com/Kong/public-ui-components/blob/main/packages/analytics/analytics-utilities/src/types/chart-types.ts)
 - `chartDatasetColors` are optional

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -77,6 +77,7 @@
         :metric-axes-title="metricAxesTitle"
         :metric-unit="computedMetricUnit"
         :orientation="barChartOrientation"
+        :stacked="chartOptions.stacked"
         :synthetics-data-key="syntheticsDataKey"
         :tooltip-title="tooltipTitle"
         @height-update="handleHeightUpdate"

--- a/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
@@ -81,7 +81,7 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
           border: {
             display: false,
           },
-          stacked: chartOptions.stacked,
+          stacked: chartOptions.stacked.value,
           grid: {
             display: false,
             drawBorder: false,

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
@@ -165,7 +165,7 @@ describe('useVitalsExploreDatasets', () => {
       },
     }))
     const result = useExploreResultToDatasets({ fill: true }, exploreResult)
-    console.log(result.value)
+
     expect(result.value).toEqual(
       {
         labels: ['group-by-1', 'group-by-2'],
@@ -224,7 +224,6 @@ it('handles empty dimension', () => {
         timestamp: '2022-01-01T01:01:02Z',
         event: {
           metric: 1,
-          dimension: 'dimension1',
         },
       },
     ],
@@ -247,6 +246,101 @@ it('handles empty dimension', () => {
       labels: ['metric'],
       datasets: [
         { label: 'metric', backgroundColor: '#a86cd5', data: [1] },
+      ],
+    },
+  )
+})
+
+it('handles multiple metrics with no dimension', () => {
+  const exploreResult: ComputedRef<AnalyticsExploreResult> = computed(() => ({
+    records: [
+      {
+        version: 'v1',
+        timestamp: '2022-01-01T01:01:02Z',
+        event: {
+          metric1: 1,
+          metric2: 2,
+        },
+      },
+    ],
+    meta: {
+      start: 1640998862,
+      end: 1640998870,
+      granularity: 5000,
+      metricNames: [
+        'metric1',
+        'metric2',
+      ],
+      queryId: '',
+      metricUnits: { metric1: 'units', metric2: 'units' },
+      truncated: false,
+      limit: 15,
+      dimensions: {},
+    },
+  }))
+  const result = useExploreResultToDatasets({ fill: true }, exploreResult)
+
+  expect(result.value).toEqual(
+    {
+      labels: ['metric1', 'metric2'],
+      datasets: [
+        { label: 'metric1', backgroundColor: '#a86cd5', data: [1, 0] },
+        { label: 'metric2', backgroundColor: '#6a86d2', data: [0, 2] },
+      ],
+    },
+  )
+})
+
+it('handles multiple metrics with dimension', () => {
+  const exploreResult: ComputedRef<AnalyticsExploreResult> = computed(() => ({
+    records: [
+      {
+        version: 'v1',
+        timestamp: '2022-01-01T01:01:02Z',
+        event: {
+          metric1: 1,
+          metric2: 2,
+          Service: 'service1',
+        },
+      },
+      {
+        version: 'v1',
+        timestamp: '2022-01-01T01:01:02Z',
+        event: {
+          metric1: 3,
+          metric2: 4,
+          Service: 'service2',
+        },
+      },
+    ],
+    meta: {
+      start: 1640998862,
+      end: 1640998870,
+      granularity: 5000,
+      metricNames: [
+        'metric1',
+        'metric2',
+      ],
+      queryId: '',
+      metricUnits: { metric1: 'units', metric2: 'units' },
+      truncated: false,
+      limit: 15,
+      dimensions: {
+        Service: [
+          'service1',
+          'service2',
+        ],
+      },
+    },
+  }))
+  const result = useExploreResultToDatasets({ fill: true }, exploreResult)
+
+  expect(result.value).toEqual(
+    {
+      labels: ['service1', 'service2'],
+      datasets: [
+        { label: 'metric1', backgroundColor: '#a86cd5', data: [1, 3] },
+        { label: 'metric2', backgroundColor: '#6a86d2', data: [2, 4] },
       ],
     },
   )

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
@@ -41,9 +41,9 @@ export default function useExploreResultToDatasets(
 
         const pivotRecords = isMultiMetric
           ? Object.fromEntries(records.flatMap(e => {
-            return metricNames.map(metric => {
+            return metricNames.map((metric, i) => {
               const dimensionValue = e.event[primaryDimension]
-              const label = `${dimensionValue},${metric}`
+              const label = hasDimensions ? `${dimensionValue},${metric}` : `${i},${metric}`
               const value = e.event[metric]
               return [label, value]
             })
@@ -76,8 +76,8 @@ export default function useExploreResultToDatasets(
               return {
                 label: metric,
                 backgroundColor: lookupDatavisColor(metricNames.indexOf(metric), datavisPalette),
-                data: rowLabels.map(rowPosition => {
-                  return pivotRecords[`${rowPosition},${metric}`] || 0
+                data: rowLabels.map((rowPosition, i) => {
+                  return hasDimensions ? pivotRecords[`${rowPosition},${metric}`] || 0 : pivotRecords[`${i},${metric}`] || 0
                 }),
               } as Dataset
             })

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
@@ -74,7 +74,8 @@ export default function useExploreResultToDatasets(
           datasets: isMultiMetric
             ? metricNames.map((metric) => {
               return {
-                label: metric,
+                // @ts-ignore - dynamic i18n key
+                label: (i18n && i18n.te(`chartLabels.${metric}`) && i18n.t(`chartLabels.${metric}`)) || metric,
                 backgroundColor: lookupDatavisColor(metricNames.indexOf(metric), datavisPalette),
                 data: rowLabels.map((rowPosition, i) => {
                   return hasDimensions ? pivotRecords[`${rowPosition},${metric}`] || 0 : pivotRecords[`${i},${metric}`] || 0

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToTimedDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToTimedDatasets.spec.ts
@@ -77,7 +77,7 @@ describe('useVitalsExploreDatasets', () => {
         start: 1640998862, // 2022-01-01T01:01:02Z
         end: 1640998870, // 2022-01-01T01:01:10Z
         granularity: 5000, // (5 seconds)
-        dimensions: { dimension: ['dimension'] },
+        dimensions: { dimension: ['label'] },
         metricNames: ['metric'],
         queryId: '',
         metricUnits: { units: 'units' },
@@ -119,7 +119,7 @@ describe('useVitalsExploreDatasets', () => {
         start: 1640998862, // 2022-01-01T01:01:02Z
         end: 1640998872, // 2022-01-01T01:01:10Z
         granularity: 5000,
-        dimensions: { dimension: ['dimension'] },
+        dimensions: { dimension: ['label'] },
         metricNames: ['metric'],
         queryId: '',
         metricUnits: { units: 'units' },
@@ -164,7 +164,7 @@ describe('useVitalsExploreDatasets', () => {
         start: 1640998862,
         end: 1640998870,
         granularity: 5000,
-        dimensions: { dimension: ['dimension'] },
+        dimensions: { dimension: ['label'] },
         metricNames: ['metric'],
         queryId: '',
         metricUnits: { units: 'units' },
@@ -213,7 +213,7 @@ describe('useVitalsExploreDatasets', () => {
         start: Math.trunc(START_FOR_DAILY_QUERY.getTime() / 1000),
         end: Math.trunc(END_FOR_DAILY_QUERY.getTime() / 1000),
         granularity: 86400000,
-        dimensions: { dimension: ['dimension'] },
+        dimensions: { dimension: ['label'] },
         metricNames: ['metric'],
         queryId: '',
         metricUnits: { units: 'units' },

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToTimedDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToTimedDatasets.spec.ts
@@ -438,3 +438,95 @@ it('handle empty dimension query', () => {
 
   expect(result.value.datasets[0].label).toEqual('metric1')
 })
+
+it('handles multiple metrics', () => {
+  const exploreResult: ComputedRef<AnalyticsExploreResult> = computed(() => ({
+    records: [
+      {
+        version: 'v1',
+        timestamp: START_FOR_DAILY_QUERY.toISOString(),
+        event: {
+          metric1: 1,
+          metric2: 2,
+        },
+      },
+      {
+        version: 'v1',
+        timestamp: END_FOR_DAILY_QUERY.toISOString(),
+        event: {
+          metric1: 3,
+          metric2: 4,
+        },
+      },
+    ],
+    meta: {
+      start: Math.trunc(START_FOR_DAILY_QUERY.getTime() / 1000),
+      end: Math.trunc(END_FOR_DAILY_QUERY.getTime() / 1000),
+      granularity: 86400000,
+      metricNames: [
+        'metric1',
+        'metric2',
+      ],
+      queryId: '',
+      metricUnits: { metric1: 'units', metric2: 'units' },
+      dimensions: {},
+    },
+  }))
+  const result = useExploreResultToTimeDataset(
+    { fill: false },
+    exploreResult,
+  )
+
+  expect(result.value.datasets).toEqual(
+    [
+      {
+        rawDimension: 'metric1',
+        rawMetric: 'metric1',
+        label: 'metric1',
+        borderColor: '#763aa3',
+        backgroundColor: '#a86cd5',
+        data: [
+          {
+            x: START_FOR_DAILY_QUERY.getTime(),
+            y: 1,
+          },
+          {
+            x: END_FOR_DAILY_QUERY.getTime(),
+            y: 3,
+          },
+        ],
+        total: 4,
+        lineTension: 0.4,
+        borderWidth: 2,
+        pointBorderWidth: 1.2,
+        borderJoinStyle: 'round',
+        fill: false,
+      },
+      {
+        rawDimension: 'metric2',
+        rawMetric: 'metric2',
+        label: 'metric2',
+        borderColor: '#3854a0',
+        backgroundColor: '#6a86d2',
+        data: [
+          {
+            x: START_FOR_DAILY_QUERY.getTime(),
+            y: 2,
+          },
+          {
+            x: END_FOR_DAILY_QUERY.getTime(),
+            y: 4,
+          },
+        ],
+        total: 6,
+        lineTension: 0.4,
+        borderWidth: 2,
+        pointBorderWidth: 1.2,
+        borderJoinStyle: 'round',
+        fill: false,
+      },
+    ],
+  )
+
+  expect(result.value.datasets[0].label).toEqual('metric1')
+})

--- a/packages/analytics/analytics-chart/src/types/chart-data.ts
+++ b/packages/analytics/analytics-chart/src/types/chart-data.ts
@@ -37,8 +37,8 @@ export interface AnalyticsChartOptions {
   type: ChartTypes
   /**
    * Are the datasets stacked or not.
-   * If stacked, the datasets are stacked on top of each other
-   * Only applies to time series line charts.
+   * If stacked, the datasets are stacked on top of each other.
+   * Applies to timeseries charts as well as bar charts.
    */
   stacked?: boolean,
   /**


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-2066
https://konghq.atlassian.net/browse/MA-2034

* Allow bar charts to be stacked/unstacked
* Update explore result --> chartJS dataset composable to detect and handle data with multiple metrics and one group-by dimension (group by dimension is inherently "time" for timeseries charts).
* Some unit tests for `useExploreResultToTimeDatasets` were not setting up the `meta` object properly. The `dataset` property in the meta object should have the dimensionName as a key, the value should be an array including all of the values present in the records for that dimensionName

Note - Metric axis title, chart title, tooltip title, as well as annotations enabled/disabled are provided by the consuming app. Any discrepancies seen in the sandbox for those aspects shouldn't be an issue.  As they are the responsibility of the consuming app to provide those options. What you see in the sandbox is not a perfect representation of the end result on the consuming app. Sandbox is just for debugging/demonstrative purposes, not a reflection of how the end result will look like exactly on the consuming app.

I will include screenshots from khcp-ui as well when it's using the temp package and providing multiple metric data to analytics-chart. That should reflect the end result when the host app is providing those options in accordance to how we want to see multiple metric charts displayed.

## Sandbox screenshots
### Vertical bar chart with multiple metrics + one group by
![image](https://github.com/Kong/public-ui-components/assets/6026470/77281c96-0d75-48e5-9de0-065913b51e46)
### Horizontal bar chart with multiple metrics + one group by
![image](https://github.com/Kong/public-ui-components/assets/6026470/51a55840-7881-4774-99f5-47893b65eb12)
### Line chart with multiple metrics
![image](https://github.com/Kong/public-ui-components/assets/6026470/b4b39155-9578-4997-a78c-8ddda7f978d2)

## KHCP-UI screenshots (using temp package)
### P99/P95/P50 latency line chart
![image](https://github.com/Kong/public-ui-components/assets/6026470/e3b224ea-f240-4a45-b6a4-fe00b2099413)

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
