### PR TITLE
fix(entities-gateway-services): fix broken radio label

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -66,9 +66,7 @@
               :selected-value="whereToSendTraffic.url"
               @change="changeCheckedGroup"
             >
-              <KLabel class="gateway-service-url-radio-label">
-                {{ t('gateway_services.form.sections.keys.urlLabel') }}
-              </KLabel>
+              {{ t('gateway_services.form.sections.keys.urlLabel') }}
             </KRadio>
           </div>
 
@@ -99,9 +97,7 @@
             :selected-value="whereToSendTraffic.protocol"
             @change="changeCheckedGroup"
           >
-            <KLabel class="gateway-service-protocol-radio-label">
-              {{ t('gateway_services.form.sections.keys.checkedGroupAltLabel') }}
-            </KLabel>
+            {{ t('gateway_services.form.sections.keys.checkedGroupAltLabel') }}
           </KRadio>
         </div>
 
@@ -857,14 +853,6 @@ defineExpose({
 
   .gateway-service-form-margin-top {
     margin-top: $kui-space-60;
-  }
-
-  .gateway-service-url-radio-label {
-    font-weight: 600;
-  }
-
-  .gateway-service-protocol-radio-label {
-    font-weight: 600;
   }
 
   .gateway-service-form-traffic-label {


### PR DESCRIPTION
Nested label will break the click reactivity. Since the radio font weight is default to 600 now, there is no need to wrap with nested `<label />` and set the `font-weight` explicitly.

# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
