### PR TITLE
fix(entities-shared): filter input style

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
+++ b/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
@@ -292,7 +292,6 @@ const applyFields = (hideMenu = false) => {
   :deep(.k-input) {
     padding-bottom: 4px!important;
     padding-top: 4px!important;
-    width: auto;
   }
 
   :deep(.k-input-wrapper) {


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes a style issue that the input width exceeds its container in the shared `EntityFilter`.

Before:
<img width="333" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/69f3566a-843d-4f24-aba6-92d0992e2cbb">

After:
<img width="327" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/4bacb1f4-9c4d-464c-9083-c2f57d426553">



## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
