### PR TITLE
fix(entities-shared): base tables should have top borders

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -386,12 +386,6 @@ const handleUpdateTablePreferences = (tablePreferences: UserTablePreferences): v
 </style>
 
 <style lang="scss">
-// Exclude the top border if contained inside a KTab element
-.k-tabs > .tab-container > .kong-ui-entity-base-table,
-.k-tabs > .tab-container > [class^="kong-ui-entities-"] > .kong-ui-entity-base-table {
-  border-top: 0;
-}
-
 .kong-ui-entity-base-table {
   :deep(.k-table) {
     table-layout: fixed;


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Now KTabs have a bottom margin, making it separated from base tables. As a result, base tables without top borders do not look right:
![image](https://github.com/Kong/public-ui-components/assets/10095631/c61059b7-c60c-48a7-85e4-4aeb4f2247d3)


#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
