### PR TITLE
fix: take into account margin between bars for height calc [MA-2409]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -155,6 +155,7 @@ const SCROLL_MIN = 0
 const SCROLL_MAX = 10
 const AXIS_BOTTOM_OFFSET = 10
 const AXIS_RIGHT_PADDING = 1
+const BAR_MARGIN = 4
 
 const totalValueOfDataset = ({ chart }: EventContext, label: string) => {
   const chartData: BarChartData = chart.data as BarChartData
@@ -364,7 +365,9 @@ const chartHeight = computed(() => {
   if (numLabels.value && isHorizontal.value) {
 
     // The goal is to keep the bar width greater than or roughly equal to the text width.
-    const preferredChartHeight = numLabels.value * MIN_BAR_HEIGHT
+    const preferredChartHeight = numLabels.value * (MIN_BAR_HEIGHT + BAR_MARGIN)
+    console.log(' >>> preferredChartHeight >> ', preferredChartHeight)
+    console.log(' >>> chartHeight >> ', chartHeight)
     chartHeight = Math.max(preferredChartHeight, chartHeight)
   }
   return chartHeight


### PR DESCRIPTION
# Summary
Needed to also take into account the slight gap between bars when determining the full chart height.
<img width="982" alt="Screenshot 2023-12-19 at 1 08 27 PM" src="https://github.com/Kong/public-ui-components/assets/103061463/21f8f3af-7f3b-475b-a966-e013db65bf78">

https://konghq.atlassian.net/browse/MA-2409

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
