### PR TITLE
fix(entities-plugins): package dist

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -137,7 +137,16 @@ import { computed, reactive, ref, watch, onBeforeMount, type PropType } from 'vu
 import { useRouter } from 'vue-router'
 import type { AxiosError, AxiosResponse } from 'axios'
 import { marked, type MarkedOptions } from 'marked'
-import { useAxios, useErrors, useHelpers, useStringHelpers, EntityBaseForm, EntityBaseFormType } from '@kong-ui-public/entities-shared'
+import {
+  useAxios,
+  useErrors,
+  useHelpers,
+  useStringHelpers,
+  EntityBaseForm,
+  EntityBaseFormType,
+  JsonCodeBlock,
+  YamlCodeBlock,
+} from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 import {
   EntityTypeIdField,
@@ -155,8 +164,6 @@ import composables from '../composables'
 import { ArrayStringFieldSchema } from '../composables/plugin-schemas/ArrayStringFieldSchema'
 import PluginEntityForm from './PluginEntityForm.vue'
 import type { Tab } from '@kong/kongponents'
-import JsonCodeBlock from '../../../entities-shared/src/components/common/JsonCodeBlock.vue'
-import YamlCodeBlock from '../../../entities-shared/src/components/common/YamlCodeBlock.vue'
 
 const emit = defineEmits<{
   (e: 'error:fetch-schema', error: AxiosError): void,

--- a/packages/entities/entities-shared/src/index.ts
+++ b/packages/entities/entities-shared/src/index.ts
@@ -10,13 +10,15 @@ import EntityToggleModal from './components/entity-toggle-modal/EntityToggleModa
 import PermissionsWrapper from './components/permissions-wrapper/PermissionsWrapper.vue'
 import EntityFormSection from './components/entity-form-section/EntityFormSection.vue'
 import EntityLink from './components/entity-link/EntityLink.vue'
+import JsonCodeBlock from './components/common/JsonCodeBlock.vue'
+import YamlCodeBlock from './components/common/YamlCodeBlock.vue'
 import composables from './composables'
 
 // Extract specific composables to export
 const { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector } = composables
 
 // Components
-export { EntityBaseConfigCard, ConfigCardItem, ConfigCardDisplay, InternalLinkItem, EntityBaseForm, EntityBaseTable, EntityDeleteModal, EntityFilter, EntityToggleModal, PermissionsWrapper, EntityFormSection, EntityLink }
+export { EntityBaseConfigCard, ConfigCardItem, ConfigCardDisplay, InternalLinkItem, EntityBaseForm, EntityBaseTable, EntityDeleteModal, EntityFilter, EntityToggleModal, PermissionsWrapper, EntityFormSection, EntityLink, JsonCodeBlock, YamlCodeBlock }
 
 // Composables
 export { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector }


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This PR fixes `@kong-ui-public/entities-plugins` package `dist/types` directory. The correct `dist/types` directory should look like this:
<img width="231" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/604cc82c-ad40-46e5-89ed-bb6cc1f465ac">

But currently it is:
<img width="209" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/8fdc36a0-278b-4767-b357-7575fb610069">

This makes linting in consuming apps to fail: https://github.com/Kong/kong-admin/actions/runs/7415707930/job/20179347265.

This PR also makes the package smaller:
| Before | After |
| -- | -- |
|<img width="409" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/cf100576-73dc-433e-989d-f5959df3188d">|<img width="406" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/863bfb04-62f4-4d23-9b46-971b8d644087">|


#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
