### PR TITLE
fix(entities-shared): tooltip for the first column

### DIFF
--- a/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
+++ b/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
@@ -484,8 +484,8 @@ describe('<CertificateList />', () => {
       })
 
       cy.mount(CertificateList, {
-        cacheIdentifier: `certificate-list-${uuidv4()}`,
         props: {
+          cacheIdentifier: `certificate-list-${uuidv4()}`,
           config: baseConfigKM,
           canCreate: () => {},
           canEdit: () => {},
@@ -505,7 +505,7 @@ describe('<CertificateList />', () => {
       const rowWithVaultRef = '.kong-ui-entities-certificates-list tr[data-testid="certificate-3"]'
 
       cy.get(rowWithVaultRef).should('exist')
-      cy.get(rowWithVaultRef).find('[data-testid="subject"] div[role="button"]').should('contain.text', '-')
+      cy.get(rowWithVaultRef).find('[data-testid="subject"] .content-wrapper').should('contain.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="expiry"]').should('have.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="san"]').should('have.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="cert"]').should('contain.text', certificateVaultRef)
@@ -814,7 +814,7 @@ describe('<CertificateList />', () => {
       const rowWithVaultRef = '.kong-ui-entities-certificates-list tr[data-testid="certificate-3"]'
 
       cy.get(rowWithVaultRef).should('exist')
-      cy.get(rowWithVaultRef).find('[data-testid="subject"] div[role="button"]').should('contain.text', '-')
+      cy.get(rowWithVaultRef).find('[data-testid="subject"] .content-wrapper').should('contain.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="expiry"]').should('have.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="san"]').should('have.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="cert"]').should('contain.text', certificateVaultRef)

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTableCell.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTableCell.vue
@@ -3,10 +3,12 @@
     ref="contentRef"
     class="content-wrapper"
   >
-    <span v-if="isFirst">
+    <span
+      v-if="isFirst"
+      data-testid="first-col"
+    >
       <KTooltip
-        :disabled="!hasTooltip"
-        :label="tooltipText"
+        :label="hasTooltip ? tooltipText : ''"
         max-width="300"
         placement="bottomStart"
       >
@@ -34,7 +36,7 @@ const props = defineProps({
 })
 
 const element = computed((): HTMLElement | null => props.rowEl?.querySelector(`[data-testid="${props.keyName}"]`) || null)
-const content = computed((): Element | null => element.value?.querySelector('[role="button"]') || null)
+const content = computed((): Element | null => element.value?.querySelector('[data-testid="first-col"]') || null)
 
 const isFirst = computed((): boolean => {
   const cells = props.rowEl?.querySelectorAll('td')
@@ -114,6 +116,10 @@ onUnmounted(() => {
 .content-wrapper {
   :deep([role='button']) {
     display: inline;
+  }
+
+  :deep(.k-tooltip) {
+    word-break: break-all;
   }
 }
 </style>


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes a warning:

<img width="1234" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/b55e3b82-b3fa-4a18-b973-5561330ab36b">

Because [`<KTooltip>`](https://kongponents.konghq.com/components/tooltip.html) does not have a `disabled` prop.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
