### PR TITLE
fix(analytics-chart): full legend label text on hover in all positions

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -23,7 +23,7 @@
         <div
           class="label"
           :class="{ 'truncate-label' : shouldTruncate }"
-          :title="position === ChartLegendPosition.Bottom && text"
+          :title="text"
         >
           {{ text }}
         </div>


### PR DESCRIPTION
# Summary

Show full legend item label text on hover regardless of chart orientation
https://kongstrong.slack.com/archives/C01RF6STU2F/p1706307888384229

<img width="191" alt="Screenshot 2024-01-26 at 3 16 51 PM" src="https://github.com/Kong/public-ui-components/assets/103061463/cdec39cd-f4db-455c-8dbf-fd0e6f742f6b">
