### PR TITLE
fix(service): `tls_verify` value in config card

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceConfigCard.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceConfigCard.vue
@@ -52,7 +52,7 @@
 
       <template #tls_verify="slotProps">
         {{
-          getPropValue('rowValue', slotProps) === true || getPropValue('rowValue', slotProps) === undefined
+          typeof getPropValue('rowValue', slotProps) === 'boolean'
             ? getTlsVerifyOption('rowValue', slotProps)
             : t('gateway_services.form.fields.tls_verify_option.unset.display')
         }}

--- a/packages/entities/entities-shared/src/composables/useHelpers.ts
+++ b/packages/entities/entities-shared/src/composables/useHelpers.ts
@@ -7,7 +7,7 @@ export default function useHelpers() {
    * @returns the property value or undefined
    */
   const getPropValue = (propName: string, slotProps?: Record<string, any>) => {
-    return slotProps?.[propName] || undefined
+    return slotProps?.[propName] ?? undefined
   }
 
   return {


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

When `tls_vefiry` is `null`, the displayed text should be `Use default system setting`.

<img width="1363" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/6424c92f-514b-464a-92ae-fce5eb3ca05e">

<img width="346" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/ab881a52-0ee1-47b8-a60d-b60c2ac22a2d">


## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
