### PR TITLE
feat(entities-plugins): add a prop to disable consumer group scope

### DIFF
--- a/packages/entities/entities-plugins/docs/plugin-form.md
+++ b/packages/entities/entities-plugins/docs/plugin-form.md
@@ -85,6 +85,12 @@ A form component for Plugins.
     - default: `''`
     - The entity type the plugin is bound to on create/edit.
 
+  - `disableConsumerGroupScope`:
+    - type: `boolean`
+    - required: `false`
+    - default: `false`
+    - *Specific to Kong Manager*. Whether or not to hide the consumer group scope field.
+
 The base konnect or kongManger config.
 
 #### `pluginType`

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -729,7 +729,9 @@ const initScopeFields = (): void => {
   const supportServiceScope = pluginMetaData[props.pluginType]?.scope.includes(PluginScope.SERVICE) ?? true
   const supportRouteScope = pluginMetaData[props.pluginType]?.scope.includes(PluginScope.ROUTE) ?? true
   const supportConsumerScope = pluginMetaData[props.pluginType]?.scope.includes(PluginScope.CONSUMER) ?? true
-  const supportConsumerGroupScope = pluginMetaData[props.pluginType]?.scope.includes(PluginScope.CONSUMER_GROUP) ?? true
+  const supportConsumerGroupScope = props.config.disableConsumerGroupScope
+    ? false
+    : (pluginMetaData[props.pluginType]?.scope.includes(PluginScope.CONSUMER_GROUP) ?? true)
 
   const scopeEntityArray = []
 

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -32,6 +32,8 @@ export interface BasePluginFormConfig {
   /** Current entity type and id for plugins for specific entity */
   entityType?: EntityType
   entityId?: string
+  /** Whether to hide the consumer group scope field. For Kong Manager OSS, this is true */
+  disableConsumerGroupScope?: boolean
 }
 
 export interface KongManagerPluginSelectConfig extends BasePluginSelectConfig, KongManagerBaseFormConfig {}


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Kong Manager OSS does not have consumer groups. So in its plugin forms, the consumer group scope should be hidden.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
