### PR TITLE
fix(*): schema desc transformation in plugin forms

### DIFF
--- a/packages/core/forms/src/forms/OIDCForm.vue
+++ b/packages/core/forms/src/forms/OIDCForm.vue
@@ -256,6 +256,20 @@ export default {
           prop: this.isEditing ? this.formModel['config-auth_methods'].includes('refresh_token') : false,
         }]
       }
+
+      const fieldMap = {}
+      for (const field of this.formSchema.fields) {
+        fieldMap[field.model] = field
+      }
+
+      for (const s of [this.commonFieldsSchema, this.authFieldsSchema, this.advancedFieldsSchema]) {
+        for (const f of s.fields) {
+          const help = fieldMap[f.model]?.help
+          if (f.help === undefined && typeof help === 'string') {
+            f.help = help
+          }
+        }
+      }
     },
     getAuthMethodsValue(prop, evt) {
       const arr = []

--- a/packages/core/forms/src/forms/schemas/ACMECommon.ts
+++ b/packages/core/forms/src/forms/schemas/ACMECommon.ts
@@ -1,4 +1,21 @@
-export const ACMECommonSchema = {
+export interface Field {
+  label: string
+  model: string
+  type: string
+  default?: any
+  disabled?: boolean
+  help?: string
+  inputType?: string
+  order?: number
+  required?: boolean
+  valueType?: string
+}
+
+export interface Schema {
+  fields: Field[]
+}
+
+export const ACMECommonSchema: Schema = {
   fields: [
     {
       inputType: 'text',
@@ -35,7 +52,7 @@ export const ACMECommonSchema = {
   ],
 }
 
-export const ACMELetsEncryptSchema = {
+export const ACMELetsEncryptSchema: Schema = {
   fields: [
     {
       type: 'input',
@@ -59,7 +76,7 @@ export const ACMELetsEncryptSchema = {
   ],
 }
 
-export const ACMEZeroSSLSchema = {
+export const ACMEZeroSSLSchema: Schema = {
   fields: [
     {
       type: 'input',

--- a/packages/core/forms/src/forms/schemas/OIDCAuth.js
+++ b/packages/core/forms/src/forms/schemas/OIDCAuth.js
@@ -1,42 +1,35 @@
 export default {
   fields: [{
-    help: 'The claim that contains the scopes.',
     inputType: 'text',
     label: 'Config.Scopes Claim',
     model: 'config-scopes_claim',
     type: 'input',
   }, {
-    help: 'The scopes required to be in the access token.',
     inputType: 'text',
     label: 'Config.Scopes Required',
     model: 'config-scopes_required',
     type: 'input',
   }, {
-    help: 'The claim that contains the audience.',
     inputType: 'text',
     label: 'Config.Audience Claim',
     model: 'config-audience_claim',
     type: 'input',
   }, {
-    help: 'The audience required to be in the access token.',
     inputType: 'text',
     label: 'Config.Audience Required',
     model: 'config-audience_required',
     type: 'input',
   }, {
-    help: 'The claim that contains the roles.',
     inputType: 'text',
     label: 'Config.Roles Claim',
     model: 'config-roles_claim',
     type: 'input',
   }, {
-    help: 'The roles required to be in the access token.',
     inputType: 'text',
     label: 'Config.Roles Required',
     model: 'config-roles_required',
     type: 'input',
   }, {
-    help: 'The claim that contains the groups.',
     inputType: 'text',
     label: 'Config.Groups Claim',
     model: 'config-groups_claim',
@@ -51,7 +44,6 @@ export default {
     styleClasses: 'w-100',
     newElementButtonLabel: '+ Add',
   }, {
-    help: 'The groups required to be in the access token.',
     inputType: 'text',
     label: 'Config.Groups Required',
     model: 'config-groups_required',
@@ -66,7 +58,6 @@ export default {
     styleClasses: 'w-100',
     newElementButtonLabel: '+ Add',
   }, {
-    help: 'The claim that contains authenticated groups.',
     inputType: 'text',
     label: 'Config.Authenticated Groups Claim',
     model: 'config-authenticated_groups_claim',

--- a/packages/core/forms/src/forms/schemas/OIDCCommon.js
+++ b/packages/core/forms/src/forms/schemas/OIDCCommon.js
@@ -1,25 +1,21 @@
 export default {
   fields: [{
-    help: 'The client id(s) that the plugin uses when it calls authenticated endpoints on the identity provider.',
     inputType: 'password',
     label: 'Config.Client Id',
     model: 'config-client_id',
     type: 'input',
   }, {
-    help: 'The client secret.',
     inputType: 'password',
     label: 'Config.Client Secret',
     model: 'config-client_secret',
     type: 'input',
   }, {
-    help: 'The discovery endpoint (or just the issuer identifier).',
     inputType: 'text',
     label: 'Config.Issuer',
     model: 'config-issuer',
     required: true,
     type: 'input',
   }, {
-    help: 'Types of credentials/grants to enable.',
     inputType: 'text',
     label: 'Config.Auth Methods',
     model: 'config-auth_methods',

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/JWT.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/JWT.ts
@@ -1,6 +1,20 @@
-import type { JwtFieldSchema } from '../../types/plugins/jwt'
+import type { JwtSecretFieldSchema, JWTPluginSchema } from '../../types/plugins/jwt'
 
-export const jwtSchema: JwtFieldSchema = {
+// KAG-3347: BE descriptions missing. Should remove when BE descriptions are available
+export const jwtSchema: JWTPluginSchema = {
+  'config-cookie_names': {
+    label: 'config.cookie_names',
+    type: 'set',
+    help: 'A comma-separated list of cookie names that Kong will inspect to retrieve JWTs.',
+  },
+  'config-uri_param_names': {
+    label: 'config.uri_param_names',
+    type: 'set',
+    help: 'A comma-separated list of querystring parameters that Kong will inspect to retrieve JWTs.',
+  },
+}
+
+export const jwtSecretSchema: JwtSecretFieldSchema = {
   fields: [
     {
       key: {
@@ -34,5 +48,6 @@ export const jwtSchema: JwtFieldSchema = {
         hint: `If algorithm is HMAC, the secret used to sign JWTs for
                this credential. If left out, will be auto-generated.`,
       },
-    }],
+    },
+  ],
 }

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/Kafka.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/Kafka.ts
@@ -7,7 +7,7 @@ export const kafkaSchema: KafkaSchema = {
     newElementButtonLabel: '+ Add Bootstrap Server',
     label: 'Bootstrap Server(s)',
     placeholder: 'Enter a Bootstrap Server',
-    help: 'A list of bootstrap servers',
+    help: 'Set of bootstrap brokers.', // KAG-3347: UI text updated. Should remove when BE description is available
     items: {
       type: 'object',
       schema: {

--- a/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
+++ b/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
@@ -10,7 +10,7 @@ import { keyAuthSchema } from './plugin-schemas/KeyAuth'
 import keyAuthCredentialsSchema from './plugin-schemas/credentials/mockedKeyAuthSchema.json'
 import { hmacAuthSchema } from './plugin-schemas/HMAC'
 import hmacAuthCredentialsSchema from './plugin-schemas/credentials/mockedHmacAuthSchema.json'
-import { jwtSchema } from './plugin-schemas/JWT'
+import { jwtSecretSchema } from './plugin-schemas/JWT'
 import jwtCredentialsSchema from './plugin-schemas/credentials/mockedJwtSchema.json'
 import OAuth2Schema from './plugin-schemas/OAuth2'
 import oauthCredentialSchema from './plugin-schemas/credentials/mockedOAuthSchema.json'
@@ -649,7 +649,7 @@ export const usePluginMetaData = () => {
     jwt: {
       title: t('plugins.meta.jwt.name'),
       plugin: 'jwt',
-      schema: jwtSchema,
+      schema: jwtSecretSchema,
       name: t('plugins.meta.jwt.credential_name'),
       endpoint: '/jwt',
       schemaEndpoint: 'jwt_secrets',

--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -6,6 +6,7 @@ import { applicationRegistrationSchema } from './plugin-schemas/ApplicationRegis
 import { dataDogSchema } from './plugin-schemas/Datadog'
 import { statsDAdvancedSchema } from './plugin-schemas/StatsDAdvanced'
 import { kafkaSchema } from './plugin-schemas/Kafka'
+import { jwtSchema } from './plugin-schemas/JWT'
 import { mockingSchema } from './plugin-schemas/Mocking'
 import { preFunctionSchema } from './plugin-schemas/PreFunction'
 import { rateLimitingSchema } from './plugin-schemas/RateLimiting'
@@ -46,6 +47,11 @@ export const useSchemas = (entityId?: string) => {
         rows: 4,
         help: 'A comma separated list of certificate values',
       },
+    },
+
+    // KAG-3347: BE descriptions missing. Should remove when BE descriptions are available
+    jwt: {
+      ...jwtSchema,
     },
 
     'kafka-upstream': {

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -7,6 +7,7 @@ import type { StatsDSchema } from './plugins/stats-d'
 import type { MockingSchema } from './plugins/mocking'
 import type { DatadogSchema } from './plugins/datadog-schema'
 import type { StatsDAdvancedSchema } from './plugins/stats-d-advanced'
+import type { JWTPluginSchema } from './plugins/jwt'
 import type { KafkaSchema } from './plugins/kafka-schema'
 import type { UpstreamTlsSchema } from './plugins/upstream-tls'
 import type { RateLimitingSchema } from './plugins/rate-limiting'
@@ -183,6 +184,7 @@ export interface CustomSchemas {
   'application-registration': ApplicationRegistrationSchema
   datadog: DatadogSchema
   'upstream-tls': UpstreamTlsSchema
+  jwt: JWTPluginSchema
   'kafka-upstream': KafkaSchema
   'kafka-log': KafkaSchema
   statsd: StatsDSchema

--- a/packages/entities/entities-plugins/src/types/plugins/jwt.d.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/jwt.d.ts
@@ -1,6 +1,11 @@
-import type { CommonSchemaFields, PluginBasicSchema } from '../../types/plugins/shared'
+import type { CommonSchemaFields, Field, PluginBasicSchema } from '../../types/plugins/shared'
 
-interface JwtFieldSchema {
+export interface JWTPluginSchema extends CommonSchemaFields{
+  'config-cookie_names': Field,
+  'config-uri_param_names': Field,
+}
+
+interface JwtSecretFieldSchema {
   fields: [
     {
       key: {
@@ -34,7 +39,7 @@ interface JwtFieldSchema {
 }
 
 export type JwtSchema = PluginBasicSchema & CommonSchemaFields & {
-  schema: JwtFieldSchema,
+  schema: JwtSecretFieldSchema,
   fields: {
     id: object,
     key: object,


### PR DESCRIPTION
# Summary

This PR makes the plugin form use descriptions from backend schemas when descriptions are not defined in frontend schemas. It also fixes some current issues with tooltips.

### Tooltips for _schema_ fields

Example: `request-validator`

|Before|After|
|-|-|
|<img width="550" alt="Screenshot 2023-12-20 at 13 58 47" src="https://github.com/Kong/public-ui-components/assets/5277268/6b6d27f1-9a34-4d2a-8562-685b0b79d14b">|<img width="499" alt="Screenshot 2023-12-20 at 14 00 12" src="https://github.com/Kong/public-ui-components/assets/5277268/a99f26c0-b496-4249-ad9f-8ee58c078a29">|

### Tooltips for nested fields

Example: `rate-limiting-advanced`

|Before|After|
|-|-|
|<img width="439" alt="Screenshot 2023-12-20 at 13 59 12" src="https://github.com/Kong/public-ui-components/assets/5277268/392fcda1-769e-49bd-8083-d2154b6e9744">|<img width="606" alt="Screenshot 2023-12-20 at 13 59 44" src="https://github.com/Kong/public-ui-components/assets/5277268/af4da84b-d2ea-4c24-82ef-f5468c52e540">|

### Missing tooltips

Example: `jwt` (some descriptions are missing from Konnect API but available in the Gateway Admin API)

|Before|After|
|-|-|
|<img width="446" alt="Screenshot 2023-12-20 at 13 57 47" src="https://github.com/Kong/public-ui-components/assets/5277268/de8bbc64-9748-4a8b-a034-8b15d770f3cc">|<img width="554" alt="Screenshot 2023-12-20 at 14 00 47" src="https://github.com/Kong/public-ui-components/assets/5277268/cb41d7bf-ce6b-4e24-95df-d1ddde27305d">|

### Outdated tooltips

Example: `kafka-upstream`

<img width="376" alt="Screenshot 2023-12-20 at 13 57 31" src="https://github.com/Kong/public-ui-components/assets/5277268/87b0175c-18fe-4311-9a73-db3a680c33f0">

KAG-3347
