### PR TITLE
fix(dashboard-renderer): ResizeObserver on dashboard tiles

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -24,6 +24,7 @@
           class="tile-container"
           :context="mergedContext"
           :definition="tile.meta"
+          :fit-to-content="tile.layout.size.fitToContent"
           :height="tile.layout.size.rows * (config.tileHeight || DEFAULT_TILE_HEIGHT) + parseInt(KUI_SPACE_70, 10)"
         />
       </template>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="tile-boundary">
+  <div
+    ref="tileBoundary"
+    class="tile-boundary"
+  >
     <component
       :is="componentData.component"
       v-if="componentData"
@@ -12,7 +15,7 @@ import { ChartTypes, type DashboardRendererContext, type TileDefinition } from '
 import type {
   Component,
 } from 'vue'
-import { computed } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toRef } from 'vue'
 import '@kong-ui-public/analytics-chart/dist/style.css'
 import '@kong-ui-public/analytics-metric-provider/dist/style.css'
 import SimpleChartRenderer from './SimpleChartRenderer.vue'
@@ -31,6 +34,13 @@ const props = withDefaults(defineProps<{
   height?: number
 }>(), {
   height: DEFAULT_TILE_HEIGHT,
+})
+
+const heightRef = ref(props.height)
+const tileBoundary = ref<HTMLDivElement | null>(null)
+
+const resizeObserver = new ResizeObserver(entries => {
+  heightRef.value = entries[0].contentRect.height
 })
 
 const rendererLookup: Record<ChartTypes, Component | undefined> = {
@@ -54,14 +64,27 @@ const componentData = computed(() => {
       context: props.context,
       queryReady: true, // TODO: Pipelining
       chartOptions: props.definition.chart,
-      height: props.height - PADDING_SIZE * 2,
+      height: heightRef.value,
     },
   }
 })
+
+onMounted(() => {
+  if (tileBoundary.value) {
+    resizeObserver.observe(tileBoundary.value as HTMLDivElement)
+  }
+})
+
+onUnmounted(() => {
+  if (tileBoundary.value) {
+    resizeObserver.unobserve(tileBoundary.value as HTMLDivElement)
+  }
+})
+
 </script>
 
 <style lang="scss" scoped>
 .tile-boundary {
-  height: v-bind('`${height}px`');
+  height: v-bind('`${heightRef}px`');
 }
 </style>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -15,7 +15,7 @@ import { ChartTypes, type DashboardRendererContext, type TileDefinition } from '
 import type {
   Component,
 } from 'vue'
-import { computed, onMounted, onUnmounted, ref, toRef } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import '@kong-ui-public/analytics-chart/dist/style.css'
 import '@kong-ui-public/analytics-metric-provider/dist/style.css'
 import SimpleChartRenderer from './SimpleChartRenderer.vue'
@@ -23,17 +23,19 @@ import BarChartRenderer from './BarChartRenderer.vue'
 import { DEFAULT_TILE_HEIGHT } from '../constants'
 import TimeseriesChartRenderer from './TimeseriesChartRenderer.vue'
 import GoldenSignalsRenderer from './GoldenSignalsRenderer.vue'
-import { KUI_SPACE_70 } from '@kong/design-tokens'
 import TopNTableRenderer from './TopNTableRenderer.vue'
+import { KUI_SPACE_70 } from '@kong/design-tokens'
 
 const PADDING_SIZE = parseInt(KUI_SPACE_70, 10)
 
 const props = withDefaults(defineProps<{
   definition: TileDefinition,
   context: DashboardRendererContext,
-  height?: number
+  height?: number,
+  fitToContent?: boolean,
 }>(), {
   height: DEFAULT_TILE_HEIGHT,
+  fitToContent: false,
 })
 
 const heightRef = ref(props.height)
@@ -64,13 +66,13 @@ const componentData = computed(() => {
       context: props.context,
       queryReady: true, // TODO: Pipelining
       chartOptions: props.definition.chart,
-      height: heightRef.value,
+      height: heightRef.value - PADDING_SIZE * 2,
     },
   }
 })
 
 onMounted(() => {
-  if (tileBoundary.value) {
+  if (tileBoundary.value && props.fitToContent) {
     resizeObserver.observe(tileBoundary.value as HTMLDivElement)
   }
 })


### PR DESCRIPTION
# Summary

implement resize observer on dashboard tiles to notify analytics-chart of height updates when rows have tiles that are "fitToContent"

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
