### PR TITLE
fix(*): create button visibility

### DIFF
--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -434,9 +434,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -501,9 +501,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -463,9 +463,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -562,9 +562,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -572,9 +572,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -524,9 +524,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -437,9 +437,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -446,9 +446,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -724,9 +724,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -498,9 +498,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -443,9 +443,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -408,9 +408,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -417,9 +417,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -435,9 +435,9 @@ const hasData = ref(true)
  * Watchers
  */
 watch(fetcherState, (state) => {
-  // if table is empty, hide the teleported Create button
-  if (state?.response?.data?.length === 0) {
-    hasData.value = false
+  // reset `hasData` to show/hide the teleported Create button
+  if (Array.isArray(state?.response?.data)) {
+    hasData.value = state.response!.data.length > 0
   }
 
   if (state.status === FetcherStatus.Error) {


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Fixes a bug where `hasData` will never be true after new entities are created: https://github.com/Kong/kong-admin/actions/runs/7053078914/job/19199527913?pr=3081.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
