### PR TITLE
chore(codeowners): add team-devx to codeowners for swagger-ui-web-component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,7 +37,7 @@
 # Portal packages
 /packages/portal/document-viewer/ @Kong/team-devx
 /packages/portal/spec-renderer/ @Kong/team-devx
-/packages/portal/swagger-ui-web-component/ @adamdehaven @davidma415 @kaiarrowood @mptap
+/packages/portal/swagger-ui-web-component/ @adamdehaven @davidma415 @kaiarrowood @mptap @Kong/team-devx
 
 # Analytics packages
 /packages/analytics/analytics-chart @Kong/team-data


### PR DESCRIPTION
# Summary

add team-devx to codeowners for swagger-ui-web-component

