### PR TITLE
fix(entities-gateway-serviecs): empty list title when readonly

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -329,7 +329,7 @@ const emptyStateOptions = computed((): EmptyStateOptions => {
     ctaPath: props.config.createRoute,
     ctaText: userCanCreate.value ? t('actions.create') : undefined,
     message: t('gateway_services.list.empty_state.description'),
-    title: userCanCreate.value ? t('gateway_services.list.empty_state.title') : '',
+    title: userCanCreate.value ? t('gateway_services.list.empty_state.title') : t('gateway_services.title'),
   }
 })
 


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Fixing a bug where the empty service list has no title for users without create permission.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
