### PR TITLE
fix(analytics-chart): do not add zero values to datasets [MA-2342]

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
@@ -170,16 +170,18 @@
       </div>
     </template>
 
-    <!-- Determine if a full blown chart is to be displayed, or a simplified one -->
-    <AnalyticsChart
-      :chart-data="(exploreResult as AnalyticsExploreV2Result)"
-      :chart-options="analyticsChartOptions"
-      chart-title="Request count by Status Code"
-      :legend-position="legendPosition"
-      :show-annotations="showAnnotationsToggle"
-      :show-legend-values="showLegendValuesToggle"
-      tooltip-title="tooltip title"
-    />
+    <div class="chart-container">
+      <!-- Determine if a full blown chart is to be displayed, or a simplified one -->
+      <AnalyticsChart
+        :chart-data="(exploreResult as AnalyticsExploreV2Result)"
+        :chart-options="analyticsChartOptions"
+        chart-title="Request count by Status Code"
+        :legend-position="legendPosition"
+        :show-annotations="showAnnotationsToggle"
+        :show-legend-values="showLegendValuesToggle"
+        tooltip-title="tooltip title"
+      />
+    </div>
 
     <br>
 
@@ -367,4 +369,12 @@ watch(multiDimensionToggle, () => {
 <style lang="scss" scoped>
 @import '../src/styles/base';
 @import '../styles/charts-sandbox';
+
+.chart-container {
+  max-width:60vw;
+
+  @media(max-width: ($kui-breakpoint-laptop - 1px)) {
+    max-width: 100vw;
+  }
+}
 </style>

--- a/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
@@ -76,6 +76,7 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
   const options = computed(() => {
     return {
       indexAxis: chartOptions.indexAxis,
+      skipNull: true,
       scales: {
         x: {
           border: {

--- a/packages/analytics/analytics-chart/src/composables/useChartLegendValues.ts
+++ b/packages/analytics/analytics-chart/src/composables/useChartLegendValues.ts
@@ -14,7 +14,7 @@ export default function useChartLegendValues(chartData: Ref<KChartData>, chartTy
       const raw = v.total
         ? v.total
         : (v.data as Array<number | AnalyticsDataPoint>).reduce((acc: number, e: number | AnalyticsDataPoint) => {
-          return acc + (typeof e === 'number' ? Number(e) || 0 : Number(e.y) || 0)
+          return acc + (typeof e === 'number' ? Number(e) || 0 : Number(e && e.y) || 0)
         }, 0) as number
 
       let formatted: string

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
@@ -170,10 +170,10 @@ describe('useVitalsExploreDatasets', () => {
       {
         labels: ['group-by-1', 'group-by-2'],
         datasets: [
-          { label: 'then-by-1', backgroundColor: '#a86cd5', data: [100, 0] },
-          { label: 'then-by-2', backgroundColor: '#6a86d2', data: [150, 0] },
-          { label: 'then-by-3', backgroundColor: '#00bbf9', data: [0, 200] },
-          { label: 'then-by-4', backgroundColor: '#00c4b0', data: [0, 250] },
+          { label: 'then-by-1', backgroundColor: '#a86cd5', data: [100, null] },
+          { label: 'then-by-2', backgroundColor: '#6a86d2', data: [150, null] },
+          { label: 'then-by-3', backgroundColor: '#00bbf9', data: [null, 200] },
+          { label: 'then-by-4', backgroundColor: '#00c4b0', data: [null, 250] },
         ],
       },
     )
@@ -284,8 +284,8 @@ it('handles multiple metrics with no dimension', () => {
     {
       labels: ['metric1', 'metric2'],
       datasets: [
-        { label: 'metric1', backgroundColor: '#a86cd5', data: [1, 0] },
-        { label: 'metric2', backgroundColor: '#6a86d2', data: [0, 2] },
+        { label: 'metric1', backgroundColor: '#a86cd5', data: [1, null] },
+        { label: 'metric2', backgroundColor: '#6a86d2', data: [null, 2] },
       ],
     },
   )

--- a/packages/analytics/analytics-chart/src/types/dataset-generation-types.ts
+++ b/packages/analytics/analytics-chart/src/types/dataset-generation-types.ts
@@ -1,0 +1,12 @@
+import type { AnalyticsChartColors } from '../types'
+
+export interface BarChartDatasetGenerationParams {
+  metricNames: string[]
+  dimensionFieldNames: string[]
+  barSegmentLabels: string[]
+  pivotRecords: { [k: string]: string | number; }
+  rowLabels: string[]
+  colorPalette: string[] | AnalyticsChartColors
+  isMultiMetric?: boolean
+  hasDimensions?: boolean
+}

--- a/packages/analytics/analytics-chart/src/types/index.ts
+++ b/packages/analytics/analytics-chart/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './chart-data'
 export * from './chartjs-options'
 export * from './explore-to-dataset-deps'
+export * from './dataset-generation-types'


### PR DESCRIPTION
# Summary

Adding `0` to datasets as empty data rather than `null` was causing https://konghq.atlassian.net/browse/MA-2342 

When unstacking, ChartJS was allocating space in the canvas for the segments the `0`s represented. 

Setting empty values to null in the dataset, and setting `skipNull: true` in the chart options, solves the problem.

also, some housekeeping fixes
  - move dataset generation to a function for code readability
  - some sandbox tweaks

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
