### PR TITLE
feat: export formatTime and useChartSelectedRange

### DIFF
--- a/packages/analytics/analytics-chart/README.md
+++ b/packages/analytics/analytics-chart/README.md
@@ -4,6 +4,7 @@ Dynamic chart component for kong analytics.
 
 - [Features](#features)
 - [Requirements](#requirements)
+- [Included composables](#included-composables)
 - [Usage](#usage)
   - [Install](#install)
   - [Props](#props)
@@ -17,6 +18,10 @@ Dynamic chart component for kong analytics.
 
 - `vue` must be initialized in the host application
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
+
+## Included components
+
+- `useChartSelectedRange`
 
 ## Usage
 

--- a/packages/analytics/analytics-chart/src/index.ts
+++ b/packages/analytics/analytics-chart/src/index.ts
@@ -2,6 +2,7 @@ import AnalyticsChart from './components/AnalyticsChart.vue'
 import SimpleChart from './components/SimpleChart.vue'
 import TopNTable from './components/TopNTable.vue'
 import CsvExportModal from './components/CsvExportModal.vue'
+import useChartSelectedRange from './composables'
 
 export { AnalyticsChart, SimpleChart, TopNTable, CsvExportModal }
 
@@ -9,3 +10,6 @@ export * from './types'
 export * from './enums'
 export * from './utils/colors'
 export * from './utils/customColors'
+export * from './utils/constants'
+
+export { useChartSelectedRange }


### PR DESCRIPTION
# Summary

Needed to export `formatTime` and `useChartSelectedRange`.  The former is needed in various Konnect unit tests, as well as Vue teplates, and needed be moved out of the so-called "konnect-vitals" package.

The latter is needed for a component spec in Konnect.


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
