### PR TITLE
fix: tooltip units were not reactive on timeseries charts

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
@@ -397,7 +397,7 @@ watch(multiDimensionToggle, () => {
 
 .chart-container {
   height: 500px;
-  max-width:60vw;
+  max-width:70vw;
 
   @media(max-width: ($kui-breakpoint-laptop - 1px)) {
     max-width: 100vw;

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -243,10 +243,10 @@ const positionToClass = (position: `${ChartLegendPosition}`) => {
   &.vertical {
     flex-direction: column;
     max-height: 90%;
-    width: 15%;
-
+    max-width: 15%;
+    min-width: 10%;
     .truncate-label {
-      max-width: 10ch;
+      max-width: 12ch;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -169,7 +169,7 @@ const tooltipData: TooltipState = reactive({
   tooltipSeries: [],
   left: '',
   top: '',
-  units: props.metricUnit,
+  units: toRef(props, 'metricUnit'),
   translateUnit,
   offsetX: 0,
   offsetY: 0,


### PR DESCRIPTION
# Summary

Make units reactive.

Fix some spacing issue when the legend is vertical (right) 

https://konghq.atlassian.net/browse/MA-2568
<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
