### PR TITLE
fix(entities-shared): config card item tag

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -289,7 +289,7 @@ const componentAttrsData = computed((): ComponentAttrsData => {
 
     default:
       return {
-        tag: 'KTooltip',
+        tag: 'div',
         attrs: {
           'data-testid': `${props.item.key}-plain-text`,
         },


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes a bug where a config car item value is wrapped inside two layers of KTooltip.
<img width="979" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/047f26e3-aae6-4ab2-8562-c001326295ad">


## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
