### PR TITLE
fix(swagger-ui styles): display code as block in spec auth [TDX-3610]

### DIFF
--- a/packages/portal/swagger-ui-web-component/src/styles/overrides.css
+++ b/packages/portal/swagger-ui-web-component/src/styles/overrides.css
@@ -6,3 +6,7 @@
 .swagger-ui .wrapper {
   padding-top: 0;
 }
+
+.swagger-ui .auth-container .renderedMarkdown code {
+  display: block;
+}


### PR DESCRIPTION
Apply display block to code elements in spec auth

# Summary

This PR applies `display: block` to code elements in security schemas rendered in the spec auth section. 

Before: 
<img width="658" alt="image" src="https://github.com/Kong/public-ui-components/assets/5304468/454ea2d6-59a5-4a2f-a5a7-1214c0b7d8c0">

After:
<img width="657" alt="image" src="https://github.com/Kong/public-ui-components/assets/5304468/257803c7-95d8-4486-a615-3816b43cc42e">


## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
