### PR TITLE
fix(plugins): persist query params on tab change [khcp-11068]

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -392,7 +392,7 @@ const fetchEntityPluginsUrl = computed((): string => {
 })
 
 const onTabsChange = (hash: string) => {
-  router.replace({ hash })
+  router.replace({ hash, query: route.query })
 }
 
 // race condition between fetch of available plugins and setting


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
Make sure query params are peristed when changing tabs.
Fixes [KHCP-11068](https://konghq.atlassian.net/browse/KHCP-11068).

`konnect-ui-apps` [PR](https://github.com/Kong/konnect-ui-apps/pull/2661) and Preview:
https://pr-2661--gateway-manager.cloud-preview.konghq.tech/gateway-manager

Verification steps:
1. Create a custom plugin
2. Go to Routes -> view a specific route's details -> Plugins -> Click `+ New Plugin`
3. Notice the entity_type/entity_id query params in the URL
4. Click the Custom Plugins tab
5. Ensure the entity_type/entity_id query params are still in the URL
6. Click a custom plugin to create an instance of it

Expected:
The scope selection in the plugin form should be hidden and it should be scoped automatically to the current route upon creation.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)


[KHCP-11068]: https://konghq.atlassian.net/browse/KHCP-11068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ