### PR TITLE
fix(swagger-ui-web-component): operationId (#987)

### DIFF
--- a/packages/portal/swagger-ui-web-component/src/utils.js
+++ b/packages/portal/swagger-ui-web-component/src/utils.js
@@ -6,7 +6,7 @@ export const attributeValueToBoolean = (value) => {
 
 // Yes, Swagger literally calls it "thing"
 export const escapeSwaggerThing = (str) => {
-  return decodeURIComponent(str.trim().replace(/\s/g, '_'))
+  return escapeDeepLinkPath(str)
 }
 
 export const operationToSwaggerThingArray = (operation) => {
@@ -16,6 +16,11 @@ export const operationToSwaggerThingArray = (operation) => {
     operation.operationId ? operation.operationId : helpers.opId(operation, operation.path, operation.method),
   ]
 }
+
+// suitable for use in URL fragments
+export const createDeepLinkPath = (str) => typeof str === 'string' || str instanceof String ? str.trim().replace(/\s/g, '%20') : ''
+// suitable for use in CSS classes and ids
+export const escapeDeepLinkPath = (str) => CSS.escape(createDeepLinkPath(str).replace(/%20/g, '_'))
 
 export const operationToSwaggerThingId = (operation) => {
   return escapeSwaggerThing(


### PR DESCRIPTION
Fixes an issue where the escaping pattern is not matched with how swagger-ui creates the id

# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
