### PR TITLE
feat: dynamic label font for axes [MA-2409]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -155,7 +155,7 @@ const SCROLL_MIN = 0
 const SCROLL_MAX = 10
 const AXIS_BOTTOM_OFFSET = 10
 const AXIS_RIGHT_PADDING = 1
-const BAR_MARGIN = 4
+const BAR_MARGIN = 10
 
 const totalValueOfDataset = ({ chart }: EventContext, label: string) => {
   const chartData: BarChartData = chart.data as BarChartData

--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -400,6 +400,7 @@ const options = computed<ChartOptions>(() => {
     metricAxesTitle: toRef(props, 'metricAxesTitle'),
     dimensionAxesTitle: toRef(props, 'dimensionAxesTitle'),
     indexAxis: isHorizontal.value ? 'y' : 'x',
+    numLabels,
   })
   return {
     ...defaultOptions.value,

--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -156,7 +156,7 @@ const SCROLL_MIN = 0
 const SCROLL_MAX = 10
 const AXIS_BOTTOM_OFFSET = 10
 const AXIS_RIGHT_PADDING = 1
-const BAR_MARGIN = 10
+const BAR_MARGIN = 6
 
 const totalValueOfDataset = ({ chart }: EventContext, label: string) => {
   const chartData: BarChartData = chart.data as BarChartData

--- a/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
@@ -129,6 +129,7 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
             drawBorder: false,
           },
           ticks: {
+            font: { size: 11 },
             callback: function(value: string, index: number): string {
               const that = this as unknown as CategoryScale
 

--- a/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
@@ -73,6 +73,9 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
     return items
   }
 
+  // For larger datasets, allow enough vertical space to display all axis labels
+  const labelFontSize = chartOptions.numLabels.value > 25 ? FONT_SIZE_SMALL : FONT_SIZE_REGULAR
+
   const options = computed(() => {
     return {
       indexAxis: chartOptions.indexAxis,
@@ -90,6 +93,7 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
           ticks: {
             maxRotation: 90,
             autoSkip: false,
+            font: labelFontSize,
             callback: function(value: string, index: number): string {
               const that = this as unknown as CategoryScale
               if (that.chart.options.indexAxis === that.axis) {
@@ -129,8 +133,7 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
             drawBorder: false,
           },
           ticks: {
-            // For larger datasets, allow enough vertical space to display all Y-Axis labels
-            font: { size: chartOptions.numLabels.value > 25 ? FONT_SIZE_SMALL : FONT_SIZE_REGULAR },
+            font: labelFontSize,
             callback: function(value: string, index: number): string {
               const that = this as unknown as CategoryScale
 

--- a/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
@@ -10,7 +10,7 @@ import type {
   CategoryScale,
 } from 'chart.js'
 import { isNullOrUndef, getRelativePosition } from 'chart.js/helpers'
-import { MAX_LABEL_LENGTH, horizontalTooltipPositioning, tooltipBehavior } from '../utils'
+import { FONT_SIZE_SMALL, FONT_SIZE_REGULAR, MAX_LABEL_LENGTH, horizontalTooltipPositioning, tooltipBehavior } from '../utils'
 import { computed } from 'vue'
 
 export default function useBarChartOptions(chartOptions: BarChartOptions) {
@@ -129,7 +129,8 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
             drawBorder: false,
           },
           ticks: {
-            font: { size: 11 },
+            // For larger datasets, allow enough vertical space to display all Y-Axis labels
+            font: { size: chartOptions.numLabels.value > 25 ? FONT_SIZE_SMALL : FONT_SIZE_REGULAR },
             callback: function(value: string, index: number): string {
               const that = this as unknown as CategoryScale
 

--- a/packages/analytics/analytics-chart/src/types/chartjs-options.ts
+++ b/packages/analytics/analytics-chart/src/types/chartjs-options.ts
@@ -32,7 +32,6 @@ export interface TooltipState {
 interface BaseChartOptions {
   tooltipState: TooltipState,
   legendID: string,
-  numLabels: Ref<number>, // number of Y axis labels in dataset
   stacked: Ref<boolean>, // stacked true or false
   metricAxesTitle?: Ref<string>, // metric axes title to display
   dimensionAxesTitle?: Ref<string> // dimension axes title to display
@@ -40,6 +39,7 @@ interface BaseChartOptions {
 
 export interface BarChartOptions extends BaseChartOptions {
   indexAxis: 'x' | 'y', // index axes x or y
+  numLabels: Ref<number>, // number of axis labels in dataset
 }
 
 export interface LineChartOptions extends BaseChartOptions {

--- a/packages/analytics/analytics-chart/src/types/chartjs-options.ts
+++ b/packages/analytics/analytics-chart/src/types/chartjs-options.ts
@@ -31,6 +31,7 @@ export interface TooltipState {
 interface BaseChartOptions {
   tooltipState: TooltipState,
   legendID: string,
+  numLabels: Ref<number>, // number of Y axis labels in dataset
   stacked: Ref<boolean>, // stacked true or false
   metricAxesTitle?: Ref<string>, // metric axes title to display
   dimensionAxesTitle?: Ref<string> // dimension axes title to display

--- a/packages/analytics/analytics-chart/src/utils/constants.ts
+++ b/packages/analytics/analytics-chart/src/utils/constants.ts
@@ -2,6 +2,8 @@ import { formatInTimeZone } from 'date-fns-tz'
 import type { TimeFormatOptions } from '../types'
 
 export const DECIMAL_DISPLAY = 2
+export const FONT_SIZE_SMALL = 10
+export const FONT_SIZE_REGULAR = 12
 
 const numberFormatter = new Intl.NumberFormat(document?.documentElement?.lang || 'en-US')
 


### PR DESCRIPTION
# Summary
https://konghq.atlassian.net/browse/MA-2409

Setting a specific Y-axis label font size so that chartjs avoids dropping every other label due to lack of space.
 
<img width="982" alt="Screenshot 2023-12-19 at 1 08 27 PM" src="https://github.com/Kong/public-ui-components/assets/103061463/e4b0c4bc-affd-4ebc-aabf-e2dd9dd843a5">

<img width="689" alt="Screenshot 2023-12-19 at 3 10 32 PM" src="https://github.com/Kong/public-ui-components/assets/103061463/b115de91-ab92-4227-8cf0-4ebf9a9ea44c">

