### PR TITLE
fix(useFetchUrlBuilder): fix exact match filter for kong manager

### DIFF
--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -317,7 +317,7 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   if (isExactMatch) {
     return {
       isExactMatch,
-      placeholder: t('consumers.search.placeholder'),
+      placeholder: t(`consumers.search.placeholder.${props.config.app}`),
     } as ExactMatchFilterConfig
   }
 

--- a/packages/entities/entities-consumers/src/locales/en.json
+++ b/packages/entities/entities-consumers/src/locales/en.json
@@ -18,7 +18,10 @@
     },
     "title": "Consumers",
     "search": {
-      "placeholder": "Filter by name"
+      "placeholder": {
+        "konnect": "Filter by name",
+        "kongManager": "Filter by exact username or ID"
+      }
     },
     "actions": {
       "add_consumer": "Add Consumer",

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -294,7 +294,7 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   if (isExactMatch) {
     return {
       isExactMatch,
-      placeholder: t('search.placeholder'),
+      placeholder: t(`search.placeholder.${props.config.app}`),
     } as ExactMatchFilterConfig
   }
 

--- a/packages/entities/entities-gateway-services/src/locales/en.json
+++ b/packages/entities/entities-gateway-services/src/locales/en.json
@@ -17,7 +17,10 @@
     }
   },
   "search": {
-    "placeholder": "Filter by name"
+    "placeholder": {
+      "konnect": "Filter by name",
+      "kongManager": "Filter by exact name or ID"
+    }
   },
   "gateway_services": {
     "title": "Gateway Services",

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -419,7 +419,7 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
         name: fields.name,
         id: { label: t('plugins.list.table_headers.id'), sortable: true },
       },
-      placeholder: t('search.placeholder.konnect'),
+      placeholder: t(`search.placeholder.${props.config.app}`),
     } as ExactMatchFilterConfig
   }
 

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -45,6 +45,7 @@
   "search": {
     "placeholder": {
       "konnect": "Filter by name",
+      "kongManager": "Filter by exact instance name or ID",
       "select": "Filter plugins"
     },
     "filter": {

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -329,7 +329,7 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   if (isExactMatch) {
     return {
       isExactMatch,
-      placeholder: t('search.placeholder'),
+      placeholder: t(`search.placeholder.${props.config.app}`),
     } as ExactMatchFilterConfig
   }
 

--- a/packages/entities/entities-routes/src/locales/en.json
+++ b/packages/entities/entities-routes/src/locales/en.json
@@ -10,7 +10,10 @@
     "loading": "Loading..."
   },
   "search": {
-    "placeholder": "Filter by name",
+    "placeholder": {
+      "konnect": "Filter by name",
+      "kongManager": "Filter by exact name or ID"
+    },
     "no_results": "No results found"
   },
   "routes": {

--- a/packages/entities/entities-shared/src/composables/tests/useFetchUrlBuilder.spec.ts
+++ b/packages/entities/entities-shared/src/composables/tests/useFetchUrlBuilder.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import useFetchUrlBuilder from '../useFetchUrlBuilder'
+
+import type { FetcherParams, KongManagerConfig, KonnectConfig } from 'src/types'
+
+describe('useFetchUrlBuilder()', () => {
+  it('should apply correct query schema for kongManager when isExactMatch is not activated', () => {
+    const config = {
+      apiBaseUrl: '/',
+      app: 'kongManager',
+      workspace: 'default',
+      isExactMatch: false,
+    } as KongManagerConfig
+
+    const builder = useFetchUrlBuilder(config, 'http://foo.bar/entity')
+
+    const query: FetcherParams = {
+      page: 1,
+      pageSize: 10,
+      offset: 0,
+      sortColumnKey: 'name',
+      sortColumnOrder: 'asc',
+      query: 'name=baz',
+    }
+
+    expect(builder(query)).toBe('http://foo.bar/entity?name=baz&sort_by=name&size=10')
+  })
+
+  it('should apply correct query schema for kongManager when isExactMatch activated', () => {
+    const config = {
+      apiBaseUrl: '/',
+      app: 'kongManager',
+      workspace: 'default',
+      isExactMatch: true,
+    } as KongManagerConfig
+
+    const builder = useFetchUrlBuilder(config, 'http://foo.bar/entity')
+
+    const query: FetcherParams = {
+      page: 1,
+      pageSize: 10,
+      offset: 0,
+      sortColumnKey: 'name',
+      sortColumnOrder: 'asc',
+      query: 'testQuery',
+    }
+
+    expect(builder(query)).toBe('http://foo.bar/entity/testQuery/')
+  })
+
+  it('should apply correct query schema for konnect', () => {
+    const config = {
+      apiBaseUrl: '/',
+      app: 'konnect',
+      controlPlaneId: 'default',
+    } as KonnectConfig
+
+    const builder = useFetchUrlBuilder(config, 'http://foo.bar/entity')
+
+    const query: FetcherParams = {
+      page: 1,
+      pageSize: 10,
+      offset: 0,
+      sortColumnKey: 'name',
+      sortColumnOrder: 'asc',
+      query: 'testQuery',
+    }
+
+    expect(builder(query)).toBe('http://foo.bar/entity?filter[name][contains]=testQuery')
+  })
+})

--- a/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
+++ b/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
@@ -35,7 +35,9 @@ export default function useFetchUrlBuilder(
       if (isExactMatch.value && query) {
         // Using exact match
         urlWithParams.search = '' // trim any query params
-        urlWithParams = new URL(`${urlWithParams.href}?filter[name][contains]=${query}`)
+        urlWithParams = _config.value.app === 'konnect'
+          ? new URL(`${urlWithParams.href}?filter[name][contains]=${query}`)
+          : new URL(`${urlWithParams.href}/${query}/`)
       } else {
         if (!isExactMatch.value) {
           // Using fuzzy match


### PR DESCRIPTION
Changes include:
* Add `/{query}/` back since kong manager and konnect have different query URL schema
* Display different placeholder for KM and konnect
