### PR TITLE
feat(copy-uuid): display tooltip on id hover

### DIFF
--- a/packages/core/copy-uuid/sandbox/App.vue
+++ b/packages/core/copy-uuid/sandbox/App.vue
@@ -48,6 +48,13 @@
         />
       </div>
       <div>
+        <h3>idTooltip</h3>
+        <CopyUuid
+          :id-tooltip="`The id is ${uuid}`"
+          :uuid="uuid"
+        />
+      </div>
+      <div>
         <h3>tooltip</h3>
         <CopyUuid
           tooltip="Click to copy"

--- a/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
+++ b/packages/core/copy-uuid/src/components/CopyUuid.cy.ts
@@ -263,6 +263,21 @@ describe('<CopyUuid />', () => {
       cy.get(container).find('.k-tooltip .k-popover-content').should('contain.text', tooltipText)
     })
 
+    it('renders with `idTooltip` prop set', () => {
+      const tooltipText = 'Custom tooltip text!'
+
+      cy.mount(CopyUuid, {
+        props: {
+          uuid,
+          idTooltip: tooltipText,
+        },
+      })
+
+      cy.get(container).should('be.visible')
+      cy.get(container).find('.k-tooltip').should('exist')
+      cy.get(container).find('.k-tooltip .k-popover-content').should('contain.text', tooltipText)
+    })
+
     it('renders `successTooltip` with `tooltip` prop set', () => {
       const tooltipText = 'Click to copy'
       const successText = 'Copied!'

--- a/packages/core/copy-uuid/src/components/CopyUuid.vue
+++ b/packages/core/copy-uuid/src/components/CopyUuid.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="kong-ui-copy-uuid">
-    <div
+    <component
+      :is="!!idTooltip ? 'KTooltip' : 'div'"
       v-if="format !== 'hidden'"
+      v-bind="idWrapperProps"
       data-testid="copy-id"
-      :title="uuid"
     >
       <div
         :class="[
@@ -14,10 +15,10 @@
       >
         {{ uuidFormat }}
       </div>
-    </div>
+    </component>
     <component
       :is="!!tooltip ? 'KTooltip' : 'div'"
-      v-bind="wrapperProps"
+      v-bind="buttonWrapperProps"
       class="uuid-icon-wrapper"
     >
       <KClipboardProvider v-slot="{ copyToClipboard }">
@@ -55,6 +56,10 @@ const props = defineProps({
   uuid: {
     type: String,
     required: true,
+  },
+  idTooltip: {
+    type: String,
+    default: '',
   },
   truncated: {
     type: Boolean,
@@ -95,9 +100,20 @@ const emit = defineEmits<{
 
 const notifyTrimLength = 15
 const notify = props.notify || inject(COPY_UUID_NOTIFY_KEY, () => { })
+const idWrapperProps = computed(() => {
+  return props.idTooltip
+    ? {
+      label: props.idTooltip,
+      positionFixed: true,
+      placement: 'bottomStart',
+    }
+    : {
+      title: props.uuid,
+    }
+})
 const hasSuccessTooltip = computed((): boolean => !!(props.tooltip && props.successTooltip))
 const tooltipText = ref(props.tooltip)
-const wrapperProps = computed(() => {
+const buttonWrapperProps = computed(() => {
   return props.tooltip
     ? {
       label: tooltipText.value,


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Add prop to support displaying custom text on hover of the `id` (does not affect existing tooltip support for the copy button).

![image](https://github.com/Kong/public-ui-components/assets/67973710/0d47a30e-f4a1-4039-a086-c634e95d874d)


## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [x] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
