### PR TITLE
fix: spacing issues in grid layout

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
@@ -70,15 +70,41 @@ const tileWidth = computed(() => {
   return (containerWidth.value / props.gridSize.cols) - GAP_SIZE
 })
 
+const tilesPerRow = computed(() => {
+  const count = new Array(props.gridSize.rows).fill(0) // Initialize an array to hold the count of tiles per row
+
+  props.tiles.forEach(tile => {
+    const rowIndex = tile.layout.position.row // Assuming rows are zero-indexed
+    count[rowIndex]++
+  })
+
+  return count
+})
+
 const gridCells = computed<Cell<T>[]>(() => {
+  const rowTileCounts: number[] = []
   return props.tiles.map((tile, i) => {
+    const row = tile.layout.position.row
+
+    // If this row hasn't been encountered yet, initialize its count
+    if (!rowTileCounts[row]) {
+      rowTileCounts[row] = 0
+    }
+
+    // Increment the tile count for this row to determine the tile's ordinal position
+    rowTileCounts[row]++
+
+    // This is the tile's nth position in its row
+    const nthPosition = rowTileCounts[row]
     // Position elements based on their grid position and dimensions.
-    const translateX = tile.layout.position.col * (tileWidth.value + GAP_SIZE)
-    // find the tile above the current tile
+    let translateX = tile.layout.position.col * (tileWidth.value + GAP_SIZE)
+    if (tile.layout.position.col > 0) {
+      translateX += (GAP_SIZE / tilesPerRow.value[tile.layout.position.row]) * (nthPosition - 1)
+    }
     const translateY = tile.layout.position.row * (props.tileHeight + GAP_SIZE)
 
     // Size tiles based on their dimensions and cell span.
-    const width = tile.layout.size.cols * tileWidth.value + (GAP_SIZE * (tile.layout.size.cols - 1))
+    const width = tile.layout.size.cols * tileWidth.value + (GAP_SIZE * (tile.layout.size.cols - 1)) + (GAP_SIZE / tilesPerRow.value[tile.layout.position.row]) - 1
     const height = tile.layout.size.rows * props.tileHeight + (GAP_SIZE * (tile.layout.size.rows - 1))
 
     return {
@@ -106,7 +132,6 @@ const gridHeight = computed(() => {
   height: v-bind('`${gridHeight}px`');
   width: 100%;
 }
-
 .grid-cell {
   position: absolute;
 


### PR DESCRIPTION
# Summary

Because cells are absolutely positioned, it's a bit more complicated to have the cells
start/end at the margins of the layout itself, while maintaining a gap betwen cells

In order to do this, the width of each cell needs to be increased by a fraction of the gap size
proportional to the number of tiles present in that row

Each cell then needs to be translated an additional fraction of the gap size based on its position
in the row

![image](https://github.com/Kong/public-ui-components/assets/6026470/5f373437-3a93-459c-9e43-34716e54bd4b)
![image](https://github.com/Kong/public-ui-components/assets/6026470/f8a10dc1-9c1a-45b3-ae8a-6a05489529f5)
![image](https://github.com/Kong/public-ui-components/assets/6026470/1c1531af-b479-44af-a12e-1ad531d1d6a6)



<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
