### PR TITLE
feat(plugins): allow creating dup plugins [khcp-10683]

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -344,14 +344,6 @@ const buildPluginList = (): PluginCardList => {
         plugin.disabledMessage = props.disabledPlugins[pluginId]
       }
 
-      if (existingEntityPlugins.value.includes(pluginId)) {
-        plugin.exists = true
-
-        if (!plugin.disabledMessage) {
-          plugin.disabledMessage = t('plugins.select.already_exists')
-        }
-      }
-
       const groupName = plugin.group || t('plugins.select.misc_plugins')
       let plugins = list[groupName]
 


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
Remove the logic that prevents users from adding duplicate plugins of the same type to the same entity. We need to support creating multiple plugins of the same type for `consumers`/`consumer_groups` to allow scoping to multiple entities simultaneously (ie. I can create a plugin scoped to a specific `consumer_group`/`route` and have a different configuration for the same plugin when it's scoped to a specific `consumer_group`/`gateway-service` correctly).
Addresses [KHCP-10683](https://konghq.atlassian.net/browse/KHCP-10683).

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)


[KHCP-10683]: https://konghq.atlassian.net/browse/KHCP-10683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ