### PR TITLE
fix(entities-plugins): custom plugins are hidden in select page for KM

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginSelect.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.cy.ts
@@ -50,8 +50,8 @@ const baseConfigKM:KongManagerPluginSelectConfig = {
 
 // filter out these 3 groups because we currently don't have
 // any plugins for 'Deployment' and 'WebSocket Plugins'.
-// Custom plugins are not shown in Kong Manager and displayed
-// separately in Konnect.
+// Custom plugins are not shown with `kmAvailablePlugins` in Kong Manager
+// and displayed separately in Konnect.
 const PLUGIN_GROUPS_IN_USE = PluginGroupArray.filter((group: string) => {
   if (group === PluginGroup.CUSTOM_PLUGINS || group === PluginGroup.DEPLOYMENT ||
       group === PluginGroup.WEBSOCKET) {
@@ -168,6 +168,35 @@ describe('<PluginSelect />', () => {
       ignoredPlugins.forEach((pluginName) => {
         cy.getTestId(`${pluginName}-card`).should('not.exist')
       })
+    })
+
+    it('should correctly render custom plugins', () => {
+      interceptKM({
+        mockData: {
+          plugins: {
+            enabled_in_cluster: [],
+            available_on_server: {
+              ...kmAvailablePlugins.plugins.available_on_server,
+              'custom-plugin-a': {},
+              'custom-plugin-b': {},
+            },
+          },
+        },
+      })
+
+      cy.mount(PluginSelect, {
+        props: {
+          config: baseConfigKM,
+        },
+      })
+
+      cy.wait('@getAvailablePlugins')
+
+      cy.get('.kong-ui-entities-plugin-select-form').should('be.visible')
+      cy.get('.kong-ui-entities-plugin-select-form .plugins-results-container').should('be.visible')
+
+      cy.get('.plugin-select-card[data-testid="custom-plugin-a-card"]').should('be.visible')
+      cy.get('.plugin-select-card[data-testid="custom-plugin-b-card"]').should('be.visible')
     })
 
     it('should correctly render available plugins when isAvailableOnly is true', () => {

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="plugin-select-grid">
     <KEmptyState
-      v-if="!Object.keys(nonCustomPlugins).length"
+      v-if="!Object.keys(displayedPlugins).length"
       class="plugins-empty-state"
       cta-is-hidden
       data-testid="plugins-empty-state"
@@ -24,7 +24,7 @@
 
     <template v-for="(group, idx) in PluginGroupArray">
       <div
-        v-if="nonCustomPlugins[group]"
+        v-if="displayedPlugins[group]"
         :key="idx"
       >
         <KCollapse
@@ -44,7 +44,7 @@
           <template #visible-content>
             <div class="plugin-card-container">
               <PluginSelectCard
-                v-for="(plugin, index) in getPluginCards('visible', nonCustomPlugins[group as keyof PluginCardList] || [], pluginsPerRow)"
+                v-for="(plugin, index) in getPluginCards('visible', displayedPlugins[group as keyof PluginCardList] || [], pluginsPerRow)"
                 :key="`plugin-card-${index}`"
                 :config="config"
                 :navigate-on-click="navigateOnClick"
@@ -56,7 +56,7 @@
 
           <div class="plugin-card-container">
             <PluginSelectCard
-              v-for="(plugin, index) in getPluginCards('hidden', nonCustomPlugins[group as keyof PluginCardList] || [], pluginsPerRow)"
+              v-for="(plugin, index) in getPluginCards('hidden', displayedPlugins[group as keyof PluginCardList] || [], pluginsPerRow)"
               :key="`plugin-card-${index}`"
               :config="config"
               :navigate-on-click="navigateOnClick"
@@ -132,24 +132,26 @@ const emitPluginData = (plugin: PluginType) => {
   emit('plugin-clicked', plugin)
 }
 
-// remove custom plugin from original pluginList
-const nonCustomPlugins = computed((): PluginCardList => {
+const displayedPlugins = computed((): PluginCardList => {
   const kongPlugins = JSON.parse(JSON.stringify(props.pluginList))
 
-  delete kongPlugins[PluginGroup.CUSTOM_PLUGINS]
+  // remove custom plugin from original pluginList in Konnect
+  if (props.config.app === 'konnect') {
+    delete kongPlugins[PluginGroup.CUSTOM_PLUGINS]
+  }
 
   return kongPlugins
 })
 
 const getGroupPluginCount = (group: string) => {
-  return nonCustomPlugins.value[group as keyof PluginCardList]?.length || 0
+  return displayedPlugins.value[group as keyof PluginCardList]?.length || 0
 }
 
 // text for plugin group "view x more" label
 const triggerLabels = computed(() => {
-  return Object.keys(nonCustomPlugins.value).reduce((acc: TriggerLabels, pluginGroup: string): TriggerLabels => {
-    const totalCount = getPluginCards('all', nonCustomPlugins.value[pluginGroup as keyof PluginCardList] || [], props.pluginsPerRow)?.length || 0
-    const hiddenCount = getPluginCards('hidden', nonCustomPlugins.value[pluginGroup as keyof PluginCardList] || [], props.pluginsPerRow)?.length || 0
+  return Object.keys(displayedPlugins.value).reduce((acc: TriggerLabels, pluginGroup: string): TriggerLabels => {
+    const totalCount = getPluginCards('all', displayedPlugins.value[pluginGroup as keyof PluginCardList] || [], props.pluginsPerRow)?.length || 0
+    const hiddenCount = getPluginCards('hidden', displayedPlugins.value[pluginGroup as keyof PluginCardList] || [], props.pluginsPerRow)?.length || 0
 
     if (totalCount > props.pluginsPerRow) {
       acc[pluginGroup as keyof TriggerLabels] = t('plugins.select.view_more', { count: hiddenCount })


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

We should still show custom plugins in KM, just not in a separate tab.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
