### PR TITLE
fix(metric-cards): determine trend range text from response [MA-2650]

### DIFF
--- a/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
@@ -48,7 +48,7 @@ const trafficCard = composables.useMetricCardBuilder({
   hasError: traffic.hasError,
   lookupKey: props.lookupKey,
   sumGroupedValues: ALL_STATUS_CODE_GROUPS,
-  trendRange: providerData.trendRange,
+  trendRange: traffic.trendRange,
 })
 
 // Error rate (special case, requires operation)
@@ -77,7 +77,7 @@ const errorRateCard = computed<MetricCardDef>(() => {
       : i18n.t('metricCard.short.errorRate'),
     description: providerData.description,
     increaseIsBad: true,
-    trendRange: providerData.trendRange.value,
+    trendRange: traffic.trendRange.value,
   }
 })
 
@@ -93,7 +93,7 @@ const latencyCard = composables.useMetricCardBuilder({
   lookupKey: props.lookupKey,
   increaseIsBad: true,
   formatValueFn: formatLatency,
-  trendRange: providerData.trendRange,
+  trendRange: latency.trendRange,
 })
 
 const cards: Ref<MetricCardDef[]> = computed(() => {
@@ -126,7 +126,6 @@ const containerOpts = computed(() => ({
   fallbackDisplayText: i18n.t('general.notAvailable'),
   cardSize: props.cardSize,
   hideTitle: true,
-  trendRange: providerData.trendRange.value,
 }))
 
 const cardValues = computed(() => ({

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsProviderInternal.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsProviderInternal.vue
@@ -5,8 +5,7 @@
   />
 </template>
 <script setup lang="ts">
-import { inject, type Ref } from 'vue'
-import { computed, provide, toRef } from 'vue'
+import { inject, computed, provide, toRef } from 'vue'
 import {
   type AnalyticsBridge,
   type ExploreFilter,
@@ -16,10 +15,7 @@ import {
 } from '@kong-ui-public/analytics-utilities'
 import { TimePeriods, TimeframeKeys } from '@kong-ui-public/analytics-utilities'
 import { METRICS_PROVIDER_KEY, defaultFetcherDefs } from './metricsProviderUtil'
-import composables from '../composables'
 import { INJECT_QUERY_PROVIDER } from '../constants'
-
-const { i18n } = composables.useI18n()
 
 const props = withDefaults(defineProps<{
   maxTimeframe?: TimeframeKeys,
@@ -95,20 +91,6 @@ const timeframe = computed(() => {
   return retval
 })
 
-// If one of our relative timeframes, we display the requested time frame (if user has trend access); otherwise fall back to one day
-// Else, we have a Custom start and end datetime coming from v-calendar, so we display "vs previous X days"
-const trendRangeText = computed(() => {
-  if (timeframe.value.key === 'custom') {
-    return i18n.t('trendRange.custom', { numDays: Math.ceil(timeframe.value.timeframeLength() / (1000 * 60 * 24)) })
-  } else {
-    return props.hasTrendAccess
-      // @ts-ignore - dynamic i18n key
-      ? i18n.t(`trendRange.${timeframe.value.key}`)
-      // @ts-ignore - dynamic i18n key
-      : i18n.t(`trendRange.${TimePeriods.get(TimeframeKeys.ONE_DAY)?.key}`)
-  }
-})
-
 const {
   trafficData,
   latencyData,
@@ -133,7 +115,6 @@ provide(METRICS_PROVIDER_KEY, {
   description: props.description,
   hasTrendAccess: props.hasTrendAccess,
   longCardTitles: props.longCardTitles,
-  trendRange: trendRangeText as Ref<string>,
 })
 
 </script>

--- a/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
+++ b/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
@@ -16,7 +16,6 @@ interface ProviderData {
   description?: string,
   hasTrendAccess: boolean,
   longCardTitles: boolean,
-  trendRange: Ref<string>,
 }
 
 export const METRICS_PROVIDER_KEY = Symbol('METRICS_PROVIDER_KEY') as InjectionKey<ProviderData>

--- a/packages/analytics/analytics-metric-provider/src/locales/en.json
+++ b/packages/analytics/analytics-metric-provider/src/locales/en.json
@@ -15,7 +15,7 @@
     }
   },
   "trendRange": {
-    "custom": "vs previous {numDays} days",
+    "custom": "vs previous {numDays, plural, =1 {day} other {# days}}",
     "15m": "vs previous 15 minutes",
     "1h": "vs previous hour",
     "6h": "vs previous 6 hours",


### PR DESCRIPTION
- Attempt to move away from `timeframeLength`; use the response coming back from the server.
- Use `withTrend` option to determine whether a trend was queried or not.
- Properly pluralize 'previous day' / 'previous N days'

# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
