### PR TITLE
fix: do not inherit height and width for internal chart parent

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -317,8 +317,8 @@ provide('legendPosition', toRef(props, 'legendPosition'))
 
 .analytics-chart-shell {
   .analytics-chart-parent {
-    height: inherit;
-    width: inherit;
+    height: 100%;
+    width: 100%;
   }
 
   .chart-empty-state {


### PR DESCRIPTION
the height that is set on the shell, should be the maximum allowed hight the chart should have internally. Setting that to inherit would cause the chart internally to overflow its container

Lets say the chart shell had a max hight of 500px

The chart parent which tells chartjs how large the chart should be would also try to be 500px.

500px is what the whole chart shell, including legend, header, etc should have so the result is that the chart would overflow its parent container.

if we set the

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
