### PR TITLE
Feat/ma 1894 gauge chart customizations

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/App.vue
+++ b/packages/analytics/analytics-chart/sandbox/App.vue
@@ -665,7 +665,7 @@ const simpleChartOptions = computed<SimpleChartOptions>(() => ({
   chartDatasetColors: twoColorPalette.value,
   metricDisplay: metricDisplay.value,
   reverseDataset: reverseDataset.value,
-  bigNumberKey: bigNumberKey.value
+  bigNumberKey: bigNumberKey.value,
 }))
 
 const randomizeData = () => {

--- a/packages/analytics/analytics-chart/sandbox/App.vue
+++ b/packages/analytics/analytics-chart/sandbox/App.vue
@@ -111,6 +111,52 @@
             </KRadio>
           </div>
         </div>
+        <KLabel>
+          Dataset order
+        </KLabel>
+        <div class="chart-radio-group">
+          <div>
+            <KRadio
+              v-model="reverseDataset"
+              name="reverseDataset"
+              :selected-value="false"
+            >
+              Normal
+            </KRadio>
+          </div>
+          <div>
+            <KRadio
+              v-model="reverseDataset"
+              name="reverseDataset"
+              :selected-value="true"
+            >
+              Reversed
+            </KRadio>
+          </div>
+        </div>
+        <KLabel>
+          Big Number Key
+        </KLabel>
+        <div class="chart-radio-group">
+          <div>
+            <KRadio
+              v-model="bigNumberKey"
+              name="bigNumberKey"
+              :selected-value="0"
+            >
+              0
+            </KRadio>
+          </div>
+          <div>
+            <KRadio
+              v-model="bigNumberKey"
+              name="bigNumberKey"
+              :selected-value="1"
+            >
+              1
+            </KRadio>
+          </div>
+        </div>
       </div>
 
       <!-- Legend position -->
@@ -347,6 +393,8 @@ const emptyState = ref(false)
 const chartType = ref<ChartTypes | ChartTypesSimple>(ChartTypes.VERTICAL_BAR)
 const legendPosition = ref(ChartLegendPosition.Right)
 const metricDisplay = ref(ChartMetricDisplay.SingleMetric)
+const reverseDataset = ref(false)
+const bigNumberKey = ref(0)
 const selectedMetric = ref<MetricSelection>({
   name: Metrics.TotalRequests,
   unit: 'count',
@@ -616,6 +664,8 @@ const simpleChartOptions = computed<SimpleChartOptions>(() => ({
   type: chartType.value,
   chartDatasetColors: twoColorPalette.value,
   metricDisplay: metricDisplay.value,
+  reverseDataset: reverseDataset.value,
+  bigNumberKey: bigNumberKey.value
 }))
 
 const randomizeData = () => {
@@ -691,6 +741,14 @@ body {
 .sandbox-container {
   margin: 0;
   padding: $kui-space-60;
+
+  .k-input-label{
+    margin-bottom: 2px;
+
+    &:not(:first-child) {
+      margin-top: 12px;
+    }
+  }
 
   .top-n-sandbox {
     margin-top: 16px;

--- a/packages/analytics/analytics-chart/src/components/SimpleChart.vue
+++ b/packages/analytics/analytics-chart/src/components/SimpleChart.vue
@@ -36,7 +36,7 @@ import type { SimpleChartOptions } from '../types'
 import { ChartTypesSimple } from '../enums'
 import GaugeChart from './chart-types/GaugeChart.vue'
 import type { PropType } from 'vue'
-import { computed, toRef } from 'vue'
+import { computed, toRef, watch } from 'vue'
 import type { AnalyticsExploreResult, AnalyticsExploreV2Result } from '@kong-ui-public/analytics-utilities'
 import { datavisPalette } from '../utils'
 
@@ -79,12 +79,19 @@ const props = defineProps({
 
 const { i18n } = composables.useI18n()
 
+const chartOptionsRef = toRef(props, 'chartOptions')
+const chartDataRef = toRef(props, 'chartData')
+
 const computedChartData = computed(() => {
+  // if (chartOptionsRef.value?.reverseDataset) {
+  //   props.chartData.records.reverse()
+  // }
+
   return composables.useExploreResultToDatasets(
     {
-      colorPalette: props.chartOptions.chartDatasetColors || datavisPalette,
+      colorPalette: chartOptionsRef.value.chartDatasetColors || datavisPalette,
     },
-    toRef(props, 'chartData'),
+    chartDataRef
   ).value
 })
 
@@ -93,7 +100,11 @@ const computedMetricUnit = computed<string>(() => {
     return ''
   }
 
-  return Object.values(props.chartData.meta.metricUnits)[0]
+  const metricKey = chartOptionsRef.value?.bigNumberKey || 0
+
+  console.log(" >>>>metricKey <<<<", metricKey)
+
+  return Object.values(props.chartData.meta.metricUnits)[metricKey]
 })
 
 const isGaugeChart = computed<boolean>(() => props.chartOptions.type === ChartTypesSimple.GAUGE)
@@ -102,6 +113,19 @@ const emptyStateTitle = computed(() => props.emptyStateTitle || i18n.t('noDataAv
 const hasValidChartData = computed(() => {
   return props.chartData && props.chartData.meta && props.chartData.records.length
 })
+
+watch(props, () => {
+  console.log(" >>> bigNumberKey", props.chartOptions.bigNumberKey)
+
+}, {deep: true})
+
+
+watch(props, () => {
+  if (chartOptionsRef.value?.reverseDataset) {
+    chartDataRef.value.records.reverse()
+    console.log("  chartDataRef order reversed >> showing record:", chartDataRef.value.records[0].event)
+  }
+}, { deep: true })
 </script>
 
 <style lang="scss" scoped>

--- a/packages/analytics/analytics-chart/src/components/SimpleChart.vue
+++ b/packages/analytics/analytics-chart/src/components/SimpleChart.vue
@@ -91,7 +91,7 @@ const computedChartData = computed(() => {
     {
       colorPalette: chartOptionsRef.value.chartDatasetColors || datavisPalette,
     },
-    chartDataRef
+    chartDataRef,
   ).value
 })
 
@@ -102,7 +102,7 @@ const computedMetricUnit = computed<string>(() => {
 
   const metricKey = chartOptionsRef.value?.bigNumberKey || 0
 
-  console.log(" >>>>metricKey <<<<", metricKey)
+  console.log(' >>>>metricKey <<<<', metricKey)
 
   return Object.values(props.chartData.meta.metricUnits)[metricKey]
 })
@@ -115,15 +115,13 @@ const hasValidChartData = computed(() => {
 })
 
 watch(props, () => {
-  console.log(" >>> bigNumberKey", props.chartOptions.bigNumberKey)
-
+  console.log(' >>> bigNumberKey', props.chartOptions.bigNumberKey)
 }, {deep: true})
-
 
 watch(props, () => {
   if (chartOptionsRef.value?.reverseDataset) {
     chartDataRef.value.records.reverse()
-    console.log("  chartDataRef order reversed >> showing record:", chartDataRef.value.records[0].event)
+    console.log('  chartDataRef order reversed >> showing record:', chartDataRef.value.records[0].event)
   }
 }, { deep: true })
 </script>

--- a/packages/analytics/analytics-chart/src/components/SimpleChart.vue
+++ b/packages/analytics/analytics-chart/src/components/SimpleChart.vue
@@ -116,7 +116,7 @@ const hasValidChartData = computed(() => {
 
 watch(props, () => {
   console.log(' >>> bigNumberKey', props.chartOptions.bigNumberKey)
-}, {deep: true})
+}, { deep: true })
 
 watch(props, () => {
   if (chartOptionsRef.value?.reverseDataset) {

--- a/packages/analytics/analytics-chart/src/components/chart-types/GaugeChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/GaugeChart.vue
@@ -178,7 +178,7 @@ const showMetricSmall = computed(() => props.metricDisplay === ChartMetricDispla
     .metric-large {
       font-size: $kui-font-size-70;
       font-weight: $kui-font-weight-medium;
-      line-height: $kui-line-height-70;
+      line-height: $kui-line-height-50;
     }
     .metric-small {
       color: $kui-color-text-neutral;

--- a/packages/analytics/analytics-chart/src/types/chart-data.ts
+++ b/packages/analytics/analytics-chart/src/types/chart-data.ts
@@ -76,9 +76,17 @@ export interface SimpleChartOptions {
    */
   chartDatasetColors?: AnalyticsChartColors | string[],
   /**
-   * Determines metric text to be shown in the center
+   * Determines how much detail about the metric (eg: value, info text, etc) is to be shown in the center
    */
   metricDisplay?: ChartMetricDisplay,
+  /**
+   * Determines whether the dataset order will be reversed
+   */
+  reverseDataset?: boolean,
+  /**
+   * Determines metric alignment
+   */
+  bigNumberKey?: number,
 }
 
 export interface LegendValueEntry {


### PR DESCRIPTION
# Summary
https://konghq.atlassian.net/browse/MA-1894

Opening up draft PR to test in Konnect.  

Sandbox doesn't seem to be picking up the custom reordering when the radio buttons are toggled, so `useExploreResultToDatasets` might be doing some automatic re-ordering internally.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
