### PR TITLE
feat(ai-plugins): added all AI plugins, included complex array schemas [KAG-3542]

### DIFF
--- a/packages/entities/entities-plugins/fixtures/mockData.ts
+++ b/packages/entities/entities-plugins/fixtures/mockData.ts
@@ -390,6 +390,30 @@ export const kmAvailablePlugins = {
         version: '3.6.0',
         priority: 400,
       },
+      "ai-response-transformer": {
+        version: "3.6.0",
+        priority: 777
+      },
+      "ai-prompt-template": {
+        version: "3.6.0",
+        priority: 773
+      },
+      "ai-prompt-decorator": {
+        version: "3.6.0",
+        priority: 772
+      },
+      "ai-prompt-guard": {
+        version: "3.6.0",
+        priority: 771
+      },
+      "ai-proxy": {
+        version: "3.6.0",
+        priority: 770
+      },
+      "ai-request-transformer": {
+        version: "3.6.0",
+        priority: 769
+      },
       mocking: {
         version: '3.6.0',
         priority: -1,

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/AIPromptDecorator.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/AIPromptDecorator.ts
@@ -1,0 +1,58 @@
+import type { AIPromptDecoratorSchema } from '../../types/plugins/ai-prompt-decorator'
+import { arrayCardContainerFieldSchema } from './ArrayCardContainerFields'
+
+export const aiPromptDecoratorSchema: AIPromptDecoratorSchema = {
+  'config-prompts-prepend': {
+    ...arrayCardContainerFieldSchema,
+    newElementButtonLabel: '+ Add Message',
+    items: {
+      type: 'object',
+      schema: {
+        fields: [{
+          label: 'Role',
+          model: 'role',
+          help: 'LLM message role',
+          type: 'select',
+          values: [
+            'system',
+            'assistant',
+            'user',
+          ],
+        }, {
+          label: 'Content',
+          model: 'content',
+          type: 'input',
+          help: 'LLM message content',
+          inputType: 'text',
+        }],
+      },
+    },
+  },
+
+  'config-prompts-append': {
+    ...arrayCardContainerFieldSchema,
+    newElementButtonLabel: '+ Add Message',
+    items: {
+      type: 'object',
+      schema: {
+        fields: [{
+          label: 'Role',
+          model: 'role',
+          help: 'LLM message role',
+          type: 'select',
+          values: [
+            'system',
+            'assistant',
+            'user',
+          ],
+        }, {
+          label: 'Content',
+          model: 'content',
+          type: 'input',
+          help: 'LLM message content',
+          inputType: 'text',
+        }],
+      },
+    },
+  },
+}

--- a/packages/entities/entities-plugins/src/composables/plugin-schemas/AIPromptTemplate.ts
+++ b/packages/entities/entities-plugins/src/composables/plugin-schemas/AIPromptTemplate.ts
@@ -1,0 +1,27 @@
+import type { AIPromptTemplateSchema } from '../../types/plugins/ai-prompt-template'
+import { arrayCardContainerFieldSchema } from './ArrayCardContainerFields'
+
+export const aiPromptTemplateSchema: AIPromptTemplateSchema = {
+  'config-templates': {
+    ...arrayCardContainerFieldSchema,
+    newElementButtonLabel: '+ Add Template',
+    items: {
+      type: 'object',
+      schema: {
+        fields: [{
+          label: 'Template Name',
+          model: 'name',
+          help: 'Template Name, for reference in user requests',
+          type: 'input',
+          inputType: 'text',
+        }, {
+          label: 'Template String',
+          model: 'template',
+          help: 'Template string content, containing {{placeholders}} for variable substitution',
+          type: 'textArea',
+          inputType: 'text',
+        }],
+      },
+    },
+  },
+}

--- a/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
+++ b/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
@@ -258,6 +258,48 @@ export const usePluginMetaData = () => {
       name: t('plugins.meta.route-by-header.name'),
       scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER],
     },
+    'ai-proxy': {
+      description: t('plugins.meta.ai-proxy.description'),
+      group: PluginGroup.SERVERLESS,
+      isEnterprise: true,
+      name: t('plugins.meta.ai-proxy.name'),
+      scope: [PluginScope.ROUTE]
+    },
+    'ai-prompt-decorator': {
+      description: t('plugins.meta.ai-prompt-decorator.description'),
+      group: PluginGroup.TRANSFORMATIONS,
+      isEnterprise: true,
+      name: t('plugins.meta.ai-prompt-decorator.name'),
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER],
+    },
+    'ai-prompt-template': {
+      description: t('plugins.meta.ai-prompt-template.description'),
+      group: PluginGroup.TRANSFORMATIONS,
+      isEnterprise: true,
+      name: t('plugins.meta.ai-prompt-template.name'),
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER],
+    },
+    'ai-prompt-guard': {
+      description: t('plugins.meta.ai-prompt-guard.description'),
+      group: PluginGroup.TRAFFIC_CONTROL,
+      isEnterprise: true,
+      name: t('plugins.meta.ai-prompt-guard.name'),
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER],
+    },
+    'ai-request-transformer': {
+      description: t('plugins.meta.ai-request-transformer.description'),
+      group: PluginGroup.TRANSFORMATIONS,
+      isEnterprise: true,
+      name: t('plugins.meta.ai-request-transformer.name'),
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE],
+    },
+    'ai-response-transformer': {
+      description: t('plugins.meta.ai-response-transformer.description'),
+      group: PluginGroup.TRANSFORMATIONS,
+      isEnterprise: true,
+      name: t('plugins.meta.ai-response-transformer.name'),
+      scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE],
+    },
     'aws-lambda': {
       description: t('plugins.meta.aws-lambda.description'),
       group: PluginGroup.SERVERLESS,

--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -12,6 +12,8 @@ import { preFunctionSchema } from './plugin-schemas/PreFunction'
 import { rateLimitingSchema } from './plugin-schemas/RateLimiting'
 import { requestTransformerAdvancedSchema } from './plugin-schemas/RequestTransformerAdvanced'
 import { routeByHeaderSchema } from './plugin-schemas/RouteByHeader'
+import { aiPromptDecoratorSchema } from './plugin-schemas/AIPromptDecorator'
+import { aiPromptTemplateSchema } from './plugin-schemas/AIPromptTemplate'
 import { graphqlRateLimitingAdvancedSchema } from './plugin-schemas/GraphQLRateLimitingAdvanced'
 import { statsDSchema } from './plugin-schemas/StatsD'
 import { samlSchema } from './plugin-schemas/SAML'
@@ -73,6 +75,14 @@ export const useSchemas = (entityId?: string, app?: 'konnect' | 'kongManager') =
 
     'route-by-header': {
       ...routeByHeaderSchema,
+    },
+
+    'ai-prompt-decorator': {
+      ...aiPromptDecoratorSchema,
+    },
+
+    'ai-prompt-template': {
+      ...aiPromptTemplateSchema,
     },
 
     'vault-auth': {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -237,6 +237,30 @@
         "name": "Route by Header",
         "description": "Route requests based on request headers"
       },
+      "ai-proxy": {
+        "name": "AI Proxy",
+        "description": "Directly call a configured LLM, with mediated security and tuning parameters, and using standardised Kong request and response formats."
+      },
+      "ai-prompt-decorator": {
+        "name": "AI Prompt Decorator",
+        "description": "Prepend and append chat prompts to AI Proxy plugin LLM requests."
+      },
+      "ai-prompt-template": {
+        "name": "AI Prompt Template",
+        "description": "Define a set of templates, containing string variable placeholders, that can be consumed by users when used with the AI Proxy plugin."
+      },
+      "ai-prompt-guard": {
+        "name": "AI Prompt Guard",
+        "description": "Define a set of valid, and a set of invalid, regular expression patterns when calling LLM models with the AI Proxy plugin."
+      },
+      "ai-request-transformer": {
+        "name": "AI Request Transformer",
+        "description": "Use an LLM to transform API request from a user, before sending to the upstream service."
+      },
+      "ai-response-transformer": {
+        "name": "AI Response Transformer",
+        "description": "Use an LLM to transform API responses from the upstream service, before returning to the user."
+      },
       "aws-lambda": {
         "name": "AWS Lambda",
         "description": "Invoke and manage AWS Lambda functions from Kong"

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -12,6 +12,8 @@ import type { KafkaSchema } from './plugins/kafka-schema'
 import type { UpstreamTlsSchema } from './plugins/upstream-tls'
 import type { RateLimitingSchema } from './plugins/rate-limiting'
 import type { RouteByHeaderSchema } from './plugins/route-by-header'
+import type { AIPromptDecoratorSchema } from './plugins/ai-prompt-decorator'
+import type { AIPromptTemplateSchema } from './plugins/ai-prompt-template'
 import type { VaultAuthSchema } from './plugins/vault-auth'
 import type { GraphQLRateLimitingAdvancedSchema } from './plugins/graphql-rate-limiting-advanced'
 import type { SAMLSchema } from './plugins/saml'
@@ -194,6 +196,8 @@ export interface CustomSchemas {
   'rate-limiting': RateLimitingSchema
   'rate-limiting-advanced': RateLimitingSchema
   'route-by-header': RouteByHeaderSchema
+  'ai-prompt-decorator': AIPromptDecoratorSchema
+  'ai-prompt-template': AIPromptTemplateSchema
   'vault-auth': VaultAuthSchema
   'graphql-rate-limiting-advanced': GraphQLRateLimitingAdvancedSchema
   'response-ratelimiting': RateLimitingSchema

--- a/packages/entities/entities-plugins/src/types/plugins/ai-prompt-decorator.d.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/ai-prompt-decorator.d.ts
@@ -1,0 +1,38 @@
+import type { Field, ItemsSchema, CommonSchemaFields } from './shared'
+
+type FieldForKeyValuePairs = Field & {
+  newElementButtonLabelClasses?: string
+  newElementButtonLabel?: string
+  keyInputPlaceholder?: string
+  valueInputPlaceholder?: string
+}
+
+type ItemsSchemaForKeyValuePairs = Omit<ItemsSchema, 'schema'> & {
+  schema: {
+    fields: FieldForKeyValuePairs[]
+  }
+}
+
+export interface AIPromptDecoratorSchema extends CommonSchemaFields {
+  'config-prompts-prepend': {
+    type: string
+    showRemoveButton: boolean
+    newElementButtonLabelClasses: string
+    itemContainerComponent: string
+    fieldClasses: string
+
+    newElementButtonLabel: string
+    items: ItemsSchemaForKeyValuePairs
+  }
+
+  'config-prompts-append': {
+    type: string
+    showRemoveButton: boolean
+    newElementButtonLabelClasses: string
+    itemContainerComponent: string
+    fieldClasses: string
+
+    newElementButtonLabel: string
+    items: ItemsSchemaForKeyValuePairs
+  }
+}

--- a/packages/entities/entities-plugins/src/types/plugins/ai-prompt-template.d.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/ai-prompt-template.d.ts
@@ -1,0 +1,27 @@
+import type { Field, ItemsSchema, CommonSchemaFields } from './shared'
+
+type FieldForKeyValuePairs = Field & {
+  newElementButtonLabelClasses?: string
+  newElementButtonLabel?: string
+  keyInputPlaceholder?: string
+  valueInputPlaceholder?: string
+}
+
+type ItemsSchemaForKeyValuePairs = Omit<ItemsSchema, 'schema'> & {
+  schema: {
+    fields: FieldForKeyValuePairs[]
+  }
+}
+
+export interface AIPromptTemplateSchema extends CommonSchemaFields {
+  'config-templates': {
+    type: string
+    showRemoveButton: boolean
+    newElementButtonLabelClasses: string
+    itemContainerComponent: string
+    fieldClasses: string
+
+    newElementButtonLabel: string
+    items: ItemsSchemaForKeyValuePairs
+  }
+}


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This PR adds complex schemas for rendering arrays-of-objects, in the following upcoming plugins:

- AI Prompt Decorator
- AI Prompt Template

As seen in screenshots here:

===

![image](https://github.com/Kong/public-ui-components/assets/91137069/1833dc62-99e7-4479-859a-b4efb36c283f)

===

![image](https://github.com/Kong/public-ui-components/assets/91137069/4c98c09f-30d6-4b3f-9f7a-43419edf2354)

===
It also adds menu options, in the right categories, for all upcoming AI plugins:

- AI Proxy
- AI Prompt Decorator
- AI Prompt Template
- AI Prompt Guard
- AI Request Transformer
- AI Response Transformer


#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
