### PR TITLE
chore: vite server setting

### DIFF
--- a/vite.config.shared.ts
+++ b/vite.config.shared.ts
@@ -17,7 +17,7 @@ dns.setDefaultResultOrder('verbatim')
 // Include the rollup-plugin-visualizer if the BUILD_VISUALIZER env var is set to "true"
 const buildVisualizerPlugin = process.env.BUILD_VISUALIZER
   ? visualizer({
-    filename: path.resolve(__dirname, `packages/${process.env.BUILD_VISUALIZER}/bundle-analyzer/stats-treemap.html`),
+    filename: path.resolve(__dirname, `packages/${ process.env.BUILD_VISUALIZER }/bundle-analyzer/stats-treemap.html`),
     template: 'treemap', // sunburst|treemap|network
     sourcemap: true,
     gzipSize: true,
@@ -92,14 +92,6 @@ export default defineConfig({
       'vue-router',
     ],
   },
-  server: {
-    fs: {
-      /**
-       * Allow serving files from one level up from the package root - IMPORTANT - since this is a monorepo
-       */
-      allow: [join(__dirname, '..')],
-    },
-  },
   // Change the root when utilizing the sandbox via USE_SANDBOX=true to use the `/sandbox/*` files
   // During the build process, the `/sandbox/*` files are not used and we should default to the package root.
   root: process.env.USE_SANDBOX ? './sandbox' : process.cwd(),
@@ -144,7 +136,7 @@ export const getApiProxies = (pathToRoot: string = '../../../.') => {
 
   const konnectAuthHeader = env.VITE_KONNECT_PAT
     ? {
-      authorization: `Bearer ${env.VITE_KONNECT_PAT}`,
+      authorization: `Bearer ${ env.VITE_KONNECT_PAT }`,
     }
     : undefined
 
@@ -160,9 +152,9 @@ export const getApiProxies = (pathToRoot: string = '../../../.') => {
   // Build the regional API proxies
   for (const region of availableRegions) {
     // @ts-ignore
-    regionalProxies[`^/${region}/kong-api/konnect-api`] = {
+    regionalProxies[`^/${ region }/kong-api/konnect-api`] = {
       target: (env.VITE_KONNECT_API ?? '').replace(/\{geo\}/, region),
-      rewrite: (path: string) => path.replace(`/${region}/kong-api`, ''),
+      rewrite: (path: string) => path.replace(`/${ region }/kong-api`, ''),
       changeOrigin: true,
       headers: {
         ...konnectAuthHeader,


### PR DESCRIPTION
# Summary

Vite now respects the `pnpm-workspace.yaml` file so the `server.fs.allow` setting shouldn't be needed.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
