### PR TITLE
fix(entities-plugins): icons with imageName overrides [KM-56]

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
@@ -37,7 +37,7 @@
         <div class="name-cell-wrapper">
           <PluginIcon
             class="plugin-icon"
-            :name="getPropValue('rowValue', slotProps)"
+            :name="pluginMetaData.getImageName(getPropValue('rowValue', slotProps))"
             :width="24"
           />
           <span class="info-name">

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -55,7 +55,7 @@
         <div class="name-cell-wrapper">
           <PluginIcon
             class="plugin-icon"
-            :name="row.name"
+            :name="pluginMetaData.getImageName(row.name)"
             :width="24"
           />
           <div class="info-wrapper">

--- a/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
+++ b/packages/entities/entities-plugins/src/composables/usePluginMeta.ts
@@ -17,8 +17,19 @@ import oauthCredentialSchema from './plugin-schemas/credentials/mockedOAuthSchem
 import KeyAuthEncSchema from './plugin-schemas/KeyAuthEnc'
 import keyEncCredentialSchema from './plugin-schemas/credentials/mockedKeyEncAuthSchema.json'
 
-export const getPluginIconURL = (pluginName: string) => {
-  return new URL(`../assets/images/plugin-icons/${pluginName}.png`, import.meta.url).href
+/**
+ * Gets the URL for a plugin icon
+ *
+ * Note: some plugins may have icons which named differently from their names
+ * (e.g. `pre-function` -> `kong-function`)
+ *
+ * Hint: you can use the helper `getImageName` returned by `usePluginMetaData`
+ *
+ * @param imageName the name of the plugin icon's image
+ * @returns the URL for the plugin icon
+ */
+export const getPluginIconURL = (imageName: string) => {
+  return new URL(`../assets/images/plugin-icons/${imageName}.png`, import.meta.url).href
 }
 
 export const usePluginMetaData = () => {
@@ -716,5 +727,9 @@ export const usePluginMetaData = () => {
     return pluginMetaData[name]?.name || name
   }
 
-  return { pluginMetaData, credentialMetaData, credentialSchemas, getDisplayName }
+  const getImageName = (name: string) => {
+    return pluginMetaData[name]?.imageName || name
+  }
+
+  return { pluginMetaData, credentialMetaData, credentialSchemas, getDisplayName, getImageName }
 }


### PR DESCRIPTION
# Summary

Fixing issues while displaying icons for plugins with `imageName` overrides

<img width="637" alt="Screenshot 2024-03-22 at 16 56 44" src="https://github.com/Kong/public-ui-components/assets/5277268/2fcb0b52-98a8-48e0-82ae-b027955b79c9">

<img width="673" alt="Screenshot 2024-03-22 at 16 56 31" src="https://github.com/Kong/public-ui-components/assets/5277268/201402ab-60aa-4c39-9803-a94e4ad1c757">

### Previously

<img width="413" alt="Screenshot 2024-03-22 at 16 55 47" src="https://github.com/Kong/public-ui-components/assets/5277268/b7d6d7e7-dfe4-4bfd-90ba-f0000e80e2ed">

<img width="654" alt="Screenshot 2024-03-22 at 16 56 19" src="https://github.com/Kong/public-ui-components/assets/5277268/e369ddd7-4410-44c0-8815-2ffe6d6958b9">

KM-56