### PR TITLE
feat(app-layout): sidebar icon slots

### DIFF
--- a/packages/core/app-layout/README.md
+++ b/packages/core/app-layout/README.md
@@ -9,7 +9,6 @@ A Kong UI application layout component that provides a responsive navbar, sideba
   - [Vue Plugin](#vue-plugin)
   - [In-Component registration](#in-component-registration)
 - [Usage](#usage)
-  - [Sidebar Icons](#sidebar-icons)
   - [Props](#props)
   - [Slots](#slots)
   - [Teleport Containers](#teleport-containers)
@@ -80,33 +79,6 @@ import { AppLayout } from '@kong-ui-public/app-layout'
 ## Usage
 
 > **Note**: TODO - for now, you can reference the sandbox app `pnpm --filter "@kong-ui-public/app-layout" run dev`
-
-### Sidebar Icons
-
-Each primary SidebarItem `key` generates a `sidebar-icon-{key}` slot in the `AppSidebar`, and a corresponding slot in the `AppLayout` component in order to slot in sidebar icons from `@kong/icons`.
-
-```html
-<template>
-  <AppLayout :sidebar-top-items="sidebarItemsTop">
-    <template #sidebar-icon-overview>
-      <OverviewIcon :size="KUI_ICON_SIZE_40" />
-    </template>
-  </AppLayout>
-</template>
-
-<script setup lang="ts">
-import { OverviewIcon } from '@kong/icons'
-import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
-
-const sidebarItemsTop = [
-  {
-    key: 'overview',
-    name: 'Overview',
-    to: '/sidebar/?overview',
-  },
-]
-</script>
-```
 
 ### Props
 

--- a/packages/core/app-layout/README.md
+++ b/packages/core/app-layout/README.md
@@ -9,6 +9,7 @@ A Kong UI application layout component that provides a responsive navbar, sideba
   - [Vue Plugin](#vue-plugin)
   - [In-Component registration](#in-component-registration)
 - [Usage](#usage)
+  - [Sidebar Icons](#sidebar-icons)
   - [Props](#props)
   - [Slots](#slots)
   - [Teleport Containers](#teleport-containers)
@@ -79,6 +80,33 @@ import { AppLayout } from '@kong-ui-public/app-layout'
 ## Usage
 
 > **Note**: TODO - for now, you can reference the sandbox app `pnpm --filter "@kong-ui-public/app-layout" run dev`
+
+### Sidebar Icons
+
+Each primary SidebarItem `key` generates a `sidebar-icon-{key}` slot in the `AppSidebar`, and a corresponding slot in the `AppLayout` component in order to slot in sidebar icons from `@kong/icons`.
+
+```html
+<template>
+  <AppLayout :sidebar-top-items="sidebarItemsTop">
+    <template #sidebar-icon-overview>
+      <OverviewIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+  </AppLayout>
+</template>
+
+<script setup lang="ts">
+import { OverviewIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+
+const sidebarItemsTop = [
+  {
+    key: 'overview',
+    name: 'Overview',
+    to: '/sidebar/?overview',
+  },
+]
+</script>
+```
 
 ### Props
 

--- a/packages/core/app-layout/docs/sidebar.md
+++ b/packages/core/app-layout/docs/sidebar.md
@@ -11,6 +11,7 @@ A Kong UI dynamic sidebar component.
 - [Usage](#usage)
   - [Install](#install)
 - [`AppSidebar.vue`](#appsidebarvue-1)
+  - [Sidebar Icons](#sidebar-icons)
   - [Props](#props)
   - [Slots](#slots)
   - [Events](#events)
@@ -38,7 +39,6 @@ A Kong UI dynamic sidebar component.
 - `@kong/kongponents` must be available as a `dependency` in the host application, along with the package's style imports. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents). Specifically, the following Kongponents must be available:
   - `KDropdownItem`
   - `KDropdown`
-  - `KIcon`
   - `KTooltip`
 - The sidebar is set to `position: fixed` and is expected to render at 100% of the viewport height. This means your Navbar, etc. should never be placed above the sidebar unless on mobile.
 - If L2 sidebar items have required `route.params` in their route, they must be properly declared in the `item.to` property. Example:
@@ -49,7 +49,6 @@ A Kong UI dynamic sidebar component.
       name: 'Runtime Manager',
       key: 'runtime-manager',
       to: { name: 'runtime-manager' },
-      icon: 'runtimes',
       // Require the 'runtime-manager' page to be active and expanded to render the L2 items
       items: active('runtime-manager') && !!String(currentRoute?.params.control_plane_id || '') && [
         {
@@ -77,6 +76,33 @@ A Kong UI dynamic sidebar component.
 You will likely want to utilize a wrapper component in your application to generate the dynamic sidebar items, so import the `AppSidebar` component and the package styles into your wrapper component.
 
 You will also need to utilize a factory function (e.g. a composable) in order to generate and update your sidebar menu items.
+
+### Sidebar Icons
+
+Each primary SidebarItem `key` generates a `sidebar-icon-{key}` slot in the `AppSidebar`, and a corresponding slot in the `AppLayout` component in order to slot in sidebar icons from `@kong/icons`.
+
+```html
+<template>
+  <AppLayout :sidebar-top-items="sidebarItemsTop">
+    <template #sidebar-icon-overview>
+      <OverviewIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+  </AppLayout>
+</template>
+
+<script setup lang="ts">
+import { OverviewIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+
+const sidebarItemsTop = [
+  {
+    key: 'overview',
+    name: 'Overview',
+    to: '/sidebar/?overview',
+  },
+]
+</script>
+```
 
 ### Props
 
@@ -360,21 +386,18 @@ export const useSidebar = () => {
         key: 'organizations',
         to: { name: 'organizations' },
         active: active('root-organizations'), // L1 active() name must point to the root parent
-        icon: 'organizations',
       },
       {
         name: 'Users',
         key: 'users',
         to: { name: 'users' },
         active: active('root-users'), // L1 active() name must point to the root parent
-        icon: 'profile',
       },
       {
         name: 'Control Planes',
         key: 'control-planes',
         to: { name: 'control-planes' },
         active: active('root-control-planes'), // L1 active() name must point to the root parent
-        icon: 'workspaces',
       },
     ]
   }

--- a/packages/core/app-layout/fixtures/sidebar-items.ts
+++ b/packages/core/app-layout/fixtures/sidebar-items.ts
@@ -5,13 +5,11 @@ export const topItems = [
     name: 'Overview',
     key: 'overview',
     to: { name: 'overview' },
-    icon: OverviewIcon,
   },
   {
     name: 'Gateway Manager',
     key: 'runtime-manager',
     to: { name: 'runtime-manager' },
-    icon: RuntimesIcon,
     label: 'runtime-group-name',
     items: [
       {
@@ -27,7 +25,6 @@ export const bottomItems = [
     name: 'Organization',
     key: 'organization',
     to: { name: 'organization' },
-    icon: PeopleIcon,
     items: [
       {
         name: 'Teams',
@@ -43,7 +40,6 @@ export const bottomItems = [
     name: 'Settings',
     key: 'settings',
     to: { name: 'settings' },
-    icon: CogIcon,
     items: [
       {
         name: 'Billing and Usage',

--- a/packages/core/app-layout/sandbox/pages/KongManagerLayoutExample.vue
+++ b/packages/core/app-layout/sandbox/pages/KongManagerLayoutExample.vue
@@ -107,6 +107,16 @@
       </div>
     </template>
 
+    <template #sidebar-icon-api-gateway>
+      <RuntimesIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+    <template #sidebar-icon-dev-portal>
+      <DevPortalIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+    <template #sidebar-icon-analytics>
+      <BarChartIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+
     <!-- Default slot content -->
 
     <p>This is the top.</p>
@@ -129,6 +139,7 @@ import type { SidebarPrimaryItem, SidebarSecondaryItem } from '../../src'
 import AppGruceLogo from '../components/icons/AppGruceLogo.vue'
 import AppLogo from '../components/icons/AppLogo.vue'
 import { RuntimesIcon, DevPortalIcon, BarChartIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const sidebarIsHidden = ref<boolean>(false)
 const toggleSidebar = (): void => {
@@ -167,7 +178,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: !activeItem.value || (activeItem.value as SidebarPrimaryItem)?.key === 'api-gateway',
       // TODO: actually when you click on API Gateway it would not expand until the user picks a runtime group
       expanded: !activeItem.value || (activeItem.value as SidebarPrimaryItem)?.key === 'api-gateway' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'api-gateway',
-      icon: RuntimesIcon,
       items: [
         {
           name: 'Runtime Instances',
@@ -218,7 +228,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'dev-portal',
-      icon: DevPortalIcon,
       items: [
         {
           name: 'Published Services',
@@ -260,7 +269,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'analytics',
-      icon: BarChartIcon,
       items: [
         {
           name: 'Overview',

--- a/packages/core/app-layout/sandbox/pages/LayoutPage.vue
+++ b/packages/core/app-layout/sandbox/pages/LayoutPage.vue
@@ -75,6 +75,30 @@
         <div>Top Slot Content</div>
       </div>
     </template>
+    <template #sidebar-icon-overview>
+      <OverviewIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+    <template #sidebar-icon-gateway-manager>
+      <RuntimesIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+    <template #sidebar-icon-servicehub>
+      <ServiceHubIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+    <template #sidebar-icon-mesh-manager>
+      <MeshIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+    <template #sidebar-icon-dev-portal>
+      <DevPortalIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+    <template #sidebar-icon-analytics>
+      <BarChartIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+    <template #sidebar-icon-organization>
+      <PeopleIcon :size="KUI_ICON_SIZE_40" />
+    </template>
+    <template #sidebar-icon-settings>
+      <CogIcon :size="KUI_ICON_SIZE_40" />
+    </template>
     <template #sidebar-footer>
       <div class="sidebar-footer-slot-content">
         <div>Footer Slot Content</div>
@@ -105,6 +129,7 @@ import NavLinks from '../components/NavLinks.vue'
 import AppGruceLogo from '../components/icons/AppGruceLogo.vue'
 import AppLogo from '../components/icons/AppLogo.vue'
 import { OverviewIcon, RuntimesIcon, ServiceHubIcon, MeshIcon, DevPortalIcon, BarChartIcon, PeopleIcon, CogIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const userNameAndEmail = ref<string>('Jackie Jiang\njackie.jiang@konghq.com')
 
@@ -126,7 +151,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       name: 'Overview',
       to: '/?overview',
       key: 'overview',
-      icon: OverviewIcon,
       // TODO: using this item as a default when `activeItem` is undefined
       active: !activeItem.value || (activeItem.value as SidebarPrimaryItem)?.key === 'overview',
     },
@@ -134,11 +158,10 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       name: 'Gateway Manager',
       to: '/?runtime-manager',
       label: 'retail-sandbox-rg', // runtime group name
-      key: 'runtime-manager',
+      key: 'gateway-manager',
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager',
       // TODO: actually when you click on Runtime Manager it would not expand until the user picks a runtime group
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'runtime-manager',
-      icon: RuntimesIcon,
       items: [
         {
           name: 'Runtime Instances',
@@ -190,7 +213,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub',
       // TODO: actually when you click on Service Hub it would not expand until the user picks a service
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'servicehub',
-      icon: ServiceHubIcon,
       items: [
         {
           name: 'Overview',
@@ -208,7 +230,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       name: 'Mesh Manager',
       to: '/?mesh-manager',
       key: 'mesh-manager',
-      icon: MeshIcon,
       // TODO: using this item as a default when `activeItem` is undefined
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'mesh-manager',
     },
@@ -219,7 +240,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'dev-portal',
-      icon: DevPortalIcon,
       items: [
         {
           name: 'Published Services',
@@ -261,7 +281,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'analytics',
-      icon: BarChartIcon,
       items: [
         {
           name: 'Overview',
@@ -287,7 +306,6 @@ const sidebarItemsBottom = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'organization',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'organization' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'organization',
-      icon: PeopleIcon,
       items: [
         {
           name: 'Teams',
@@ -308,7 +326,6 @@ const sidebarItemsBottom = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'settings',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'settings' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'settings',
-      icon: CogIcon,
       items: [
         {
           name: 'Billing and Usage',

--- a/packages/core/app-layout/sandbox/pages/SidebarPage.vue
+++ b/packages/core/app-layout/sandbox/pages/SidebarPage.vue
@@ -47,6 +47,27 @@
           </router-link>
         </div>
       </template>
+      <template #sidebar-icon-overview>
+        <OverviewIcon :size="KUI_ICON_SIZE_40" />
+      </template>
+      <template #sidebar-icon-gateway-manager>
+        <RuntimesIcon :size="KUI_ICON_SIZE_40" />
+      </template>
+      <template #sidebar-icon-servicehub>
+        <ServiceHubIcon :size="KUI_ICON_SIZE_40" />
+      </template>
+      <template #sidebar-icon-dev-portal>
+        <DevPortalIcon :size="KUI_ICON_SIZE_40" />
+      </template>
+      <template #sidebar-icon-analytics>
+        <BarChartIcon :size="KUI_ICON_SIZE_40" />
+      </template>
+      <template #sidebar-icon-organization>
+        <PeopleIcon :size="KUI_ICON_SIZE_40" />
+      </template>
+      <template #sidebar-icon-settings>
+        <CogIcon :size="KUI_ICON_SIZE_40" />
+      </template>
     </AppSidebar>
     <main>
       <p>This is the SIDEBAR page.</p>
@@ -66,7 +87,8 @@ import { AppLogo, AppGruceLogo } from '../components/icons'
 import '@kong/kongponents/dist/style.css'
 // Sandbox only
 import NavLinks from '../components/NavLinks.vue'
-import { OverviewIcon, RuntimesIcon, ServiceHubIcon, MeshIcon, DevPortalIcon, BarChartIcon, PeopleIcon, CogIcon } from '@kong/icons'
+import { OverviewIcon, RuntimesIcon, ServiceHubIcon, DevPortalIcon, BarChartIcon, PeopleIcon, CogIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const activeItem = ref<SidebarPrimaryItem | SidebarSecondaryItem>()
 
@@ -83,7 +105,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       // external: true,
       newWindow: true,
       key: 'overview',
-      icon: OverviewIcon,
       // TODO: using this item as a default when `activeItem` is undefined
       active: !activeItem.value || (activeItem.value as SidebarPrimaryItem)?.key === 'overview',
     },
@@ -91,11 +112,10 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       name: 'Gateway Manager',
       to: '/sidebar/?runtime-manager',
       label: 'retail-sandbox-rg', // runtime group name
-      key: 'runtime-manager',
+      key: 'gateway-manager',
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager',
       // TODO: actually when you click on Runtime Manager it would not expand until the user picks a runtime group
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'runtime-manager',
-      icon: RuntimesIcon,
       items: [
         {
           name: 'Runtime Instances',
@@ -147,7 +167,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub',
       // TODO: actually when you click on Service Hub it would not expand until the user picks a service
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'servicehub',
-      icon: ServiceHubIcon,
       items: [
         {
           name: 'Overview',
@@ -168,7 +187,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'dev-portal',
-      icon: DevPortalIcon,
       items: [
         {
           name: 'Published Services',
@@ -210,7 +228,6 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'analytics',
-      icon: BarChartIcon,
       items: [
         {
           name: 'Overview',
@@ -236,7 +253,6 @@ const sidebarItemsBottom = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'organization',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'organization' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'organization',
-      icon: PeopleIcon,
       items: [
         {
           name: 'Teams',
@@ -257,7 +273,6 @@ const sidebarItemsBottom = computed((): SidebarPrimaryItem[] => {
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'settings',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'settings' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'settings',
-      icon: CogIcon,
       items: [
         {
           name: 'Billing and Usage',

--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -92,6 +92,13 @@
       >
         <slot name="sidebar-footer" />
       </template>
+      <template
+        v-for="item in [...(sidebar.topItems || []), ...(sidebar.bottomItems || [])]"
+        :key="item.key"
+        #[`sidebar-icon-${item.key}`]
+      >
+        <slot :name="`sidebar-icon-${(item as SidebarPrimaryItem).key}`" />
+      </template>
     </AppSidebar>
 
     <main

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.cy.ts
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.cy.ts
@@ -331,9 +331,9 @@ describe('<AppSidebar />', () => {
                 active: true,
                 expanded: true,
               }],
-              slots: {
-                'sidebar-icon-runtime-manager': RuntimesIcon,
-              },
+            },
+            slots: {
+              'sidebar-icon-runtime-manager': RuntimesIcon,
             },
           })
 
@@ -471,7 +471,6 @@ describe('<AppSidebar />', () => {
                 cy.wrap(evt[0][0]).should('have.property', 'name')
                 cy.wrap(evt[0][0]).should('have.property', 'key')
                 cy.wrap(evt[0][0]).should('have.property', 'to')
-                cy.wrap(evt[0][0]).should('have.property', 'icon')
                 cy.wrap(evt[0][0]).should('have.property', 'testId')
               })
             })

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.cy.ts
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.cy.ts
@@ -3,7 +3,7 @@
 import AppSidebar from './AppSidebar.vue'
 import { h } from 'vue'
 import { topItems, bottomItems } from '../../../fixtures/sidebar-items'
-import { RuntimesIcon, PeopleIcon, MeshIcon } from '@kong/icons'
+import { RuntimesIcon } from '@kong/icons'
 
 const viewports = {
   desktop: {
@@ -67,7 +67,6 @@ describe('<AppSidebar />', () => {
                 name: 'Organization',
                 key: 'organization',
                 to: { name: 'organization' }, // Route must be defined in `cypress/fixtures/routes.ts`
-                icon: PeopleIcon,
               }],
             },
           })
@@ -84,7 +83,6 @@ describe('<AppSidebar />', () => {
                 name: 'Organization',
                 key: 'organization',
                 to: 'https://google.com',
-                icon: PeopleIcon,
               }],
             },
           })
@@ -102,7 +100,6 @@ describe('<AppSidebar />', () => {
                 key: 'organization',
                 to: '/organizations',
                 external: true,
-                icon: PeopleIcon,
               }],
             },
           })
@@ -120,7 +117,6 @@ describe('<AppSidebar />', () => {
                 key: 'organization',
                 to: '/organizations',
                 external: true,
-                icon: PeopleIcon,
               }],
             },
           })
@@ -139,7 +135,6 @@ describe('<AppSidebar />', () => {
                 to: '/mesh/',
                 newWindow: true,
                 external: true,
-                icon: MeshIcon,
               }],
             },
           })
@@ -159,7 +154,6 @@ describe('<AppSidebar />', () => {
                 to: '/mesh/',
                 newWindow: true,
                 external: false,
-                icon: MeshIcon,
               }],
             },
           })
@@ -179,7 +173,6 @@ describe('<AppSidebar />', () => {
                 to: '/mesh/',
                 newWindow: true,
                 external: false,
-                icon: MeshIcon,
               }],
             },
           })
@@ -197,7 +190,6 @@ describe('<AppSidebar />', () => {
                 name: 'Organization',
                 key: 'organization',
                 to: { name: 'organization' }, // Route must be defined in `cypress/fixtures/routes.ts`
-                icon: PeopleIcon,
               }],
             },
           })
@@ -277,7 +269,6 @@ describe('<AppSidebar />', () => {
                 key: 'runtime-manager',
                 active: true,
                 expanded: true,
-                icon: RuntimesIcon,
                 items: [
                   {
                     name: 'Runtime Instances',
@@ -310,7 +301,6 @@ describe('<AppSidebar />', () => {
                 key: 'runtime-manager',
                 active: true,
                 expanded: true,
-                icon: RuntimesIcon,
                 testId: testIdL1,
                 items: [
                   {
@@ -340,8 +330,10 @@ describe('<AppSidebar />', () => {
                 key: 'runtime-manager',
                 active: true,
                 expanded: true,
-                icon: RuntimesIcon,
               }],
+              slots: {
+                'sidebar-icon-runtime-manager': RuntimesIcon,
+              },
             },
           })
 
@@ -385,7 +377,6 @@ describe('<AppSidebar />', () => {
                   key: 'runtime-manager',
                   active: true,
                   expanded: true,
-                  icon: RuntimesIcon,
                   items: [
                     {
                       name: childItemName,
@@ -416,7 +407,6 @@ describe('<AppSidebar />', () => {
                   key: 'runtime-manager',
                   active: true,
                   expanded: true,
-                  icon: RuntimesIcon,
                   items: [
                     {
                       name: 'Runtime Instances',
@@ -446,7 +436,6 @@ describe('<AppSidebar />', () => {
                   key: 'runtime-manager',
                   active: true,
                   expanded: false,
-                  icon: RuntimesIcon,
                   items: [
                     {
                       name: 'Runtime Instances',

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -45,7 +45,11 @@
               :key="item.name"
               :item="item"
               @click="itemClick"
-            />
+            >
+              <template #[`sidebar-icon-${item.key}`]>
+                <slot :name="`sidebar-icon-${(item as SidebarPrimaryItem).key}`" />
+              </template>
+            </SidebarItem>
           </ul>
 
           <div
@@ -63,7 +67,11 @@
               :key="item.name"
               :item="item"
               @click="itemClick"
-            />
+            >
+              <template #[`sidebar-icon-${item.key}`]>
+                <slot :name="`sidebar-icon-${(item as SidebarPrimaryItem).key}`" />
+              </template>
+            </SidebarItem>
           </ul>
         </nav>
       </div>

--- a/packages/core/app-layout/src/components/sidebar/SidebarItem.vue
+++ b/packages/core/app-layout/src/components/sidebar/SidebarItem.vue
@@ -31,11 +31,6 @@
               v-if="!subnavItem"
               :name="`sidebar-icon-${(item as SidebarPrimaryItem).key}`"
             />
-            <!-- <component
-              :is="(item as SidebarPrimaryItem).icon"
-              v-if="(item as SidebarPrimaryItem).icon"
-              :size="KUI_ICON_SIZE_40"
-            /> -->
           </div>
           <div class="sidebar-item-name-container">
             <div
@@ -94,7 +89,6 @@ import type { PropType } from 'vue'
 import { computed } from 'vue'
 import type { SidebarPrimaryItem, SidebarSecondaryItem } from '../../types'
 import ItemBadge from './ItemBadge.vue'
-import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const emit = defineEmits(['click'])
 

--- a/packages/core/app-layout/src/components/sidebar/SidebarItem.vue
+++ b/packages/core/app-layout/src/components/sidebar/SidebarItem.vue
@@ -24,14 +24,18 @@
           :class="{ 'has-label': !!(item as SidebarPrimaryItem).label && (item as SidebarPrimaryItem).expanded, 'has-badge': itemHasBadge }"
         >
           <div
-            v-if="(item as SidebarPrimaryItem).icon !== undefined && typeof (item as SidebarPrimaryItem).icon !== 'string'"
+            v-if="$slots[`sidebar-icon-${(item as SidebarPrimaryItem).key}`]"
             class="sidebar-item-icon"
           >
-            <component
+            <slot
+              v-if="!subnavItem"
+              :name="`sidebar-icon-${(item as SidebarPrimaryItem).key}`"
+            />
+            <!-- <component
               :is="(item as SidebarPrimaryItem).icon"
               v-if="(item as SidebarPrimaryItem).icon"
               :size="KUI_ICON_SIZE_40"
-            />
+            /> -->
           </div>
           <div class="sidebar-item-name-container">
             <div
@@ -99,6 +103,7 @@ const props = defineProps({
     type: Object as PropType<SidebarPrimaryItem | SidebarSecondaryItem>,
     required: true,
   },
+  /** True if the item is not an L1 primary sidebar item */
   subnavItem: {
     type: Boolean,
     default: false,

--- a/packages/core/app-layout/src/types/sidebar.ts
+++ b/packages/core/app-layout/src/types/sidebar.ts
@@ -1,6 +1,3 @@
-// Get a generic `@kong/icons` interface for the option prop
-import type { SearchIcon as GenericIcon } from '@kong/icons'
-
 export interface SidebarSecondaryItem {
   /** The display text of the sidebar item */
   name: string
@@ -27,8 +24,6 @@ export interface SidebarPrimaryItem extends Omit<SidebarSecondaryItem, 'parentKe
   label?: string
   /** Is the top-level sidebar item expanded */
   expanded?: boolean
-  /** An icon Vue component exported from `@kong/icons` that will be rendered as a [dynamic component](https://vuejs.org/guide/essentials/component-basics.html#dynamic-components) in the `SidebarItem.vue` template. */
-  icon?: typeof GenericIcon
   /** Nested sidebar items (children) without icons */
   items?: SidebarSecondaryItem[]
 }


### PR DESCRIPTION
# Summary

You must now slot in the sidebar icons rather than passing them in via slot.

BREAKING CHANGE: The AppLayout and AppSidebar components now require slotting in the sidebar icons via sidebar-icon-KEY slots.

```html
<template>
  <AppLayout :sidebar-top-items="sidebarItemsTop">
    <template #sidebar-icon-overview>
      <OverviewIcon :size="KUI_ICON_SIZE_40" />
    </template>
  </AppLayout>
</template>

<script setup lang="ts">
import { OverviewIcon } from '@kong/icons'
import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'

const sidebarItemsTop = [
  {
    key: 'overview',
    name: 'Overview',
    to: '/sidebar/?overview',
  },
]
</script>
```