### PR TITLE
fix(chart): only show two rows max in legend [MA-2670]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -96,10 +96,10 @@ const checkForWrap = () => {
   if (legendContainerRef.value && position.value === ChartLegendPosition.Bottom) {
     if (doesTheLegendWrap()) {
       // Allow for two rows of legend items
-      legendHeight.value = '60px'
+      legendHeight.value = '48px'
     } else {
       // Only need space for one row of legend items
-      legendHeight.value = '30px'
+      legendHeight.value = '24px'
     }
   }
 }

--- a/packages/analytics/analytics-chart/src/styles/chart.scss
+++ b/packages/analytics/analytics-chart/src/styles/chart.scss
@@ -1,4 +1,4 @@
-$legend-height: $kui-space-130;
+$legend-height: $kui-space-120;
 
 .chart-parent {
   align-items: center;

--- a/packages/analytics/analytics-chart/src/styles/chart.scss
+++ b/packages/analytics/analytics-chart/src/styles/chart.scss
@@ -1,4 +1,4 @@
-$legend-height: $kui-space-120;
+$legend-height: $kui-space-110;
 
 .chart-parent {
   align-items: center;


### PR DESCRIPTION
# Summary

When legend wraps to a third line, it should force a scroll to see the third row

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
