### PR TITLE
fix(entities-plugins): spec input for OAS

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -663,6 +663,10 @@ onBeforeMount(() => {
       margin-bottom: $kui-space-0;
     }
 
+    .form-group.field-textArea textarea {
+      resize: vertical;
+    }
+
     .hint {
       font-size: $kui-font-size-20;
       margin-bottom: 10px;

--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -89,6 +89,13 @@ export const useSchemas = (entityId?: string, app?: 'konnect' | 'kongManager') =
       ...vaultAuthSchema,
     },
 
+    'oas-validation': {
+      'config-api_spec': {
+        type: 'textArea',
+        rows: 15,
+      },
+    },
+
     mocking: {
       ...mockingSchema,
     },

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -17,6 +17,7 @@ import type { AIPromptTemplateSchema } from './plugins/ai-prompt-template'
 import type { VaultAuthSchema } from './plugins/vault-auth'
 import type { GraphQLRateLimitingAdvancedSchema } from './plugins/graphql-rate-limiting-advanced'
 import type { SAMLSchema } from './plugins/saml'
+import type { OasValidationSchema } from './plugins/oas-validation'
 
 export interface BasePluginSelectConfig {
   /** A function that returns the route for creating a plugin */
@@ -209,4 +210,5 @@ export interface CustomSchemas {
   'request-validator': CommonSchemaFields & Record<string, any>
   zipkin: CommonSchemaFields & Record<string, any>
   saml: SAMLSchema
+  'oas-validation': OasValidationSchema
 }

--- a/packages/entities/entities-plugins/src/types/plugins/oas-validation.d.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/oas-validation.d.ts
@@ -1,0 +1,8 @@
+import type { CommonSchemaFields } from './shared'
+
+export interface OasValidationSchema extends CommonSchemaFields {
+  'config-api_spec': {
+    type: string
+    rows: number
+  }
+}


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Currently we have an `<input>` element for the `api_spec` field, making it impossible to input a JSON/YAML format spec:
![image](https://github.com/Kong/public-ui-components/assets/10095631/b2b551c3-48db-4c73-87a5-055484fc7080)

After this PR:
<img width="1564" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/daf75819-180e-4133-94d0-c6fc181898d9">


#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
