### PR TITLE
fix(swagger-ui-web-component): replace error with warning [KHCP-10405]

### DIFF
--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -144,15 +144,18 @@ export class SwaggerUIElement extends HTMLElement {
 
   init() {
     if (this.#instance) {
-      throw new Error('SwaggerUI is already initialized')
+      console.warn('SwaggerUI is already initialized')
+      return
     }
 
     if (!this.isConnected) {
-      throw new Error('kong-swagger-ui is no longer connected')
+      console.warn('kong-swagger-ui is no longer connected')
+      return
     }
 
     if (!this.#url && !this.#spec) {
-      throw new Error('either `spec` or `url` has to be set to initialize SwaggerUI')
+      console.warn('either `spec` or `url` has to be set to initialize SwaggerUI')
+      return
     }
 
     if ((this.relativeSidebar && !this.#hasSidebar) || (this.#relativeSidebar && !this.#essentialsOnly)) {
@@ -305,7 +308,8 @@ export class SwaggerUIElement extends HTMLElement {
 
   set spec(spec) {
     if (!spec) {
-      throw new Error('Spec cannot be empty')
+      console.warn('spec cannot be empty')
+      return
     }
 
     let parsedSpec


### PR DESCRIPTION
# Summary

Jira: https://konghq.atlassian.net/browse/KHCP-10405

Replace `throw new Error(...` with `console.warn` to avoid logging those errors in DD:
https://app.datadoghq.com/rum/error-tracking?issueId=1abb89b0-b9e1-11ee-ba2a-da7ad0900002

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
