### PR TITLE
feat(useFetcher): allow passing in axios request config

### DIFF
--- a/packages/entities/entities-shared/src/composables/useFetcher.ts
+++ b/packages/entities/entities-shared/src/composables/useFetcher.ts
@@ -10,6 +10,7 @@ import type {
 import { FetcherStatus } from '../types'
 import useAxios from './useAxios'
 import useFetchUrlBuilder from './useFetchUrlBuilder'
+import type { AxiosRequestConfig } from 'axios'
 
 export default function useFetcher(
   config: KonnectBaseTableConfig | KongManagerBaseTableConfig,
@@ -21,12 +22,17 @@ export default function useFetcher(
    * { data: [{ ... }] }
    */
   dataKeyName = 'data',
+  /** @param {AxiosRequestConfig} An optional configuration object for the underlying Axios request. Defaults to an empty object. */
+  axiosRequestConfig: AxiosRequestConfig = {},
 ) {
   const _baseUrl = unref(baseUrl)
 
+  // Combine any config.requestHeaders with the optional axiosRequestConfig.headers
+
   // Is this reactive?
   const { axiosInstance } = useAxios({
-    headers: config.requestHeaders,
+    ...axiosRequestConfig,
+    ...{ headers: { ...axiosRequestConfig.headers, ...config.requestHeaders } },
   })
 
   const buildFetchUrl = useFetchUrlBuilder(config, _baseUrl)


### PR DESCRIPTION
# Summary

Add a new, optional `axiosRequestConfig` option to the shared `useFetcher` function to allow passing in an `AxiosRequestConfig` object.

As an example, if you have an endpoint needing to allow `404` status responses, you could do something like this:

```typescript
const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value, undefined, {
  validateStatus: (status: any) => status === 404 || (status >= 200 && status < 300),
})
```