### PR TITLE
feat(*): reuse preprocessing form fields for config forms and save [khcp-10152]

### DIFF
--- a/packages/entities/entities-certificates/sandbox/pages/CACertificateFormPage.vue
+++ b/packages/entities/entities-certificates/sandbox/pages/CACertificateFormPage.vue
@@ -41,6 +41,7 @@ const konnectConfig = ref<KonnectCertificateFormConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   cancelRoute: { name: 'ca-certificate-list' },
+  jsonYamlFormsEnabled: true,
 })
 
 const kongManagerConfig = ref<KongManagerCertificateFormConfig>({

--- a/packages/entities/entities-certificates/sandbox/pages/CertificateFormPage.vue
+++ b/packages/entities/entities-certificates/sandbox/pages/CertificateFormPage.vue
@@ -41,6 +41,7 @@ const konnectConfig = ref<KonnectCertificateFormConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   cancelRoute: { name: 'certificate-list' },
+  jsonYamlFormsEnabled: true,
 })
 
 const kongManagerConfig = ref<KongManagerCertificateFormConfig>({

--- a/packages/entities/entities-certificates/src/components/CACertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateForm.vue
@@ -187,11 +187,13 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
-const requestBody: Record<string, any> = {
-  cert: form.fields.cert,
-  cert_digest: form.fields.certDigest || null,
-  tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
-}
+const requestBody = computed((): Record<string, any> => {
+  return {
+    cert: form.fields.cert,
+    cert_digest: form.fields.certDigest || null,
+    tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
+  }
+})
 
 const saveFormData = async (): Promise<void> => {
   try {
@@ -199,16 +201,16 @@ const saveFormData = async (): Promise<void> => {
 
     let response: AxiosResponse | undefined
 
-    await axiosInstance.post(validateSubmitUrl.value, requestBody)
+    await axiosInstance.post(validateSubmitUrl.value, requestBody.value)
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, requestBody)
+      response = await axiosInstance.post(submitUrl.value, requestBody.value)
     } else if (formType.value === 'edit') {
       response = props.config?.app === 'konnect'
         // Note: Konnect currently uses PUT because PATCH is not fully supported in Koko
         //       If this changes, the `edit` form methods should be re-evaluated/updated accordingly
-        ? await axiosInstance.put(submitUrl.value, requestBody)
-        : await axiosInstance.patch(submitUrl.value, requestBody)
+        ? await axiosInstance.put(submitUrl.value, requestBody.value)
+        : await axiosInstance.patch(submitUrl.value, requestBody.value)
     }
 
     form.fields.cert = response?.data?.cert || ''

--- a/packages/entities/entities-certificates/src/components/CACertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateForm.vue
@@ -6,7 +6,7 @@
       :edit-id="certificateId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="form.fields"
+      :form-fields="requestBody"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -187,15 +187,15 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
+const requestBody: Record<string, any> = {
+  cert: form.fields.cert,
+  cert_digest: form.fields.certDigest || null,
+  tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
+}
+
 const saveFormData = async (): Promise<void> => {
   try {
     form.isReadonly = true
-
-    const requestBody: Record<string, any> = {
-      cert: form.fields.cert,
-      cert_digest: form.fields.certDigest || null,
-      tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
-    }
 
     let response: AxiosResponse | undefined
 

--- a/packages/entities/entities-certificates/src/components/CertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.vue
@@ -255,13 +255,15 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
-const requestBody: Record<string, any> = {
-  cert: form.fields.cert,
-  key: form.fields.key,
-  cert_alt: form.fields.certAlt || null,
-  key_alt: form.fields.keyAlt || null,
-  tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
-}
+const requestBody = computed((): Record<string, any> => {
+  return {
+    cert: form.fields.cert,
+    key: form.fields.key,
+    cert_alt: form.fields.certAlt || null,
+    key_alt: form.fields.keyAlt || null,
+    tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
+  }
+})
 
 const saveFormData = async (): Promise<void> => {
   try {
@@ -269,16 +271,16 @@ const saveFormData = async (): Promise<void> => {
 
     let response: AxiosResponse | undefined
 
-    await axiosInstance.post(validateSubmitUrl.value, requestBody)
+    await axiosInstance.post(validateSubmitUrl.value, requestBody.value)
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, requestBody)
+      response = await axiosInstance.post(submitUrl.value, requestBody.value)
     } else if (formType.value === 'edit') {
       response = props.config?.app === 'konnect'
         // Note: Konnect currently uses PUT because PATCH is not fully supported in Koko
         //       If this changes, the `edit` form methods should be re-evaluated/updated accordingly
-        ? await axiosInstance.put(submitUrl.value, requestBody)
-        : await axiosInstance.patch(submitUrl.value, requestBody)
+        ? await axiosInstance.put(submitUrl.value, requestBody.value)
+        : await axiosInstance.patch(submitUrl.value, requestBody.value)
     }
 
     form.fields.cert = response?.data?.cert || ''

--- a/packages/entities/entities-certificates/src/components/CertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.vue
@@ -6,7 +6,7 @@
       :edit-id="certificateId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="form.fields"
+      :form-fields="requestBody"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -255,17 +255,17 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
+const requestBody: Record<string, any> = {
+  cert: form.fields.cert,
+  key: form.fields.key,
+  cert_alt: form.fields.certAlt || null,
+  key_alt: form.fields.keyAlt || null,
+  tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
+}
+
 const saveFormData = async (): Promise<void> => {
   try {
     form.isReadonly = true
-
-    const requestBody: Record<string, any> = {
-      cert: form.fields.cert,
-      key: form.fields.key,
-      cert_alt: form.fields.certAlt || null,
-      key_alt: form.fields.keyAlt || null,
-      tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
-    }
 
     let response: AxiosResponse | undefined
 

--- a/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupFormPage.vue
+++ b/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupFormPage.vue
@@ -45,6 +45,7 @@ const konnectConfig = ref<KonnectConsumerGroupFormConfig>({
   apiBaseUrl: '/us/kong-api/konnect-api',
   controlPlaneId,
   cancelRoute: { name: 'consumer-group-list' },
+  jsonYamlFormsEnabled: true,
 })
 
 const KMConfig = ref<KongManagerConsumerGroupFormConfig>({

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
@@ -6,7 +6,7 @@
       :edit-id="consumerGroupId"
       :error-message="state.errorMessage || fetchError || preValidateErrorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getPayload()"
+      :form-fields="getPayload"
       :is-readonly="state.readonly"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler($event)"
@@ -241,10 +241,12 @@ const preValidateErrorMessage = computed(() => {
   return namePattern.test(state.fields.name) ? '' : t('consumer_groups.form.validation_errors.name')
 })
 
-const getPayload = (): ConsumerGroupPayload => ({
-  name: state.fields.name,
-  tags: state.fields.tags.split(',')?.map((tag: string) => String(tag || '')
-    .trim())?.filter((tag: string) => tag !== ''),
+const getPayload = computed((): ConsumerGroupPayload => {
+  return {
+    name: state.fields.name,
+    tags: state.fields.tags.split(',')?.map((tag: string) => String(tag || '')
+      .trim())?.filter((tag: string) => tag !== ''),
+  }
 })
 
 const addConsumer = async (consumerId: string, groupId = ''): Promise<void> => {
@@ -281,7 +283,7 @@ const handleConsumers = (results: any[] | undefined, message: string, groupId = 
 const createGroup = async (): Promise<void> => {
   let newGroupId = ''
   try {
-    const { data } = await axiosInstance.post(getUrl('create'), getPayload())
+    const { data } = await axiosInstance.post(getUrl('create'), getPayload.value)
 
     newGroupId = ('item' in data) ? data.item.id : data.id
   } catch (e) {
@@ -306,9 +308,9 @@ const createGroup = async (): Promise<void> => {
 const updateGroup = async (): Promise<void> => {
   try {
     if (props.config?.app === 'konnect') {
-      await axiosInstance.put(getUrl('edit'), getPayload())
+      await axiosInstance.put(getUrl('edit'), getPayload.value)
     } else {
-      await axiosInstance.patch(getUrl('edit'), getPayload())
+      await axiosInstance.patch(getUrl('edit'), getPayload.value)
     }
   } catch (e) {
     emitError(e as AxiosError)

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
@@ -6,7 +6,7 @@
       :edit-id="consumerGroupId"
       :error-message="state.errorMessage || fetchError || preValidateErrorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="state.fields"
+      :form-fields="getPayload()"
       :is-readonly="state.readonly"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler($event)"

--- a/packages/entities/entities-consumers/sandbox/pages/ConsumerFormPage.vue
+++ b/packages/entities/entities-consumers/sandbox/pages/ConsumerFormPage.vue
@@ -45,6 +45,7 @@ const konnectConfig = ref<KonnectConsumerFormConfig>({
   apiBaseUrl: '/us/kong-api/konnect-api',
   controlPlaneId,
   cancelRoute: { name: 'consumer-list' },
+  jsonYamlFormsEnabled: true,
 })
 
 const KMConfig = ref<KongManagerConsumerFormConfig>({

--- a/packages/entities/entities-consumers/src/components/ConsumerForm.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerForm.vue
@@ -6,7 +6,7 @@
       :edit-id="consumerId"
       :error-message="state.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="state.fields"
+      :form-fields="payload"
       :is-readonly="state.readonly"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler($event)"
@@ -210,16 +210,16 @@ const getUrl = (action: 'validate' | 'create' | 'edit'): string => {
 const isFormValid = computed((): boolean => !!state.fields.username || !!state.fields.customId)
 const changesExist = computed((): boolean => JSON.stringify(state.fields) !== JSON.stringify(originalFields))
 
+const payload: ConsumerPayload = {
+  username: state.fields.username || null,
+  custom_id: state.fields.customId || null,
+  tags: state.fields.tags.split(',')?.map((tag: string) => String(tag || '')
+    .trim())?.filter((tag: string) => tag !== ''),
+}
+
 const submitData = async (): Promise<void> => {
   try {
     state.readonly = true
-
-    const payload: ConsumerPayload = {
-      username: state.fields.username || null,
-      custom_id: state.fields.customId || null,
-      tags: state.fields.tags.split(',')?.map((tag: string) => String(tag || '')
-        .trim())?.filter((tag: string) => tag !== ''),
-    }
 
     let response: AxiosResponse | undefined
 

--- a/packages/entities/entities-consumers/src/components/ConsumerForm.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerForm.vue
@@ -210,12 +210,14 @@ const getUrl = (action: 'validate' | 'create' | 'edit'): string => {
 const isFormValid = computed((): boolean => !!state.fields.username || !!state.fields.customId)
 const changesExist = computed((): boolean => JSON.stringify(state.fields) !== JSON.stringify(originalFields))
 
-const payload: ConsumerPayload = {
-  username: state.fields.username || null,
-  custom_id: state.fields.customId || null,
-  tags: state.fields.tags.split(',')?.map((tag: string) => String(tag || '')
-    .trim())?.filter((tag: string) => tag !== ''),
-}
+const payload = computed((): ConsumerPayload => {
+  return {
+    username: state.fields.username || null,
+    custom_id: state.fields.customId || null,
+    tags: state.fields.tags.split(',')?.map((tag: string) => String(tag || '')
+      .trim())?.filter((tag: string) => tag !== ''),
+  }
+})
 
 const submitData = async (): Promise<void> => {
   try {
@@ -223,14 +225,14 @@ const submitData = async (): Promise<void> => {
 
     let response: AxiosResponse | undefined
 
-    await axiosInstance.post(getUrl('validate'), payload)
+    await axiosInstance.post(getUrl('validate'), payload.value)
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(getUrl('create'), payload)
+      response = await axiosInstance.post(getUrl('create'), payload.value)
     } else if (formType.value === 'edit') {
       response = props.config?.app === 'konnect'
-        ? await axiosInstance.put(getUrl('edit'), payload)
-        : await axiosInstance.patch(getUrl('edit'), payload)
+        ? await axiosInstance.put(getUrl('edit'), payload.value)
+        : await axiosInstance.patch(getUrl('edit'), payload.value)
     }
 
     updateFormValues(response?.data)

--- a/packages/entities/entities-gateway-services/sandbox/pages/GatewayServiceFormPage.vue
+++ b/packages/entities/entities-gateway-services/sandbox/pages/GatewayServiceFormPage.vue
@@ -39,7 +39,9 @@ const konnectConfig = ref<KonnectGatewayServiceFormConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   cancelRoute: { name: 'gateway-services-list' },
+  jsonYamlFormsEnabled: true,
 })
+
 const kongManagerConfig = ref<KongManagerGatewayServiceFormConfig>({
   app: 'kongManager',
   // Uncomment to test compatibility with different Gateway editions and versions

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -6,7 +6,7 @@
       :edit-id="gatewayServiceId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getProcessedPayload()"
+      :form-fields="getProcessedPayload"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -765,18 +765,18 @@ const getPayload = (): Record<string, any> => {
   return requestBody
 }
 
-const getProcessedPayload = (): Record<string, any> => {
+const getProcessedPayload = computed((): Record<string, any> => {
   validateUrl()
   const processedPayload = getPayload()
   saveTlsVerify(processedPayload)
   return processedPayload
-}
+})
 
 const saveFormData = async (): Promise<AxiosResponse | undefined> => {
   try {
     form.isReadonly = true
 
-    const payload = getProcessedPayload()
+    const payload = getProcessedPayload.value
 
     let response: AxiosResponse | undefined
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -6,7 +6,7 @@
       :edit-id="gatewayServiceId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="form.fields"
+      :form-fields="getProcessedPayload()"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -765,16 +765,21 @@ const getPayload = (): Record<string, any> => {
   return requestBody
 }
 
+const getProcessedPayload = (): Record<string, any> => {
+  validateUrl()
+  const processedPayload = getPayload()
+  saveTlsVerify(processedPayload)
+  return processedPayload
+}
+
 const saveFormData = async (): Promise<AxiosResponse | undefined> => {
   try {
     form.isReadonly = true
 
-    validateUrl()
+    const payload = getProcessedPayload()
 
-    const payload = getPayload()
     let response: AxiosResponse | undefined
 
-    saveTlsVerify(payload)
     await axiosInstance.post(validateSubmitUrl.value, payload)
 
     if (formType.value === 'create') {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -767,7 +767,7 @@ const getPayload = (): Record<string, any> => {
 
 const getProcessedPayload = computed((): Record<string, any> => {
   validateUrl()
-  const processedPayload = getPayload()
+  r getPayload()
   saveTlsVerify(processedPayload)
   return processedPayload
 })
@@ -777,6 +777,7 @@ const saveFormData = async (): Promise<AxiosResponse | undefined> => {
     form.isReadonly = true
 
     const payload = getProcessedPayload.value
+    saveTlsVerify(payload)
 
     let response: AxiosResponse | undefined
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -767,9 +767,8 @@ const getPayload = (): Record<string, any> => {
 
 const getProcessedPayload = computed((): Record<string, any> => {
   validateUrl()
-  r getPayload()
-  saveTlsVerify(processedPayload)
-  return processedPayload
+  return getPayload()
+
 })
 
 const saveFormData = async (): Promise<AxiosResponse | undefined> => {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -6,7 +6,7 @@
       :edit-id="gatewayServiceId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getProcessedPayload"
+      :form-fields="getProcessedPayload()"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -714,7 +714,7 @@ const saveTlsVerify = (gatewayService: Record<string, any>) => {
   delete gatewayService.tls_verify_value
 }
 
-const getPayload = (): Record<string, any> => {
+const getPayload = computed((): Record<string, any> => {
   const requestBody: Record<string, any> = {
     name: form.fields.name || null,
     tags: form.fields.tags ? form.fields.tags?.split(',').filter(tag => tag !== '') : null,
@@ -763,19 +763,18 @@ const getPayload = (): Record<string, any> => {
   }
 
   return requestBody
-}
-
-const getProcessedPayload = computed((): Record<string, any> => {
-  validateUrl()
-  return getPayload()
-
 })
+
+const getProcessedPayload = (): Record<string, any> => {
+  validateUrl()
+  return getPayload.value
+}
 
 const saveFormData = async (): Promise<AxiosResponse | undefined> => {
   try {
     form.isReadonly = true
 
-    const payload = getProcessedPayload.value
+    const payload = getProcessedPayload()
     saveTlsVerify(payload)
 
     let response: AxiosResponse | undefined
@@ -834,11 +833,11 @@ watch(() => props.gatewayServiceId, () => {
 
 watch(form.fields, (newValue) => {
   form.fields.port = getPort.getPortFromProtocol(newValue.protocol, String(newValue.port))
-  emit('model-updated', getPayload())
+  emit('model-updated', getPayload.value)
 })
 
 onMounted(() => {
-  emit('model-updated', getPayload())
+  emit('model-updated', getPayload.value)
 })
 
 defineExpose({

--- a/packages/entities/entities-key-sets/sandbox/pages/KeySetFormPage.vue
+++ b/packages/entities/entities-key-sets/sandbox/pages/KeySetFormPage.vue
@@ -38,6 +38,7 @@ const konnectConfig = ref<KonnectKeySetFormConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   cancelRoute: { name: 'key-set-list' },
+  jsonYamlFormsEnabled: true,
 })
 const kongManagerConfig = ref<KongManagerKeySetFormConfig>({
   app: 'kongManager',

--- a/packages/entities/entities-key-sets/src/components/KeySetForm.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetForm.vue
@@ -6,7 +6,7 @@
       :edit-id="keySetId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="form.fields"
+      :form-fields="requestBody"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -159,14 +159,14 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
+const requestBody: Record<string, any> = {
+  name: form.fields.name,
+  tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== '') || '',
+}
+
 const saveFormData = async (): Promise<void> => {
   try {
     form.isReadonly = true
-
-    const requestBody: Record<string, any> = {
-      name: form.fields.name,
-      tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== '') || '',
-    }
 
     let response: AxiosResponse | undefined
 

--- a/packages/entities/entities-key-sets/src/components/KeySetForm.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetForm.vue
@@ -159,10 +159,12 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
-const requestBody: Record<string, any> = {
-  name: form.fields.name,
-  tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== '') || '',
-}
+const requestBody = computed((): Record<string, any> => {
+  return {
+    name: form.fields.name,
+    tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== '') || '',
+  }
+})
 
 const saveFormData = async (): Promise<void> => {
   try {
@@ -171,13 +173,13 @@ const saveFormData = async (): Promise<void> => {
     let response: AxiosResponse | undefined
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, requestBody)
+      response = await axiosInstance.post(submitUrl.value, requestBody.value)
     } else if (formType.value === 'edit') {
       response = props.config?.app === 'konnect'
         // Note: Konnect currently uses PUT because PATCH is not fully supported in Koko
         //       If this changes, the `edit` form methods should be re-evaluated/updated accordingly
-        ? await axiosInstance.put(submitUrl.value, requestBody)
-        : await axiosInstance.patch(submitUrl.value, requestBody)
+        ? await axiosInstance.put(submitUrl.value, requestBody.value)
+        : await axiosInstance.patch(submitUrl.value, requestBody.value)
     }
 
     if (response) {

--- a/packages/entities/entities-keys/sandbox/pages/KeyFormPage.vue
+++ b/packages/entities/entities-keys/sandbox/pages/KeyFormPage.vue
@@ -51,6 +51,7 @@ const konnectConfig = ref<KonnectKeyFormConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   cancelRoute: { name: 'key-list' },
+  jsonYamlFormsEnabled: true,
 })
 
 const kongManagerConfig = ref<KongManagerKeyFormConfig>({

--- a/packages/entities/entities-keys/src/components/KeyForm.vue
+++ b/packages/entities/entities-keys/src/components/KeyForm.vue
@@ -333,14 +333,16 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
-const requestBody: Record<string, any> = {
-  kid: form.fields.key_id,
-  name: form.fields.name || null,
-  tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== '') || [],
-  set: form.fields.key_set ? { id: form.fields.key_set } : null,
-  jwk: form.fields.key_format === 'jwk' ? form.fields.jwk : null,
-  pem: form.fields.key_format === 'pem' ? { private_key: form.fields.private_key, public_key: form.fields.public_key } : null,
-}
+const requestBody = computed((): Record<string, any> => {
+  return {
+    kid: form.fields.key_id,
+    name: form.fields.name || null,
+    tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== '') || [],
+    set: form.fields.key_set ? { id: form.fields.key_set } : null,
+    jwk: form.fields.key_format === 'jwk' ? form.fields.jwk : null,
+    pem: form.fields.key_format === 'pem' ? { private_key: form.fields.private_key, public_key: form.fields.public_key } : null,
+  }
+})
 
 const saveFormData = async (): Promise<void> => {
   try {
@@ -349,13 +351,13 @@ const saveFormData = async (): Promise<void> => {
     let response: AxiosResponse | undefined
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, requestBody)
+      response = await axiosInstance.post(submitUrl.value, requestBody.value)
     } else if (formType.value === 'edit') {
       response = props.config?.app === 'konnect'
         // Note: Konnect currently uses PUT because PATCH is not fully supported in Koko
         //       If this changes, the `edit` form methods should be re-evaluated/updated accordingly
-        ? await axiosInstance.put(submitUrl.value, requestBody)
-        : await axiosInstance.patch(submitUrl.value, requestBody)
+        ? await axiosInstance.put(submitUrl.value, requestBody.value)
+        : await axiosInstance.patch(submitUrl.value, requestBody.value)
     }
 
     if (response) {

--- a/packages/entities/entities-keys/src/components/KeyForm.vue
+++ b/packages/entities/entities-keys/src/components/KeyForm.vue
@@ -6,7 +6,7 @@
       :edit-id="keyId"
       :error-message="form.errorMessage || fetchKeySetsErrorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="form.fields"
+      :form-fields="requestBody"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -333,18 +333,18 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
+const requestBody: Record<string, any> = {
+  kid: form.fields.key_id,
+  name: form.fields.name || null,
+  tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== '') || [],
+  set: form.fields.key_set ? { id: form.fields.key_set } : null,
+  jwk: form.fields.key_format === 'jwk' ? form.fields.jwk : null,
+  pem: form.fields.key_format === 'pem' ? { private_key: form.fields.private_key, public_key: form.fields.public_key } : null,
+}
+
 const saveFormData = async (): Promise<void> => {
   try {
     form.isReadonly = true
-
-    const requestBody: Record<string, any> = {
-      kid: form.fields.key_id,
-      name: form.fields.name || null,
-      tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== '') || [],
-      set: form.fields.key_set ? { id: form.fields.key_set } : null,
-      jwk: form.fields.key_format === 'jwk' ? form.fields.jwk : null,
-      pem: form.fields.key_format === 'pem' ? { private_key: form.fields.private_key, public_key: form.fields.public_key } : null,
-    }
 
     let response: AxiosResponse | undefined
 

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -25,7 +25,7 @@
       :edit-id="pluginId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getRequestBody()"
+      :form-fields="getRequestBody"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -965,7 +965,7 @@ const isCustomPlugin = computed((): boolean => {
   return !Object.keys(pluginMetaData).includes(props.pluginType)
 })
 
-const getRequestBody = () => {
+const getRequestBody = computed(() => {
   const requestBody: Record<string, any> = submitPayload.value
   // credentials incorrectly build the entity id object
   if (treatAsCredential.value) {
@@ -980,7 +980,7 @@ const getRequestBody = () => {
     delete requestBody.created_at
   }
   return requestBody
-}
+})
 
 // make the actual API request to save on create/edit
 const saveFormData = async (): Promise<void> => {
@@ -997,17 +997,17 @@ const saveFormData = async (): Promise<void> => {
     // TODO: determine validate URL for credentials
     // don't validate custom plugins
     if (!treatAsCredential.value && !isCustomPlugin.value) {
-      await axiosInstance.post(validateSubmitUrl.value, getRequestBody())
+      await axiosInstance.post(validateSubmitUrl.value, getRequestBody.value)
     }
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, getRequestBody())
+      response = await axiosInstance.post(submitUrl.value, getRequestBody.value)
     } else if (formType.value === 'edit') {
       response = props.config.app === 'konnect'
         // Note: Konnect currently uses PUT because PATCH is not fully supported in Koko
         //       If this changes, the `edit` form methods should be re-evaluated/updated accordingly
-        ? await axiosInstance.put(submitUrl.value, getRequestBody())
-        : await axiosInstance.patch(submitUrl.value, getRequestBody())
+        ? await axiosInstance.put(submitUrl.value, getRequestBody.value)
+        : await axiosInstance.patch(submitUrl.value, getRequestBody.value)
     }
 
     // Set initial state of `formFieldsOriginal` to these values in order to detect changes

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -965,7 +965,7 @@ const isCustomPlugin = computed((): boolean => {
   return !Object.keys(pluginMetaData).includes(props.pluginType)
 })
 
-const getRequestBody = computed(() => {
+const getRequestBody = computed((): Record<string, any> => {
   const requestBody: Record<string, any> = submitPayload.value
   // credentials incorrectly build the entity id object
   if (treatAsCredential.value) {

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -25,7 +25,7 @@
       :edit-id="pluginId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="form.fields"
+      :form-fields="getRequestBody()"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -965,6 +965,23 @@ const isCustomPlugin = computed((): boolean => {
   return !Object.keys(pluginMetaData).includes(props.pluginType)
 })
 
+const getRequestBody = () => {
+  const requestBody: Record<string, any> = submitPayload.value
+  // credentials incorrectly build the entity id object
+  if (treatAsCredential.value) {
+    for (const key in PluginScope) {
+      const entityKey = PluginScope[key as keyof typeof PluginScope]
+      // ex. { consumer: '1234-567-899' } => { consumer: { id: '1234-567-899' } }
+      if (requestBody[entityKey] && !requestBody[entityKey].id) {
+        requestBody[entityKey] = { id: props.config.entityId }
+      }
+    }
+
+    delete requestBody.created_at
+  }
+  return requestBody
+}
+
 // make the actual API request to save on create/edit
 const saveFormData = async (): Promise<void> => {
   // if save/cancel buttons are hidden, don't submit on hitting Enter
@@ -975,36 +992,22 @@ const saveFormData = async (): Promise<void> => {
   try {
     form.isReadonly = true
 
-    const requestBody: Record<string, any> = submitPayload.value
     let response: AxiosResponse | undefined
-
-    // credentials incorrectly build the entity id object
-    if (treatAsCredential.value) {
-      for (const key in PluginScope) {
-        const entityKey = PluginScope[key as keyof typeof PluginScope]
-        // ex. { consumer: '1234-567-899' } => { consumer: { id: '1234-567-899' } }
-        if (requestBody[entityKey] && !requestBody[entityKey].id) {
-          requestBody[entityKey] = { id: props.config.entityId }
-        }
-      }
-
-      delete requestBody.created_at
-    }
 
     // TODO: determine validate URL for credentials
     // don't validate custom plugins
     if (!treatAsCredential.value && !isCustomPlugin.value) {
-      await axiosInstance.post(validateSubmitUrl.value, requestBody)
+      await axiosInstance.post(validateSubmitUrl.value, getRequestBody())
     }
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, requestBody)
+      response = await axiosInstance.post(submitUrl.value, getRequestBody())
     } else if (formType.value === 'edit') {
       response = props.config.app === 'konnect'
         // Note: Konnect currently uses PUT because PATCH is not fully supported in Koko
         //       If this changes, the `edit` form methods should be re-evaluated/updated accordingly
-        ? await axiosInstance.put(submitUrl.value, requestBody)
-        : await axiosInstance.patch(submitUrl.value, requestBody)
+        ? await axiosInstance.put(submitUrl.value, getRequestBody())
+        : await axiosInstance.patch(submitUrl.value, getRequestBody())
     }
 
     // Set initial state of `formFieldsOriginal` to these values in order to detect changes

--- a/packages/entities/entities-routes/sandbox/pages/RouteFormPage.vue
+++ b/packages/entities/entities-routes/sandbox/pages/RouteFormPage.vue
@@ -67,6 +67,7 @@ const konnectConfig = ref<KonnectRouteFormConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   cancelRoute: { name: 'route-list' },
+  jsonYamlFormsEnabled: true,
 })
 
 const kongManagerConfig = ref<KongManagerRouteFormConfig>({

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -875,9 +875,9 @@ watch(() => form.fields, () => {
 
 const getArrPayload = (arr?: any[]) => arr?.length ? arr : null
 
-const getPayload = computed((serviceId?: string): RoutePayload => {
+const getPayload = computed((): RoutePayload => {
   const payload: RoutePayload = {
-    service: (form.fields.service_id || serviceId) ? { id: serviceId || form.fields.service_id } : null,
+    service: (form.fields.service_id) ? { id: form.fields.service_id } : null,
     ...(!props.hideNameField && { name: form.fields.name || null }),
     paths: getArrPayload(cleanDataArr(RoutingRulesEntities.PATHS, form.fields.paths || [])),
     snis: getArrPayload(cleanDataArr(RoutingRulesEntities.SNIS, form.fields.snis || [])),

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -6,7 +6,7 @@
       :edit-id="routeId"
       :error-message="form.errorMessage || fetchServicesErrorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="form.fields"
+      :form-fields="getPayload()"
       :is-readonly="form.isReadonly"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -6,7 +6,7 @@
       :edit-id="routeId"
       :error-message="form.errorMessage || fetchServicesErrorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getPayload()"
+      :form-fields="getPayload"
       :is-readonly="form.isReadonly"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"
@@ -870,12 +870,12 @@ const submitUrl = computed<string>(() => {
 })
 
 watch(() => form.fields, () => {
-  emit('model-updated', getPayload())
+  emit('model-updated', getPayload.value)
 }, { deep: true })
 
 const getArrPayload = (arr?: any[]) => arr?.length ? arr : null
 
-const getPayload = (serviceId?: string): RoutePayload => {
+const getPayload = computed((serviceId?: string): RoutePayload => {
   const payload: RoutePayload = {
     service: (form.fields.service_id || serviceId) ? { id: serviceId || form.fields.service_id } : null,
     ...(!props.hideNameField && { name: form.fields.name || null }),
@@ -919,10 +919,10 @@ const getPayload = (serviceId?: string): RoutePayload => {
   }
 
   return payload
-}
+})
 
 const saveFormData = async (payload?: RoutePayload): Promise<void> => {
-  const validPayload: RoutePayload = (payload && isRoutePayloadValid(payload)) ? payload : getPayload()
+  const validPayload: RoutePayload = (payload && isRoutePayloadValid(payload)) ? payload : getPayload.value
 
   try {
     form.isReadonly = true
@@ -977,7 +977,7 @@ onBeforeMount(async () => {
 })
 
 onMounted(() => {
-  emit('model-updated', getPayload())
+  emit('model-updated', getPayload.value)
 })
 
 defineExpose({ saveFormData, getPayload })

--- a/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType, reactive } from 'vue'
+import { computed, type PropType } from 'vue'
 import type { BadgeAppearance } from '@kong/kongponents/dist/types'
 import type { KonnectBaseEntityConfig, KongManagerBaseEntityConfig, KonnectBaseFormConfig, KongManagerBaseFormConfig } from '../../types'
 
@@ -57,7 +57,7 @@ const props = defineProps({
   },
 })
 
-const jsonContent = reactive(props.jsonRecord)
+const jsonContent = computed(() => props.jsonRecord)
 
 const displayedCharLength = computed((): number => {
   if (!props.fetcherUrl) {

--- a/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
@@ -57,7 +57,7 @@ const props = defineProps({
   },
 })
 
-const jsonContent = computed(() => props.jsonRecord)
+const jsonContent = computed((): Record<string, any> => props.jsonRecord)
 
 const displayedCharLength = computed((): number => {
   if (!props.fetcherUrl) {

--- a/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
@@ -23,7 +23,7 @@ const props = defineProps({
   },
 })
 
-const yamlContent = computed(() => props.yamlRecord)
+const yamlContent = computed((): Record<string, any> => props.yamlRecord)
 </script>
 
 <style lang="scss">

--- a/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
@@ -13,7 +13,7 @@
 <script setup lang="ts">
 import yaml from 'js-yaml'
 import type { PropType } from 'vue'
-import { reactive } from 'vue'
+import { computed } from 'vue'
 
 const props = defineProps({
   /** A record to indicate the entity's configuration, used to populate the YAML code block */
@@ -23,7 +23,7 @@ const props = defineProps({
   },
 })
 
-const yamlContent = reactive(props.yamlRecord)
+const yamlContent = computed(() => props.yamlRecord)
 </script>
 
 <style lang="scss">

--- a/packages/entities/entities-snis/sandbox/pages/SniFormPage.vue
+++ b/packages/entities/entities-snis/sandbox/pages/SniFormPage.vue
@@ -41,8 +41,10 @@ const konnectConfig = ref<KonnectSniFormConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   cancelRoute: { name: 'snis-list' },
+  jsonYamlFormsEnabled: true,
   // uncomment to see create with provided certificate
   /* certificateId: '1234-ilove-cats', */
+
 })
 
 const kongManagerConfig = ref<KongManagerSniFormConfig>({

--- a/packages/entities/entities-snis/src/components/SniForm.vue
+++ b/packages/entities/entities-snis/src/components/SniForm.vue
@@ -228,11 +228,13 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
-const requestBody: Record<string, any> = {
-  name: form.fields.name,
-  tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
-  certificate: { id: certificateId.value || form.fields.certificate_id },
-}
+const requestBody = computed((): Record<string, any> => {
+  return {
+    name: form.fields.name,
+    tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
+    certificate: { id: certificateId.value || form.fields.certificate_id },
+  }
+})
 
 const saveFormData = async (): Promise<void> => {
   try {
@@ -240,16 +242,16 @@ const saveFormData = async (): Promise<void> => {
 
     let response: AxiosResponse | undefined
 
-    await axiosInstance.post(validateSubmitUrl.value, requestBody)
+    await axiosInstance.post(validateSubmitUrl.value, requestBody.value)
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, requestBody)
+      response = await axiosInstance.post(submitUrl.value, requestBody.value)
     } else if (formType.value === 'edit') {
       response = props.config?.app === 'konnect'
         // Note: Konnect currently uses PUT because PATCH is not fully supported in Koko
         //       If this changes, the `edit` form methods should be re-evaluated/updated accordingly
-        ? await axiosInstance.put(submitUrl.value, requestBody)
-        : await axiosInstance.patch(submitUrl.value, requestBody)
+        ? await axiosInstance.put(submitUrl.value, requestBody.value)
+        : await axiosInstance.patch(submitUrl.value, requestBody.value)
     }
 
     form.fields.name = response?.data?.name || ''

--- a/packages/entities/entities-snis/src/components/SniForm.vue
+++ b/packages/entities/entities-snis/src/components/SniForm.vue
@@ -6,7 +6,7 @@
       :edit-id="sniId"
       :error-message="form.errorMessage || fetchCertsErrorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="form.fields"
+      :form-fields="requestBody"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -228,15 +228,15 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
+const requestBody: Record<string, any> = {
+  name: form.fields.name,
+  tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
+  certificate: { id: certificateId.value || form.fields.certificate_id },
+}
+
 const saveFormData = async (): Promise<void> => {
   try {
     form.isReadonly = true
-
-    const requestBody: Record<string, any> = {
-      name: form.fields.name,
-      tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
-      certificate: { id: certificateId.value || form.fields.certificate_id },
-    }
 
     let response: AxiosResponse | undefined
 

--- a/packages/entities/entities-upstreams-targets/sandbox/pages/UpstreamFormPage.vue
+++ b/packages/entities/entities-upstreams-targets/sandbox/pages/UpstreamFormPage.vue
@@ -39,6 +39,7 @@ const konnectConfig = ref<KonnectUpstreamsFormConfig>({
   apiBaseUrl: '/us/kong-api/konnect-api',
   controlPlaneId,
   cancelRoute: { name: 'upstreams-list' },
+  jsonYamlFormsEnabled: true,
 })
 
 const KMConfig = ref<KongManagerUpstreamsFormConfig>({

--- a/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
@@ -233,12 +233,14 @@ const submitUrl = computed((): string => {
   return url
 })
 
-const requestBody: Record<string, any> = {
-  target: form.fields.target,
-  weight: parseInt(form.fields.weight as unknown as string),
-  tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
-  upstream: { id: props.config.upstreamId },
-}
+const requestBody = computed((): Record<string, any> => {
+  return {
+    target: form.fields.target,
+    weight: parseInt(form.fields.weight as unknown as string),
+    tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
+    upstream: { id: props.config.upstreamId },
+  }
+})
 
 const saveFormData = async (): Promise<void> => {
   try {
@@ -247,16 +249,16 @@ const saveFormData = async (): Promise<void> => {
 
     let response: AxiosResponse | undefined
 
-    await axiosInstance.post(validateSubmitUrl.value, requestBody)
+    await axiosInstance.post(validateSubmitUrl.value, requestBody.value)
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, requestBody)
+      response = await axiosInstance.post(submitUrl.value, requestBody.value)
     } else if (formType.value === 'edit') {
       response = props.config?.app === 'konnect'
         // Note: Konnect currently uses PUT because PATCH is not fully supported in Koko
         //       If this changes, the `edit` form methods should be re-evaluated/updated accordingly
-        ? await axiosInstance.put(submitUrl.value, requestBody)
-        : await axiosInstance.patch(submitUrl.value, requestBody)
+        ? await axiosInstance.put(submitUrl.value, requestBody.value)
+        : await axiosInstance.patch(submitUrl.value, requestBody.value)
     }
 
     if (response) {

--- a/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
@@ -15,7 +15,7 @@
           :edit-id="targetId"
           :error-message="form.errorMessage"
           :fetch-url="fetchUrl"
-          :form-fields="form.fields"
+          :form-fields="requestBody"
           :is-readonly="form.isReadonly"
           @cancel="onCancel"
           @fetch:error="(err: any) => $emit('error', err)"
@@ -233,17 +233,17 @@ const submitUrl = computed((): string => {
   return url
 })
 
+const requestBody: Record<string, any> = {
+  target: form.fields.target,
+  weight: parseInt(form.fields.weight as unknown as string),
+  tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
+  upstream: { id: props.config.upstreamId },
+}
+
 const saveFormData = async (): Promise<void> => {
   try {
     form.isReadonly = true
     form.errorMessage = ''
-
-    const requestBody: Record<string, any> = {
-      target: form.fields.target,
-      weight: parseInt(form.fields.weight as unknown as string),
-      tags: form.fields.tags?.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
-      upstream: { id: props.config.upstreamId },
-    }
 
     let response: AxiosResponse | undefined
 

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
@@ -6,7 +6,7 @@
       :edit-id="upstreamId"
       :error-message="state.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="state.fields"
+      :form-fields="getPayload()"
       :is-readonly="state.readonly"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
@@ -6,7 +6,7 @@
       :edit-id="upstreamId"
       :error-message="state.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getPayload()"
+      :form-fields="getPayload"
       :is-readonly="state.readonly"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"
@@ -232,7 +232,7 @@ const fetchErrorHandler = (err: AxiosError): void => {
   emit('error', err)
 }
 
-const getPayload = (): UpstreamFormPayload => {
+const getPayload = computed((): UpstreamFormPayload => {
   const result: UpstreamFormPayload = {
     name: state.fields.name,
     slots: Number(state.fields.slots),
@@ -429,7 +429,7 @@ const getPayload = (): UpstreamFormPayload => {
   }
 
   return result
-}
+})
 
 const getUrl = (action: UpstreamsFormActions): string => {
   let url = `${props.config?.apiBaseUrl}${endpoints.form[props.config?.app][action]}`
@@ -449,16 +449,16 @@ const submitData = async (): Promise<void> => {
   try {
     state.readonly = true
 
-    await axiosInstance.post(getUrl('validate'), getPayload())
+    await axiosInstance.post(getUrl('validate'), getPayload.value)
 
     let response: AxiosResponse | undefined
 
     if (formType.value === EntityBaseFormType.Create) {
-      response = await axiosInstance.post(getUrl('create'), getPayload())
+      response = await axiosInstance.post(getUrl('create'), getPayload.value)
     } else if (formType.value === EntityBaseFormType.Edit) {
       response = props.config?.app === 'konnect'
-        ? await axiosInstance.put(getUrl('edit'), getPayload())
-        : await axiosInstance.patch(getUrl('edit'), getPayload())
+        ? await axiosInstance.put(getUrl('edit'), getPayload.value)
+        : await axiosInstance.patch(getUrl('edit'), getPayload.value)
     }
 
     emit('update', response?.data as UpstreamResponse)

--- a/packages/entities/entities-vaults/sandbox/pages/VaultFormPage.vue
+++ b/packages/entities/entities-vaults/sandbox/pages/VaultFormPage.vue
@@ -36,6 +36,7 @@ const konnectConfig = ref<KonnectVaultFormConfig>({
   controlPlaneId,
   cancelRoute: { name: 'vault-list' },
   azureVaultProviderAvailable: true,
+  jsonYamlFormsEnabled: true,
   ttl: true,
 })
 

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -6,7 +6,7 @@
       :edit-id="vaultId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getPayload()"
+      :form-fields="getPayload"
       :is-readonly="form.isReadonly"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"
@@ -753,7 +753,7 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
-const getPayload = () => {
+const getPayload = computed(() => {
   const hcvConfig = {
     protocol: configFields[VaultProviders.HCV].protocol,
     host: configFields[VaultProviders.HCV].host,
@@ -806,7 +806,7 @@ const getPayload = () => {
   }
 
   return payload
-}
+})
 
 const saveFormData = async (): Promise<void> => {
   try {
@@ -815,11 +815,11 @@ const saveFormData = async (): Promise<void> => {
     let response: AxiosResponse | undefined
 
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, getPayload())
+      response = await axiosInstance.post(submitUrl.value, getPayload.value)
     } else if (formType.value === 'edit') {
       response = props.config?.app === 'konnect'
-        ? await axiosInstance.put(submitUrl.value, getPayload())
-        : await axiosInstance.patch(submitUrl.value, getPayload())
+        ? await axiosInstance.put(submitUrl.value, getPayload.value)
+        : await axiosInstance.patch(submitUrl.value, getPayload.value)
     }
 
     updateFormValues(response?.data)

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -753,7 +753,7 @@ const submitUrl = computed<string>(() => {
   return url
 })
 
-const getPayload = computed(() => {
+const getPayload = computed((): Record<string, any> => {
   const hcvConfig = {
     protocol: configFields[VaultProviders.HCV].protocol,
     host: configFields[VaultProviders.HCV].host,


### PR DESCRIPTION

# Summary
https://konghq.atlassian.net/browse/KHCP-10152
Extracted preprocessing form fields logic in reusable helpers, for use in both JSON/YAML config forms and form submission

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


