### PR TITLE
refactor: expose swagger UI to enable OAuth2 try-it-out in upstream applications

### DIFF
--- a/packages/portal/spec-renderer/src/components/SpecDetails.vue
+++ b/packages/portal/spec-renderer/src/components/SpecDetails.vue
@@ -76,6 +76,10 @@ const { i18n } = composables.useI18n()
 
 const swaggerRef = ref<SwaggerUIElement | null>(null)
 
+defineExpose({
+  swaggerInstance: swaggerRef,
+})
+
 const hasRequiredProps = computed((): boolean => {
   return !!(props.document || props.url)
 })

--- a/packages/portal/swagger-ui-web-component/src/element.js
+++ b/packages/portal/swagger-ui-web-component/src/element.js
@@ -307,6 +307,10 @@ export class SwaggerUIElement extends HTMLElement {
     this.#essentialsOnly = attributeValueToBoolean(essentialsOnly)
   }
 
+  get instance() {
+    return this.#instance
+  }
+
   get spec() {
     return this.#spec
   }


### PR DESCRIPTION
# Summary

This is a Proof-of-Concept to attempt a fix to some issues in an [upstream repository](https://github.com/Kong/konnect-portal) (`konnect-portal`). The issue is that for client-side-only OIDC "Try It Out" authorization, one needs to be able to initialize oauth with certain values available.

## More info!

For SPA-based requests to the `/authorize` endpoint, one needs to invoke the following (where `swaggerUI` is an instance that has already been initialized.
```typescript
swaggerUI.initOAuth({
          usePkceWithAuthorizationCodeGrant: true,
          additionalQueryStringParams: {
            nonce: Math.random().toString(36).substring(7)
          }
        })
```

Rather than initializing that within `spec-renderer` (really within `swagger-ui-web-component`), I think the better move is to allow more flexibility and to expose `#instance` so that folks can call it from the consuming application.

Open to differing opinions, this is just how we got things working for our use case: https://gist.github.com/andrewwylde/d47c94c7629a81a0232ac80ef862e788

