### PR TITLE
refactor(TopN): remove support for old explore v3 format [MA-2094]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/TopNTable.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/TopNTable.cy.ts
@@ -3,13 +3,7 @@ import TopNTable from './TopNTable.vue'
 const ROUTE_ID = 'b486fb30-e058-4b5f-85c2-495ec26ba522:09ba7bc7-58d6-42d5-b9c0-3ffb28b307e6'
 const ROUTE_NAME = 'GetMeAKongDefault (secondaryRuntime)'
 const DELETED_NAME = 'No longer extant entity'
-const ROUTE_DISPLAY_V1 = {
-  [ROUTE_ID]: ROUTE_NAME,
-  'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:2a3e9d21-804b-4b3b-ab7e-c6f002dadbf4': 'dp-mock-msg-per-sec-us-dev (default)',
-  'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:8b1db7eb-5c3c-489c-9344-eb0b272019ca': '8b1db (default)',
-  'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:8f3f6808-a723-4793-8444-f2046961226b': 'dp-mock-us-dev (default)',
-  'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:b4cd1c10-d77f-41b0-a84d-31fc0d99f0d9': 'GetMeASongRoute (default)',
-}
+
 const ROUTE_DISPLAY_V2 = {
   [ROUTE_ID]: {
     name: ROUTE_NAME,
@@ -70,26 +64,6 @@ const TABLE_RECORDS = [
   },
 ]
 
-const TABLE_DATA_V1 = {
-  meta: {
-    display: {
-      ROUTE: ROUTE_DISPLAY_V1,
-    },
-    endMs: 1692295253000,
-    granularity: 300000,
-    limit: 50,
-    metricNames: [
-      'REQUEST_COUNT',
-    ],
-    metricUnits: {
-      REQUEST_COUNT: 'count',
-    },
-    queryId: '4cc77ce4-6458-49f0-8a7e-443a4312dacd',
-    startMs: 1692294953000,
-    truncated: false,
-  },
-  records: TABLE_RECORDS,
-}
 const TABLE_DATA_V2 = {
   meta: {
     display: {
@@ -114,23 +88,7 @@ const TITLE = 'Top 5 Routes'
 const DESCRIPTION = 'Last 30-Day Summary'
 
 describe('<TopNTable />', () => {
-  it('correctly renders v1 prop data', () => {
-    cy.mount(TopNTable, {
-      props: {
-        data: TABLE_DATA_V1,
-        title: TITLE,
-        description: DESCRIPTION,
-      },
-    })
-
-    cy.get('.kong-ui-public-top-n-table').should('be.visible')
-    cy.getTestId('top-n-card-title').should('contain.text', TITLE)
-    cy.getTestId('top-n-card-description').should('contain.text', DESCRIPTION)
-    cy.getTestId('top-n-table').should('be.visible')
-    cy.get('.table-row').should('have.length', TABLE_DATA_V1.records.length + 1)
-  })
-
-  it('correctly renders v2 prop data', () => {
+  it('correctly renders explore v3 prop data', () => {
     cy.mount(TopNTable, {
       props: {
         data: TABLE_DATA_V2,
@@ -143,7 +101,7 @@ describe('<TopNTable />', () => {
     cy.getTestId('top-n-card-title').should('contain.text', TITLE)
     cy.getTestId('top-n-card-description').should('contain.text', DESCRIPTION)
     cy.getTestId('top-n-table').should('be.visible')
-    cy.get('.table-row').should('have.length', TABLE_DATA_V1.records.length + 1)
+    cy.get('.table-row').should('have.length', TABLE_DATA_V2.records.length + 1)
     cy.get('.table-row').last().should('contain.text', DELETED_NAME)
   })
 
@@ -168,7 +126,7 @@ describe('<TopNTable />', () => {
       props: {
         data: {
           meta: {},
-          records: TABLE_DATA_V1.records,
+          records: TABLE_DATA_V2.records,
         },
         title: TITLE,
         description: DESCRIPTION,
@@ -184,7 +142,7 @@ describe('<TopNTable />', () => {
 
     cy.mount(TopNTable, {
       props: {
-        data: TABLE_DATA_V1,
+        data: TABLE_DATA_V2,
         title: TITLE,
         description: DESCRIPTION,
       },

--- a/packages/analytics/analytics-chart/src/components/TopNTable.vue
+++ b/packages/analytics/analytics-chart/src/components/TopNTable.vue
@@ -197,11 +197,6 @@ const getName = (record: AnalyticsExploreRecord): string => {
     return '-'
   }
 
-  if (typeof idRecord === 'string') {
-    // TODO: Remove shim after API is updated.
-    return idRecord
-  }
-
   return idRecord.name
 }
 const getDeleted = (record: AnalyticsExploreRecord): boolean => {
@@ -209,11 +204,6 @@ const getDeleted = (record: AnalyticsExploreRecord): boolean => {
   const idRecord = displayRecord.value[id]
 
   if (!idRecord) {
-    return false
-  }
-
-  if (typeof idRecord === 'string') {
-    // TODO: Remove shim after API is updated.
     return false
   }
 

--- a/packages/analytics/analytics-utilities/src/types/analytics-data.ts
+++ b/packages/analytics/analytics-utilities/src/types/analytics-data.ts
@@ -103,7 +103,7 @@ export interface AnalyticsExploreV3Meta extends Omit<AnalyticsExploreV2Meta, 'di
   /*
    * Structure containing mappings of IDs to display names
   */
-  display: Record<string, Record<string, string>> | Record<string, Record<string, AnalyticsExploreV3Display>>
+  display: Record<string, Record<string, AnalyticsExploreV3Display>>
 }
 
 /**


### PR DESCRIPTION
- Remove union type for explore v3 display blob
- Remove shims for old display blob support

BREAKING CHANGE: removed support for old display blob style.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
