### PR TITLE
fix(entities-plugins): app-registration plugin scope

### DIFF
--- a/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
+++ b/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
@@ -465,7 +465,7 @@ export const usePluginMetaData = () => {
       group: PluginGroup.AUTHENTICATION,
       isEnterprise: true,
       name: t('plugins.meta.application-registration.name'),
-      scope: [PluginScope.GLOBAL, PluginScope.SERVICE],
+      scope: [PluginScope.SERVICE],
     },
     'konnect-application-auth': {
       description: t('plugins.meta.konnect-application-auth.description'),


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

The Application Registration plugin can only be scoped to a service.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
