### PR TITLE
feat(entities-vaults): add approle method support

### DIFF
--- a/packages/entities/entities-vaults/docs/vault-form.md
+++ b/packages/entities/entities-vaults/docs/vault-form.md
@@ -74,6 +74,18 @@ A form component for Vaults.
     - *Specific to Konnect*. Show/hide Azure option.
     - **Note:** This is experimental and not supported by the backend right now
 
+  - `ttl`
+    - type: `boolean`
+    - required: `true`
+    - default: `undefined`
+    - Show/hide SupportTTL option.
+
+  - `hcvAppRoleMethodAvailable`
+    - type: `boolean`
+    - required: `false`
+    - default: `undefined`
+    - Show/hide approle option and corresponding fields.
+
 The base konnect or kongManger config.
 
 #### `vaultId`

--- a/packages/entities/entities-vaults/sandbox/pages/VaultFormPage.vue
+++ b/packages/entities/entities-vaults/sandbox/pages/VaultFormPage.vue
@@ -38,6 +38,7 @@ const konnectConfig = ref<KonnectVaultFormConfig>({
   azureVaultProviderAvailable: true,
   jsonYamlFormsEnabled: true,
   ttl: true,
+  hcvAppRoleMethodAvailable: true,
 })
 
 const kongManagerConfig = ref<KongManagerVaultFormConfig>({
@@ -52,6 +53,7 @@ const kongManagerConfig = ref<KongManagerVaultFormConfig>({
   cancelRoute: { name: 'vault-list' },
   azureVaultProviderAvailable: false,
   ttl: true,
+  hcvAppRoleMethodAvailable: true,
 })
 
 const onError = (error: AxiosError) => {

--- a/packages/entities/entities-vaults/src/locales/en.json
+++ b/packages/entities/entities-vaults/src/locales/en.json
@@ -213,8 +213,26 @@
           "kube_role": {
             "label": "Kubernetes Role"
           },
+          "kube_auth_path": {
+            "label": "Kubernetes Auth Path"
+          },
           "kube_api_token_file": {
             "label": "Kubernetes API Token File"
+          },
+          "approle_auth_path": {
+            "label": "App Role Auth Path"
+          },
+          "approle_role_id": {
+            "label": "App Role Role ID"
+          },
+          "approle_secret_id": {
+            "label": "App Role Secret ID"
+          },
+          "approle_secret_id_file": {
+            "label": "App Role Secret ID File"
+          },
+          "approle_response_wrapping": {
+            "label": "App Role Response Wrapping"
           }
         }
       },

--- a/packages/entities/entities-vaults/src/types/vault-form.ts
+++ b/packages/entities/entities-vaults/src/types/vault-form.ts
@@ -14,6 +14,11 @@ export interface BaseVaultFormConfig extends Omit<BaseFormConfig, 'cancelRoute'>
    * TODO: remove when support for Support TTL is added
    */
   ttl: boolean
+  /**
+   * Show/hide approle option and corresponding fields
+   * TODO: remove when support for approle option is added
+   */
+  hcvAppRoleMethodAvailable?: boolean
 }
 
 /** Konnect Vault form config */
@@ -32,7 +37,8 @@ export enum VaultProviders {
 
 export enum VaultAuthMethods {
   TOKEN = 'token',
-  K8S = 'kubernetes'
+  K8S = 'kubernetes',
+  APP_ROLE = 'approle'
 }
 
 export interface KongVaultConfig {
@@ -63,7 +69,13 @@ export interface HCVVaultConfig {
   auth_method: string
   token?: string
   kube_role?: string
+  kube_auth_path?: string
   kube_api_token_file?: string
+  approle_auth_path?: string
+  approle_role_id?: string
+  approle_secret_id?: string
+  approle_secret_id_file?: string
+  approle_response_wrapping?: boolean
   ttl?: number
   neg_ttl?: number
   resurrect_ttl?: number


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

For the HCV provider:
- Adding support for `approle` auth method
- Adding the missing `kube_auth_path` field which should have been added for Kong Gateway 3.5

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
