### PR TITLE
fix: enhance text consistency and SNI table UI

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -207,7 +207,7 @@
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :description="t('delete.description')"
-      :entity-name="pluginToBeDeleted && (pluginToBeDeleted.name || pluginToBeDeleted.id)"
+      :entity-name="pluginToBeDeleted && (pluginToBeDeleted.instance_name || pluginToBeDeleted.name || pluginToBeDeleted.id)"
       :entity-type="EntityTypes.Plugin"
       :error="deleteModalError"
       :title="t('delete.title')"

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -9,7 +9,7 @@
     "configure_dynamic_ordering": "Configure Dynamic Ordering"
   },
   "delete": {
-    "title": "Delete Plugin",
+    "title": "Delete a Plugin",
     "description": "Are you sure you want to delete this plugin? This action cannot be reversed."
   },
   "copy": {

--- a/packages/entities/entities-shared/docs/entity-base-table.md
+++ b/packages/entities/entities-shared/docs/entity-base-table.md
@@ -125,6 +125,9 @@ Table key to use for user table preferences. If empty, will fallback to use defa
 
 The table is rendered inside a `KCard`. `tttle` text is displayed in the upper left corner of the `KCard` above the table.
 
+#### `disableRowClick`
+Controls whether the table rows are clickable or not. Defaults to `false`. Setting to `true` will suppress the `click:row` event even if a `@click:row` handler is provided.
+
 ### Slots
 
 #### `toolbar-filter`

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -223,6 +223,11 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  /** default to false, setting to true will suppress the row click event even if "@click:row" is attached */
+  disableRowClick: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const emit = defineEmits<{
@@ -304,9 +309,13 @@ const clearSearchInput = () => {
   emit('clear-search-input')
 }
 
-const handleRowClick = (_: MouseEvent, row: BaseTableHeaders) => {
-  emit('click:row', row)
-}
+const handleRowClick = computed(() => {
+  return props.disableRowClick
+    ? undefined
+    : (_: MouseEvent, row: BaseTableHeaders) => {
+      emit('click:row', row)
+    }
+})
 
 const handleSortChanged = (sortParams: TableSortParams) => {
   emit('sort', sortParams)

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -4,6 +4,7 @@
       :cache-identifier="cacheIdentifier"
       :cell-attributes="cellAttrsFn"
       disable-pagination-page-jump
+      :disable-row-click="true"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions

--- a/packages/entities/entities-snis/src/locales/en.json
+++ b/packages/entities/entities-snis/src/locales/en.json
@@ -44,7 +44,7 @@
     "fields": {
       "name": {
         "label": "Name",
-        "placeholder": "Enter a unique name for this key set"
+        "placeholder": "Enter a unique name for this SNI"
       },
       "tags": {
         "label": "Tags",

--- a/packages/entities/entities-vaults/src/locales/en.json
+++ b/packages/entities/entities-vaults/src/locales/en.json
@@ -8,7 +8,7 @@
     "view": "View Details"
   },
   "delete": {
-    "title": "Delete Vault",
+    "title": "Delete a Vault",
     "description": "Are you sure you want to delete this vault? This action cannot be reversed."
   },
   "errors": {


### PR DESCRIPTION
Changes:
* Align vault and plugin delete modal titles by changing "Delete Plugin/Vault" to "Delete a Plugin/Vault", matching other entity modal titles.
* Correct typo in the SNI name placeholder.
* Introduce `disable-row-click` prop to `EntityBaseTable` for improved control over clickable row UI in the `KTable` component. The current implementation of `KTable` doesn't allow us to wrap it in other component while still keeping row clickable UI switchable
* Deactivate clickable UI for SNI list (no detail page for SNI entity).
* Prioritize displaying the plugin instance name over the plugin name in the delete modal.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
