### PR TITLE
fix(dashboard-renderer): tweak default options [MA-2709]

### DIFF
--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -131,7 +131,6 @@ const dashboardConfig: DashboardConfig = {
         chart: {
           chartTitle: 'Timeseries line chart of mock data',
           type: ChartTypes.TimeseriesLine,
-          fill: true,
         },
         query: {
           dimensions: ['time'],

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
@@ -95,6 +95,9 @@ const { data: v4Data, error, isValidating } = useSWRV(queryKey, async () => {
   } finally {
     emit('queryComplete')
   }
+}, {
+  refreshInterval: 0,
+  revalidateOnFocus: false,
 })
 
 const { state, swrvState: STATE } = useSwrvState(v4Data, error, isValidating)

--- a/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
@@ -32,12 +32,19 @@ const chartTypeLookup = {
   // TODO: Timeseries bar
 }
 
-const options = computed<AnalyticsChartOptions>(() => ({
-  type: chartTypeLookup[props.chartOptions.type],
-  fill: props.chartOptions.fill,
-  stacked: props.chartOptions.stacked,
-  chartDatasetColors: props.chartOptions.chartDatasetColors,
-}))
+const options = computed<AnalyticsChartOptions>(() => {
+  // Default `stacked` to false.
+  const stacked = props.chartOptions.stacked ?? false
+
+  // Note that `fill` and `stacked` are linked; it's not possible to have a non-filled stacked chart.
+  // This matches our intuitions about how these charts work.
+  return {
+    type: chartTypeLookup[props.chartOptions.type],
+    fill: stacked,
+    stacked,
+    chartDatasetColors: props.chartOptions.chartDatasetColors,
+  }
+})
 </script>
 
 <style scoped lang="scss">

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -85,9 +85,6 @@ export const timeseriesChartSchema = {
     stacked: {
       type: 'boolean',
     },
-    fill: {
-      type: 'boolean',
-    },
     chartDatasetColors: chartDatasetColorsSchema,
     syntheticsDataKey,
     chartTitle,


### PR DESCRIPTION
- Don't stack timeseries charts by default.
- If a timeseries chart is stacked, it should also be filled.
- Don't autorefresh charts on the dashboard.

# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
