### PR TITLE
feat: add ICU datetime date format

### DIFF
--- a/packages/core/i18n/sandbox/App.vue
+++ b/packages/core/i18n/sandbox/App.vue
@@ -2,6 +2,9 @@
   <div class="sandbox-container">
     <main>
       <p>{{ i18n.t('global.ok') }}</p>
+      <p>{{ i18n.t('global.dates', {amount: '1000', value: Date.now()}) }}</p>
+      <p>{{ i18n.t('global.dates', {amount: '1000', value: undefined}) }}</p>
+      <p>{{ i18n.t('global.dates', {amount: '1000', value: new Date(0).getTime()}) }}</p>
 
       <i18n-t
         keypath="global.named"

--- a/packages/core/i18n/sandbox/locales/en.json
+++ b/packages/core/i18n/sandbox/locales/en.json
@@ -2,6 +2,7 @@
   "global": {
     "ok": "O-k-key",
     "named": "{greeting}, my name is {name}. And I am {occupation}. I want {amount}",
+    "dates": "I want {amount, number, :: ! currency/USD} {value, select, 0 { for Christmas! } undefined { for Christmas! } other { on { value, date, datetime } } }",
     "default": "See the news at {0}. There is a lot there."
   },
   "custom_dogs": {

--- a/packages/core/i18n/src/i18n.spec.ts
+++ b/packages/core/i18n/src/i18n.spec.ts
@@ -8,6 +8,7 @@ const english = {
   test: {
     withParams: 'Good {dayPart}, My name is {name}!',
     withPluralization: 'There are {count} {count, plural, =0 {versions} =1 {version} other {versions}} available',
+    withDateTimeFormatting: '{value, date, datetime}',
   },
   array: {
     disabled: [
@@ -67,6 +68,15 @@ describe('i18n', () => {
       expect(t('test.withPluralization', { count: 0 })).toEqual('There are 0 versions available')
       expect(t('test.withPluralization', { count: 1 })).toEqual('There are 1 version available')
       expect(t('test.withPluralization', { count: 11 })).toEqual('There are 11 versions available')
+    })
+    it('should format message with datetime', () => {
+      const { t } = useI18n<typeof english>()
+      expect(t('test.withDateTimeFormatting', { value: new Date(0).getTime() })).toEqual('Jan 1, 1970, 12:00 AM')
+      expect(t('test.withDateTimeFormatting', { value: new Date(1701344449607).getTime() })).toEqual('Nov 30, 2023, 11:40 AM')
+      expect(t('test.withDateTimeFormatting', { value: 0 })).toEqual('Jan 1, 1970, 12:00 AM')
+      expect(t('test.withDateTimeFormatting', { value: 1701344449607 })).toEqual('Nov 30, 2023, 11:40 AM')
+      expect(t('test.withDateTimeFormatting', { value: Date.parse('Jan 1, 1970, 12:00 AM') })).toEqual('Jan 1, 1970, 12:00 AM')
+      expect(t('test.withDateTimeFormatting', { value: Date.parse('Nov 30, 2023, 11:40 AM') })).toEqual('Nov 30, 2023, 11:40 AM')
     })
   })
 

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -11,7 +11,13 @@ const intlCache = createIntlCache()
 // this is global var to hold global (application) instance of Intl
 // typed as any since we don't have access to MessageSource here
 let globIntl: any
-
+const datetimeFormat: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+}
 /**
  * Creates and returns global or local instance of Intl
  * @param {SupportedLocales} locale one of the locales supported
@@ -22,13 +28,21 @@ let globIntl: any
 export const createI18n = <MessageSource extends Record<string, any>>
 (locale: SupportedLocales, messages: MessageSource, config: boolean|IntlConfigCore = false): IntlShapeEx<MessageSource> => {
 
+  const booleanConfig = typeof (config) === 'boolean'
   const intlOriginal = createIntl(
     {
-      ...(typeof (config) === 'boolean' ? null : config),
+      ...(booleanConfig ? null : config),
       locale,
       messages: flatten(messages, {
         safe: true, // Preserve arrays
       }),
+      formats: {
+        ...(booleanConfig ? null : config.formats),
+        date: {
+          ...(booleanConfig ? null : config.formats?.date),
+          datetime: datetimeFormat,
+        },
+      },
     },
     intlCache,
   )
@@ -52,13 +66,7 @@ export const createI18n = <MessageSource extends Record<string, any>>
     try {
       const date = new Date(timestamp * 1000)
 
-      return intl.formatDate(date, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-      })
+      return intl.formatDate(date, datetimeFormat)
     } catch (err) {
       return invalidDate
     }


### PR DESCRIPTION
# Summary

Adds an ICU message format `datetime` format exactly the same as `formatIsoDate` for usage from within ICU files, making it easier to use a standard format within longer form texts such as:

```
I want a present {value, select, 
  0 { for Christmas! }
  undefined { for Christmas! }
  other { on { value, date, datetime } } 
}
```


## PR Checklist

* [x] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [x] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [x] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
