### PR TITLE
fix(entities-plugins): collapse status of plugin groups

### DIFF
--- a/packages/entities/entities-plugins/src/components/select/PluginSelectCard.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectCard.vue
@@ -219,6 +219,7 @@ const handleCustomClick = (): void => {
   flex-basis: 100%;
   flex-flow: row-wrap;
   max-width: 335px;
+  overflow: hidden;
 
   .actions-trigger {
     color: $kui-color-text-neutral-stronger;

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
@@ -28,11 +28,11 @@
         :key="idx"
       >
         <KCollapse
-          v-model="shouldCollapsed[idx]"
+          v-model="shouldCollapsed[group]"
           class="plugins-collapse"
           :data-testid="`${group}-collapse`"
           :title="group"
-          :trigger-label="!shouldCollapsed[idx] ? triggerLabels[group] : t('plugins.select.view_less')"
+          :trigger-label="shouldCollapsed[group] ? triggerLabels[group] : t('plugins.select.view_less')"
         >
           <!-- don't display a trigger if all plugins will already be visible -->
           <template

--- a/packages/entities/entities-plugins/src/types/plugin.ts
+++ b/packages/entities/entities-plugins/src/types/plugin.ts
@@ -25,15 +25,15 @@ export const PluginGroupArray = [
 ]
 
 export const PLUGIN_GROUPS_COLLAPSE_STATUS = {
-  AUTHENTICATION: true,
-  SECURITY: true,
-  TRAFFIC_CONTROL: true,
-  SERVERLESS: true,
-  ANALYTICS_AND_MONITORING: true,
-  TRANSFORMATIONS: true,
-  LOGGING: true,
-  DEPLOYMENT: true,
-  CUSTOM_PLUGINS: true,
+  [PluginGroup.AUTHENTICATION]: true,
+  [PluginGroup.SECURITY]: true,
+  [PluginGroup.TRAFFIC_CONTROL]: true,
+  [PluginGroup.SERVERLESS]: true,
+  [PluginGroup.ANALYTICS_AND_MONITORING]: true,
+  [PluginGroup.TRANSFORMATIONS]: true,
+  [PluginGroup.LOGGING]: true,
+  [PluginGroup.DEPLOYMENT]: true,
+  [PluginGroup.CUSTOM_PLUGINS]: true,
 }
 
 // this is the entity associated with a specific plugin, if no associated entity, then it's a global plugin meaning EntityType will be 'plugins'


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes the collapse states of plugin groups in the plugin select page.

Before:
![Kapture 2023-11-30 at 17 43 31](https://github.com/Kong/public-ui-components/assets/10095631/e7cf947e-dce8-4fdb-8125-3bdb9cf480a8)

<hr>

After:
![Kapture 2023-11-30 at 17 42 22](https://github.com/Kong/public-ui-components/assets/10095631/fa3b7308-a1d0-444a-8d2d-20f4c371469b)

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
