### PR TITLE
feat(documentation): add document download

### DIFF
--- a/packages/core/documentation/src/components/DocumentationContent.vue
+++ b/packages/core/documentation/src/components/DocumentationContent.vue
@@ -28,6 +28,7 @@
           :hide-publish-toggle="hidePublishToggle"
           :selected-document="selectedDocument"
           @add="handleAddClick"
+          @download="emit('download')"
           @edit="handleEditClick"
           @toggle-published="(data) => emit('toggle-published', data)"
         />
@@ -60,6 +61,7 @@ import type { ChangeEvent, ChildChangeEvent, TreeListItem } from '@kong/kongpone
 const emit = defineEmits<{
   (e: 'child-change', data: ChildChangeEvent): void,
   (e: 'delete'): void,
+  (e: 'download'): void,
   (e: 'edit'): void,
   (e: 'document-selection', data: TreeListItem): void,
   (e: 'modal-closed'): void,

--- a/packages/core/documentation/src/components/DocumentationDisplay.vue
+++ b/packages/core/documentation/src/components/DocumentationDisplay.vue
@@ -188,7 +188,7 @@ const handleDownloadDocument = (): void => {
     const data = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = data
-    link.download = `${fileName.value.replace(/(\.md)+$/g, '')}.md`
+    link.download = `${(fileName.value ? fileName.value : 'document').replace(/(\.md)+$/g, '')}.md`
 
     // link.click() doesn't work in Firefox
     link.dispatchEvent(

--- a/packages/core/documentation/src/components/DocumentationDisplay.vue
+++ b/packages/core/documentation/src/components/DocumentationDisplay.vue
@@ -39,6 +39,19 @@
       <div
         class="document-display-actions"
       >
+        <PermissionsWrapper
+          :auth-function="() => canEdit()"
+        >
+          <KInputSwitch
+            v-if="!hidePublishToggle && !card"
+            v-model="publishModel"
+            class="document-publish-toggle"
+            data-testid="document-publish-toggle"
+            :label="publishedStatusText"
+            label-before
+            @click="handlePublishToggle"
+          />
+        </PermissionsWrapper>
         <KButton
           v-if="!!selectedDocument.markdown"
           appearance="secondary"
@@ -52,15 +65,6 @@
         <PermissionsWrapper
           :auth-function="() => canEdit()"
         >
-          <KInputSwitch
-            v-if="!hidePublishToggle && !card"
-            v-model="publishModel"
-            class="document-publish-toggle"
-            data-testid="document-publish-toggle"
-            :label="publishedStatusText"
-            label-before
-            @click="handlePublishToggle"
-          />
           <KButton
             appearance="secondary"
             class="document-edit-button"
@@ -184,7 +188,7 @@ const handleDownloadDocument = (): void => {
     const data = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = data
-    link.download = `${fileName.value.replace(/ /g, '-').replace(/[^-+.a-zA-Z0-9_]/g, '').replace(/(\.md)+$/g, '')}.md`
+    link.download = `${fileName.value.replace(/(\.md)+$/g, '')}.md`
 
     // link.click() doesn't work in Firefox
     link.dispatchEvent(
@@ -298,6 +302,7 @@ const handleDocument = () => {
     margin-right: $kui-space-80;
   }
 
+  .document-download-button,
   .document-edit-button {
     margin-right: $kui-space-40;
   }

--- a/packages/core/documentation/src/locales/en.json
+++ b/packages/core/documentation/src/locales/en.json
@@ -8,6 +8,7 @@
       "added_label": "Added: ",
       "status_label": "Status: ",
       "edit_button": "Edit",
+      "download_button": "Download",
       "add_new": "Add Page"
     },
     "errors": {


### PR DESCRIPTION
# Summary

Add document download functionality to the `documentation` package.
