### PR TITLE
feat(entities-shared): consumers are not showing up in consumer group [KHCP-10622]

### DIFF
--- a/packages/entities/entities-shared/src/composables/useFetcher.ts
+++ b/packages/entities/entities-shared/src/composables/useFetcher.ts
@@ -47,6 +47,7 @@ export default function useFetcher(
       }
 
       const { data } = await axiosInstance.get(requestUrl)
+
       const dataKey = (dataKeyName && dataKeyName.replace(/[^\w-_]/gi, ''))
       let tableData
 
@@ -55,6 +56,9 @@ export default function useFetcher(
       } else if (Array.isArray(data)) {
         // An array of object is returned
         tableData = data
+      } else if (data?.data && Array.isArray(data.data)) {
+        // Structure { data: { data: [{ id: 1, ... }]
+        tableData = data.data
       } else {
         // Single object is returned, so wrap in an array
         tableData = Object.keys(data).length ? [data] : []


### PR DESCRIPTION
# Summary
- **Fix** - Adding support for `useFetcher` when a response from BE arrives of the type:
```ts
data: {
    data: [
        {
            id: '1',
            ...
        }
    ]
}
```
![Screenshot 2024-02-07 at 13 20 08](https://github.com/Kong/public-ui-components/assets/40358447/44f66409-12b2-44f9-8068-c75c84ac8f90)


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
