### PR TITLE
fix(swagger-ui-web-component): operationId

### DIFF
--- a/packages/portal/swagger-ui-web-component/src/utils.js
+++ b/packages/portal/swagger-ui-web-component/src/utils.js
@@ -6,7 +6,7 @@ export const attributeValueToBoolean = (value) => {
 
 // Yes, Swagger literally calls it "thing"
 export const escapeSwaggerThing = (str) => {
-  return decodeURIComponent(str.trim().replace(/\s/g, '_'))
+  return escapeDeepLinkPath(str)
 }
 
 export const operationToSwaggerThingArray = (operation) => {
@@ -16,6 +16,11 @@ export const operationToSwaggerThingArray = (operation) => {
     operation.operationId ? operation.operationId : helpers.opId(operation, operation.path, operation.method),
   ]
 }
+
+// suitable for use in URL fragments
+export const createDeepLinkPath = (str) => typeof str === 'string' || str instanceof String ? str.trim().replace(/\s/g, '%20') : ''
+// suitable for use in CSS classes and ids
+export const escapeDeepLinkPath = (str) => CSS.escape(createDeepLinkPath(str).replace(/%20/g, '_'))
 
 export const operationToSwaggerThingId = (operation) => {
   return escapeSwaggerThing(


### PR DESCRIPTION
Fixes an issue where the escaping pattern is not matched with how swagger-ui creates the id

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
