### PR TITLE
feat(app-layout): dark theme

### DIFF
--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -219,6 +219,7 @@ const sidebarMobileTopOffset = computed((): number => {
 const appLayoutBackgroundColor = computed((): string => props.theme === 'light' ? APP_LAYOUT_BACKGROUND : KUI_COLOR_BACKGROUND_INVERSE)
 const layoutMainColor = computed((): string => props.theme === 'light' ? KUI_COLOR_TEXT : KUI_COLOR_TEXT_INVERSE)
 const layoutMainBackgroundColor = computed((): string => props.theme === 'light' ? KUI_COLOR_BACKGROUND : KUI_COLOR_BACKGROUND_INVERSE)
+const layoutMainBoxShadow = computed((): string => props.theme === 'light' ? 'var(--kong-ui-app-layout-main-box-shadow, -30px 174px 250px #0023db)' : 'none')
 const layoutMainMarginTop = computed((): string => `${sidebarMobileTopOffset.value}px`)
 const layoutMainTopLeftBorderRadius = computed((): string => sidebar.hidden || navbar.hidden ? KUI_SPACE_0 : KUI_SPACE_60)
 
@@ -337,7 +338,7 @@ onBeforeUnmount(() => {
   .kong-ui-app-layout-main {
     align-items: stretch;
     background-color: v-bind('layoutMainBackgroundColor');
-    box-shadow: var(--kong-ui-app-layout-main-box-shadow, -30px 174px 250px #0023db);
+    box-shadow: v-bind('layoutMainBoxShadow');
     color: v-bind('layoutMainColor');
     display: flex;
     flex-grow: 1;

--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -337,7 +337,7 @@ onBeforeUnmount(() => {
   .kong-ui-app-layout-main {
     align-items: stretch;
     background-color: v-bind('layoutMainBackgroundColor');
-    box-shadow: $app-layout-main-box-shadow;
+    box-shadow: var(--kong-ui-app-layout-main-box-shadow, -30px 174px 250px #0023db);
     color: v-bind('layoutMainColor');
     display: flex;
     flex-grow: 1;

--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -121,7 +121,8 @@ import AppSidebar from './sidebar/AppSidebar.vue'
 import SidebarToggle from './sidebar/SidebarToggle.vue'
 import type { SidebarPrimaryItem, SidebarSecondaryItem } from '../types'
 import { useDebounce } from '../composables'
-import { KUI_SPACE_0, KUI_SPACE_60 } from '@kong/design-tokens'
+import { APP_LAYOUT_BACKGROUND } from '../constants'
+import { KUI_SPACE_0, KUI_SPACE_60, KUI_COLOR_BACKGROUND, KUI_COLOR_BACKGROUND_INVERSE, KUI_COLOR_TEXT, KUI_COLOR_TEXT_INVERSE } from '@kong/design-tokens'
 
 interface AppSidebarProperties {
   topItems?: SidebarPrimaryItem[]
@@ -156,6 +157,11 @@ const props = defineProps({
   sidebarBottomItems: {
     type: Array as PropType<SidebarPrimaryItem[]>,
     default: () => ([]),
+  },
+  theme: {
+    type: String as PropType<'light' | 'dark'>,
+    default: 'light',
+    validator: (theme: 'light' | 'dark'): boolean => ['light', 'dark'].includes(theme),
   },
 })
 
@@ -210,6 +216,9 @@ const sidebarMobileTopOffset = computed((): number => {
 
   return navbarHeight.value + notificationHeight.value
 })
+const appLayoutBackgroundColor = computed((): string => props.theme === 'light' ? APP_LAYOUT_BACKGROUND : KUI_COLOR_BACKGROUND_INVERSE)
+const layoutMainColor = computed((): string => props.theme === 'light' ? KUI_COLOR_TEXT : KUI_COLOR_TEXT_INVERSE)
+const layoutMainBackgroundColor = computed((): string => props.theme === 'light' ? KUI_COLOR_BACKGROUND : KUI_COLOR_BACKGROUND_INVERSE)
 const layoutMainMarginTop = computed((): string => `${sidebarMobileTopOffset.value}px`)
 const layoutMainTopLeftBorderRadius = computed((): string => sidebar.hidden || navbar.hidden ? KUI_SPACE_0 : KUI_SPACE_60)
 
@@ -284,7 +293,7 @@ onBeforeUnmount(() => {
 @import "../styles/variables";
 
 .kong-ui-app-layout {
-  background: $app-layout-background;
+  background: v-bind('appLayoutBackgroundColor');
   bottom: 0;
   display: flex;
   flex-direction: column;
@@ -327,8 +336,9 @@ onBeforeUnmount(() => {
 
   .kong-ui-app-layout-main {
     align-items: stretch;
-    background-color: $kui-color-background;
+    background-color: v-bind('layoutMainBackgroundColor');
     box-shadow: $app-layout-main-box-shadow;
+    color: v-bind('layoutMainColor');
     display: flex;
     flex-grow: 1;
     height: 100%;

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -82,6 +82,7 @@ import type { SidebarPrimaryItem } from '../../types'
 import SidebarItem from '../sidebar/SidebarItem.vue'
 import { FocusTrap } from 'focus-trap-vue'
 import { useDebounce } from '../../composables'
+import { APP_LAYOUT_BACKGROUND } from '../../constants'
 import clonedeep from 'lodash.clonedeep'
 
 const emit = defineEmits(['click', 'toggle'])
@@ -313,7 +314,7 @@ onBeforeUnmount(() => {
 @import "../../styles/variables";
 
 .kong-ui-app-sidebar {
-  background: $app-layout-background;
+  background: v-bind('APP_LAYOUT_BACKGROUND');
   display: flex;
   flex-direction: column;
   height: v-bind('sidebarContainerStyles.mobileHeight');

--- a/packages/core/app-layout/src/constants.ts
+++ b/packages/core/app-layout/src/constants.ts
@@ -1,0 +1,1 @@
+export const APP_LAYOUT_BACKGROUND = 'linear-gradient(180deg, #001740 0%, #073382 100%)'

--- a/packages/core/app-layout/src/styles/_variables.scss
+++ b/packages/core/app-layout/src/styles/_variables.scss
@@ -1,3 +1,2 @@
-@import "./variables/app-layout";
 @import "./variables/app-navbar";
 @import "./variables/app-sidebar";

--- a/packages/core/app-layout/src/styles/variables/_app-layout.scss
+++ b/packages/core/app-layout/src/styles/variables/_app-layout.scss
@@ -1,1 +1,0 @@
-$app-layout-main-box-shadow: var(--kong-ui-app-layout-main-box-shadow, -30px 174px 250px #0023db);

--- a/packages/core/app-layout/src/styles/variables/_app-layout.scss
+++ b/packages/core/app-layout/src/styles/variables/_app-layout.scss
@@ -1,2 +1,1 @@
-$app-layout-background: linear-gradient(180deg, #001740 0%, #073382 100%);
 $app-layout-main-box-shadow: var(--kong-ui-app-layout-main-box-shadow, -30px 174px 250px #0023db);


### PR DESCRIPTION
# Summary

Adds a new `theme` prop that accepts `light` (default) or `dark` to modify the app layout background color.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
