### PR TITLE
fix(entities-plugins): empty state description

### DIFF
--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -83,7 +83,7 @@
       },
       "empty_state": {
         "title": "Configure a New Plugin",
-        "description": "Improve the security of your Kong Gateway deployment with centralized secrets."
+        "description": "Plugins are used to extend Kong functionality."
       }
     },
     "meta": {


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

The empty state description for the `PluginList` is wrong. The PR updates it with the text from the original Figma mocks.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
