### PR TITLE
fix(entities-consumer-credentials): hide encrypted fields in toast

### DIFF
--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -376,11 +376,14 @@ const notifyCopyAction = (param: CopyUuidNotifyParam, entity: EntityRow, field: 
 }
 
 const onCopySuccess = (entity: EntityRow, field: string | undefined) => {
+  const encryptedFields = ['password', 'key', 'client_secret', 'secret']
   // Emit the success event for the host app
   emit('copy:success', {
     entity,
     field,
-    message: field ? t('credentials.copy.success', { val: entity[field] }) : t('credentials.copy.success_brief'),
+    message: field && !encryptedFields.includes(field)
+      ? t('credentials.copy.success', { val: entity[field] })
+      : t('credentials.copy.success_brief'),
   })
 }
 


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

When encrypted fields are successfully copied, their values should be hidden from the toast.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
