### PR TITLE
fix(entities-plugins): use plain text input for encrypted fields in forms

### DIFF
--- a/packages/core/forms/src/forms/schemas/OIDCCommon.js
+++ b/packages/core/forms/src/forms/schemas/OIDCCommon.js
@@ -1,11 +1,11 @@
 export default {
   fields: [{
-    inputType: 'password',
+    inputType: 'text',
     label: 'Config.Client Id',
     model: 'config-client_id',
     type: 'input',
   }, {
-    inputType: 'password',
+    inputType: 'text',
     label: 'Config.Client Secret',
     model: 'config-client_secret',
     type: 'input',

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -616,7 +616,7 @@ const buildFormSchema = (parentKey: string, response: Record<string, any>, initi
       }
 
       initialFormSchema[field].inputType = scheme.type === 'array' || scheme.type === 'string'
-        ? (scheme.encrypted ? 'password' : 'text')
+        ? 'text'
         : scheme.type
     }
 

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/BasicAuth.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/BasicAuth.ts
@@ -8,7 +8,7 @@ export const basicAuthSchema: BasicAuthFieldSchema = {
 
     {
       password: {
-        inputType: 'password',
+        inputType: 'text',
       },
     },
   ],

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/HMAC.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/HMAC.ts
@@ -9,7 +9,7 @@ export const hmacAuthSchema: HmacAuthFieldSchema = {
     },
     {
       secret: {
-        inputType: 'password',
+        inputType: 'text',
         submitWhenNull: false,
         hint: `The secret to use in the HMAC Signature verification. Note that
         if this parameter isn’t provided, Kong will generate a value for you and

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/JWT.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/JWT.ts
@@ -44,7 +44,7 @@ export const jwtSecretSchema: JwtSecretFieldSchema = {
     },
     {
       secret: {
-        inputType: 'password',
+        inputType: 'text',
         hint: `If algorithm is HMAC, the secret used to sign JWTs for
                this credential. If left out, will be auto-generated.`,
       },

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/KeyAuthEnc.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/KeyAuthEnc.ts
@@ -5,7 +5,7 @@ export default {
         submitWhenNull: false,
         hint: `You can optionally set your own unique key to authenticate the
                client. If missing, it will be generated for you.`,
-        inputType: 'password',
+        inputType: 'text',
         encrypted: true,
       },
     },

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/OAuth2.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/OAuth2.ts
@@ -9,7 +9,7 @@ export default {
         submitWhenNull: false,
         hint: `You can optionally set your own unique client_id. If missing, it
                will be generated for you.`,
-        inputType: 'password',
+        inputType: 'text',
         encrypted: true,
       },
     },
@@ -18,7 +18,7 @@ export default {
         submitWhenNull: false,
         hint: `You can optionally set your own unique client_secret. If missing,
                it will be generated for you.`,
-        inputType: 'password',
+        inputType: 'text',
         encrypted: true,
       },
     },


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

In plugin forms, password inputs are used for encrypted fields. This PR changes them to text inputs.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
