### PR TITLE
feat(documentation): add prop to wrap empty state in a KCard

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,6 +32,7 @@
 /packages/core/i18n/ @adamdehaven @ValeryG @jillztom
 /packages/core/misc-widgets/ @Kong/team-core-ui
 /packages/core/forms/ @Kong/team-km @Kong/team-core-ui @LukeSwierlik @QueaT-kong
+/packages/core/documentation/ @Kong/team-core-ui @dustinryerson @lukewhchen
 
 # Portal packages
 /packages/portal/document-viewer/ @Kong/team-devx

--- a/packages/core/documentation/docs/DocumentationContent/README.md
+++ b/packages/core/documentation/docs/DocumentationContent/README.md
@@ -12,6 +12,7 @@ The main Kong UI component for display documentation.
   - [`cacheKey`](#cachekey)
   - [`canEdit`](#canedit)
   - [`documentList`](#documentlist)
+  - [`emptyStateCard`](#emptystatecard)
   - [`entityId`](#entityid)
   - [`hidePublishToggle`](#hidepublishtoggle)
   - [`card`](#card)
@@ -53,6 +54,7 @@ yarn add @kong-ui-public/documentation
   :cache-key="cacheKey"
   :can-edit="isAllowed"
   :document-list="documentList"
+  empty-state-card
   :entity-id="serviceId"
   hide-publish-toggle
   :card="false"
@@ -103,6 +105,13 @@ yarn add @kong-ui-public/documentation
 - Required: true
 - Default: N/A
 - Use: The list of document items passed into the `items` prop of the `KTreeList` component
+
+### `emptyStateCard`
+
+- Type: Boolean
+- Required: false
+- Default: false
+- Use: Boolean for wrapping the empty state component in a KCard
 
 ### `entityId`
 

--- a/packages/core/documentation/src/components/DocumentationContent.vue
+++ b/packages/core/documentation/src/components/DocumentationContent.vue
@@ -1,10 +1,18 @@
 <template>
   <div class="documentation">
-    <DocumentationPageEmptyState
-      v-if="documentList && !documentList.length"
-      :can-edit="canEdit"
-      @create-documentation="handleAddClick"
-    />
+    <div v-if="documentList && !documentList.length">
+      <KCard v-if="emptyStateCard">
+        <DocumentationPageEmptyState
+          :can-edit="canEdit"
+          @create-documentation="handleAddClick"
+        />
+      </KCard>
+      <DocumentationPageEmptyState
+        v-else
+        :can-edit="canEdit"
+        @create-documentation="handleAddClick"
+      />
+    </div>
     <KCard
       v-else
       class="documentation-card"
@@ -105,6 +113,13 @@ const props = defineProps({
   documentList: {
     type: Array as PropType<DocumentListItem[]>,
     required: true,
+  },
+  /**
+   * Boolean for wrapping the empty state component in a KCard
+   */
+  emptyStateCard: {
+    type: Boolean,
+    default: false,
   },
   /**
    * The ID of the entity to which a document is associated.


### PR DESCRIPTION
# Summary

Adds an optional prop (defaulted to false) to wrap the documentation empty state with a KCard. This provides the ability to align empty state designs across Konnect.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
