### PR TITLE
fix(app-layout): sidebar overflow

### DIFF
--- a/packages/core/app-layout/sandbox/pages/LayoutPage.vue
+++ b/packages/core/app-layout/sandbox/pages/LayoutPage.vue
@@ -159,9 +159,9 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       to: '/?runtime-manager',
       label: 'retail-sandbox-rg', // runtime group name
       key: 'gateway-manager',
-      active: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager',
+      active: (activeItem.value as SidebarPrimaryItem)?.key === 'gateway-manager',
       // TODO: actually when you click on Runtime Manager it would not expand until the user picks a runtime group
-      expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'runtime-manager',
+      expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'gateway-manager' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'gateway-manager',
       items: [
         {
           name: 'Runtime Instances',

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -360,6 +360,7 @@ onBeforeUnmount(() => {
   }
 
   .sidebar-content-container {
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -368,6 +369,8 @@ onBeforeUnmount(() => {
     // Must use `scroll` so that the scrollbar width is always accounted for. Cannot use `overlay` here as it breaks in Firefox.
     overflow-y: scroll;
     padding-top: $sidebar-header-spacing;
+    position: relative;
+    width: 100%;
     // Only some browsers support `overflow: overlay`, it's deprecated
     @supports(overflow: overlay) {
       overflow-y: overlay;
@@ -377,6 +380,11 @@ onBeforeUnmount(() => {
     // Only show scrollbar when hovering over nav
     &:hover {
       @include scrollbarVisible;
+    }
+
+    nav {
+      box-sizing: border-box;
+      width: 100%;
     }
   }
 
@@ -532,9 +540,15 @@ onBeforeUnmount(() => {
   }
 
   .level-primary {
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    padding: $kui-space-0 $kui-space-40; // if changed, ensure you test in ALL browsers
+    padding: $kui-space-0 $kui-space-10 $kui-space-0 $kui-space-50; // if changed, ensure you test in ALL browsers
+    width: 100%;
+    // Adjust padding for Safari-only
+    @supports (background: -webkit-named-image(i)) {
+      padding: $kui-space-0 $kui-space-40;
+    }
 
     &:last-of-type {
       margin-bottom: $sidebar-header-spacing * 4;

--- a/packages/core/app-layout/src/styles/variables/_app-sidebar.scss
+++ b/packages/core/app-layout/src/styles/variables/_app-sidebar.scss
@@ -25,7 +25,7 @@ $scrollbar-background-color: $kui-color-background-transparent;
 
   // Standard version (Firefox only for now) - always include
   scrollbar-color: $kui-color-background-transparent $kui-color-background-transparent;
-  scrollbar-gutter: stable both-edges;
+  scrollbar-gutter: stable;
   scrollbar-width: thin;
 }
 
@@ -42,6 +42,6 @@ $scrollbar-background-color: $kui-color-background-transparent;
 
   // Standard version (Firefox only for now) - always include
   scrollbar-color: $foreground-color $background-color;
-  scrollbar-gutter: stable both-edges;
+  scrollbar-gutter: stable;
   scrollbar-width: thin;
 }


### PR DESCRIPTION
# Summary

Fix the sidebar items from being cut off when expanded (notice the right edge)

## Before

![image](https://github.com/Kong/public-ui-components/assets/2229946/205a70e6-a144-4dfb-ab70-46a1b92fe689)


## After

![image](https://github.com/Kong/public-ui-components/assets/2229946/3a767d4a-7c5c-4530-a68f-5530142a01b2)
