### PR TITLE
fix(entities-keys): introduce `keySetId` prop to `<KeyForm />` and `<KeyConfigCard />`

### DIFF
--- a/packages/entities/entities-keys/docs/key-config-card.md
+++ b/packages/entities/entities-keys/docs/key-config-card.md
@@ -85,6 +85,14 @@ Set this value to display the documentation button.
 
 Set this value to `true` to hide the card title.
 
+#### `keySetId`
+
+- type: `string | null`
+- required: `false`
+- default: `null`
+
+Specify the KeySet ID once you want to fetch the key within a KeySet URL scope.
+
 ### Events
 
 #### fetch:error

--- a/packages/entities/entities-keys/docs/key-form.md
+++ b/packages/entities/entities-keys/docs/key-form.md
@@ -77,6 +77,14 @@ The base konnect or kongManger config.
 
 If showing the `Edit` type form, the ID of the Key.
 
+#### `keySetId`
+
+- type: `string | null`
+- required: `false`
+- default: `null`
+
+Specify the KeySet ID once you want to create/fetch/edit a key within a KeySet URL scope.
+
 #### `fixedKeySetId`
 
 - type: `String`

--- a/packages/entities/entities-keys/sandbox/pages/KeyConfigCardPage.vue
+++ b/packages/entities/entities-keys/sandbox/pages/KeyConfigCardPage.vue
@@ -2,6 +2,7 @@
   <h2>Konnect API</h2>
   <KeyConfigCard
     :config="konnectConfig"
+    :key-set-id="keySetId"
     @copy:success="onCopy"
     @fetch:error="onError"
     @fetch:success="onSuccess"
@@ -10,6 +11,7 @@
   <h2>Kong Manager API</h2>
   <KeyConfigCard
     :config="kongManagerConfig"
+    :key-set-id="keySetId"
     @copy:success="onCopy"
     @fetch:error="onError"
     @fetch:success="onSuccess"
@@ -17,7 +19,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import type { AxiosError } from 'axios'
 import type { KonnectKeyEntityConfig, KongManagerKeyEntityConfig } from '../../src'
 import { KeyConfigCard } from '../../src'
@@ -29,7 +32,17 @@ const props = defineProps({
     default: '',
   },
 })
+const router = useRouter()
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
+// extract the keySetId from the route query
+const keySetId = computed(() => {
+  if (!router.currentRoute.value.query?.keySetId) {
+    return null
+  }
+
+  return router.currentRoute.value.query?.keySetId as string
+})
+
 const konnectConfig = ref<KonnectKeyEntityConfig>({
   app: 'konnect',
   apiBaseUrl: '/us/kong-api/konnect-api', // `/{geo}/kong-api`, with leading slash and no trailing slash; Consuming app would pass in something like `https://us.api.konghq.com`

--- a/packages/entities/entities-keys/sandbox/pages/KeyFormPage.vue
+++ b/packages/entities/entities-keys/sandbox/pages/KeyFormPage.vue
@@ -3,6 +3,7 @@
   <KeyForm
     :config="konnectConfig"
     :key-id="id"
+    :key-set-id="keySetId"
     @error="onError"
     @update="onUpdate"
   />
@@ -11,13 +12,14 @@
   <KeyForm
     :config="kongManagerConfig"
     :key-id="id"
+    :key-set-id="keySetId"
     @error="onError"
     @update="onUpdate"
   />
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import type { AxiosError } from 'axios'
 import type { KonnectKeyFormConfig, KongManagerKeyFormConfig } from '../../src'
@@ -34,6 +36,14 @@ defineProps({
 
 const router = useRouter()
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
+// extract the keySetId from the route query
+const keySetId = computed(() => {
+  if (!router.currentRoute.value.query?.keySetId) {
+    return null
+  }
+
+  return router.currentRoute.value.query?.keySetId as string
+})
 
 const konnectConfig = ref<KonnectKeyFormConfig>({
   app: 'konnect',

--- a/packages/entities/entities-keys/src/components/KeyForm.vue
+++ b/packages/entities/entities-keys/src/components/KeyForm.vue
@@ -199,6 +199,12 @@ const props = defineProps({
     required: false,
     default: '',
   },
+  /** Specific the keyset Id if the key entity is a scoped entity [both create and edit form] */
+  keySetId: {
+    type: String as PropType<string | null>,
+    required: false,
+    default: null,
+  },
   /** Pre-select the Key Set field and mark it as read-only [create form only] */
   fixedKeySetId: {
     type: String,
@@ -215,7 +221,11 @@ const { axiosInstance } = useAxios({
   headers: props.config?.requestHeaders,
 })
 
-const fetchUrl = computed<string>(() => endpoints.form[props.config.app].edit)
+const fetchUrl = computed<string>(() => {
+  return props.keySetId
+    ? endpoints.form[props.config.app].edit.forKeySet.replace(/{keySetId}/gi, props.keySetId)
+    : endpoints.form[props.config.app].edit.all
+})
 const formType = computed((): EntityBaseFormType => props.keyId ? EntityBaseFormType.Edit : EntityBaseFormType.Create)
 
 const form = reactive<KeyFormState>({
@@ -307,7 +317,7 @@ const handleClickCancel = (): void => {
  * Build the submit URL
  */
 const submitUrl = computed<string>(() => {
-  let url = `${props.config.apiBaseUrl}${endpoints.form[props.config.app][formType.value]}`
+  let url = `${props.config.apiBaseUrl}${endpoints.form[props.config.app][formType.value][props.keySetId ? 'forKeySet' : 'all']}`
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
@@ -317,6 +327,7 @@ const submitUrl = computed<string>(() => {
 
   // Always replace the id when editing
   url = url.replace(/{id}/gi, props.keyId)
+    .replace(/{keySetId}/gi, props.keySetId || '')
 
   return url
 })

--- a/packages/entities/entities-keys/src/keys-endpoints.ts
+++ b/packages/entities/entities-keys/src/keys-endpoints.ts
@@ -11,14 +11,26 @@ export default {
   },
   form: {
     konnect: {
-      create: '/api/runtime_groups/{controlPlaneId}/keys',
-      edit: '/api/runtime_groups/{controlPlaneId}/keys/{id}',
+      create: {
+        all: '/api/runtime_groups/{controlPlaneId}/keys',
+        forKeySet: '/api/runtime_groups/{controlPlaneId}/key-sets/{keySetId}/keys',
+      },
+      edit: {
+        all: '/api/runtime_groups/{controlPlaneId}/keys/{id}',
+        forKeySet: '/api/runtime_groups/{controlPlaneId}/key-sets/{keySetId}/keys/{id}',
+      },
       keySets: '/api/runtime_groups/{controlPlaneId}/key-sets',
       getKeySet: '/api/runtime_groups/{controlPlaneId}/key-sets/{keySetId}',
     },
     kongManager: {
-      create: '/{workspace}/keys',
-      edit: '/{workspace}/keys/{id}',
+      create: {
+        all: '/{workspace}/keys',
+        forKeySet: '/{workspace}/key-sets/{keySetId}/keys',
+      },
+      edit: {
+        all: '/{workspace}/keys/{id}',
+        forKeySet: '/{workspace}/key-sets/{keySetId}/keys/{id}',
+      },
       keySets: '/{workspace}/key-sets',
       getKeySet: '/{workspace}/key-sets/{keySetId}',
     },


### PR DESCRIPTION
Previously, `<KeyForm />` and `<KeyConfigCard />` interacted with the key entity by using a global scope endpoint for all operations.

This patch introduces the `keySetId` property, allowing these components to utilize keyset-scoped entity endpoints, aligning with the functionality already present in `<KeyList />`.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
