### PR TITLE
fix(analytics-chart): style tweaks

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
@@ -288,7 +288,7 @@ const dimensionItems = [{
 
 // Short labels
 const statusCodeLabels = [
-  '200', '300', '400', '500',
+  '200', '300', '400', '123123213asasdfasdfasd', 'asdfasdfasdfasdfadsfasdf',
 ]
 
 const statusCodeDimensionValues = ref(new Set(statusCodeLabels))

--- a/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
@@ -164,17 +164,17 @@
     </template>
 
     <div style="height: 500px">
-    <!-- Determine if a full blown chart is to be displayed, or a simplified one -->
-    <AnalyticsChart
-      :allow-csv-export="true"
-      :chart-data="(exploreResult as AnalyticsExploreV2Result)"
-      :chart-options="analyticsChartOptions"
-      chart-title="Request count by Status Code"
-      :legend-position="legendPosition"
-      :show-annotations="showAnnotationsToggle"
-      :show-legend-values="showLegendValuesToggle"
-      tooltip-title="tooltip title"
-    />
+      <!-- Determine if a full blown chart is to be displayed, or a simplified one -->
+      <AnalyticsChart
+        :allow-csv-export="true"
+        :chart-data="(exploreResult as AnalyticsExploreV2Result)"
+        :chart-options="analyticsChartOptions"
+        chart-title="Request count by Status Code"
+        :legend-position="legendPosition"
+        :show-annotations="showAnnotationsToggle"
+        :show-legend-values="showLegendValuesToggle"
+        tooltip-title="tooltip title"
+      />
     </div>
 
     <br>

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -169,6 +169,11 @@ onMounted(() => {
   if (legendContainerRef.value) {
     resizeObserver.observe(legendContainerRef.value)
   }
+
+  window.requestAnimationFrame(() => {
+    checkForWrap()
+    formatGrid()
+  })
 })
 
 onBeforeUnmount(() => {

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -141,9 +141,22 @@ watch(() => props.items, () => {
   }
 }, { immediate: true, flush: 'post' })
 
-const resizeObserver = new ResizeObserver(debounce(() => {
-  checkForWrap()
-  formatGrid()
+const oldWidth = ref(0)
+const oldHeight = ref(0)
+
+const resizeObserver = new ResizeObserver(debounce((entries: ResizeObserverEntry[]) => {
+
+  const entry = entries[0]
+  const newWidth = entry.contentRect.width
+  const newHeight = entry.contentRect.height
+
+  // Check if the resize is only in the X direction
+  if (newWidth !== oldWidth.value && newHeight === oldHeight.value) {
+    checkForWrap()
+    formatGrid()
+  }
+  oldWidth.value = newWidth
+  oldHeight.value = newHeight
 }, 100))
 
 watch(() => position.value, () => {

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -43,6 +43,7 @@ import { ChartLegendPosition } from '../../enums'
 import { Chart, type LegendItem } from 'chart.js'
 import { inject, onBeforeUnmount, onMounted, ref, watch, type PropType } from 'vue'
 import { KUI_SPACE_100 } from '@kong/design-tokens'
+import { debounce } from '../../utils'
 
 const props = defineProps({
   id: {
@@ -140,11 +141,13 @@ watch(() => props.items, () => {
   }
 }, { immediate: true, flush: 'post' })
 
-const resizeObserver = new ResizeObserver(() => {
+const resizeObserver = new ResizeObserver(debounce(() => {
   checkForWrap()
-})
+  formatGrid()
+}, 100))
 
 watch(() => position.value, () => {
+  checkForWrap()
   formatGrid()
 })
 
@@ -233,11 +236,10 @@ const positionToClass = (position: `${ChartLegendPosition}`) => {
   }
 
   &.horizontal {
-    column-gap: $kui-space-10;
     display: grid;
     justify-content: center;
     max-height: 12%;
-    width: 95%;
+    width: 99%;
     .truncate-label {
       max-width: 15ch;
       overflow: hidden;

--- a/packages/analytics/analytics-chart/src/utils/commonOptions.ts
+++ b/packages/analytics/analytics-chart/src/utils/commonOptions.ts
@@ -129,3 +129,13 @@ export const verticalTooltipPositioning = (position: Point, tooltipHeight: numbe
 
   return y
 }
+
+export function debounce(fn: Function, delay: number) {
+  let timeoutId: number
+  return (...args: any) => {
+    clearTimeout(timeoutId)
+    timeoutId = window.setTimeout(() => {
+      fn(...args)
+    }, delay)
+  }
+}


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-2457

Issue: Legend items only rendering with one item per row when there's definitely more room/ 
<img width="715" alt="image" src="https://github.com/Kong/public-ui-components/assets/6026470/2536c037-23bf-44bf-8eca-54bc906a3f0e">

Fix: style tweaks, plus run the formatGrid() function on mounted and on resize (behind a debounce for performance) in order to consistently re-arrange the legend grid for the available space. 
<img width="703" alt="image" src="https://github.com/Kong/public-ui-components/assets/6026470/a22f9883-1644-4df0-8284-cbcc79a8cba2">



<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
