### PR TITLE
fix(gatewayServicesForm): not use computed in gateway service form [khcp-10152]

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
@@ -297,6 +297,25 @@ describe('<GatewayServiceForm />', { viewportHeight: 800, viewportWidth: 700 }, 
       cy.getTestId('gateway-service-host-input').should('have.value', gatewayService1.host)
     })
 
+    it('should correctly pass getPayload as props to json/yaml code blocks', () => {
+      interceptKonnect()
+
+      cy.mount(GatewayServiceForm, {
+        props: {
+          config: baseConfigKonnect,
+          gatewayServiceId: gatewayService1.id,
+          isEditing: true,
+        },
+      })
+
+      cy.wait('@getGatewayService')
+      cy.get('.kong-ui-entities-gateway-service-form').should('be.visible')
+      // view configuration cta
+      cy.getTestId('form-view-configuration').should('be.visible')
+      cy.getTestId('form-view-configuration').click()
+      cy.getTestId('k-code-block-highlighted-code-block').should('be.visible')
+    })
+
     it('should correctly show zero values', () => {
       interceptKonnect({
         mockData: {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
@@ -11,6 +11,7 @@ const baseConfigKonnect:KonnectGatewayServiceFormConfig = {
   controlPlaneId: '1234-abcd-ilove-dogs',
   apiBaseUrl: '/us/kong-api/konnect-api',
   cancelRoute,
+  jsonYamlFormsEnabled: true,
 }
 
 const baseConfigKM:KongManagerGatewayServiceFormConfig = {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -6,7 +6,7 @@
       :edit-id="gatewayServiceId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getPayload()"
+      :form-fields="getPayload"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -713,7 +713,7 @@ const saveTlsVerify = (gatewayService: Record<string, any>) => {
   delete gatewayService.tls_verify_value
 }
 
-const getPayload = (): Record<string, any> => {
+const getPayload = computed((): Record<string, any> => {
   const requestBody: Record<string, any> = {
     name: form.fields.name || null,
     tags: form.fields.tags ? form.fields.tags?.split(',').filter(tag => tag !== '') : null,
@@ -762,14 +762,14 @@ const getPayload = (): Record<string, any> => {
   }
 
   return requestBody
-}
+})
 
 const saveFormData = async (): Promise<AxiosResponse | undefined> => {
   try {
     form.isReadonly = true
 
     validateUrl()
-    const payload = getPayload()
+    const payload = getPayload.value
     saveTlsVerify(payload)
 
     let response: AxiosResponse | undefined
@@ -828,11 +828,11 @@ watch(() => props.gatewayServiceId, () => {
 
 watch(form.fields, (newValue) => {
   form.fields.port = getPort.getPortFromProtocol(newValue.protocol, String(newValue.port))
-  emit('model-updated', getPayload())
+  emit('model-updated', getPayload.value)
 })
 
 onMounted(() => {
-  emit('model-updated', getPayload())
+  emit('model-updated', getPayload.value)
 })
 
 defineExpose({

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -6,7 +6,7 @@
       :edit-id="gatewayServiceId"
       :error-message="form.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getPayload.value"
+      :form-fields="getPayload()"
       :is-readonly="form.isReadonly"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -713,7 +713,7 @@ const saveTlsVerify = (gatewayService: Record<string, any>) => {
   delete gatewayService.tls_verify_value
 }
 
-const getPayload = computed((): Record<string, any> => {
+const getPayload = (): Record<string, any> => {
   const requestBody: Record<string, any> = {
     name: form.fields.name || null,
     tags: form.fields.tags ? form.fields.tags?.split(',').filter(tag => tag !== '') : null,
@@ -762,14 +762,14 @@ const getPayload = computed((): Record<string, any> => {
   }
 
   return requestBody
-})
+}
 
 const saveFormData = async (): Promise<AxiosResponse | undefined> => {
   try {
     form.isReadonly = true
 
     validateUrl()
-    const payload = getPayload.value
+    const payload = getPayload()
     saveTlsVerify(payload)
 
     let response: AxiosResponse | undefined
@@ -828,11 +828,11 @@ watch(() => props.gatewayServiceId, () => {
 
 watch(form.fields, (newValue) => {
   form.fields.port = getPort.getPortFromProtocol(newValue.protocol, String(newValue.port))
-  emit('model-updated', getPayload.value)
+  emit('model-updated', getPayload())
 })
 
 onMounted(() => {
-  emit('model-updated', getPayload.value)
+  emit('model-updated', getPayload())
 })
 
 defineExpose({


### PR DESCRIPTION
# Summary
https://konghq.atlassian.net/browse/KHCP-10152
Fixes bug `GatewayServiceForm` where json/yaml blocks are empty in https://github.com/Kong/public-ui-components/pull/1080

Verified unique name constraint is still enforced
<img width="1141" alt="Screenshot 2024-01-18 at 10 22 51 AM" src="https://github.com/Kong/public-ui-components/assets/2568272/81e3592b-112c-4ddd-bb57-9fbbf58dff81">

Deploy Preview https://pr-7419--khcp-ui.cloud-preview.konghq.tech/

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
