### PR TITLE
fix(core): provide a default value for axios injection

### DIFF
--- a/packages/core/core/src/useAxios/index.ts
+++ b/packages/core/core/src/useAxios/index.ts
@@ -10,7 +10,7 @@ export default function useAxios() {
    */
   const getAxiosInstance = (options: AxiosRequestConfig = {}) => {
     try {
-      const injectedInstance = inject<(options?: AxiosRequestConfig) => AxiosInstance>('get-axios-instance')
+      const injectedInstance = inject<((options?: AxiosRequestConfig) => AxiosInstance) | undefined>('get-axios-instance', undefined)
       // If the injected instance exists, return the called function
       if (typeof injectedInstance === 'function') {
         return injectedInstance(options)


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

There's a warning if we don't provide `get-axios-instance` in the host app:
<img width="1458" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/7d37381f-f070-43e4-8d91-9d240de0bf4e">

We need to explicitly provide a default value to clear the warning: https://github.com/vuejs/core/blob/89de26cdcdddef8096417ea494de113399629d5b/packages/runtime-core/src/apiInject.ts#L68


#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
