### PR TITLE
fix(entities-plugins): remove click handler from submit button

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -655,8 +655,7 @@ describe('<PluginForm />', () => {
         cy.get('#tags').clear()
         cy.get('#tags').type('tag1,tag2')
 
-        cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
-          .vm.$emit('submit'))
+        cy.getTestId('form-submit').click()
 
         cy.wait(['@validatePlugin', '@updatePlugin'])
 
@@ -1310,8 +1309,7 @@ describe('<PluginForm />', () => {
         cy.get('#tags').clear()
         cy.get('#tags').type('tag1,tag2')
 
-        cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
-          .vm.$emit('submit'))
+        cy.getTestId('form-submit').click()
 
         cy.wait(['@validatePlugin', '@updatePlugin']).then(() => {
           cy.get('@onUpdateSpy').should('have.been.calledOnce')

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -30,7 +30,6 @@
       @fetch:error="(err: any) => $emit('error', err)"
       @fetch:success="initForm"
       @loading="(val: boolean) => $emit('loading', val)"
-      @submit="saveFormData"
     >
       <!-- Having a hidden form here allows us to @submit like a native html form -->
       <form


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

The submit button already has `saveFormData` as its click handler: https://github.com/Kong/public-ui-components/blob/76d87a0a2f176b0687f90b4511f210db2115feee/packages/entities/entities-plugins/src/components/PluginForm.vue#L83
So the form doesn't need a submit handler. Otherwise, in some circumstances, `saveFormData` will run twice when the submit button is clicked, e.g. https://github.com/Kong/kong-test-automation/actions/runs/7393902026/job/20114469588.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
