### PR TITLE
fix(service): interpreting 0 as a boolean true

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
@@ -297,6 +297,37 @@ describe('<GatewayServiceForm />', { viewportHeight: 800, viewportWidth: 700 }, 
       cy.getTestId('gateway-service-host-input').should('have.value', gatewayService1.host)
     })
 
+    it('should correctly show zero values', () => {
+      interceptKonnect({
+        mockData: {
+          ...gatewayService1,
+          read_timeout: 0,
+          retries: 0,
+          connect_timeout: 0,
+          write_timeout: 0,
+          port: 0,
+        },
+      })
+
+      cy.mount(GatewayServiceForm, {
+        props: {
+          config: baseConfigKonnect,
+          gatewayServiceId: gatewayService1.id,
+          isEditing: true,
+        },
+      })
+
+      cy.wait('@getGatewayService')
+      cy.get('.kong-ui-entities-gateway-service-form').should('be.visible')
+
+      // form fields
+      cy.getTestId('gateway-service-readTimeout-input').should('have.value', 0)
+      cy.getTestId('gateway-service-retries-input').should('have.value', 0)
+      cy.getTestId('gateway-service-connTimeout-input').should('have.value', 0)
+      cy.getTestId('gateway-service-writeTimeout-input').should('have.value', 0)
+      cy.getTestId('gateway-service-port-input').should('have.value', 0)
+    })
+
     it('update event should be emitted when Gateway Service was edited', () => {
       interceptKonnect()
       interceptUpdate()
@@ -598,6 +629,37 @@ describe('<GatewayServiceForm />', { viewportHeight: 800, viewportWidth: 700 }, 
         })
       })
       cy.getTestId('gateway-service-host-input').should('have.value', gatewayService1.host)
+    })
+
+    it('should correctly show zero values', () => {
+      interceptKM({
+        mockData: {
+          ...gatewayService1,
+          read_timeout: 0,
+          retries: 0,
+          connect_timeout: 0,
+          write_timeout: 0,
+          port: 0,
+        },
+      })
+
+      cy.mount(GatewayServiceForm, {
+        props: {
+          config: baseConfigKM,
+          gatewayServiceId: gatewayService1.id,
+          isEditing: true,
+        },
+      })
+
+      cy.wait('@getGatewayService')
+      cy.get('.kong-ui-entities-gateway-service-form').should('be.visible')
+
+      // form fields
+      cy.getTestId('gateway-service-readTimeout-input').should('have.value', 0)
+      cy.getTestId('gateway-service-retries-input').should('have.value', 0)
+      cy.getTestId('gateway-service-connTimeout-input').should('have.value', 0)
+      cy.getTestId('gateway-service-writeTimeout-input').should('have.value', 0)
+      cy.getTestId('gateway-service-port-input').should('have.value', 0)
     })
 
     it('update event should be emitted when Gateway Service was edited', () => {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -649,16 +649,16 @@ const initForm = (data: Record<string, any>): void => {
   form.fields.tags = data?.tags?.join(',') || ''
   form.fields.protocol = data?.protocol || 'http'
   form.fields.path = data?.path || ''
-  form.fields.read_timeout = (data?.read_timeout || data?.read_timeout === 0) ?? 60000
-  form.fields.retries = (data?.retries || data?.retries === 0) ?? 5
+  form.fields.read_timeout = (data?.read_timeout || data?.read_timeout === 0) ? data?.read_timeout : 60000
+  form.fields.retries = (data?.retries || data?.retries === 0) ? data?.retries : 5
   form.fields.host = data?.host || ''
-  form.fields.connect_timeout = (data?.connect_timeout || data?.connect_timeout === 0) ?? 60000
+  form.fields.connect_timeout = (data?.connect_timeout || data?.connect_timeout === 0) ? data?.connect_timeout : 60000
   form.fields.tls_verify_enabled = data?.tls_verify !== '' && data?.tls_verify !== null && data?.tls_verify !== undefined
   form.fields.tls_verify_value = data?.tls_verify ? data?.tls_verify : false
   form.fields.ca_certificates = data?.ca_certificates?.join(',') || ''
   form.fields.client_certificate = data?.client_certificate?.id || ''
-  form.fields.write_timeout = (data?.write_timeout || data?.write_timeout === 0) ?? 60000
-  form.fields.port = (data?.port || data?.port === 0) ?? 80
+  form.fields.write_timeout = (data?.write_timeout || data?.write_timeout === 0) ? data?.write_timeout : 60000
+  form.fields.port = (data?.port || data?.port === 0) ? data?.port : 80
   // Set initial state of `formFieldsOriginal` to these values in order to detect changes
   Object.assign(formFieldsOriginal, form.fields)
 }
@@ -794,10 +794,10 @@ const saveFormData = async (): Promise<AxiosResponse | undefined> => {
       form.fields.host = data?.host || ''
       form.fields.path = data?.path || ''
       form.fields.url = data?.url || ''
-      form.fields.retries = (data?.retries || data?.retries === 0) ?? 5
-      form.fields.connect_timeout = (data?.connect_timeout || data?.connect_timeout === 0) ?? 60000
-      form.fields.write_timeout = (data?.write_timeout || data?.write_timeout === 0) ?? 60000
-      form.fields.read_timeout = (data?.read_timeout || data?.read_timeout === 0) ?? 60000
+      form.fields.retries = (data?.retries || data?.retries === 0) ? data?.retries : 5
+      form.fields.connect_timeout = (data?.connect_timeout || data?.connect_timeout === 0) ? data?.connect_timeout : 60000
+      form.fields.write_timeout = (data?.write_timeout || data?.write_timeout === 0) ? data?.write_timeout : 60000
+      form.fields.read_timeout = (data?.read_timeout || data?.read_timeout === 0) ? data?.read_timeout : 60000
       form.fields.client_certificate = data?.client_certificate?.id || ''
       form.fields.ca_certificates = data?.ca_certificates?.length ? data?.ca_certificates.join(',') : ''
       form.fields.tls_verify_enabled = data?.tls_verify !== '' && data?.tls_verify !== null && data?.tls_verify !== undefined

--- a/packages/entities/entities-gateway-services/src/composables/getPortFromProtocol.ts
+++ b/packages/entities/entities-gateway-services/src/composables/getPortFromProtocol.ts
@@ -3,7 +3,7 @@ export default function usePortFromProtocol() {
     const defaultPorts: Array<number> = [80, 443]
     const portValue = Number(port)
 
-    if (portValue && !defaultPorts.includes(portValue)) { return portValue }
+    if ((portValue || portValue === 0) && !defaultPorts.includes(portValue)) { return portValue }
 
     switch (protocol) {
       case 'grpcs':


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
This PR fixes a bug where zero values are interpreted as `true`.

Before:
```ts
// when data.read_timeout is 0, the following evaluates to true
(data?.read_timeout || data?.read_timeout === 0) ?? 60000
```

After:
```ts
// when data.read_timeout is 0, the following evaluates to 0
(data?.read_timeout || data?.read_timeout === 0) ? data?.read_timeout : 60000
```

Fixes FTI-5437

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
