### PR TITLE
feat(entities-plugins): UX improvements on plugin select [KM-18]

### DIFF
--- a/packages/entities/entities-plugins/docs/plugin-select.md
+++ b/packages/entities/entities-plugins/docs/plugin-select.md
@@ -30,55 +30,65 @@ A grid component for selecting Plugins.
 - type: `Object as PropType<KonnectPluginSelectConfig | KongManagerPluginSelectConfig>`
 - required: `true`
 - properties:
+
   - `app`:
+
     - type: `'konnect' | 'kongManager'`
     - required: `true`
     - default: `undefined`
     - App name.
 
   - `apiBaseUrl`:
+
     - type: `string`
     - required: `true`
     - default: `undefined`
     - Base URL for API requests.
 
   - `requestHeaders`:
+
     - type: `RawAxiosRequestHeaders | AxiosHeaders`
     - required: `false`
     - default: `undefined`
     - Additional headers to send with all Axios requests.
 
   - `getCreateRoute`:
+
     - type: `(plugin: string) => RouteLocationRaw`
     - required: `true`
     - default: `undefined`
     - A function that returns the route for creating a specific plugin type.
 
   - `createCustomRoute`:
+
     - type: RouteLocationRaw
     - required: `false`
     - default: `undefined`
     - The route for creating a custom plugin.
 
   - `getCustomEditRoute`:
+
     - type: `(plugin: string) => RouteLocationRaw`
     - required: `false`
     - default: `undefined`
     - A function that returns the route for editing a custom plugin.
 
   - `workspace`:
+
     - type: `string`
     - required: `true`
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - _Specific to Kong Manager_. Name of the current workspace.
 
   - `controlPlaneId`:
+
     - type: `string`
     - required: `true`
     - default: `undefined`
-    - *Specific to Konnect*. Name of the current control plane.
+    - _Specific to Konnect_. Name of the current control plane.
 
   - `entityId`:
+
     - type: `string`
     - required: `false`
     - default: `null`
@@ -159,7 +169,7 @@ Example:
 
 ```json
 {
-  'acl': 'ACL is not supported for this entity type',
+  "acl": "ACL is not supported for this entity type"
 }
 ```
 
@@ -170,6 +180,22 @@ Example:
 - default: `4`
 
 Number of plugins to always have visible (never will be collapsed).
+
+#### `highlightedPluginIds`
+
+- type: `string[]`
+- required: `false`
+- default: `[]`
+
+Ids of plugins to show in the highlighted plugins group.
+
+#### `highlightedPluginsTitle`
+
+- type: `string`
+- required: `false`
+- default: `''`
+
+Title for the highlighted plugins group
 
 ### Events
 

--- a/packages/entities/entities-plugins/docs/plugin-select.md
+++ b/packages/entities/entities-plugins/docs/plugin-select.md
@@ -30,70 +30,51 @@ A grid component for selecting Plugins.
 - type: `Object as PropType<KonnectPluginSelectConfig | KongManagerPluginSelectConfig>`
 - required: `true`
 - properties:
-
   - `app`:
-
     - type: `'konnect' | 'kongManager'`
     - required: `true`
     - default: `undefined`
     - App name.
-
   - `apiBaseUrl`:
-
     - type: `string`
     - required: `true`
     - default: `undefined`
     - Base URL for API requests.
-
   - `requestHeaders`:
-
     - type: `RawAxiosRequestHeaders | AxiosHeaders`
     - required: `false`
     - default: `undefined`
     - Additional headers to send with all Axios requests.
-
   - `getCreateRoute`:
-
     - type: `(plugin: string) => RouteLocationRaw`
     - required: `true`
     - default: `undefined`
     - A function that returns the route for creating a specific plugin type.
-
   - `createCustomRoute`:
-
     - type: RouteLocationRaw
     - required: `false`
     - default: `undefined`
     - The route for creating a custom plugin.
-
   - `getCustomEditRoute`:
-
     - type: `(plugin: string) => RouteLocationRaw`
     - required: `false`
     - default: `undefined`
     - A function that returns the route for editing a custom plugin.
-
   - `workspace`:
-
     - type: `string`
     - required: `true`
     - default: `undefined`
-    - _Specific to Kong Manager_. Name of the current workspace.
-
+    - *Specific to Kong Manager*. Name of the current workspace.
   - `controlPlaneId`:
-
     - type: `string`
     - required: `true`
     - default: `undefined`
-    - _Specific to Konnect_. Name of the current control plane.
-
+    - *Specific to Konnect*. Name of the current control plane.
   - `entityId`:
-
     - type: `string`
     - required: `false`
     - default: `null`
     - Current entity id if the PluginSelect is being launched from the plugins tab on a consumer, consumer group, gateway service, or route detail page.
-
   - `entityType`:
     - type: `'consumers' | 'consumer_groups' | 'services' | 'routes'`
     - required: `false`
@@ -193,7 +174,7 @@ Ids of plugins to show in the highlighted plugins group.
 
 - type: `string`
 - required: `false`
-- default: `''`
+- default: `i18n.t('plugins.select.highlighted_plugins.title')`
 
 Title for the highlighted plugins group
 

--- a/packages/entities/entities-plugins/sandbox/pages/PluginSelectPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginSelectPage.vue
@@ -4,12 +4,14 @@
     <PluginSelect
       :config="konnectConfig"
       :disabled-plugins="{ 'acl': 'ACL is not supported for this entity type'}"
+      :highlighted-plugin-ids="highlightedPluginIds"
       @delete-custom:success="handleDeleteSuccess"
     />
 
     <h2>Kong Manager API</h2>
     <PluginSelect
       :config="kongManagerConfig"
+      :highlighted-plugin-ids="highlightedPluginIds"
     />
   </div>
 </template>
@@ -61,6 +63,11 @@ const kongManagerConfig = ref<KongManagerPluginSelectConfig>({
     },
   }),
 })
+
+const highlightedPluginIds = ref([
+  'basic-auth', 'ip-restriction', 'jwt', 'key-auth',
+  'rate-limiting', 'request-termination', 'response-ratelimiting', 'tcp-log',
+])
 
 const handleDeleteSuccess = (plugin: string): void => {
   console.log(`Custom plugin ${plugin} deleted`)

--- a/packages/entities/entities-plugins/src/components/PluginSelect.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.cy.ts
@@ -106,6 +106,62 @@ describe('<PluginSelect />', () => {
       }
     })
 
+    it('should show highlighted plugins', () => {
+      interceptKM()
+
+      cy.mount(PluginSelect, {
+        props: {
+          config: baseConfigKM,
+          highlightedPluginIds: ['basic-auth'],
+        },
+      })
+
+      cy.wait('@getAvailablePlugins')
+
+      cy.getTestId('Highlighted Plugins-collapse').as('highlightedPlugins').should('be.visible')
+
+      cy.get('@highlightedPlugins').findTestId('k-collapse-trigger-content').should('not.exist')
+      cy.get('@highlightedPlugins').findTestId('basic-auth-card').should('be.visible')
+
+      // highlighted plugins should be hidden
+      cy.getTestId('plugins-filter').type('gnok')
+      cy.get('@highlightedPlugins').should('not.exist')
+    })
+
+    it('should show highlighted plugins and collapse trigger', () => {
+      interceptKM()
+
+      const highlightedPluginIds = ['basic-auth', 'hmac-auth', 'ip-restriction', 'rate-limiting', 'syslog']
+
+      cy.mount(PluginSelect, {
+        props: {
+          config: baseConfigKM,
+          highlightedPluginIds,
+        },
+      })
+
+      cy.wait('@getAvailablePlugins')
+
+      cy.getTestId('Highlighted Plugins-collapse').as('highlightedPlugins').should('be.visible')
+
+      cy.get('@highlightedPlugins').findTestId('k-collapse-trigger-content')
+        .should('be.visible')
+        .should('contain.text', 'View less')
+
+      for (const pluginId of highlightedPluginIds) {
+        cy.get('@highlightedPlugins').findTestId(`${pluginId}-card`).should('be.visible')
+      }
+
+      cy.get('@highlightedPlugins').findTestId('k-collapse-trigger-content').click()
+      cy.get('@highlightedPlugins').findTestId('k-collapse-trigger-content')
+        .should('be.visible')
+        .should('contain.text', 'View 1 more')
+
+      // highlighted plugins should be hidden
+      cy.getTestId('plugins-filter').type('gnok')
+      cy.get('@highlightedPlugins').should('not.exist')
+    })
+
     it('should allow customizing the pluginsPerRow', () => {
       const pluginsPerRow = 3
       const expectedCount = pluginsPerRow * PLUGIN_GROUPS_IN_USE.length
@@ -390,6 +446,62 @@ describe('<PluginSelect />', () => {
       customPluginNames.forEach((pluginName: string) => {
         cy.getTestId(`${pluginName}-card`).should('exist')
       })
+    })
+
+    it('should show highlighted plugins', () => {
+      interceptKonnect()
+
+      cy.mount(PluginSelect, {
+        props: {
+          config: baseConfigKonnect,
+          highlightedPluginIds: ['basic-auth'],
+        },
+      })
+
+      cy.wait('@getAvailablePlugins')
+
+      cy.getTestId('Highlighted Plugins-collapse').as('highlightedPlugins').should('be.visible')
+
+      cy.get('@highlightedPlugins').findTestId('k-collapse-trigger-content').should('not.exist')
+      cy.get('@highlightedPlugins').findTestId('basic-auth-card').should('be.visible')
+
+      // highlighted plugins should be hidden
+      cy.getTestId('plugins-filter').type('gnok')
+      cy.get('@highlightedPlugins').should('not.exist')
+    })
+
+    it('should show highlighted plugins and collapse trigger', () => {
+      interceptKonnect()
+
+      const highlightedPluginIds = ['basic-auth', 'hmac-auth', 'ip-restriction', 'rate-limiting', 'syslog']
+
+      cy.mount(PluginSelect, {
+        props: {
+          config: baseConfigKonnect,
+          highlightedPluginIds,
+        },
+      })
+
+      cy.wait('@getAvailablePlugins')
+
+      cy.getTestId('Highlighted Plugins-collapse').as('highlightedPlugins').should('be.visible')
+
+      cy.get('@highlightedPlugins').findTestId('k-collapse-trigger-content')
+        .should('be.visible')
+        .should('contain.text', 'View less')
+
+      for (const pluginId of highlightedPluginIds) {
+        cy.get('@highlightedPlugins').findTestId(`${pluginId}-card`).should('be.visible')
+      }
+
+      cy.get('@highlightedPlugins').findTestId('k-collapse-trigger-content').click()
+      cy.get('@highlightedPlugins').findTestId('k-collapse-trigger-content')
+        .should('be.visible')
+        .should('contain.text', 'View 1 more')
+
+      // highlighted plugins should be hidden
+      cy.getTestId('plugins-filter').type('gnok')
+      cy.get('@highlightedPlugins').should('not.exist')
     })
 
     it('should allow customizing the pluginsPerRow', () => {

--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -69,8 +69,12 @@
             <p class="tab-description">
               {{ t('plugins.select.tabs.kong.description') }}
             </p>
+
             <PluginSelectGrid
               :config="config"
+              :hide-highlighted-plugins="filter.length > 0"
+              :highlighted-plugins="highlightedPlugins"
+              :highlighted-plugins-title="props.highlightedPluginsTitle"
               :navigate-on-click="navigateOnClick"
               :plugin-list="filteredPlugins"
               :plugins-per-row="pluginsPerRow"
@@ -105,6 +109,9 @@
       <PluginSelectGrid
         v-else
         :config="config"
+        :hide-highlighted-plugins="filter.length > 0"
+        :highlighted-plugins="highlightedPlugins"
+        :highlighted-plugins-title="props.highlightedPluginsTitle"
         :navigate-on-click="navigateOnClick"
         :plugin-list="filteredPlugins"
         :plugins-per-row="pluginsPerRow"
@@ -208,6 +215,20 @@ const props = defineProps({
     type: Number,
     default: 4,
   },
+  /**
+   * Ids of plugins to show in the highlighted plugins group
+   */
+  highlightedPluginIds: {
+    type: Array as PropType<string[]>,
+    default: () => [],
+  },
+  /**
+   * Title for the highlighted plugins group
+   */
+  highlightedPluginsTitle: {
+    type: String,
+    default: '',
+  },
 })
 
 const emit = defineEmits<{
@@ -235,6 +256,21 @@ const { axiosInstance } = useAxios({
   headers: props.config.requestHeaders,
 })
 
+const flattenPluginMap = computed(() => {
+  if (!pluginsList.value) {
+    return {}
+  }
+
+  return Object.entries(pluginsList.value)
+    .filter(([group]) => group !== PluginGroup.CUSTOM_PLUGINS)
+    .reduce((m, [, plugins]) => {
+      for (const plugin of plugins) {
+        m[plugin.id] = plugin
+      }
+      return m
+    }, {} as Record<string, PluginType>)
+})
+
 const filteredPlugins = computed((): PluginCardList => {
   if (!pluginsList.value) {
     return {}
@@ -254,6 +290,18 @@ const filteredPlugins = computed((): PluginCardList => {
   }
 
   return results
+})
+
+const highlightedPlugins = computed(() => {
+  return props.highlightedPluginIds.reduce((plugins, id) => {
+    const plugin = flattenPluginMap.value[id]
+
+    if (plugin) {
+      plugins.push(plugin)
+    }
+
+    return plugins
+  }, [] as PluginType[])
 })
 
 const hasFilteredResults = computed((): boolean => {

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
@@ -25,7 +25,7 @@
       v-if="!props.hideHighlightedPlugins && props.highlightedPlugins.length > 0"
       v-model="isHighlightedPluginsCollapsed"
       :config="config"
-      :name="props.highlightedPluginsTitle ?? t('plugins.select.highlighted_plugins.title')"
+      :name="props.highlightedPluginsTitle || t('plugins.select.highlighted_plugins.title')"
       :navigate-on-click="navigateOnClick"
       :plugins="props.highlightedPlugins"
       :plugins-per-row="pluginsPerRow"

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectGroup.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectGroup.vue
@@ -1,0 +1,150 @@
+<template>
+  <KCollapse
+    v-model="isCollapsed"
+    class="plugins-collapse"
+    :data-testid="`${props.name}-collapse`"
+    :title="props.name"
+    :trigger-label="isCollapsed ? triggerLabel : t('plugins.select.view_less')"
+  >
+    <!-- don't display a trigger if all plugins will already be visible -->
+    <template
+      v-if="props.plugins.length <= pluginsPerRow"
+      #trigger
+    >
+      &nbsp;
+    </template>
+
+    <template #visible-content>
+      <div class="plugin-card-container">
+        <PluginSelectCard
+          v-for="(plugin, index) in getPluginCards('visible', props.plugins, props.pluginsPerRow)"
+          :key="`plugin-card-${index}`"
+          :config="config"
+          :navigate-on-click="navigateOnClick"
+          :plugin="plugin"
+          @plugin-clicked="emit('plugin-clicked', plugin)"
+        />
+      </div>
+    </template>
+
+    <div class="plugin-card-container">
+      <PluginSelectCard
+        v-for="(plugin, index) in getPluginCards('hidden', props.plugins, props.pluginsPerRow)"
+        :key="`plugin-card-${index}`"
+        :config="config"
+        :navigate-on-click="navigateOnClick"
+        :plugin="plugin"
+        @plugin-clicked="emit('plugin-clicked', plugin)"
+      />
+    </div>
+  </KCollapse>
+</template>
+
+<script setup lang="ts">
+import { computed, type PropType } from 'vue'
+import composables from '../../composables'
+import PluginSelectCard from './PluginSelectCard.vue'
+import type { KongManagerPluginSelectConfig, KonnectPluginSelectConfig, PluginType } from '../../types'
+
+const isCollapsed = defineModel<boolean>({ required: true })
+
+const props = defineProps({
+  /** The base konnect or kongManger config. Pass additional config props in the shared entity component as needed. */
+  config: {
+    type: Object as PropType<KonnectPluginSelectConfig | KongManagerPluginSelectConfig>,
+    required: true,
+    validator: (config: KonnectPluginSelectConfig | KongManagerPluginSelectConfig): boolean => {
+      if (!config || !['konnect', 'kongManager'].includes(config?.app)) return false
+      if (!config.getCreateRoute) return false
+      return true
+    },
+  },
+  /**
+   * Name of the group
+   */
+  name: {
+    type: String,
+    required: true,
+  },
+  /**
+   * Plugins to display in the grid
+   */
+  plugins: {
+    type: Array as PropType<PluginType[]>,
+    required: true,
+  },
+  /**
+   * @param {boolean} navigateOnClick if false, let consuming component handle event when clicking on a plugin
+   * Used in conjunction with `@plugin-clicked` event
+   */
+  navigateOnClick: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * Number of plugins to always have visible (never will be collapsed)
+   */
+  pluginsPerRow: {
+    type: Number,
+    default: 4,
+  },
+})
+
+const emit = defineEmits<{
+  'plugin-clicked': [plugin: PluginType]
+}>()
+
+const { i18n: { t } } = composables.useI18n()
+const { getPluginCards } = composables.usePluginHelpers()
+
+const triggerLabel = computed(() => {
+  const totalCount = getPluginCards('all', props.plugins, props.pluginsPerRow)?.length || 0
+  const hiddenCount = getPluginCards('hidden', props.plugins || [], props.pluginsPerRow)?.length || 0
+  return totalCount > props.pluginsPerRow ? t('plugins.select.view_more', { count: hiddenCount }) : undefined
+})
+</script>
+
+<style lang="scss" scoped>
+.plugins-collapse {
+  margin-bottom: $kui-space-90;
+}
+
+.plugin-card-container {
+  column-gap: 50px;
+  display: grid;
+  grid-auto-rows: 1fr;
+  margin-top: $kui-space-90;
+  row-gap: $kui-space-90;
+
+  .plugin-card-cursor-pointer {
+    cursor: pointer;
+  }
+
+  :deep(.kong-card) {
+    display: flex;
+    flex: 1 0 0;
+    flex-direction: column;
+    margin: $kui-space-0;
+    padding: $kui-space-0;
+    text-align: center;
+  }
+
+  :deep(.k-card-body) {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+  }
+
+  @media (min-width: $kui-breakpoint-phablet) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: $kui-breakpoint-tablet) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media (min-width: $kui-breakpoint-laptop) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -476,6 +476,9 @@
             "description": "Upload schema file to create custom plugin"
           }
         }
+      },
+      "highlighted_plugins": {
+        "title": "Highlighted Plugins"
       }
     },
     "form": {

--- a/packages/entities/entities-plugins/src/types/plugin.ts
+++ b/packages/entities/entities-plugins/src/types/plugin.ts
@@ -25,15 +25,15 @@ export const PluginGroupArray = [
 ]
 
 export const PLUGIN_GROUPS_COLLAPSE_STATUS = {
-  [PluginGroup.AUTHENTICATION]: true,
-  [PluginGroup.SECURITY]: true,
-  [PluginGroup.TRAFFIC_CONTROL]: true,
-  [PluginGroup.SERVERLESS]: true,
-  [PluginGroup.ANALYTICS_AND_MONITORING]: true,
-  [PluginGroup.TRANSFORMATIONS]: true,
-  [PluginGroup.LOGGING]: true,
-  [PluginGroup.DEPLOYMENT]: true,
-  [PluginGroup.CUSTOM_PLUGINS]: true,
+  [PluginGroup.AUTHENTICATION]: false,
+  [PluginGroup.SECURITY]: false,
+  [PluginGroup.TRAFFIC_CONTROL]: false,
+  [PluginGroup.SERVERLESS]: false,
+  [PluginGroup.ANALYTICS_AND_MONITORING]: false,
+  [PluginGroup.TRANSFORMATIONS]: false,
+  [PluginGroup.LOGGING]: false,
+  [PluginGroup.DEPLOYMENT]: false,
+  [PluginGroup.CUSTOM_PLUGINS]: false,
 }
 
 // this is the entity associated with a specific plugin, if no associated entity, then it's a global plugin meaning EntityType will be 'plugins'


### PR DESCRIPTION
# Summary

1. Expand each plugin group by default
2. Add an optional `highlightedPlugins` field to `plugin-select`'s `config` to specify highlighted plugins which will appear at the top of the list (show as a separate plugin group)

![image](https://github.com/Kong/public-ui-components/assets/5277268/386bd4a6-40bc-41de-92aa-07ff9fa5941a)

KM-18