### PR TITLE
feat(spec-renderer): utilize kemptystate for empty state

### DIFF
--- a/packages/portal/spec-renderer/src/components/SpecRenderer.vue
+++ b/packages/portal/spec-renderer/src/components/SpecRenderer.vue
@@ -35,7 +35,15 @@
       data-testid="kong-ui-public-spec-renderer-error"
     >
       <slot name="error-state">
-        {{ i18n.t('specRenderer.error') }}
+        <KEmptyState
+          cta-is-hidden
+          icon-size="50"
+          :is-error="true"
+        >
+          <template #title>
+            {{ i18n.t('specRenderer.error') }}
+          </template>
+        </KEmptyState>
       </slot>
     </div>
   </div>


### PR DESCRIPTION
# Summary
Improves the error handling for when there is no spec. Uses `KEmptyState` instead
<img width="933" alt="Screenshot 2023-11-07 at 9 53 59 AM" src="https://github.com/Kong/public-ui-components/assets/40131297/2f906632-4040-432d-9c74-a8d3acb7c11f">

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
