### PR TITLE
 feat(dashboard-renderer): add TopN table support to dashboard renderer

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
@@ -288,7 +288,7 @@ const dimensionItems = [{
 
 // Short labels
 const statusCodeLabels = [
-  '200', '300', '400', '123123213asa sdfasdfasd', 'asdfasdfasdfasdfadsfasdf',
+  '200', '300', '400', '123123213asa-asdasdf', 'asdfasdfasdfasdfadsfasdf',
 ]
 
 const statusCodeDimensionValues = ref(new Set(statusCodeLabels))

--- a/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
@@ -189,6 +189,7 @@
       :data="topNTableData"
       description="Last 30-Day Summary"
       :is-loading="showLoadingState"
+      no-border
       title="Top 5 Routes"
     >
       <template #name="{ record }">

--- a/packages/analytics/analytics-chart/src/components/TopNTable.vue
+++ b/packages/analytics/analytics-chart/src/components/TopNTable.vue
@@ -1,5 +1,8 @@
 <template>
-  <KCard class="kong-ui-public-top-n-table">
+  <KCard
+    class="kong-ui-public-top-n-table"
+    :class="{ 'border-none': noBorder }"
+  >
     <template
       v-if="title"
       #title
@@ -132,6 +135,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  noBorder: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const { i18n } = composables.useI18n()
@@ -227,6 +234,9 @@ const getValue = (record: AnalyticsExploreRecord): string => {
 .kong-ui-public-top-n-table {
   border-radius: $kui-border-radius-40 !important;
 
+  &.border-none {
+    border: none !important;
+  }
   .top-n-card-title {
     font-size: $kui-font-size-40;
   }

--- a/packages/analytics/analytics-chart/src/components/TopNTable.vue
+++ b/packages/analytics/analytics-chart/src/components/TopNTable.vue
@@ -233,6 +233,7 @@ const getValue = (record: AnalyticsExploreRecord): string => {
 <style lang="scss" scoped>
 .kong-ui-public-top-n-table {
   border-radius: $kui-border-radius-40 !important;
+  padding: 0 !important;
 
   &.border-none {
     border: none !important;

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -67,6 +67,7 @@ const shouldTruncate = ref(false)
 const showValues = inject('showLegendValues', true)
 const position = inject('legendPosition', ref(ChartLegendPosition.Right))
 const legendItemsTracker = ref<LegendItem[]>([])
+const legendHeight = ref('30px')
 
 // Check if the legend wraps by comparing the top position of each item.
 const doesTheLegendWrap = () => {
@@ -92,8 +93,12 @@ const checkForWrap = () => {
   if (legendContainerRef.value && position.value === ChartLegendPosition.Bottom) {
     if (doesTheLegendWrap()) {
       shouldTruncate.value = true
+      // Allow for two rows of legend items
+      legendHeight.value = '60px'
     } else {
       shouldTruncate.value = false
+      // Only need space for one row of legend items
+      legendHeight.value = '30px'
     }
   } else if (legendContainerRef.value && position.value === ChartLegendPosition.Right) {
     shouldTruncate.value = true
@@ -225,7 +230,6 @@ const positionToClass = (position: `${ChartLegendPosition}`) => {
     [ChartLegendPosition.Hidden]: 'hidden',
   }[position]
 }
-
 </script>
 
 <style lang="scss" scoped>
@@ -271,8 +275,8 @@ const positionToClass = (position: `${ChartLegendPosition}`) => {
   &.horizontal {
     column-gap: $kui-space-80;
     display: grid;
+    height: v-bind('legendHeight');
     justify-content: center;
-    max-height: 12%;
     width: 99%;
     .truncate-label {
       max-width: 15ch;

--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -373,6 +373,9 @@ onMounted(() => {
   }
 
   if (chartContainerRef.value) {
+    // Initialize base dimensions since resize observer is debounced.
+    baseWidth.value = (chartContainerRef.value as HTMLDivElement).offsetWidth
+    baseHeight.value = (chartContainerRef.value as HTMLDivElement).offsetHeight
     resizeObserver.observe(chartContainerRef.value as HTMLDivElement)
   }
 })

--- a/packages/analytics/analytics-chart/src/styles/chart.scss
+++ b/packages/analytics/analytics-chart/src/styles/chart.scss
@@ -11,7 +11,7 @@
     flex-direction: column;
 
     .chart-container {
-      height: 88%;
+      height: calc(100% - 80px);
       width: 100%;
     }
   }

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -65,7 +65,7 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "200KB"
+    "errorLimit": "256KB"
   },
   "peerDependencies": {
     "@kong-ui-public/analytics-chart": "workspace:^",

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -96,6 +96,26 @@ const dashboardConfig: DashboardConfig = {
     {
       definition: {
         chart: {
+          type: ChartTypes.TopN,
+          chartTitle: 'Top N chart of mock data',
+          description: 'Description',
+        },
+        query: {},
+      },
+      layout: {
+        position: {
+          col: 0,
+          row: 3,
+        },
+        size: {
+          cols: 3,
+          rows: 2,
+        },
+      },
+    } as TileConfig,
+    {
+      definition: {
+        chart: {
           type: ChartTypes.TimeseriesLine,
           fill: true,
         },
@@ -105,11 +125,11 @@ const dashboardConfig: DashboardConfig = {
       },
       layout: {
         position: {
-          col: 0,
+          col: 3,
           row: 3,
         },
         size: {
-          cols: 6,
+          cols: 3,
           rows: 2,
         },
       },

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -116,6 +116,7 @@ const dashboardConfig: DashboardConfig = {
     {
       definition: {
         chart: {
+          chartTitle: 'Timeseries line chart of mock data',
           type: ChartTypes.TimeseriesLine,
           fill: true,
         },

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -21,6 +21,7 @@ import { DEFAULT_TILE_HEIGHT } from '../constants'
 import TimeseriesChartRenderer from './TimeseriesChartRenderer.vue'
 import GoldenSignalsRenderer from './GoldenSignalsRenderer.vue'
 import { KUI_SPACE_70 } from '@kong/design-tokens'
+import TopNTableRenderer from './TopNTableRenderer.vue'
 
 const PADDING_SIZE = parseInt(KUI_SPACE_70, 10)
 
@@ -38,6 +39,7 @@ const rendererLookup: Record<ChartTypes, Component> = {
   [ChartTypes.VerticalBar]: BarChartRenderer,
   [ChartTypes.Gauge]: SimpleChartRenderer,
   [ChartTypes.GoldenSignals]: GoldenSignalsRenderer,
+  [ChartTypes.TopN]: TopNTableRenderer,
 }
 
 const componentData = computed(() => {

--- a/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
@@ -1,0 +1,25 @@
+<template>
+  <QueryDataProvider
+    v-slot="{ data }"
+    :context="context"
+    :query="query"
+    :query-ready="queryReady"
+  >
+    <TopNTable
+      :data="data"
+      :description="chartOptions.description"
+      no-border
+      :synthetics-data-key="chartOptions.syntheticsDataKey"
+      :title="chartOptions.chartTitle || ''"
+    />
+  </QueryDataProvider>
+</template>
+
+<script setup lang="ts">
+import type { RendererProps, TopNTableOptions } from '../types'
+import { TopNTable } from '@kong-ui-public/analytics-chart'
+import QueryDataProvider from './QueryDataProvider.vue'
+
+defineProps<RendererProps<TopNTableOptions>>()
+
+</script>

--- a/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
@@ -133,10 +133,6 @@ const gridHeight = computed(() => {
 }
 .grid-cell {
   position: absolute;
-
-  .tile-container {
-    margin: $kui-space-70;
-  }
 }
 
 @media (max-width: $kui-breakpoint-phablet) {

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -119,7 +119,7 @@ export const topNTableSchema = {
       type: 'string',
     },
   },
-  required: ['chartTitle'],
+  required: ['type'],
   additionalProperties: false,
 } as const satisfies JSONSchema
 

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -15,6 +15,7 @@ export enum ChartTypes {
   Gauge = 'gauge',
   TimeseriesLine = 'timeseries_line',
   GoldenSignals = 'golden_signals',
+  TopN = 'top_n',
 }
 
 // Common definition for many ChartJS tiles.
@@ -104,6 +105,25 @@ export const gaugeChartSchema = {
 } as const satisfies JSONSchema
 
 export type GaugeChartOptions = FromSchema<typeof gaugeChartSchema>
+
+export const topNTableSchema = {
+  type: 'object',
+  properties: {
+    chartTitle,
+    syntheticsDataKey,
+    type: {
+      type: 'string',
+      enum: [ChartTypes.TopN],
+    },
+    description: {
+      type: 'string',
+    },
+  },
+  required: ['chartTitle'],
+  additionalProperties: false,
+} as const satisfies JSONSchema
+
+export type TopNTableOptions = FromSchema<typeof topNTableSchema>
 
 export const metricCardSchema = {
   type: 'object',
@@ -320,7 +340,7 @@ export const tileDefinitionSchema = {
   properties: {
     query: exploreV4QuerySchema,
     chart: {
-      oneOf: [barChartSchema, gaugeChartSchema, timeseriesChartSchema, metricCardSchema],
+      oneOf: [barChartSchema, gaugeChartSchema, timeseriesChartSchema, metricCardSchema, topNTableSchema],
     },
   },
   required: ['query', 'chart'],


### PR DESCRIPTION
# Summary

<img width="1343" alt="image" src="https://github.com/Kong/public-ui-components/assets/6026470/37c2093b-8644-49f9-b27d-839f8807ee26">

add optional prop to hide the default border on TopNTable

dynamically set the hight of the horizontal legend based on if there needs to be
more than one row or not.

Only need to allocate space for one row if there's only one row.

If there's more than one row, allocate space for 2 rows, the rest overflows.

Set the chart-container hight to 100% - 80px to account for the legend + chart title
when chart and legend is stacked

https://konghq.atlassian.net/browse/MA-2637

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
