### PR TITLE
test: fix findTestId command

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -15,8 +15,8 @@ Cypress.Commands.add('getTestId', (dataTestId: string): any => {
   return cy.get(`[data-testid=${dataTestId}]`)
 })
 
-Cypress.Commands.add('findTestId', { prevSubject: true }, (subject, dataTestId: string): any => {
-  return cy.get(subject).find(`[data-testid="${dataTestId}"]`)
+Cypress.Commands.add('findTestId', { prevSubject: 'element' }, (subject, dataTestId: string): any => {
+  return cy.wrap(subject).find(`[data-testid="${dataTestId}"]`)
 })
 
 Cypress.Commands.add('onVueError', (vueError: VueError) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -15,8 +15,8 @@ Cypress.Commands.add('getTestId', (dataTestId: string): any => {
   return cy.get(`[data-testid=${dataTestId}]`)
 })
 
-Cypress.Commands.add('findTestId', (dataTestId: string): any => {
-  return cy.find(`[data-testid=${dataTestId}]`)
+Cypress.Commands.add('findTestId', { prevSubject: true }, (subject, dataTestId: string): any => {
+  return cy.get(subject).find(`[data-testid="${dataTestId}"]`)
 })
 
 Cypress.Commands.add('onVueError', (vueError: VueError) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -12,7 +12,7 @@ interface VueError {
 }
 
 Cypress.Commands.add('getTestId', (dataTestId: string): any => {
-  return cy.get(`[data-testid=${dataTestId}]`)
+  return cy.get(`[data-testid="${dataTestId}"]`)
 })
 
 Cypress.Commands.add('findTestId', { prevSubject: 'element' }, (subject, dataTestId: string): any => {


### PR DESCRIPTION
# Summary

The `findTestId` command wasn't supported chaining.

## PR Checklist

* [ ] **Naming & Structure:** the files and package structure use the conventions outlined in the [Creating a Package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md).
* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Functional:** all changes do not break existing APIs, but if so, a BREAKING CHANGE commit is in place to bump the major version.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/public-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
