### PR TITLE
chore(eslint): enforce data-testid instead of data-test-id

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
     indent: 'off',
     semi: ['error', 'never'],
     'space-before-function-paren': 'off',
-    quotes: ['error', 'single', { avoidEscape: true }],
+    quotes: ['error', 'single', {avoidEscape: true}],
     'no-multi-spaces': 'error',
     'no-unused-vars': 'off',
     'no-trailing-spaces': 'error',
@@ -63,6 +63,12 @@ module.exports = {
     'vue/no-restricted-class': ['error', ...kongponentsUtilityClasses],
     // This rule is too restrictive: https://github.com/vuejs/eslint-plugin-vue/issues/2259
     'vue/no-setup-props-destructure': 'off',
+    'vue/no-restricted-static-attribute': ['error',
+      {
+        key: 'data-test-id',
+        message: 'Using "data-test-id" is not allowed. Use "data-testid" instead.',
+      },
+    ],
   },
   overrides: [
     {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -69,6 +69,12 @@ module.exports = {
         message: 'Using "data-test-id" is not allowed. Use "data-testid" instead.',
       },
     ],
+    'vue/no-restricted-v-bind': ['error',
+      {
+        argument: 'data-test-id',
+        message: 'Using "data-test-id" is not allowed. Use "data-testid" instead.',
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
# Summary

Enforce using `data-testid` and error if `data-test-id` is used.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
