### PR TITLE
fix(config-card-display): remove line links

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
@@ -67,7 +67,6 @@
       id="config-card-codeblock"
       :code="yamlContent"
       language="yaml"
-      :show-line-number-links="true"
       theme="dark"
     />
   </div>


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR removes line links when format is `'yaml'`.
<img width="968" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/3c3aa14a-2472-4858-864c-99d0fe00c6f1">


## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
