### PR TITLE
fix(app-page-header): provide title fallback

### DIFF
--- a/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
+++ b/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
@@ -71,6 +71,7 @@ const props = defineProps({
   title: {
     type: String,
     required: true,
+    default: '', // Provide a fallback string to prevent the component unmounting from throwing an error
   },
   breadcrumbs: {
     type: Array as PropType<BreadcrumbItem[]>,

--- a/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
+++ b/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
@@ -70,7 +70,6 @@ import type { BreadcrumbItem } from '@kong/kongponents'
 const props = defineProps({
   title: {
     type: String,
-    required: true,
     default: '', // Provide a fallback string to prevent the component unmounting from throwing an error
   },
   breadcrumbs: {


### PR DESCRIPTION
# Summary

Provide a fallback for the `AppPageHeader` title prop to prevent prop validation errors when the component is on a page in the process of changing routes/determining the title.

![image](https://github.com/Kong/public-ui-components/assets/2229946/4914830f-50aa-4a07-98fc-efc610380259)
