### PR TITLE
fix(*): issues in plugin form

### DIFF
--- a/packages/core/forms/src/generator/fields/advanced/FieldAutoSuggest.vue
+++ b/packages/core/forms/src/generator/fields/advanced/FieldAutoSuggest.vue
@@ -105,6 +105,16 @@ export default {
     },
   },
 
+  watch: {
+    idValue: {
+      handler(newVal, oldVal) {
+        if (newVal !== oldVal) {
+          this.updateModel(newVal)
+        }
+      },
+    },
+  },
+
   async created() {
     await this.$nextTick()
     let presetEntity
@@ -258,7 +268,7 @@ export default {
 
     updateModel(value) {
       // Emit value of field to EntityForm. If empty string send as null
-      this.$emit('model-updated', value && value.length ? value : null, this.schema.model)
+      this.$emit('model-updated', value?.length ? value : null, this.schema.model)
     },
 
     onSelected(item) {

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/StatsD.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/StatsD.ts
@@ -55,11 +55,6 @@ export const statsDSchema: StatsDSchema = {
             'username',
           ],
         }, {
-          model: 'custom_identifier',
-          label: 'Custom Identifier',
-          type: 'input',
-          inputType: 'text',
-        }, {
           model: 'service_identifier',
           label: 'Service Identifier',
           type: 'select',


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Fixing two bugs:
- According to [the backend schema](https://github.com/Kong/kong-ee/blob/master/kong/plugins/statsd/schema.lua), the `StatsD` plugin does not have a `custom_identifier` sub-field in the `metrics` field. If a user types something in its input box and then submits the form, both Admin API and KoKo will throw an error: 
<img width="1411" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/8cc72e88-589b-487b-90ee-2c34b66f97d5">

- With the latest vue version, AutoSuggest needs to manually emit the `model-updated` event (observed [here](https://github.com/Kong/kong-admin/actions/runs/7327128857/job/19953671476)). This is more like a temporary solution and we will revisit AutoSuggest when the KSelect reskin is done.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
