### PR TITLE
fix(app-layout): bottom padding for intercom

### DIFF
--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -362,7 +362,7 @@ onBeforeUnmount(() => {
 
       // Apply the padding to the inner element
       &-inner {
-        padding: var(--kong-ui-app-layout-content-padding, $kui-space-70);
+        padding: var(--kong-ui-app-layout-content-padding-top, $kui-space-70) var(--kong-ui-app-layout-content-padding-x, $kui-space-70) var(--kong-ui-app-layout-content-padding-bottom, $kui-space-130);
       }
     }
   }


### PR DESCRIPTION
# Summary

Add bottom padding of `64px` to allow room for the infamous Intercom floating chat bubble.
