### PR TITLE
style(doc-viewer): add lineheight for code blocks in table cells (TDX-3667)

### DIFF
--- a/packages/portal/document-viewer/src/components/nodes/TableCell.vue
+++ b/packages/portal/document-viewer/src/components/nodes/TableCell.vue
@@ -38,6 +38,10 @@ th, td {
   padding: $kui-space-40;
   text-align: left;
   vertical-align: top;
+
+  :deep(code) {
+    line-height: $kui-line-height-40;
+  }
 }
 
 th:not(:last-of-type), td:not(:last-of-type) {


### PR DESCRIPTION
# Summary
Adds line-height to code blocks that are inside table cells just so they do not overlap with each other.
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
