### PR TITLE
fix(core): catch an improper inject and provide fallback

### DIFF
--- a/packages/core/core/src/useAxios/index.ts
+++ b/packages/core/core/src/useAxios/index.ts
@@ -8,14 +8,24 @@ export default function useAxios() {
    * @param {AxiosRequestConfig} options The axios request config
    * @returns {AxiosInstance} The axios instance
    */
-  const getAxiosInstance = inject<(options?: AxiosRequestConfig) => AxiosInstance>('get-axios-instance', (options: AxiosRequestConfig = {}): AxiosInstance => {
-    // Return a fallback instance
-    return axios.create({
+  const getAxiosInstance = (options?: AxiosRequestConfig) => {
+    const fallbackInstance: AxiosInstance = axios.create({
       withCredentials: true,
       timeout: 30000,
       ...options,
     })
-  })
+
+    try {
+      return inject<(options?: AxiosRequestConfig) => AxiosInstance>('get-axios-instance', (): AxiosInstance => {
+        // Return a fallback instance if the injection key is not provided
+        return fallbackInstance
+      })
+    } catch (err: any) {
+      console.warn('getAxiosInstance:', err.message || err)
+      // inject() can only be used inside setup() or functional components, so provide the fallback instance
+      return fallbackInstance
+    }
+  }
 
   /**
    * Get the `x-datadog-trace-id` header from the provided error, if it exists

--- a/packages/core/core/src/useAxios/index.ts
+++ b/packages/core/core/src/useAxios/index.ts
@@ -8,22 +8,30 @@ export default function useAxios() {
    * @param {AxiosRequestConfig} options The axios request config
    * @returns {AxiosInstance} The axios instance
    */
-  const getAxiosInstance = (options?: AxiosRequestConfig) => {
-    const fallbackInstance: AxiosInstance = axios.create({
-      withCredentials: true,
-      timeout: 30000,
-      ...options,
-    })
-
+  const getAxiosInstance = (options: AxiosRequestConfig = {}) => {
     try {
-      return inject<(options?: AxiosRequestConfig) => AxiosInstance>('get-axios-instance', (): AxiosInstance => {
-        // Return a fallback instance if the injection key is not provided
-        return fallbackInstance
+      const injectedInstance = inject<(options?: AxiosRequestConfig) => AxiosInstance>('get-axios-instance')
+      // If the injected instance exists, return the called function
+      if (typeof injectedInstance === 'function') {
+        return injectedInstance(options)
+      }
+
+      // Return a fallback instance
+      return axios.create({
+        withCredentials: true,
+        timeout: 30000,
+        ...options,
       })
     } catch (err: any) {
+      // Log a warning
       console.warn('getAxiosInstance:', err.message || err)
-      // inject() can only be used inside setup() or functional components, so provide the fallback instance
-      return fallbackInstance
+
+      // Return a fallback instance
+      return axios.create({
+        withCredentials: true,
+        timeout: 30000,
+        ...options,
+      })
     }
   }
 

--- a/packages/core/core/src/useAxios/index.ts
+++ b/packages/core/core/src/useAxios/index.ts
@@ -16,7 +16,7 @@ export default function useAxios() {
         return injectedInstance(options)
       }
 
-      // Return a fallback instance
+      // Otherwise, return a fallback instance
       return axios.create({
         withCredentials: true,
         timeout: 30000,


### PR DESCRIPTION
# Summary

Wrap the `inject` axios instance with try/catch to provide a fallback instance if the `getAxiosInstance` method is called outside of the setup function.
