### PR TITLE
feat(entities-plugins): support array fields in custom plugins

### DIFF
--- a/packages/entities/entities-plugins/fixtures/mockData.ts
+++ b/packages/entities/entities-plugins/fixtures/mockData.ts
@@ -831,6 +831,84 @@ export const credentialSchema = {
   ],
 }
 
+// custom plugin with array of custom schema objects
+export const customPluginSchema = {
+  fields: [
+    {
+      consumer: {
+        description: 'Custom type for representing a foreign key with a null value allowed.',
+        eq: null,
+        reference: 'consumers',
+        type: 'foreign',
+      },
+    },
+    {
+      protocols: {
+        default: [
+          'grpc',
+          'grpcs',
+          'http',
+          'https',
+        ],
+        description: 'A set of strings representing HTTP protocols.',
+        elements: {
+          one_of: [
+            'grpc',
+            'grpcs',
+            'http',
+            'https',
+          ],
+          type: 'string',
+        },
+        required: true,
+        type: 'set',
+      },
+    },
+    {
+      config: {
+        fields: [
+          {
+            discovery_uris: {
+              elements: {
+                fields: [
+                  {
+                    issuer: {
+                      required: true,
+                      type: 'string',
+                    },
+                  },
+                  {
+                    requires_proxy: {
+                      default: true,
+                      type: 'boolean',
+                    },
+                  },
+                  {
+                    ssl_verify: {
+                      default: false,
+                      type: 'boolean',
+                    },
+                  },
+                  {
+                    timeout_ms: {
+                      default: 5000,
+                      type: 'number',
+                    },
+                  },
+                ],
+                type: 'record',
+              },
+              type: 'array',
+            },
+          },
+        ],
+        required: true,
+        type: 'record',
+      },
+    },
+  ],
+}
+
 const serviceId = '6ecce9f2-4f3e-45aa-af18-a0553d354845'
 // CORS plugin
 export const plugin1 = {

--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -10,6 +10,7 @@ import {
   schema2,
   scopedService,
   scopedConsumer,
+  customPluginSchema,
 } from '../../fixtures/mockData'
 import PluginForm from './PluginForm.vue'
 import { VueFormGenerator } from '../../src'
@@ -295,6 +296,29 @@ describe('<PluginForm />', () => {
       cy.get('@advancedFields').find('#config-include_base_path').should('be.visible')
       cy.get('@advancedFields').find('#config-included_status_codes').should('be.visible')
       cy.get('@advancedFields').find('#config-random_status_code').should('be.visible')
+    })
+
+    it('should show correct form components for custom plugin with arrays of objects', () => {
+      interceptKMSchema({ mockData: customPluginSchema })
+
+      cy.mount(PluginForm, {
+        global: { components: { VueFormGenerator } },
+        props: {
+          config: baseConfigKM,
+          pluginType: 'custom',
+        },
+        router,
+      })
+
+      cy.wait('@getPluginSchema')
+      cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
+
+      // array field
+      cy.getTestId('add-config-discovery_uris').click()
+      cy.get('#config-discovery_uris-issuer-0').should('have.attr', 'required')
+      cy.get('#config-discovery_uris-requires_proxy-0').should('have.attr', 'type', 'checkbox').and('be.checked')
+      cy.get('#config-discovery_uris-ssl_verify-0').should('have.attr', 'type', 'checkbox').and('not.be.checked')
+      cy.get('#config-discovery_uris-timeout_ms-0').should('have.attr', 'type', 'number').and('have.value', '5000')
     })
 
     it('should hide scope selection when hideScopeSelection is true', () => {
@@ -1018,6 +1042,30 @@ describe('<PluginForm />', () => {
       cy.get('@advancedFields').find('#config-include_base_path').should('be.visible')
       cy.get('@advancedFields').find('#config-included_status_codes').should('be.visible')
       cy.get('@advancedFields').find('#config-random_status_code').should('be.visible')
+    })
+
+    it('should show correct form components for custom plugin with arrays of objects', () => {
+      interceptKonnectSchema({ mockData: customPluginSchema })
+
+      cy.mount(PluginForm, {
+        global: { components: { VueFormGenerator } },
+        props: {
+          config: baseConfigKonnect,
+          pluginType: 'custom',
+          useCustomNamesForPlugin: true,
+        },
+        router,
+      })
+
+      cy.wait('@getPluginSchema')
+      cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
+
+      // array field
+      cy.getTestId('add-config-discovery_uris').click()
+      cy.get('#config-discovery_uris-issuer-0').should('have.attr', 'required')
+      cy.get('#config-discovery_uris-requires_proxy-0').should('have.attr', 'type', 'checkbox').and('be.checked')
+      cy.get('#config-discovery_uris-ssl_verify-0').should('have.attr', 'type', 'checkbox').and('not.be.checked')
+      cy.get('#config-discovery_uris-timeout_ms-0').should('have.attr', 'type', 'number').and('have.value', '5000')
     })
 
     it('should hide scope selection when hideScopeSelection is true', () => {


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Support arrays of custom schema objects in custom plugins, e.g.
```json
{
  "config":{
    "fields":[
      {
        "parent_foo":{
          "elements":{
            "fields":[
              {
                "child_bar":{
                  "required":true,
                  "type":"string"
                }
              },
              {
                "child_baz":{
                  "default":true,
                  "type":"boolean"
                }
              }
            ],
            "type":"record"
          },
          "type":"array"
        }
      }
    ],
    "required":true,
    "type":"record"
  }
}
```

| Before | After |
| - | - |
| <img width="1514" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/d95749a0-5a8a-49af-bfbc-bc5da374b47d"> | <img width="1504" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/2f64ff41-668b-4220-99ad-f9725a890e49"> |

This PR also fixes a bug where default values are not prefilled for arrays of objects, e.g. `session_redis_cluster_nodes` of the SAML plugin:

| Before | After |
| - | - |
| <img width="1507" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/56d7d887-6ffc-4ada-a3e9-94bd39c0a3db"> | <img width="1505" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/dcc52c0f-d0d6-422d-8520-6e3e6c34ac77"> |

KM-49

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
