### PR TITLE
fix(*): tooltip label in config card item

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -103,8 +103,9 @@
               />
             </div>
 
-            <KTooltip v-else
-              :label="isTruncated && item.value"
+            <KTooltip
+              v-else
+              :label="isTruncated ? item.value : ''"
             >
               <span
                 ref="textContent"


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
This PR fixes a Vue warning:
<img width="1202" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/af1707fb-c8b3-48fa-a59c-778ae19a67d8">

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
