### PR TITLE
fix(entities-shared): update useFetchUrlBuilder to allow exact match search from host app. [KHCP-11054]

### DIFF
--- a/packages/entities/entities-shared/src/composables/tests/useFetchUrlBuilder.spec.ts
+++ b/packages/entities/entities-shared/src/composables/tests/useFetchUrlBuilder.spec.ts
@@ -48,7 +48,7 @@ describe('useFetchUrlBuilder()', () => {
     expect(builder(query)).toBe('http://foo.bar/entity/testQuery/')
   })
 
-  it('should apply correct query schema for konnect', () => {
+  it('should apply correct query schema for konnect when isExactMatch is not activated', () => {
     const config = {
       apiBaseUrl: '/',
       app: 'konnect',
@@ -67,5 +67,27 @@ describe('useFetchUrlBuilder()', () => {
     }
 
     expect(builder(query)).toBe('http://foo.bar/entity?filter[name][contains]=testQuery')
+  })
+
+  it('should apply correct query schema for konnect when isExactMatch activated', () => {
+    const config = {
+      apiBaseUrl: '/',
+      app: 'konnect',
+      controlPlaneId: 'default',
+      isExactMatch: true,
+    } as KonnectConfig
+
+    const builder = useFetchUrlBuilder(config, 'http://foo.bar/entity')
+
+    const query: FetcherParams = {
+      page: 1,
+      pageSize: 10,
+      offset: 0,
+      sortColumnKey: 'name',
+      sortColumnOrder: 'asc',
+      query: 'testQuery',
+    }
+
+    expect(builder(query)).toBe('http://foo.bar/entity/testQuery/')
   })
 })

--- a/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
+++ b/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
@@ -33,12 +33,15 @@ export default function useFetchUrlBuilder(
     try {
       let urlWithParams: URL = new URL(baseRequestUrl.value.href)
       if (isExactMatch.value && query) {
-        // Using exact match
+        // handle
+        // 1) all konnect usage or
+        // 2) kongManager usage with _config.value.isExactMatch === true
         urlWithParams.search = '' // trim any query params
-        urlWithParams = _config.value.app === 'konnect'
-          ? new URL(`${urlWithParams.href}?filter[name][contains]=${query}`)
-          : new URL(`${urlWithParams.href}/${query}/`)
+        urlWithParams = _config.value.isExactMatch
+          ? new URL(`${urlWithParams.href}/${query}/`)
+          : new URL(`${urlWithParams.href}?filter[name][contains]=${query}`)
       } else {
+        // handle kongManager usage with _config.value.isExactMatch === false
         if (!isExactMatch.value) {
           // Using fuzzy match
           new URLSearchParams(query).forEach((value, key) => {

--- a/packages/entities/entities-shared/src/types/app-config.ts
+++ b/packages/entities/entities-shared/src/types/app-config.ts
@@ -16,6 +16,8 @@ export interface KonnectConfig extends BaseAppConfig {
   app: 'konnect'
   /** The control plane id */
   controlPlaneId: string
+  /** Should use exact match */
+  isExactMatch?: boolean
 }
 
 /** Base config properties for Kong Manager. All entity configs should extend this interface for the app. */

--- a/packages/entities/entities-upstreams-targets/docs/upstreams-list.md
+++ b/packages/entities/entities-upstreams-targets/docs/upstreams-list.md
@@ -84,7 +84,7 @@ A table component for upstreams.
     - type: `boolean`
     - required: `false`
     - default: `undefined`
-    - *Specific to Kong Manager*. Whether to use exact match.
+    - Whether to use exact match.
 
   - `disableSorting`:
     - type: `boolean`


### PR DESCRIPTION
# Summary
Ticket: https://konghq.atlassian.net/browse/KHCP-11054

Update `useFetchUrlBuilder` to allow using exact match search on upstream list from konnect.

[slack](https://kongstrong.slack.com/archives/C03LRB400TC/p1709217149772489?thread_ts=1709216110.973549&cid=C03LRB400TC): 
Upstreams are not being served from Kanalytics/Open Search. We are still hitting Koko for upstream.
In this case, the upstream page should be using the old way of getting by name/id not the filter call


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
