### PR TITLE
fix: lost data-testid on plaintext config card items

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
@@ -549,6 +549,24 @@ describe('<ConfigCardItem />', () => {
         cy.getTestId(`${item.key}-external-link`).should('contain.text', link)
         cy.get(`a[href="${link}"]`).should('exist')
       })
+
+      it('plaintext config card item has data-testid', () => {
+        const item: RecordItem = {
+          type: ConfigurationSchemaType.Text,
+          key: 'textItem',
+          label: 'textItem',
+          value: 'asdf',
+        }
+
+        cy.mount(ConfigCardItem, {
+          props: {
+            item,
+          },
+        })
+
+        cy.get('[data-testid="textItem-plain-text"]').should('exist')
+        cy.get('[data-testid="textItem-plain-text"]').should('contain.text', 'asdf')
+      })
     })
   })
 })

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -288,7 +288,7 @@ const componentAttrsData = computed((): ComponentAttrsData => {
 
     default:
       return {
-        tag: 'div',
+        tag: 'KTooltip',
         attrs: {
           'data-testid': `${props.item.key}-plain-text`,
         },


### PR DESCRIPTION
# Summary

Update the tag prop on the `componentAttrsData` to match the tag which is now a `KTooltip` 

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
