### PR TITLE
fix(entities-list): show response error message in entity list

### DIFF
--- a/packages/entities/entities-certificates/src/components/CACertificateList.cy.ts
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.cy.ts
@@ -244,31 +244,39 @@ describe('<CACertificateList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/ca_certificates*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getCaCertificate')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/ca_certificates*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getCaCertificate')
 
-      cy.mount(CACertificateList, {
-        props: {
-          cacheIdentifier: `ca-certificate-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(CACertificateList, {
+          props: {
+            cacheIdentifier: `ca-certificate-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getCaCertificate')
-      cy.get('.kong-ui-entities-ca-certificates-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getCaCertificate')
+        cy.get('.kong-ui-entities-ca-certificates-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should allow switching between pages', () => {
@@ -546,31 +554,39 @@ describe('<CACertificateList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/ca_certificates*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getCaCertificate')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/ca_certificates*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getCaCertificate')
 
-      cy.mount(CACertificateList, {
-        props: {
-          cacheIdentifier: `ca-certificate-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(CACertificateList, {
+          props: {
+            cacheIdentifier: `ca-certificate-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getCaCertificate')
-      cy.get('.kong-ui-entities-ca-certificates-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getCaCertificate')
+        cy.get('.kong-ui-entities-ca-certificates-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should allow switching between pages', () => {

--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -162,6 +162,7 @@ import type {
   EmptyStateOptions,
   ExactMatchFilterConfig,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
@@ -283,7 +284,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref<string>('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy ID action
@@ -419,7 +420,12 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('ca-certificates.errors.general')
+    errorMessage.value = {
+      title: t('ca-certificates.errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
@@ -427,7 +433,7 @@ watch(fetcherState, (state) => {
   }
 
   certificateDataCache.value = {}
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
+++ b/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
@@ -284,31 +284,39 @@ describe('<CertificateList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/certificates*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getCertificate')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/certificates*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getCertificate')
 
-      cy.mount(CertificateList, {
-        props: {
-          cacheIdentifier: `certificate-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(CertificateList, {
+          props: {
+            cacheIdentifier: `certificate-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getCertificate')
-      cy.get('.kong-ui-entities-certificates-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getCertificate')
+        cy.get('.kong-ui-entities-certificates-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should allow switching between pages', () => {
@@ -593,31 +601,39 @@ describe('<CertificateList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/certificates*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getCertificate')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/certificates*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getCertificate')
 
-      cy.mount(CertificateList, {
-        props: {
-          cacheIdentifier: `certificate-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(CertificateList, {
+          props: {
+            cacheIdentifier: `certificate-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getCertificate')
-      cy.get('.kong-ui-entities-certificates-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getCertificate')
+        cy.get('.kong-ui-entities-certificates-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should allow switching between pages', () => {

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -189,6 +189,7 @@ import type {
   EmptyStateOptions,
   ExactMatchFilterConfig,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 import '@kong-ui-public/copy-uuid/dist/style.css'
@@ -319,7 +320,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref<string>('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy ID action
@@ -486,7 +487,12 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('certificates.errors.general')
+    errorMessage.value = {
+      title: t('certificates.errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
@@ -494,7 +500,7 @@ watch(fetcherState, (state) => {
   }
 
   certificateDataCache.value = {}
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.cy.ts
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.cy.ts
@@ -315,31 +315,39 @@ describe('<ConsumerCredentialList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumers/${baseConfigKonnect.consumerId}/*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getCredentials')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumers/${baseConfigKonnect.consumerId}/*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getCredentials')
 
-      cy.mount(ConsumerCredentialList, {
-        props: {
-          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(ConsumerCredentialList, {
+          props: {
+            cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getCredentials')
-      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getCredentials')
+        cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show credential items', () => {
@@ -615,30 +623,38 @@ describe('<ConsumerCredentialList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumers/${baseConfigKonnect.consumerId}/*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getCredentials')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumers/${baseConfigKonnect.consumerId}/*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getCredentials')
 
-      cy.mount(ConsumerCredentialList, {
-        props: {
-          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-        },
-      })
+        cy.mount(ConsumerCredentialList, {
+          props: {
+            cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+          },
+        })
 
-      cy.wait('@getCredentials')
-      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getCredentials')
+        cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show route items', () => {

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -205,6 +205,7 @@ import type {
 import type {
   BaseTableHeaders,
   EmptyStateOptions,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
@@ -337,7 +338,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref<string>('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy action
@@ -447,14 +448,19 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('credentials.error.general')
+    errorMessage.value = {
+      title: t('credentials.error.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -162,31 +162,39 @@ describe('<ConsumerGroupList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumer_groups*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getConsumerGroups')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumer_groups*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getConsumerGroups')
 
-      cy.mount(ConsumerGroupList, {
-        props: {
-          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getConsumerGroups')
-      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getConsumerGroups')
+        cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show consumer group items', () => {
@@ -783,31 +791,39 @@ describe('<ConsumerGroupList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumer_groups*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getConsumerGroups')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumer_groups*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getConsumerGroups')
 
-      cy.mount(ConsumerGroupList, {
-        props: {
-          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(ConsumerGroupList, {
+          props: {
+            cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getConsumerGroups')
-      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getConsumerGroups')
+        cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show consumer group items', () => {

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -196,6 +196,7 @@ import type {
   EmptyStateOptions,
   ExactMatchFilterConfig,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 import AddToGroupModal from './AddToGroupModal.vue'
@@ -339,7 +340,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy ID action
@@ -547,14 +548,19 @@ const exitGroups = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('consumer_groups.errors.general')
+    errorMessage.value = {
+      title: t('consumer_groups.errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
@@ -162,31 +162,39 @@ describe('<ConsumerList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumers*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getConsumers')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/consumers*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getConsumers')
 
-      cy.mount(ConsumerList, {
-        props: {
-          cacheIdentifier: `consumer-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(ConsumerList, {
+          props: {
+            cacheIdentifier: `consumer-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getConsumers')
-      cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getConsumers')
+        cy.get('.kong-ui-entities-consumers-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show consumer items', () => {
@@ -783,31 +791,39 @@ describe('<ConsumerList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumers*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getConsumers')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/consumers*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getConsumers')
 
-      cy.mount(ConsumerList, {
-        props: {
-          cacheIdentifier: `consumer-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(ConsumerList, {
+          props: {
+            cacheIdentifier: `consumer-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getConsumers')
-      cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getConsumers')
+        cy.get('.kong-ui-entities-consumers-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show consumer items', () => {

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -196,6 +196,7 @@ import type {
   EmptyStateOptions,
   ExactMatchFilterConfig,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 import AddConsumerModal from './AddConsumerModal.vue'
@@ -335,7 +336,7 @@ const getRowValue = (val: any) => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy ID action
@@ -557,14 +558,19 @@ const removeConsumers = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('consumers.errors.general')
+    errorMessage.value = {
+      title: t('consumers.errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -260,31 +260,39 @@ describe('<GatewayServiceList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/services*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getGatewayServices')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/services*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getGatewayServices')
 
-      cy.mount(GatewayServiceList, {
-        props: {
-          cacheIdentifier: `gateway-service-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => { },
-          canEdit: () => { },
-          canDelete: () => { },
-          canRetrieve: () => { },
-        },
-      })
+        cy.mount(GatewayServiceList, {
+          props: {
+            cacheIdentifier: `gateway-service-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => { },
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+          },
+        })
 
-      cy.wait('@getGatewayServices')
-      cy.get('.kong-ui-entities-gateway-services-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getGatewayServices')
+        cy.get('.kong-ui-entities-gateway-services-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show gateway service items', () => {
@@ -562,31 +570,39 @@ describe('<GatewayServiceList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/services*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getGatewayServices')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/services*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getGatewayServices')
 
-      cy.mount(GatewayServiceList, {
-        props: {
-          cacheIdentifier: `gateway-service-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => { },
-          canEdit: () => { },
-          canDelete: () => { },
-          canRetrieve: () => { },
-        },
-      })
+        cy.mount(GatewayServiceList, {
+          props: {
+            cacheIdentifier: `gateway-service-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => { },
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+          },
+        })
 
-      cy.wait('@getGatewayServices')
-      cy.get('.kong-ui-entities-gateway-services-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getGatewayServices')
+        cy.get('.kong-ui-entities-gateway-services-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show gateway service items', () => {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -154,6 +154,7 @@ import type {
   ExactMatchFilterConfig,
   FilterFields,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import type {
   KongManagerGatewayServiceListConfig,
@@ -307,7 +308,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 const emptyStateOptions = computed((): EmptyStateOptions => {
   return {
@@ -508,14 +509,19 @@ const deleteRow = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('errors.general')
+    errorMessage.value = {
+      title: t('errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 const userCanCreate = ref(false)

--- a/packages/entities/entities-key-sets/src/components/KeySetList.cy.ts
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.cy.ts
@@ -244,31 +244,39 @@ describe('<KeySetList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/key-sets*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getKeySets')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/key-sets*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getKeySets')
 
-      cy.mount(KeySetList, {
-        props: {
-          cacheIdentifier: `key-set-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(KeySetList, {
+          props: {
+            cacheIdentifier: `key-set-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getKeySets')
-      cy.get('.kong-ui-entities-key-sets-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getKeySets')
+        cy.get('.kong-ui-entities-key-sets-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show key set items', () => {
@@ -546,31 +554,39 @@ describe('<KeySetList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/key-sets*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getKeySets')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/key-sets*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getKeySets')
 
-      cy.mount(KeySetList, {
-        props: {
-          cacheIdentifier: `key-set-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(KeySetList, {
+          props: {
+            cacheIdentifier: `key-set-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getKeySets')
-      cy.get('.kong-ui-entities-key-sets-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getKeySets')
+        cy.get('.kong-ui-entities-key-sets-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show key set items', () => {

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -151,6 +151,7 @@ import type {
   ExactMatchFilterConfig,
   FilterFields,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
@@ -275,7 +276,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy action
@@ -422,14 +423,19 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('keySets.errors.general')
+    errorMessage.value = {
+      title: t('keySets.errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-keys/src/components/KeyList.cy.ts
+++ b/packages/entities/entities-keys/src/components/KeyList.cy.ts
@@ -244,31 +244,39 @@ describe('<KeyList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/keys*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getKeys')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/keys*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getKeys')
 
-      cy.mount(KeyList, {
-        props: {
-          cacheIdentifier: `key-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(KeyList, {
+          props: {
+            cacheIdentifier: `key-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getKeys')
-      cy.get('.kong-ui-entities-keys-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getKeys')
+        cy.get('.kong-ui-entities-keys-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show key items', () => {
@@ -546,31 +554,39 @@ describe('<KeyList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/keys*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getKeys')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/keys*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getKeys')
 
-      cy.mount(KeyList, {
-        props: {
-          cacheIdentifier: `key-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(KeyList, {
+          props: {
+            cacheIdentifier: `key-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getKeys')
-      cy.get('.kong-ui-entities-keys-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getKeys')
+        cy.get('.kong-ui-entities-keys-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show key items', () => {

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -157,6 +157,7 @@ import type {
   ExactMatchFilterConfig,
   FilterFields,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
@@ -284,7 +285,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy action
@@ -431,14 +432,19 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('keys.errors.general')
+    errorMessage.value = {
+      title: t('keys.errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-plugins/src/components/PluginList.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginList.cy.ts
@@ -464,31 +464,39 @@ describe('<PluginList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/plugins*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getRoutes')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/plugins*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getRoutes')
 
-      cy.mount(PluginList, {
-        props: {
-          cacheIdentifier: `plugin-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => { },
-          canEdit: () => { },
-          canDelete: () => { },
-          canRetrieve: () => { },
-        },
-      })
+        cy.mount(PluginList, {
+          props: {
+            cacheIdentifier: `plugin-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => { },
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+          },
+        })
 
-      cy.wait('@getRoutes')
-      cy.get('.kong-ui-entities-plugins-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getRoutes')
+        cy.get('.kong-ui-entities-plugins-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show plugin items', () => {
@@ -795,31 +803,39 @@ describe('<PluginList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/plugins*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getRoutes')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/plugins*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getRoutes')
 
-      cy.mount(PluginList, {
-        props: {
-          cacheIdentifier: `plugin-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => { },
-          canEdit: () => { },
-          canDelete: () => { },
-          canRetrieve: () => { },
-        },
-      })
+        cy.mount(PluginList, {
+          props: {
+            cacheIdentifier: `plugin-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => { },
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+          },
+        })
 
-      cy.wait('@getRoutes')
-      cy.get('.kong-ui-entities-plugins-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getRoutes')
+        cy.get('.kong-ui-entities-plugins-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show plugin items', () => {

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -245,6 +245,7 @@ import type {
   ExactMatchFilterConfig,
   FilterFields,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 
 import composables from '../composables'
@@ -438,7 +439,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Applied To ...
@@ -709,14 +710,19 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('errors.general')
+    errorMessage.value = {
+      title: t('errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-routes/src/components/RouteList.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteList.cy.ts
@@ -244,31 +244,39 @@ describe('<RouteList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/routes*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getRoutes')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/routes*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getRoutes')
 
-      cy.mount(RouteList, {
-        props: {
-          cacheIdentifier: `route-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(RouteList, {
+          props: {
+            cacheIdentifier: `route-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getRoutes')
-      cy.get('.kong-ui-entities-routes-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getRoutes')
+        cy.get('.kong-ui-entities-routes-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show route items', () => {
@@ -546,31 +554,39 @@ describe('<RouteList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/routes*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getRoutes')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/routes*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getRoutes')
 
-      cy.mount(RouteList, {
-        props: {
-          cacheIdentifier: `route-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(RouteList, {
+          props: {
+            cacheIdentifier: `route-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getRoutes')
-      cy.get('.kong-ui-entities-routes-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getRoutes')
+        cy.get('.kong-ui-entities-routes-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show route items', () => {

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -203,6 +203,7 @@ import type {
   ExactMatchFilterConfig,
   FilterFields,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
@@ -349,7 +350,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy ID action
@@ -483,14 +484,19 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('errors.general')
+    errorMessage.value = {
+      title: t('errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-shared/docs/entity-base-table.md
+++ b/packages/entities/entities-shared/docs/entity-base-table.md
@@ -107,11 +107,11 @@ Options for the empty state.
 
 #### `errorMessage`
 
-- type: `String`
+- type: `TableErrorMessage`
 - required: `false`
-- default: `''`
+- default: `null`
 
-Error message to show in the error state.
+Error message to show in the error state. `string` is also supported for backwards compatibility.
 
 #### `preferencesStorageKey`
 
@@ -173,5 +173,6 @@ import type {
   FetcherParams,
   FetcherResponse,
   InternalHeader,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 ```

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.cy.ts
@@ -95,4 +95,52 @@ describe('<EntityBaseTable />', () => {
     cy.get('.kong-ui-entity-base-table tbody tr').eq(1).should('have.attr', 'data-rowid', mockTableData.data[1].id)
     cy.get('.kong-ui-entity-base-table tbody tr').eq(1).should('have.attr', 'data-testid', mockTableData.data[1].name)
   })
+
+  it('should not enter error state', () => {
+    cy.mount(EntityBaseTable, {
+      props: {
+        errorMessage: null,
+        fetcher: () => mockTableData,
+      },
+    })
+    cy.get('.kong-ui-entity-base-table .k-table-error-state').should('not.exist')
+
+    cy.mount(EntityBaseTable, {
+      props: {
+        errorMessage: '',
+        fetcher: () => mockTableData,
+      },
+    })
+    cy.get('.kong-ui-entity-base-table .k-table-error-state').should('not.exist')
+  })
+
+  it('should accept string for table error message', () => {
+    const message = 'I am an error message'
+
+    cy.mount(EntityBaseTable, {
+      props: {
+        errorMessage: message,
+        fetcher: () => mockTableData,
+      },
+    })
+
+    cy.get('.kong-ui-entity-base-table .k-empty-state-title-header').should('contain.text', message)
+  })
+
+  it('should accept object for table error message', () => {
+    const errorMessage = {
+      title: 'My error title',
+      message: 'My error message',
+    }
+
+    cy.mount(EntityBaseTable, {
+      props: {
+        errorMessage,
+        fetcher: () => mockTableData,
+      },
+    })
+
+    cy.get('.kong-ui-entity-base-table .k-empty-state-title-header').should('contain.text', errorMessage.title)
+    cy.get('.kong-ui-entity-base-table .k-empty-state-message').should('contain.text', errorMessage.message)
+  })
 })

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -18,10 +18,11 @@
         :empty-state-message="query ? t('baseTable.emptyState.noSearchResultsMessage') : emptyStateOptions.message"
         :empty-state-title="query ? t('baseTable.emptyState.noSearchResultsTitle') : emptyStateOptions.title"
         :enable-client-sort="enableClientSort"
-        :error-state-title="errorMessage"
+        :error-state-message="tableErrorState.message"
+        :error-state-title="tableErrorState.title"
         :fetcher="fetcher"
         :fetcher-cache-key="String(fetcherCacheKey)"
-        :has-error="!!errorMessage"
+        :has-error="tableErrorState.hasError"
         :headers="headers"
         hide-pagination-when-optional
         :initial-fetcher-params="combinedInitialFetcherParams"
@@ -122,6 +123,7 @@ import type {
   FetcherResponse,
   InternalHeader,
   TableSortParams,
+  TableErrorMessage,
 } from '../../types'
 
 const props = defineProps({
@@ -181,9 +183,10 @@ const props = defineProps({
   },
   // error message to show in the error state
   // this prop being set (or empty) determines if the KTable is in an error state
+  // please use `TableErrorMessage` since `string` is only for backwards compatibility
   errorMessage: {
-    type: String,
-    default: '',
+    type: [String, Object] as PropType<string | TableErrorMessage>,
+    default: null,
   },
   disablePaginationPageJump: {
     type: Boolean,
@@ -238,6 +241,22 @@ const emit = defineEmits<{
 }>()
 
 const { i18n: { t } } = composables.useI18n()
+
+const tableErrorState = computed((): { hasError: boolean, title?: string, message?: string } => {
+  if (typeof props.errorMessage === 'string') {
+    return {
+      hasError: !!props.errorMessage,
+      title: props.errorMessage,
+      message: undefined,
+    }
+  } else {
+    return {
+      hasError: !!props.errorMessage,
+      title: props.errorMessage?.title,
+      message: props.errorMessage?.message,
+    }
+  }
+})
 
 const cacheId = computed((): string => {
   // Utilize the cacheIdentifier if provided; otherwise, fallback to the preferencesStorageKey that should always be defined

--- a/packages/entities/entities-shared/src/types/entity-base-table.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-table.ts
@@ -71,3 +71,5 @@ export interface TableSortParams {
   sortColumnKey: string
   sortColumnOrder: 'asc' | 'desc'
 }
+
+export type TableErrorMessage = { title?: string; message?: string } | null

--- a/packages/entities/entities-snis/src/components/SniList.cy.ts
+++ b/packages/entities/entities-snis/src/components/SniList.cy.ts
@@ -204,31 +204,39 @@ describe('<SniList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/snis*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getSnis')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/snis*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getSnis')
 
-      cy.mount(SniList, {
-        props: {
-          cacheIdentifier: `sni-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => { },
-          canEdit: () => { },
-          canDelete: () => { },
-          canRetrieve: () => { },
-        },
-      })
+        cy.mount(SniList, {
+          props: {
+            cacheIdentifier: `sni-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => { },
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+          },
+        })
 
-      cy.wait('@getSnis')
-      cy.get('.kong-ui-entities-snis-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getSnis')
+        cy.get('.kong-ui-entities-snis-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show SNI items', () => {
@@ -502,31 +510,39 @@ describe('<SniList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/snis*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getSnis')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/snis*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getSnis')
 
-      cy.mount(SniList, {
-        props: {
-          cacheIdentifier: `sni-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => { },
-          canEdit: () => { },
-          canDelete: () => { },
-          canRetrieve: () => { },
-        },
-      })
+        cy.mount(SniList, {
+          props: {
+            cacheIdentifier: `sni-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => { },
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+          },
+        })
 
-      cy.wait('@getSnis')
-      cy.get('.kong-ui-entities-snis-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getSnis')
+        cy.get('.kong-ui-entities-snis-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show SNI items', () => {

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -148,6 +148,7 @@ import type {
   ExactMatchFilterConfig,
   FilterFields,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import type { CopyUuidNotifyParam } from '@kong-ui-public/copy-uuid'
 import { CopyUuid } from '@kong-ui-public/copy-uuid'
@@ -304,7 +305,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 // Initialize the empty state options assuming a user does not have create permissions
 // IMPORTANT: you must initialize this object assuming the user does **NOT** have create
@@ -428,14 +429,19 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('errors.general')
+    errorMessage.value = {
+      title: t('errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 onBeforeMount(async () => {

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.cy.ts
@@ -312,31 +312,39 @@ describe('<TargetsList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/upstreams/${baseConfigKM.upstreamId}/targets*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getTargets')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/upstreams/${baseConfigKM.upstreamId}/targets*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getTargets')
 
-      cy.mount(TargetsList, {
-        props: {
-          cacheIdentifier: `targets-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(TargetsList, {
+          props: {
+            cacheIdentifier: `targets-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getTargets')
-      cy.get('.kong-ui-entities-targets-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getTargets')
+        cy.get('.kong-ui-entities-targets-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show targets items', () => {
@@ -614,31 +622,39 @@ describe('<TargetsList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/upstreams/${baseConfigKonnect.upstreamId}/targets*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getTargets')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/upstreams/${baseConfigKonnect.upstreamId}/targets*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getTargets')
 
-      cy.mount(TargetsList, {
-        props: {
-          cacheIdentifier: `targets-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(TargetsList, {
+          props: {
+            cacheIdentifier: `targets-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getTargets')
-      cy.get('.kong-ui-entities-targets-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getTargets')
+        cy.get('.kong-ui-entities-targets-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show targets items', () => {

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -157,6 +157,7 @@ import composables from '../composables'
 import type {
   BaseTableHeaders,
   EmptyStateOptions,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import endpoints from '../targets-endpoints'
 import '@kong-ui-public/entities-shared/dist/style.css'
@@ -258,7 +259,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref<string>('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Create target
@@ -393,14 +394,19 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('targets.errors.general')
+    errorMessage.value = {
+      title: t('targets.errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.cy.ts
@@ -247,31 +247,39 @@ describe('<UpstreamsList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/upstreams*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getUpstreams')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/upstreams*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getUpstreams')
 
-      cy.mount(UpstreamsList, {
-        props: {
-          cacheIdentifier: `certificate-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(UpstreamsList, {
+          props: {
+            cacheIdentifier: `certificate-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getUpstreams')
-      cy.get('.kong-ui-entities-upstreams-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getUpstreams')
+        cy.get('.kong-ui-entities-upstreams-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show upstreams items', () => {
@@ -549,31 +557,39 @@ describe('<UpstreamsList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/upstreams*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getUpstreams')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/upstreams*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getUpstreams')
 
-      cy.mount(UpstreamsList, {
-        props: {
-          cacheIdentifier: `certificate-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => {},
-          canEdit: () => {},
-          canDelete: () => {},
-          canRetrieve: () => {},
-        },
-      })
+        cy.mount(UpstreamsList, {
+          props: {
+            cacheIdentifier: `certificate-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => {},
+            canEdit: () => {},
+            canDelete: () => {},
+            canRetrieve: () => {},
+          },
+        })
 
-      cy.wait('@getUpstreams')
-      cy.get('.kong-ui-entities-upstreams-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getUpstreams')
+        cy.get('.kong-ui-entities-upstreams-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show upstreams items', () => {

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -142,6 +142,7 @@ import type {
   FilterFields,
   FuzzyMatchFilterConfig,
   EmptyStateOptions,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 import endpoints from '../upstreams-endpoints'
 import '@kong-ui-public/entities-shared/dist/style.css'
@@ -268,7 +269,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref<string>('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy ID action
@@ -402,14 +403,19 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('upstreams.errors.general')
+    errorMessage.value = {
+      title: t('upstreams.errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions

--- a/packages/entities/entities-vaults/src/components/VaultList.cy.ts
+++ b/packages/entities/entities-vaults/src/components/VaultList.cy.ts
@@ -240,31 +240,39 @@ describe('<VaultList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/vaults*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getRoutes')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/vaults*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getRoutes')
 
-      cy.mount(VaultList, {
-        props: {
-          cacheIdentifier: `vault-list-${uuidv4()}`,
-          config: baseConfigKM,
-          canCreate: () => { },
-          canEdit: () => { },
-          canDelete: () => { },
-          canRetrieve: () => { },
-        },
-      })
+        cy.mount(VaultList, {
+          props: {
+            cacheIdentifier: `vault-list-${uuidv4()}`,
+            config: baseConfigKM,
+            canCreate: () => { },
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+          },
+        })
 
-      cy.wait('@getRoutes')
-      cy.get('.kong-ui-entities-vaults-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getRoutes')
+        cy.get('.kong-ui-entities-vaults-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show vault items', () => {
@@ -542,31 +550,39 @@ describe('<VaultList />', () => {
     })
 
     it('should handle error state', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/vaults*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getRoutes')
+      const testHandleErrorRequest = (message?: string) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/api/runtime_groups/${baseConfigKonnect.controlPlaneId}/vaults*`,
+          },
+          {
+            statusCode: 500,
+            body: message ? { message } : {},
+          },
+        ).as('getRoutes')
 
-      cy.mount(VaultList, {
-        props: {
-          cacheIdentifier: `vault-list-${uuidv4()}`,
-          config: baseConfigKonnect,
-          canCreate: () => { },
-          canEdit: () => { },
-          canDelete: () => { },
-          canRetrieve: () => { },
-        },
-      })
+        cy.mount(VaultList, {
+          props: {
+            cacheIdentifier: `vault-list-${uuidv4()}`,
+            config: baseConfigKonnect,
+            canCreate: () => { },
+            canEdit: () => { },
+            canDelete: () => { },
+            canRetrieve: () => { },
+          },
+        })
 
-      cy.wait('@getRoutes')
-      cy.get('.kong-ui-entities-vaults-list').should('be.visible')
-      cy.get('.k-table-error-state').should('be.visible')
+        cy.wait('@getRoutes')
+        cy.get('.kong-ui-entities-vaults-list').should('be.visible')
+        cy.get('.k-table-error-state').should('be.visible')
+        if (message) {
+          cy.get('.k-table-error-state .k-empty-state-message').should('contain.text', message)
+        }
+      }
+
+      testHandleErrorRequest()
+      testHandleErrorRequest('Custom error message')
     })
 
     it('should show vault items', () => {

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -147,6 +147,7 @@ import type {
   ExactMatchFilterConfig,
   FilterFields,
   FuzzyMatchFilterConfig,
+  TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
 
 import composables from '../composables'
@@ -286,7 +287,7 @@ const resetPagination = (): void => {
 /**
  * loading, Error, Empty state
  */
-const errorMessage = ref('')
+const errorMessage = ref<TableErrorMessage>(null)
 
 /**
  * Copy ID action
@@ -420,14 +421,19 @@ const confirmDelete = async (): Promise<void> => {
  */
 watch(fetcherState, (state) => {
   if (state.status === FetcherStatus.Error) {
-    errorMessage.value = t('errors.general')
+    errorMessage.value = {
+      title: t('errors.general'),
+    }
+    if (state.error?.response?.data?.message) {
+      errorMessage.value.message = state.error.response.data.message
+    }
     // Emit the error for the host app
     emit('error', state.error)
 
     return
   }
 
-  errorMessage.value = ''
+  errorMessage.value = null
 })
 
 // Initialize the empty state options assuming a user does not have create permissions


### PR DESCRIPTION
The current implementation just display general error message when error happens, and `<EntityBaseTable />` doesn't support set error message for the list (only error title allowed).

To display the message returned from server, prop `errorMessage` in `<EntityBaseTable />` now supports both string form (title only) and object form (title and message).

All kinds of entity lists are modified to set the error message when available.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
