### PR TITLE
fix(analytics-chart): remove fill prop [MA-2659]

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
@@ -95,12 +95,6 @@
             :label="multiMetricToggle ? 'Multi Metric' : 'Single Metric'"
           />
         </div>
-        <div v-if="chartType.includes('Line')">
-          <KInputSwitch
-            v-model="fillToggle"
-            :label="fillToggle ? 'Fill' : 'No Fill'"
-          />
-        </div>
         <div>
           <KInputSwitch
             v-model="stackToggle"
@@ -271,7 +265,6 @@ interface MetricSelection {
 const appLinks: SandboxNavigationItem[] = inject('app-links', [])
 
 const multiMetricToggle = ref(false)
-const fillToggle = ref(true)
 const stackToggle = ref(true)
 const limitToggle = ref(false)
 const multiDimensionToggle = ref(false)
@@ -364,7 +357,6 @@ const analyticsChartOptions = computed<AnalyticsChartOptions>(() => {
   return {
     type: chartType.value,
     stacked: stackToggle.value,
-    fill: fillToggle.value,
     chartDatasetColors: colorPalette.value,
   }
 })

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -63,7 +63,7 @@
         :chart-tooltip-sort-fn="chartOptions.chartTooltipSortFn"
         :dataset-colors="chartOptions.chartDatasetColors"
         :dimension-axes-title="timestampAxisTitle"
-        :fill="chartOptions.fill"
+        :fill="chartOptions.stacked"
         :granularity="timeSeriesGranularity"
         :legend-values="legendValues"
         :metric-axes-title="metricAxesTitle"
@@ -94,7 +94,6 @@
         v-else-if="isDoughnutChart"
         :chart-data="computedChartData"
         :dataset-colors="chartOptions.chartDatasetColors"
-        :fill="chartOptions.fill"
         :legend-position="legendPosition"
         :legend-values="legendValues"
         :metric-unit="computedMetricUnit"
@@ -190,14 +189,14 @@ const computedChartData = computed(() => {
   return isTimeSeriesChart.value
     ? composables.useExploreResultToTimeDataset(
       {
-        fill: props.chartOptions.fill,
+        fill: props.chartOptions.stacked,
         colorPalette: props.chartOptions.chartDatasetColors || datavisPalette,
       },
       toRef(props, 'chartData'),
     ).value
     : composables.useExploreResultToDatasets(
       {
-        fill: props.chartOptions.fill,
+        fill: props.chartOptions.stacked,
         colorPalette: props.chartOptions.chartDatasetColors || datavisPalette,
       },
       toRef(props, 'chartData'),

--- a/packages/analytics/analytics-chart/src/components/chart-types/DoughnutChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DoughnutChart.vue
@@ -58,11 +58,6 @@ const props = defineProps({
     required: false,
     default: null,
   },
-  fill: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
   tooltipTitle: {
     type: String,
     required: true,

--- a/packages/analytics/analytics-chart/src/types/chart-data.ts
+++ b/packages/analytics/analytics-chart/src/types/chart-data.ts
@@ -60,12 +60,6 @@ export interface AnalyticsChartOptions {
    */
   stacked?: boolean,
   /**
-   * Apply fill to datasets.
-   * If true, fill the area under the line.
-   * Only applies to time series charts.
-   */
-  fill?: boolean,
-  /**
    * Title to display for the metric axis
    * If not provided, show nothing
    */

--- a/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
@@ -41,7 +41,6 @@ const options = computed<AnalyticsChartOptions>(() => {
   // This matches our intuitions about how these charts work.
   return {
     type: chartTypeLookup[props.chartOptions.type],
-    fill: stacked,
     stacked,
     chartDatasetColors: props.chartOptions.chartDatasetColors,
   }


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-2659

fill is now controlled by the stacked prop

BREAKING CHANGE: removed the fill prop from chart options

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
