### PR TITLE
feat(app-layout): use dynamic component for sidebar icons [KHCP-10350]

### DIFF
--- a/packages/core/app-layout/fixtures/sidebar-items.ts
+++ b/packages/core/app-layout/fixtures/sidebar-items.ts
@@ -1,15 +1,17 @@
+import { OverviewIcon, RuntimesIcon, PeopleIcon, CogIcon } from '@kong/icons'
+
 export const topItems = [
   {
     name: 'Overview',
     key: 'overview',
     to: { name: 'overview' },
-    icon: 'sharedConfig',
+    icon: OverviewIcon,
   },
   {
     name: 'Gateway Manager',
     key: 'runtime-manager',
     to: { name: 'runtime-manager' },
-    icon: 'runtimes',
+    icon: RuntimesIcon,
     label: 'runtime-group-name',
     items: [
       {
@@ -25,7 +27,7 @@ export const bottomItems = [
     name: 'Organization',
     key: 'organization',
     to: { name: 'organization' },
-    icon: 'organizations',
+    icon: PeopleIcon,
     items: [
       {
         name: 'Teams',
@@ -41,7 +43,7 @@ export const bottomItems = [
     name: 'Settings',
     key: 'settings',
     to: { name: 'settings' },
-    icon: 'cogwheel',
+    icon: CogIcon,
     items: [
       {
         name: 'Billing and Usage',

--- a/packages/core/app-layout/sandbox/pages/KongManagerLayoutExample.vue
+++ b/packages/core/app-layout/sandbox/pages/KongManagerLayoutExample.vue
@@ -128,6 +128,7 @@ import { ref, computed } from 'vue'
 import type { SidebarPrimaryItem, SidebarSecondaryItem } from '../../src'
 import AppGruceLogo from '../components/icons/AppGruceLogo.vue'
 import AppLogo from '../components/icons/AppLogo.vue'
+import { RuntimesIcon, DevPortalIcon, BarChartIcon } from '@kong/icons'
 
 const sidebarIsHidden = ref<boolean>(false)
 const toggleSidebar = (): void => {
@@ -166,7 +167,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: !activeItem.value || (activeItem.value as SidebarPrimaryItem)?.key === 'api-gateway',
       // TODO: actually when you click on API Gateway it would not expand until the user picks a runtime group
       expanded: !activeItem.value || (activeItem.value as SidebarPrimaryItem)?.key === 'api-gateway' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'api-gateway',
-      icon: 'runtimes',
+      icon: RuntimesIcon,
       items: [
         {
           name: 'Runtime Instances',
@@ -217,7 +218,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'dev-portal',
-      icon: 'devPortal',
+      icon: DevPortalIcon,
       items: [
         {
           name: 'Published Services',
@@ -259,7 +260,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'analytics',
-      icon: 'vitalsChart',
+      icon: BarChartIcon,
       items: [
         {
           name: 'Overview',

--- a/packages/core/app-layout/sandbox/pages/LayoutPage.vue
+++ b/packages/core/app-layout/sandbox/pages/LayoutPage.vue
@@ -104,6 +104,7 @@ import { AccountDropdown } from '../../src'
 import NavLinks from '../components/NavLinks.vue'
 import AppGruceLogo from '../components/icons/AppGruceLogo.vue'
 import AppLogo from '../components/icons/AppLogo.vue'
+import { OverviewIcon, RuntimesIcon, ServiceHubIcon, MeshIcon, DevPortalIcon, BarChartIcon, PeopleIcon, CogIcon } from '@kong/icons'
 
 const userNameAndEmail = ref<string>('Jackie Jiang\njackie.jiang@konghq.com')
 
@@ -125,7 +126,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       name: 'Overview',
       to: '/?overview',
       key: 'overview',
-      icon: 'sharedConfig',
+      icon: OverviewIcon,
       // TODO: using this item as a default when `activeItem` is undefined
       active: !activeItem.value || (activeItem.value as SidebarPrimaryItem)?.key === 'overview',
     },
@@ -137,7 +138,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager',
       // TODO: actually when you click on Runtime Manager it would not expand until the user picks a runtime group
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'runtime-manager',
-      icon: 'runtimes',
+      icon: RuntimesIcon,
       items: [
         {
           name: 'Runtime Instances',
@@ -189,7 +190,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub',
       // TODO: actually when you click on Service Hub it would not expand until the user picks a service
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'servicehub',
-      icon: 'serviceHub',
+      icon: ServiceHubIcon,
       items: [
         {
           name: 'Overview',
@@ -207,7 +208,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       name: 'Mesh Manager',
       to: '/?mesh-manager',
       key: 'mesh-manager',
-      icon: 'mesh',
+      icon: MeshIcon,
       // TODO: using this item as a default when `activeItem` is undefined
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'mesh-manager',
     },
@@ -218,7 +219,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'dev-portal',
-      icon: 'devPortal',
+      icon: DevPortalIcon,
       items: [
         {
           name: 'Published Services',
@@ -260,7 +261,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'analytics',
-      icon: 'vitalsChart',
+      icon: BarChartIcon,
       items: [
         {
           name: 'Overview',
@@ -286,7 +287,7 @@ const sidebarItemsBottom = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'organization',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'organization' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'organization',
-      icon: 'organizations',
+      icon: PeopleIcon,
       items: [
         {
           name: 'Teams',
@@ -307,7 +308,7 @@ const sidebarItemsBottom = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'settings',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'settings' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'settings',
-      icon: 'cogwheel',
+      icon: CogIcon,
       items: [
         {
           name: 'Billing and Usage',

--- a/packages/core/app-layout/sandbox/pages/SidebarPage.vue
+++ b/packages/core/app-layout/sandbox/pages/SidebarPage.vue
@@ -66,6 +66,7 @@ import { AppLogo, AppGruceLogo } from '../components/icons'
 import '@kong/kongponents/dist/style.css'
 // Sandbox only
 import NavLinks from '../components/NavLinks.vue'
+import { OverviewIcon, RuntimesIcon, ServiceHubIcon, MeshIcon, DevPortalIcon, BarChartIcon, PeopleIcon, CogIcon } from '@kong/icons'
 
 const activeItem = ref<SidebarPrimaryItem | SidebarSecondaryItem>()
 
@@ -82,7 +83,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       // external: true,
       newWindow: true,
       key: 'overview',
-      icon: 'sharedConfig',
+      icon: OverviewIcon,
       // TODO: using this item as a default when `activeItem` is undefined
       active: !activeItem.value || (activeItem.value as SidebarPrimaryItem)?.key === 'overview',
     },
@@ -94,7 +95,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager',
       // TODO: actually when you click on Runtime Manager it would not expand until the user picks a runtime group
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'runtime-manager',
-      icon: 'runtimes',
+      icon: RuntimesIcon,
       items: [
         {
           name: 'Runtime Instances',
@@ -146,7 +147,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub',
       // TODO: actually when you click on Service Hub it would not expand until the user picks a service
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'servicehub',
-      icon: 'serviceHub',
+      icon: ServiceHubIcon,
       items: [
         {
           name: 'Overview',
@@ -167,7 +168,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'dev-portal',
-      icon: 'devPortal',
+      icon: DevPortalIcon,
       items: [
         {
           name: 'Published Services',
@@ -209,7 +210,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'analytics',
-      icon: 'vitalsChart',
+      icon: BarChartIcon,
       items: [
         {
           name: 'Overview',
@@ -235,7 +236,7 @@ const sidebarItemsBottom = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'organization',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'organization' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'organization',
-      icon: 'organizations',
+      icon: PeopleIcon,
       items: [
         {
           name: 'Teams',
@@ -256,7 +257,7 @@ const sidebarItemsBottom = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'settings',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'settings' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'settings',
-      icon: 'cogwheel',
+      icon: CogIcon,
       items: [
         {
           name: 'Billing and Usage',

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.cy.ts
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.cy.ts
@@ -3,6 +3,7 @@
 import AppSidebar from './AppSidebar.vue'
 import { h } from 'vue'
 import { topItems, bottomItems } from '../../../fixtures/sidebar-items'
+import { RuntimesIcon, PeopleIcon, MeshIcon } from '@kong/icons'
 
 const viewports = {
   desktop: {
@@ -66,7 +67,7 @@ describe('<AppSidebar />', () => {
                 name: 'Organization',
                 key: 'organization',
                 to: { name: 'organization' }, // Route must be defined in `cypress/fixtures/routes.ts`
-                icon: 'organizations',
+                icon: PeopleIcon,
               }],
             },
           })
@@ -83,7 +84,7 @@ describe('<AppSidebar />', () => {
                 name: 'Organization',
                 key: 'organization',
                 to: 'https://google.com',
-                icon: 'organizations',
+                icon: PeopleIcon,
               }],
             },
           })
@@ -101,7 +102,7 @@ describe('<AppSidebar />', () => {
                 key: 'organization',
                 to: '/organizations',
                 external: true,
-                icon: 'organizations',
+                icon: PeopleIcon,
               }],
             },
           })
@@ -119,7 +120,7 @@ describe('<AppSidebar />', () => {
                 key: 'organization',
                 to: '/organizations',
                 external: true,
-                icon: 'organizations',
+                icon: PeopleIcon,
               }],
             },
           })
@@ -138,7 +139,7 @@ describe('<AppSidebar />', () => {
                 to: '/mesh/',
                 newWindow: true,
                 external: true,
-                icon: 'info',
+                icon: MeshIcon,
               }],
             },
           })
@@ -158,7 +159,7 @@ describe('<AppSidebar />', () => {
                 to: '/mesh/',
                 newWindow: true,
                 external: false,
-                icon: 'info',
+                icon: MeshIcon,
               }],
             },
           })
@@ -178,7 +179,7 @@ describe('<AppSidebar />', () => {
                 to: '/mesh/',
                 newWindow: true,
                 external: false,
-                icon: 'info',
+                icon: MeshIcon,
               }],
             },
           })
@@ -196,7 +197,7 @@ describe('<AppSidebar />', () => {
                 name: 'Organization',
                 key: 'organization',
                 to: { name: 'organization' }, // Route must be defined in `cypress/fixtures/routes.ts`
-                icon: 'organizations',
+                icon: PeopleIcon,
               }],
             },
           })
@@ -276,7 +277,7 @@ describe('<AppSidebar />', () => {
                 key: 'runtime-manager',
                 active: true,
                 expanded: true,
-                icon: 'runtimes',
+                icon: RuntimesIcon,
                 items: [
                   {
                     name: 'Runtime Instances',
@@ -309,7 +310,7 @@ describe('<AppSidebar />', () => {
                 key: 'runtime-manager',
                 active: true,
                 expanded: true,
-                icon: 'runtimes',
+                icon: RuntimesIcon,
                 testId: testIdL1,
                 items: [
                   {
@@ -339,13 +340,13 @@ describe('<AppSidebar />', () => {
                 key: 'runtime-manager',
                 active: true,
                 expanded: true,
-                icon: 'runtimes',
+                icon: RuntimesIcon,
               }],
             },
           })
 
           cy.get('.kong-ui-app-sidebar').find('.level-primary.top-items').find('li').eq(0).should('be.visible')
-          cy.get('.kong-ui-app-sidebar').find('.level-primary.top-items').find('.sidebar-item-icon .kong-icon').should('be.visible')
+          cy.get('.kong-ui-app-sidebar').find('.level-primary.top-items').find('.sidebar-item-icon .kui-icon').should('be.visible')
         })
 
         it('does not render an icon next to L1 items when not provided', () => {
@@ -365,7 +366,7 @@ describe('<AppSidebar />', () => {
           })
 
           cy.get('.kong-ui-app-sidebar').find('.level-primary.top-items').find('li').eq(0).should('be.visible')
-          cy.get('.kong-ui-app-sidebar').find('.level-primary.top-items').find('.sidebar-item-icon .kong-icon').should('not.exist')
+          cy.get('.kong-ui-app-sidebar').find('.level-primary.top-items').find('.sidebar-item-icon .kui-icon').should('not.exist')
         })
 
         // Expanded
@@ -384,7 +385,7 @@ describe('<AppSidebar />', () => {
                   key: 'runtime-manager',
                   active: true,
                   expanded: true,
-                  icon: 'runtimes',
+                  icon: RuntimesIcon,
                   items: [
                     {
                       name: childItemName,
@@ -415,7 +416,7 @@ describe('<AppSidebar />', () => {
                   key: 'runtime-manager',
                   active: true,
                   expanded: true,
-                  icon: 'runtimes',
+                  icon: RuntimesIcon,
                   items: [
                     {
                       name: 'Runtime Instances',
@@ -445,7 +446,7 @@ describe('<AppSidebar />', () => {
                   key: 'runtime-manager',
                   active: true,
                   expanded: false,
-                  icon: 'runtimes',
+                  icon: RuntimesIcon,
                   items: [
                     {
                       name: 'Runtime Instances',

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -489,7 +489,7 @@ onBeforeUnmount(() => {
     outline: 1px solid #afb7c5 !important;
   }
 
-  :deep(.kong-icon) {
+  :deep(.kui-icon) {
     display: inline-flex;
     margin-bottom: -7px;
   }

--- a/packages/core/app-layout/src/components/sidebar/SidebarItem.vue
+++ b/packages/core/app-layout/src/components/sidebar/SidebarItem.vue
@@ -24,13 +24,12 @@
           :class="{ 'has-label': !!(item as SidebarPrimaryItem).label && (item as SidebarPrimaryItem).expanded, 'has-badge': itemHasBadge }"
         >
           <div
-            v-if="(item as SidebarPrimaryItem).icon"
+            v-if="(item as SidebarPrimaryItem).icon !== undefined && typeof (item as SidebarPrimaryItem).icon !== 'string'"
             class="sidebar-item-icon"
           >
-            <!-- TODO: Replace with dynamic icon import(?) or a slot based on the `item.key` -->
-            <KIcon
-              :icon="String((item as SidebarPrimaryItem).icon)"
-              size="20"
+            <component
+              :is="(item as SidebarPrimaryItem).icon"
+              :size="KUI_ICON_SIZE_40"
             />
           </div>
           <div class="sidebar-item-name-container">
@@ -90,6 +89,7 @@ import type { PropType } from 'vue'
 import { computed } from 'vue'
 import type { SidebarPrimaryItem, SidebarSecondaryItem } from '../../types'
 import ItemBadge from './ItemBadge.vue'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const emit = defineEmits(['click'])
 

--- a/packages/core/app-layout/src/types/sidebar.ts
+++ b/packages/core/app-layout/src/types/sidebar.ts
@@ -1,3 +1,6 @@
+// Get a generic `@kong/icons` interface for the option prop
+import type { SearchIcon as GenericIcon } from '@kong/icons'
+
 export interface SidebarSecondaryItem {
   /** The display text of the sidebar item */
   name: string
@@ -24,8 +27,8 @@ export interface SidebarPrimaryItem extends Omit<SidebarSecondaryItem, 'parentKe
   label?: string
   /** Is the top-level sidebar item expanded */
   expanded?: boolean
-  /** The name of the [Kongponent KIcon](https://beta.kongponents.konghq.com/components/icon.html#icon-1) to display next to the top-level item name */
-  icon?: string
+  /** An icon Vue component exported from `@kong/icons` that will be rendered as a [dynamic component](https://vuejs.org/guide/essentials/component-basics.html#dynamic-components) in the `SidebarItem.vue` template. */
+  icon?: typeof GenericIcon
   /** Nested sidebar items (children) without icons */
   items?: SidebarSecondaryItem[]
 }


### PR DESCRIPTION
# Summary

Change the sidebar item 'icon' prop to accept a component instance rather than a KIcon name string.

**BREAKING CHANGE**: The SidebarPrimaryItem 'icon' property now accepts a component instance rather than a KIcon name string.

## Examples

### New usage

```html
<template>
  <AppLayout
    :sidebar-top-items="sidebarItemsTop"
  >
</template>

<script setup lang="ts">
import { PeopleIcon } from '@kong/icons'

const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
  return [
    {
      name: 'Organization',
      to: '/global/organization',
      key: 'organization',
      icon: PeopleIcon, // New usage: pass the `@kong/icons` icon component instance directly to the object
    },
  ]
})
</script>
```

### Old usage

```html
<template>
  <AppLayout
    :sidebar-top-items="sidebarItemsTop"
  >
</template>

<script setup lang="ts">
const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
  return [
    {
      name: 'Organization',
      to: '/global/organization',
      key: 'organization',
      icon:'organizations', // Old usage: pass the KIcon name as a string
    },
  ]
})
</script>
```