### PR TITLE
fix(vaults): fix delete modal for vault and plugin entities [khcp-9683]

### DIFF
--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -18,7 +18,7 @@
     "title": "Delete a Plugin",
     "custom_title": "Delete {name}",
     "custom_plugin": "Custom Plugin",
-    "description": "Are you sure you want to delete this plugin? This action cannot be reversed.",
+    "description": "This action cannot be reversed.",
     "description_custom": "Please ensure this plugin is not in use. This action cannot be reversed.",
     "plugin_schema_in_use_title": "Unable to Delete Custom Plugin",
     "plugin_schema_in_use_message": "The custom plugin schema {name} is being used in this control plane, please delete any existing instances before you delete this schema.",

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -112,7 +112,7 @@
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :description="t('delete.description')"
-      :entity-name="vaultToBeDeleted && (vaultToBeDeleted.name || vaultToBeDeleted.id)"
+      :entity-name="vaultToBeDeleted && (vaultToBeDeleted.prefix || vaultToBeDeleted.id)"
       :entity-type="EntityTypes.Vault"
       :error="deleteModalError"
       :title="t('delete.title')"

--- a/packages/entities/entities-vaults/src/locales/en.json
+++ b/packages/entities/entities-vaults/src/locales/en.json
@@ -9,7 +9,7 @@
   },
   "delete": {
     "title": "Delete a Vault",
-    "description": "Are you sure you want to delete this vault? This action cannot be reversed."
+    "description": "This action cannot be reversed."
   },
   "errors": {
     "general": "Vaults could not be retrieved",


### PR DESCRIPTION
# Summary
https://konghq.atlassian.net/browse/KHCP-9683
The good news is it affects only vaults and plugins
Tested Deploy Preview in khcp-ui: https://github.com/Kong/khcp-ui/pull/7120

<img width="1143" alt="Screenshot 2023-11-09 at 1 11 48 PM" src="https://github.com/Kong/public-ui-components/assets/2568272/53ce34c0-f0a5-46ea-934e-6ca183b26d3c">
<img width="1146" alt="Screenshot 2023-11-09 at 1 12 28 PM" src="https://github.com/Kong/public-ui-components/assets/2568272/51587317-70b7-4fb0-810c-79152694de0b">


<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
