### PR TITLE
fix(*): kongponents alpha phase 10 [KHCP-11172]

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^1.6.7",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "@rushstack/eslint-patch": "^1.7.2",
     "@types/flat": "^5.0.5",
     "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^1.6.7",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "@rushstack/eslint-patch": "^1.7.2",
     "@types/flat": "^5.0.5",
     "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^1.6.7",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "@rushstack/eslint-patch": "^1.7.2",
     "@types/flat": "^5.0.5",
     "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^1.6.7",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "@rushstack/eslint-patch": "^1.7.2",
     "@types/flat": "^5.0.5",
     "@types/js-yaml": "^4.0.9",

--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -29,7 +29,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "@types/uuid": "^9.0.8",
     "file-saver": "^2.0.5",
     "lodash.mapkeys": "^4.6.0",

--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -29,7 +29,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "@types/uuid": "^9.0.8",
     "file-saver": "^2.0.5",
     "lodash.mapkeys": "^4.6.0",

--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -22,14 +22,14 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": ">= 3.3.13 < 4"
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "@types/uuid": "^9.0.8",
     "file-saver": "^2.0.5",
     "lodash.mapkeys": "^4.6.0",

--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -29,7 +29,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "@types/uuid": "^9.0.8",
     "file-saver": "^2.0.5",
     "lodash.mapkeys": "^4.6.0",

--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -65,7 +65,7 @@
     "@kong-ui-public/analytics-config-store": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "pinia": ">= 2.1.7 < 3"
   }
 }

--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -65,7 +65,7 @@
     "@kong-ui-public/analytics-config-store": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "pinia": ">= 2.1.7 < 3"
   }
 }

--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -65,7 +65,7 @@
     "@kong-ui-public/analytics-config-store": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "pinia": ">= 2.1.7 < 3"
   }
 }

--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -65,7 +65,7 @@
     "@kong-ui-public/analytics-config-store": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "pinia": ">= 2.1.7 < 3"
   }
 }

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -45,7 +45,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "json-schema-to-ts": "^3.0.1",
     "pinia": ">= 2.1.7 < 3",
     "swrv": "^1.0.4",

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -45,7 +45,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "json-schema-to-ts": "^3.0.1",
     "pinia": ">= 2.1.7 < 3",
     "swrv": "^1.0.4",

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -45,7 +45,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "json-schema-to-ts": "^3.0.1",
     "pinia": ">= 2.1.7 < 3",
     "swrv": "^1.0.4",

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -45,7 +45,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "json-schema-to-ts": "^3.0.1",
     "pinia": ">= 2.1.7 < 3",
     "swrv": "^1.0.4",
@@ -73,7 +73,7 @@
     "@kong-ui-public/analytics-metric-provider": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "swrv": "^1.0.4",
     "vue": ">= 3.3.13 < 4"
   },

--- a/packages/analytics/metric-cards/package.json
+++ b/packages/analytics/metric-cards/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "vue": "^3.4.21"
   },
   "dependencies": {

--- a/packages/analytics/metric-cards/package.json
+++ b/packages/analytics/metric-cards/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "vue": "^3.4.21"
   },
   "dependencies": {

--- a/packages/analytics/metric-cards/package.json
+++ b/packages/analytics/metric-cards/package.json
@@ -39,12 +39,12 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
   },
   "peerDependencies": {
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": ">= 3.3.13 < 4"
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": "^3.4.21"
   },
   "dependencies": {

--- a/packages/analytics/metric-cards/package.json
+++ b/packages/analytics/metric-cards/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "vue": "^3.4.21"
   },
   "dependencies": {

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -39,7 +39,7 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
   },
   "peerDependencies": {
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
   },
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/core/app-layout/sandbox/pages/PageHeaderPage.vue
+++ b/packages/core/app-layout/sandbox/pages/PageHeaderPage.vue
@@ -4,13 +4,8 @@
       :breadcrumbs="breadcrumbs"
       title="Cats are Cool"
     >
-      <template #icon-home>
-        <KIcon
-          class="home-breadcrumb-icon"
-          color="#169fcc"
-          icon="immunity"
-          size="16"
-        />
+      <template #icon-app-layout>
+        <KongIcon :color="KUI_COLOR_TEXT_DECORATIVE_AQUA" />
       </template>
       <template #title-before>
         <KIcon
@@ -116,14 +111,20 @@
 import { computed, ref } from 'vue'
 import type { BadgeMethodAppearance } from '@kong/kongponents'
 import { AppAboutSection, AppPageHeader } from '../../src'
-import { EditIcon } from '@kong/icons'
+import { EditIcon, KongIcon } from '@kong/icons'
+import { KUI_COLOR_TEXT_DECORATIVE_AQUA } from '@kong/design-tokens'
 
 const breadcrumbs = computed(() => {
   return [
     {
-      key: 'home',
+      key: 'app-layout',
       to: { name: 'home' },
-      text: 'Home',
+      text: 'App Layout',
+    },
+    {
+      key: 'app-page-header',
+      to: { name: 'page-header' },
+      text: 'App Page Header',
     },
   ]
 })

--- a/packages/core/app-layout/src/components/pageHeader/AppPageHeader.cy.ts
+++ b/packages/core/app-layout/src/components/pageHeader/AppPageHeader.cy.ts
@@ -21,7 +21,7 @@ describe('<AppPageHeader />', () => {
 
     cy.get('.kong-ui-app-page-header').should('exist')
     cy.getTestId('page-header-breadcrumbs').should('be.visible')
-    cy.get('.k-breadcrumb-text').should('contain.text', breadcrumbTitle)
+    cy.get('.breadcrumb-text').should('contain.text', breadcrumbTitle)
     cy.getTestId('page-header-title').should('be.visible')
     cy.getTestId('page-header-title').should('contain.text', title)
   })
@@ -53,8 +53,8 @@ describe('<AppPageHeader />', () => {
     })
 
     cy.get('.kong-ui-app-page-header').should('exist')
-    cy.get('.k-breadcrumb-icon-wrapper').should('be.visible')
-    cy.get('.k-breadcrumb-icon-wrapper').should('contain.text', breadcrumbIcon)
+    cy.get('.breadcrumb-icon-container').should('be.visible')
+    cy.get('.breadcrumb-icon-container').should('contain.text', breadcrumbIcon)
     cy.getTestId('page-header-title-before').should('be.visible')
     cy.getTestId('page-header-title-before').should('contain.text', iconText)
     cy.getTestId('page-header-title-after').should('be.visible')

--- a/packages/core/app-layout/src/components/pageHeader/AppPageHeader.cy.ts
+++ b/packages/core/app-layout/src/components/pageHeader/AppPageHeader.cy.ts
@@ -21,7 +21,7 @@ describe('<AppPageHeader />', () => {
 
     cy.get('.kong-ui-app-page-header').should('exist')
     cy.getTestId('page-header-breadcrumbs').should('be.visible')
-    cy.get('.breadcrumb-text').should('contain.text', breadcrumbTitle)
+    cy.get('.breadcrumbs-text').should('contain.text', breadcrumbTitle)
     cy.getTestId('page-header-title').should('be.visible')
     cy.getTestId('page-header-title').should('contain.text', title)
   })
@@ -53,8 +53,8 @@ describe('<AppPageHeader />', () => {
     })
 
     cy.get('.kong-ui-app-page-header').should('exist')
-    cy.get('.breadcrumb-icon-container').should('be.visible')
-    cy.get('.breadcrumb-icon-container').should('contain.text', breadcrumbIcon)
+    cy.get('.breadcrumbs-icon-container').should('be.visible')
+    cy.get('.breadcrumbs-icon-container').should('contain.text', breadcrumbIcon)
     cy.getTestId('page-header-title-before').should('be.visible')
     cy.getTestId('page-header-title-before').should('contain.text', iconText)
     cy.getTestId('page-header-title-after').should('be.visible')

--- a/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
+++ b/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
@@ -6,9 +6,6 @@
       data-testid="page-header-breadcrumbs"
     >
       <KBreadcrumbs :items="breadcrumbs">
-        <template #divider>
-          <span class="page-header-breadcrumb-divider">/</span>
-        </template>
         <template
           v-for="slotName in breadcrumbIconSlots"
           #[slotName]
@@ -88,10 +85,6 @@ const breadcrumbIconSlots = computed((): string[] => {
 <style lang="scss" scoped>
 .kong-ui-app-page-header {
   margin-bottom: $kui-space-70;
-
-  .page-header-breadcrumb-divider {
-    color: $kui-color-text-neutral-weak;
-  }
 
   .page-header-title-section {
     align-items: center;

--- a/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
+++ b/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
@@ -5,7 +5,10 @@
       class="page-header-breadcrumbs"
       data-testid="page-header-breadcrumbs"
     >
-      <KBreadcrumbs :items="breadcrumbs">
+      <KBreadcrumbs
+        item-max-width="150px"
+        :items="breadcrumbs"
+      >
         <template
           v-for="slotName in breadcrumbIconSlots"
           #[slotName]
@@ -61,7 +64,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed } from 'vue'
+import { computed, useSlots } from 'vue'
 import type { BreadcrumbItem } from '@kong/kongponents'
 
 const props = defineProps({
@@ -75,10 +78,12 @@ const props = defineProps({
   },
 })
 
+const slots = useSlots()
+
 const hasBreadcrumbs = computed((): boolean => !!props.breadcrumbs?.length)
-const getBreadcrumbKey = (item: BreadcrumbItem, idx: number): string => { return item.key || `breadcrumb-${idx}` }
 const breadcrumbIconSlots = computed((): string[] => {
-  return props.breadcrumbs.map((item, idx) => `icon-${getBreadcrumbKey(item, idx)}`) || []
+  // only return used icon slots
+  return Object.keys(slots).filter((slotName) => slotName.startsWith('icon-'))
 })
 </script>
 

--- a/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
+++ b/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
@@ -6,7 +6,7 @@
       data-testid="page-header-breadcrumbs"
     >
       <KBreadcrumbs
-        item-max-width="150px"
+        item-max-width="150"
         :items="breadcrumbs"
       >
         <template

--- a/packages/core/documentation/package.json
+++ b/packages/core/documentation/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": ">= 3.3.13 < 4"
   },

--- a/packages/core/documentation/package.json
+++ b/packages/core/documentation/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": ">= 3.3.13 < 4"
   },

--- a/packages/core/documentation/package.json
+++ b/packages/core/documentation/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4"
   },

--- a/packages/core/documentation/package.json
+++ b/packages/core/documentation/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4"
   },
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": "^3.4.21"
   },
   "dependencies": {

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -40,8 +40,8 @@
   },
   "devDependencies": {
     "@kong/atc-router": "1.6.0-rc.1",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "@kong/design-tokens": "1.12.10",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "monaco-editor": "0.47.0",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vite-plugin-top-level-await": "^1.4.1",

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@kong/atc-router": "1.6.0-rc.1",
     "@kong/design-tokens": "1.12.7",
-    "@kong/kongponents": "9.0.0-alpha.105",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "monaco-editor": "0.21.3",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vite-plugin-top-level-await": "^1.4.1",

--- a/packages/core/forms/package.json
+++ b/packages/core/forms/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "@types/lodash": "^4.14.202",
     "pug": "^3.0.2"
   },

--- a/packages/core/forms/package.json
+++ b/packages/core/forms/package.json
@@ -56,13 +56,13 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": "^3.4.21"
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "@types/lodash": "^4.14.202",
     "pug": "^3.0.2"
   },

--- a/packages/core/forms/package.json
+++ b/packages/core/forms/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "@types/lodash": "^4.14.202",
     "pug": "^3.0.2"
   },

--- a/packages/core/forms/package.json
+++ b/packages/core/forms/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "@types/lodash": "^4.14.202",
     "pug": "^3.0.2"
   },

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "vue": "^3.4.21"
   },
   "repository": {

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -40,12 +40,12 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": ">= 3.3.13 < 4"
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": "^3.4.21"
   },
   "repository": {

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "vue": "^3.4.21"
   },
   "repository": {

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "vue": "^3.4.21"
   },
   "repository": {

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"
   },
@@ -62,7 +62,7 @@
     "errorLimit": "200KB"
   },
   "peerDependencies": {
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": ">= 3.3.13 < 4"
   },
   "dependencies": {

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"
   },

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"
   },

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"
   },

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -22,14 +22,14 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "axios": "^1.6.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/portal/document-viewer/package.json
+++ b/packages/portal/document-viewer/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "@types/prismjs": "^1.26.3",
     "@vitejs/plugin-vue-jsx": "^3.1.0",
     "vue": "^3.4.21"

--- a/packages/portal/document-viewer/package.json
+++ b/packages/portal/document-viewer/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "@types/prismjs": "^1.26.3",
     "@vitejs/plugin-vue-jsx": "^3.1.0",
     "vue": "^3.4.21"

--- a/packages/portal/document-viewer/package.json
+++ b/packages/portal/document-viewer/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "@types/prismjs": "^1.26.3",
     "@vitejs/plugin-vue-jsx": "^3.1.0",
     "vue": "^3.4.21"

--- a/packages/portal/document-viewer/package.json
+++ b/packages/portal/document-viewer/package.json
@@ -37,12 +37,12 @@
     "test:component:open": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress open --component -b chrome --project '../../../.'"
   },
   "peerDependencies": {
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": ">= 3.3.13 < 4"
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "@types/prismjs": "^1.26.3",
     "@vitejs/plugin-vue-jsx": "^3.1.0",
     "vue": "^3.4.21"

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -39,12 +39,12 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
   },
   "peerDependencies": {
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "vue": ">= 3.3.13 < 4"
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/uuid": "^9.0.8",

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-alpha.121",
+    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/uuid": "^9.0.8",

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.b6f40934.0",
+    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/uuid": "^9.0.8",

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.10",
-    "@kong/kongponents": "9.0.0-pr.2097.1fe79832.0",
+    "@kong/kongponents": "9.0.0-pr.2097.2c290faf.0",
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/uuid": "^9.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(vue-router@4.3.0)(vue@3.4.21)
       '@rushstack/eslint-patch':
         specifier: ^1.7.2
         version: 1.7.2
@@ -252,8 +252,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
@@ -313,8 +313,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)
       pinia:
         specifier: '>= 2.1.7 < 3'
         version: 2.1.7
@@ -363,8 +363,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
       json-schema-to-ts:
         specifier: ^3.0.1
         version: 3.0.1
@@ -391,8 +391,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
         version: 3.4.21
@@ -416,8 +416,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(vue-router@4.3.0)(vue@3.4.21)
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -484,8 +484,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue@3.3.13)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue@3.3.13)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -524,8 +524,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
@@ -551,8 +551,8 @@ importers:
         specifier: workspace:^
         version: link:../i18n
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
         version: 3.4.21
@@ -567,8 +567,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(vue-router@4.3.0)(vue@3.4.21)
       vue:
         specifier: ^3.4.21
         version: 3.4.21
@@ -592,8 +592,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -617,8 +617,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -642,8 +642,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -667,8 +667,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -692,8 +692,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -714,8 +714,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -739,8 +739,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -785,8 +785,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -810,8 +810,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -841,8 +841,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -866,8 +866,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -891,8 +891,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -916,8 +916,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
@@ -941,8 +941,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
       '@types/prismjs':
         specifier: ^1.26.3
         version: 1.26.3
@@ -975,8 +975,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.b6f40934.0
-        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.1fe79832.0
+        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.0
         version: 1.1.0
@@ -2339,8 +2339,8 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: false
 
-  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0:
-    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0:
+    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2361,8 +2361,8 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(axios@1.6.7):
-    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0(axios@1.6.7):
+    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2384,8 +2384,8 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2409,8 +2409,8 @@ packages:
       vue-router: 4.3.0(vue@3.4.21)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue@3.3.13):
-    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0(axios@1.6.7)(vue@3.3.13):
+    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2433,8 +2433,8 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.3.13)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2457,8 +2457,8 @@ packages:
       vue-router: 4.3.0(vue@3.4.21)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(vue@3.4.21):
-    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0(vue@3.4.21):
+    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue-router@4.3.0)(vue@3.4.21)
       '@rushstack/eslint-patch':
         specifier: ^1.7.2
         version: 1.7.2
@@ -252,8 +252,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
@@ -313,8 +313,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(axios@1.6.8)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)
       pinia:
         specifier: '>= 2.1.7 < 3'
         version: 2.1.7
@@ -363,8 +363,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
       json-schema-to-ts:
         specifier: ^3.0.1
         version: 3.0.1
@@ -391,8 +391,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
         version: 3.4.21
@@ -416,8 +416,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue-router@4.3.0)(vue@3.4.21)
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -484,8 +484,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue@3.3.13)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue@3.3.13)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -518,8 +518,8 @@ importers:
         specifier: 1.12.7
         version: 1.12.7
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.105
-        version: 9.0.0-alpha.105(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
       monaco-editor:
         specifier: 0.21.3
         version: 0.21.3
@@ -555,8 +555,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
@@ -582,8 +582,8 @@ importers:
         specifier: workspace:^
         version: link:../i18n
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
         version: 3.4.21
@@ -598,8 +598,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue-router@4.3.0)(vue@3.4.21)
       vue:
         specifier: ^3.4.21
         version: 3.4.21
@@ -623,8 +623,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -648,8 +648,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -673,8 +673,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -698,8 +698,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -723,8 +723,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -745,8 +745,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -770,8 +770,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -816,8 +816,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -841,8 +841,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -872,8 +872,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -897,8 +897,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -922,8 +922,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -947,8 +947,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -972,8 +972,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
       '@types/prismjs':
         specifier: ^1.26.3
         version: 1.26.3
@@ -1006,8 +1006,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.1fe79832.0
-        version: 9.0.0-pr.2097.1fe79832.0(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.2c290faf.0
+        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.0
         version: 1.1.0
@@ -2378,31 +2378,53 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: false
 
-  /@kong/kongponents@9.0.0-alpha.105(vue@3.4.21):
-    resolution: {integrity: sha512-ZCoA3RxtzHUAvBVcxmMvG7gF0nnlmj/pM+/ZvnVgOydfOIhgMPZ6Ou19XQa10gcGD+h90BhBJR4+TXAamkb/OQ==}
+  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0:
+    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
       vue: '>= 3.3.4 < 4'
-      vue-router: ^4.2.5
+      vue-router: ^4.3.0
     dependencies:
-      '@kong/icons': 1.8.14(vue@3.4.21)
+      '@kong/icons': 1.8.14
       '@popperjs/core': 2.11.8
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       focus-trap: 7.5.4
-      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.4.21)
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
       popper.js: 1.16.1
       sortablejs: 1.15.2
-      swrv: 1.0.4(vue@3.4.21)
+      swrv: 1.0.4
       uuid: 9.0.1
-      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.4.21)
-      vue: 3.4.21
-      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.4.21)
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: true
 
-  /@kong/kongponents@9.0.0-alpha.121(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-4ksgaSJeASw7B5OxTn73KB9s2F2gIP91Nw7aqnWlTBUxtxX8GHv/o9tBZ9EO+poRNjGxz48m18yF5k9fHbkojA==}
+  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(axios@1.6.8):
+    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
+    engines: {node: '>=v16.20.2'}
+    peerDependencies:
+      axios: ^1.6.7
+      vue: '>= 3.3.4 < 4'
+      vue-router: ^4.3.0
+    dependencies:
+      '@kong/icons': 1.8.14
+      '@popperjs/core': 2.11.8
+      axios: 1.6.8
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      focus-trap: 7.5.4
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
+      popper.js: 1.16.1
+      sortablejs: 1.15.2
+      swrv: 1.0.4
+      uuid: 9.0.1
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
+    dev: true
+
+  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2426,8 +2448,8 @@ packages:
       vue-router: 4.3.0(vue@3.4.21)
     dev: true
 
-  /@kong/kongponents@9.0.0-alpha.121(axios@1.6.8)(vue@3.3.13):
-    resolution: {integrity: sha512-4ksgaSJeASw7B5OxTn73KB9s2F2gIP91Nw7aqnWlTBUxtxX8GHv/o9tBZ9EO+poRNjGxz48m18yF5k9fHbkojA==}
+  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue@3.3.13):
+    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2450,53 +2472,8 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.3.13)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0:
-    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
-    engines: {node: '>=v16.20.2'}
-    peerDependencies:
-      axios: ^1.6.7
-      vue: '>= 3.3.4 < 4'
-      vue-router: ^4.3.0
-    dependencies:
-      '@kong/icons': 1.8.14
-      '@popperjs/core': 2.11.8
-      date-fns: 2.30.0
-      date-fns-tz: 2.0.1(date-fns@2.30.0)
-      focus-trap: 7.5.4
-      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
-      popper.js: 1.16.1
-      sortablejs: 1.15.2
-      swrv: 1.0.4
-      uuid: 9.0.1
-      v-calendar: 3.1.2(@popperjs/core@2.11.8)
-      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
-    dev: true
-
-  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0(axios@1.6.8):
-    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
-    engines: {node: '>=v16.20.2'}
-    peerDependencies:
-      axios: ^1.6.7
-      vue: '>= 3.3.4 < 4'
-      vue-router: ^4.3.0
-    dependencies:
-      '@kong/icons': 1.8.14
-      '@popperjs/core': 2.11.8
-      axios: 1.6.8
-      date-fns: 2.30.0
-      date-fns-tz: 2.0.1(date-fns@2.30.0)
-      focus-trap: 7.5.4
-      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
-      popper.js: 1.16.1
-      sortablejs: 1.15.2
-      swrv: 1.0.4
-      uuid: 9.0.1
-      v-calendar: 3.1.2(@popperjs/core@2.11.8)
-      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
-    dev: true
-
-  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
+  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2519,8 +2496,8 @@ packages:
       vue-router: 4.3.0(vue@3.4.21)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.1fe79832.0(vue@3.4.21):
-    resolution: {integrity: sha512-BZzIOPg5/6BcqJM7nKy6TyyanEw7CyQbkJhlqhMGNGKlVVeqTVkj9fBUZOYHO2kHewOI/+CwfTmpyvA60QEwLw==}
+  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(vue@3.4.21):
+    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue-router@4.3.0)(vue@3.4.21)
       '@rushstack/eslint-patch':
         specifier: ^1.7.2
         version: 1.7.2
@@ -252,8 +252,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue@3.4.21)
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
@@ -313,8 +313,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)
       pinia:
         specifier: '>= 2.1.7 < 3'
         version: 2.1.7
@@ -363,8 +363,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue@3.4.21)
       json-schema-to-ts:
         specifier: ^3.0.1
         version: 3.0.1
@@ -391,8 +391,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue@3.4.21)
       vue:
         specifier: ^3.4.21
         version: 3.4.21
@@ -416,8 +416,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue-router@4.3.0)(vue@3.4.21)
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -484,8 +484,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue@3.3.13)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue@3.3.13)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -518,8 +518,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue@3.4.21)
       monaco-editor:
         specifier: 0.47.0
         version: 0.47.0
@@ -555,8 +555,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
@@ -582,8 +582,8 @@ importers:
         specifier: workspace:^
         version: link:../i18n
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue@3.4.21)
       vue:
         specifier: ^3.4.21
         version: 3.4.21
@@ -598,8 +598,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue-router@4.3.0)(vue@3.4.21)
       vue:
         specifier: ^3.4.21
         version: 3.4.21
@@ -623,8 +623,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -648,8 +648,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -673,8 +673,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -698,8 +698,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -723,8 +723,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -745,8 +745,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -770,8 +770,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -816,8 +816,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -841,8 +841,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -872,8 +872,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -897,8 +897,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -922,8 +922,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -947,8 +947,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -972,8 +972,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue@3.4.21)
       '@types/prismjs':
         specifier: ^1.26.3
         version: 1.26.3
@@ -1006,8 +1006,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-pr.2097.2c290faf.0
-        version: 9.0.0-pr.2097.2c290faf.0(vue@3.4.21)
+        specifier: 9.0.0-alpha.123
+        version: 9.0.0-alpha.123(vue@3.4.21)
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.0
         version: 1.1.0
@@ -2374,8 +2374,8 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: false
 
-  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0:
-    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
+  /@kong/kongponents@9.0.0-alpha.123:
+    resolution: {integrity: sha512-YmdZHksjRdQU238/kjHGUuwskhDSAt0ULSOW7aOZhLTsYksd36f4+z5JS58cGtcw1C+4nc5QBnqALDuDpEbr6A==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2396,8 +2396,8 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(axios@1.6.8):
-    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
+  /@kong/kongponents@9.0.0-alpha.123(axios@1.6.8):
+    resolution: {integrity: sha512-YmdZHksjRdQU238/kjHGUuwskhDSAt0ULSOW7aOZhLTsYksd36f4+z5JS58cGtcw1C+4nc5QBnqALDuDpEbr6A==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2419,8 +2419,8 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
+  /@kong/kongponents@9.0.0-alpha.123(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-YmdZHksjRdQU238/kjHGUuwskhDSAt0ULSOW7aOZhLTsYksd36f4+z5JS58cGtcw1C+4nc5QBnqALDuDpEbr6A==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2444,8 +2444,8 @@ packages:
       vue-router: 4.3.0(vue@3.4.21)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(axios@1.6.8)(vue@3.3.13):
-    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
+  /@kong/kongponents@9.0.0-alpha.123(axios@1.6.8)(vue@3.3.13):
+    resolution: {integrity: sha512-YmdZHksjRdQU238/kjHGUuwskhDSAt0ULSOW7aOZhLTsYksd36f4+z5JS58cGtcw1C+4nc5QBnqALDuDpEbr6A==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2468,8 +2468,8 @@ packages:
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.3.13)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
+  /@kong/kongponents@9.0.0-alpha.123(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-YmdZHksjRdQU238/kjHGUuwskhDSAt0ULSOW7aOZhLTsYksd36f4+z5JS58cGtcw1C+4nc5QBnqALDuDpEbr6A==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2492,8 +2492,8 @@ packages:
       vue-router: 4.3.0(vue@3.4.21)
     dev: true
 
-  /@kong/kongponents@9.0.0-pr.2097.2c290faf.0(vue@3.4.21):
-    resolution: {integrity: sha512-2OxEXZL58bmTlygz8DmrcnUCkDiW8/RxJchN9zWTaGdNo9g8JKD/lgso4uos3u2ljcGamwbSnntJxIHknQzMUQ==}
+  /@kong/kongponents@9.0.0-alpha.123(vue@3.4.21):
+    resolution: {integrity: sha512-YmdZHksjRdQU238/kjHGUuwskhDSAt0ULSOW7aOZhLTsYksd36f4+z5JS58cGtcw1C+4nc5QBnqALDuDpEbr6A==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -4066,7 +4066,6 @@ packages:
 
   /@types/lodash@4.17.0:
     resolution: {integrity: sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==}
-    dev: true
 
   /@types/mime@1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
@@ -14454,7 +14453,7 @@ packages:
       vue: ^3.1.0
     dependencies:
       '@popperjs/core': 2.4.0
-      '@types/lodash': 4.14.202
+      '@types/lodash': 4.17.0
       date-fns: 2.30.0
       date-fns-tz: 1.3.8(date-fns@2.30.0)
       lodash: 4.17.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -27,8 +23,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(vue-router@4.3.0)(vue@3.4.21)
       '@rushstack/eslint-patch':
         specifier: ^1.7.2
         version: 1.7.2
@@ -256,8 +252,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
@@ -278,7 +274,7 @@ importers:
         version: 5.4.1
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/analytics/analytics-config-store:
     devDependencies:
@@ -287,16 +283,16 @@ importers:
         version: link:../analytics-utilities
       pinia:
         specifier: '>= 2.1.7 < 3'
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.21)
+        version: 2.1.7(vue@3.4.21)
       vue:
         specifier: '>= 3.4.21 < 4'
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/analytics/analytics-metric-provider:
     dependencies:
       '@kong-ui-public/core':
         specifier: 1.1.0
-        version: 1.1.0(axios@1.6.7)(swrv@1.0.4)(vue@3.4.21)
+        version: 1.1.0(axios@1.6.7)(swrv@1.0.4)
       '@kong-ui-public/metric-cards':
         specifier: workspace:^
         version: link:../metric-cards
@@ -305,7 +301,7 @@ importers:
         version: 1.6.7
       swrv:
         specifier: ^1.0.4
-        version: 1.0.4(vue@3.4.21)
+        version: 1.0.4
     devDependencies:
       '@kong-ui-public/analytics-config-store':
         specifier: workspace:^
@@ -317,11 +313,11 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)
       pinia:
         specifier: '>= 2.1.7 < 3'
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.21)
+        version: 2.1.7
 
   packages/analytics/analytics-utilities:
     dependencies:
@@ -367,20 +363,20 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
       json-schema-to-ts:
         specifier: ^3.0.1
         version: 3.0.1
       pinia:
         specifier: '>= 2.1.7 < 3'
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.21)
+        version: 2.1.7(vue@3.4.21)
       swrv:
         specifier: ^1.0.4
         version: 1.0.4(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/analytics/metric-cards:
     dependencies:
@@ -395,11 +391,11 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/core/app-layout:
     dependencies:
@@ -420,14 +416,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(vue-router@4.3.0)(vue@3.4.21)
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -467,7 +463,7 @@ importers:
         version: 1.6.7
       swrv:
         specifier: ^1.0.4
-        version: 1.0.4(vue@3.4.21)
+        version: 1.0.4
 
   packages/core/documentation:
     dependencies:
@@ -488,14 +484,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.3.13)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue@3.3.13)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: '>= 3.3.13 < 4'
-        version: 3.3.13(typescript@5.3.3)
+        version: 3.3.13
 
   packages/core/error-boundary:
     devDependencies:
@@ -507,13 +503,13 @@ importers:
         version: 1.8.14(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/core/forms:
     dependencies:
       '@kong/icons':
         specifier: ^1.8.14
-        version: 1.8.14(vue@3.4.21)
+        version: 1.8.14
       fecha:
         specifier: ^4.2.3
         version: 4.2.3
@@ -528,8 +524,8 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
@@ -541,7 +537,7 @@ importers:
     dependencies:
       '@formatjs/intl':
         specifier: ^2.10.0
-        version: 2.10.0(typescript@5.3.3)
+        version: 2.10.0
       flat:
         specifier: ^6.0.1
         version: 6.0.1
@@ -555,11 +551,11 @@ importers:
         specifier: workspace:^
         version: link:../i18n
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/core/sandbox-layout:
     dependencies:
@@ -571,11 +567,11 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(vue-router@4.3.0)(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -596,14 +592,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -621,14 +617,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -646,14 +642,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -671,14 +667,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -696,14 +692,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -718,14 +714,14 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -743,14 +739,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -789,14 +785,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -814,14 +810,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -845,14 +841,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -870,14 +866,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -895,14 +891,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -920,14 +916,14 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.7
         version: 1.6.7
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -945,17 +941,17 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
       '@types/prismjs':
         specifier: ^1.26.3
         version: 1.26.3
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.1.0
-        version: 3.1.0(vite@5.2.6)(vue@3.4.21)
+        version: 3.1.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/portal/spec-renderer:
     dependencies:
@@ -979,11 +975,11 @@ importers:
         specifier: 1.12.10
         version: 1.12.10
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.121
-        version: 9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2097.b6f40934.0
+        version: 9.0.0-pr.2097.b6f40934.0(vue@3.4.21)
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.0
-        version: 1.1.0(vite@5.2.6)
+        version: 1.1.0
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -995,13 +991,13 @@ importers:
         version: 12.1.3
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/portal/swagger-ui-web-component:
     dependencies:
       '@kong/swagger-ui-kong-theme-universal':
         specifier: ^4.3.3
-        version: 4.3.3(react-dom@17.0.2)(react@17.0.2)(vue-router@4.3.0)(vue@3.4.21)
+        version: 4.3.3(react-dom@17.0.2)(react@17.0.2)
       react:
         specifier: 17.0.2
         version: 17.0.2
@@ -1087,7 +1083,7 @@ packages:
       '@babel/traverse': 7.23.4
       '@babel/types': 7.24.0
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1446,7 +1442,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
       '@babel/types': 7.24.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1464,7 +1460,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
       '@babel/types': 7.24.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2085,7 +2081,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.3.0
@@ -2160,7 +2156,7 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@formatjs/intl@2.10.0(typescript@5.3.3):
+  /@formatjs/intl@2.10.0:
     resolution: {integrity: sha512-X3xT9guVkKDS86EKV80lS0KxoazUglkJTGZO66sKY7otgl0VeStPA8B3u8UkKT47PexVV98fUzjpkchYmbe9nw==}
     peerDependencies:
       typescript: ^4.7 || 5
@@ -2175,7 +2171,6 @@ packages:
       '@formatjs/intl-listformat': 7.5.5
       intl-messageformat: 10.5.11
       tslib: 2.6.2
-      typescript: 5.3.3
     dev: false
 
   /@humanwhocodes/config-array@0.11.14:
@@ -2183,7 +2178,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2286,7 +2281,7 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@kong-ui-public/core@1.1.0(axios@1.6.7)(swrv@1.0.4)(vue@3.4.21):
+  /@kong-ui-public/core@1.1.0(axios@1.6.7)(swrv@1.0.4):
     resolution: {integrity: sha512-j1kK07/zDyxwePi1EX1rZ+3iL955VdhZiodzeT5ift7iVQTiPt9VNUFu9+IXJ/AxHfuYu/gaL+gily9TsJTX3w==}
     peerDependencies:
       axios: ^1.4.0
@@ -2295,13 +2290,18 @@ packages:
     dependencies:
       axios: 1.6.7
       date-fns: 2.30.0
-      swrv: 1.0.4(vue@3.4.21)
-      vue: 3.4.21(typescript@5.3.3)
+      swrv: 1.0.4
     dev: false
 
   /@kong/design-tokens@1.12.10:
     resolution: {integrity: sha512-6IY1H6UMg95BqjU4Xov5sfjsG94G8KadUnf8MawuovbjGAcOh1Avr5Ooq4jEqmFcfjH6q+BjZHgKxO4A6Vt0kA==}
     dev: true
+
+  /@kong/icons@1.8.14:
+    resolution: {integrity: sha512-nJUTtLpqelKCTY8lS8VByWaHYUq1CuB5cBUX/q2FEDu5o6IKH/B7fEDQpb/pB1lLRYTqZXneHR/lGYjxy4u8eQ==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      vue: '>= 3.3.4 < 4'
 
   /@kong/icons@1.8.14(vue@3.3.13):
     resolution: {integrity: sha512-nJUTtLpqelKCTY8lS8VByWaHYUq1CuB5cBUX/q2FEDu5o6IKH/B7fEDQpb/pB1lLRYTqZXneHR/lGYjxy4u8eQ==}
@@ -2309,7 +2309,7 @@ packages:
     peerDependencies:
       vue: '>= 3.3.4 < 4'
     dependencies:
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
 
   /@kong/icons@1.8.14(vue@3.4.21):
     resolution: {integrity: sha512-nJUTtLpqelKCTY8lS8VByWaHYUq1CuB5cBUX/q2FEDu5o6IKH/B7fEDQpb/pB1lLRYTqZXneHR/lGYjxy4u8eQ==}
@@ -2317,9 +2317,9 @@ packages:
     peerDependencies:
       vue: '>= 3.3.4 < 4'
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
-  /@kong/kongponents@8.127.0(vue-router@4.3.0)(vue@3.4.21):
+  /@kong/kongponents@8.127.0:
     resolution: {integrity: sha512-C/MFT+OZtyul62ElgHEggqMYPbLjXiRJg5GE3il8MZpaep2D5QV+F5UQ7frbA98TkZCCVBD4LpR0OmiwXKs+tg==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
@@ -2330,44 +2330,62 @@ packages:
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       focus-trap: 7.5.4
-      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.4.21)
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
       popper.js: 1.16.1
       sortablejs: 1.15.2
-      swrv: 1.0.4(vue@3.4.21)
+      swrv: 1.0.4
       uuid: 9.0.1
-      v-calendar: 3.0.0-alpha.8(vue@3.4.21)
-      vue: 3.4.21(typescript@5.3.3)
-      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.4.21)
-      vue-router: 4.3.0(vue@3.4.21)
+      v-calendar: 3.0.0-alpha.8
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: false
 
-  /@kong/kongponents@9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.3.13):
-    resolution: {integrity: sha512-4ksgaSJeASw7B5OxTn73KB9s2F2gIP91Nw7aqnWlTBUxtxX8GHv/o9tBZ9EO+poRNjGxz48m18yF5k9fHbkojA==}
+  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0:
+    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
       vue: '>= 3.3.4 < 4'
       vue-router: ^4.3.0
     dependencies:
-      '@kong/icons': 1.8.14(vue@3.3.13)
+      '@kong/icons': 1.8.14
+      '@popperjs/core': 2.11.8
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      focus-trap: 7.5.4
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
+      popper.js: 1.16.1
+      sortablejs: 1.15.2
+      swrv: 1.0.4
+      uuid: 9.0.1
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
+    dev: true
+
+  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(axios@1.6.7):
+    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+    engines: {node: '>=v16.20.2'}
+    peerDependencies:
+      axios: ^1.6.7
+      vue: '>= 3.3.4 < 4'
+      vue-router: ^4.3.0
+    dependencies:
+      '@kong/icons': 1.8.14
       '@popperjs/core': 2.11.8
       axios: 1.6.7
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       focus-trap: 7.5.4
-      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.3.13)
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
       popper.js: 1.16.1
       sortablejs: 1.15.2
-      swrv: 1.0.4(vue@3.3.13)
+      swrv: 1.0.4
       uuid: 9.0.1
-      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.3.13)
-      vue: 3.3.13(typescript@5.3.3)
-      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.3.13)
-      vue-router: 4.3.0(vue@3.4.21)
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: true
 
-  /@kong/kongponents@9.0.0-alpha.121(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-4ksgaSJeASw7B5OxTn73KB9s2F2gIP91Nw7aqnWlTBUxtxX8GHv/o9tBZ9EO+poRNjGxz48m18yF5k9fHbkojA==}
+  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
       axios: ^1.6.7
@@ -2386,18 +2404,89 @@ packages:
       swrv: 1.0.4(vue@3.4.21)
       uuid: 9.0.1
       v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.4.21)
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.4.21)
       vue-router: 4.3.0(vue@3.4.21)
     dev: true
 
-  /@kong/swagger-ui-kong-theme-universal@4.3.3(react-dom@17.0.2)(react@17.0.2)(vue-router@4.3.0)(vue@3.4.21):
+  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(axios@1.6.7)(vue@3.3.13):
+    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+    engines: {node: '>=v16.20.2'}
+    peerDependencies:
+      axios: ^1.6.7
+      vue: '>= 3.3.4 < 4'
+      vue-router: ^4.3.0
+    dependencies:
+      '@kong/icons': 1.8.14(vue@3.3.13)
+      '@popperjs/core': 2.11.8
+      axios: 1.6.7
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      focus-trap: 7.5.4
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.3.13)
+      popper.js: 1.16.1
+      sortablejs: 1.15.2
+      swrv: 1.0.4(vue@3.3.13)
+      uuid: 9.0.1
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.3.13)
+      vue: 3.3.13
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.3.13)
+    dev: true
+
+  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+    engines: {node: '>=v16.20.2'}
+    peerDependencies:
+      axios: ^1.6.7
+      vue: '>= 3.3.4 < 4'
+      vue-router: ^4.3.0
+    dependencies:
+      '@kong/icons': 1.8.14(vue@3.4.21)
+      '@popperjs/core': 2.11.8
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      focus-trap: 7.5.4
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.4.21)
+      popper.js: 1.16.1
+      sortablejs: 1.15.2
+      swrv: 1.0.4(vue@3.4.21)
+      uuid: 9.0.1
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.4.21)
+      vue: 3.4.21
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.4.21)
+      vue-router: 4.3.0(vue@3.4.21)
+    dev: true
+
+  /@kong/kongponents@9.0.0-pr.2097.b6f40934.0(vue@3.4.21):
+    resolution: {integrity: sha512-82KcM/zbYtFcjQqmcnWThwajLLsu/+NPgyThcnqUfcWb1SiD0tPjlCL+Gx+b78vrI9i+9CaG7ZbB898hpGsZzQ==}
+    engines: {node: '>=v16.20.2'}
+    peerDependencies:
+      axios: ^1.6.7
+      vue: '>= 3.3.4 < 4'
+      vue-router: ^4.3.0
+    dependencies:
+      '@kong/icons': 1.8.14(vue@3.4.21)
+      '@popperjs/core': 2.11.8
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      focus-trap: 7.5.4
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.4.21)
+      popper.js: 1.16.1
+      sortablejs: 1.15.2
+      swrv: 1.0.4(vue@3.4.21)
+      uuid: 9.0.1
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.4.21)
+      vue: 3.4.21
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.4.21)
+    dev: true
+
+  /@kong/swagger-ui-kong-theme-universal@4.3.3(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-g89NLf7Vu19BJ157fVUkLIrjzTmNE74zGfzktK2rxdZgIUegt4VBDsG8K0MAxDwQELQqSK3kPkamgdD9j1eV3Q==}
     peerDependencies:
       react: 17.0.2
     dependencies:
       '@braintree/sanitize-url': 6.0.2
-      '@kong/kongponents': 8.127.0(vue-router@4.3.0)(vue@3.4.21)
+      '@kong/kongponents': 8.127.0
       '@kyleshockey/xml': 1.0.2
       classnames: 2.3.2
       curl-to-har: 1.0.1
@@ -2522,7 +2611,7 @@ packages:
       call-bind: 1.0.7
     dev: true
 
-  /@modyfi/vite-plugin-yaml@1.1.0(vite@5.2.6):
+  /@modyfi/vite-plugin-yaml@1.1.0:
     resolution: {integrity: sha512-L26xfzkSo1yamODCAtk/ipVlL6OEw2bcJ92zunyHu8zxi7+meV0zefA9xscRMDCsMY8xL3C3wi3DhMiPxcbxbw==}
     peerDependencies:
       vite: ^3.2.7 || ^4.0.5 || ^5.0.5
@@ -2530,7 +2619,6 @@ packages:
       '@rollup/pluginutils': 5.1.0
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
-      vite: 5.2.6(@types/node@18.19.24)(sass@1.71.1)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -3974,7 +4062,7 @@ packages:
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.0
@@ -4000,7 +4088,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -4027,7 +4115,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       ts-api-utils: 1.0.1(typescript@5.3.3)
       typescript: 5.3.3
@@ -4051,7 +4139,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -4105,6 +4193,21 @@ packages:
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.3)
       vite: 5.2.6(@types/node@18.19.24)(sass@1.71.1)
       vue: 3.4.21(typescript@5.3.3)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vitejs/plugin-vue-jsx@3.1.0(vue@3.4.21):
+    resolution: {integrity: sha512-w9M6F3LSEU5kszVb9An2/MmXNxocAnUb3WhRr8bHlimhDrXNt6n6D2nJQR3UXpGlZHh/EsgouOHCsM8V3Ln+WA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
+    dependencies:
+      '@babel/core': 7.23.3
+      '@babel/plugin-transform-typescript': 7.23.4(@babel/core@7.23.3)
+      '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.3)
+      vue: 3.4.21
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4286,6 +4389,7 @@ packages:
 
   /@vue/devtools-api@6.6.1:
     resolution: {integrity: sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA==}
+    dev: true
 
   /@vue/devtools-core@7.0.20(vite@5.2.6)(vue@3.4.21):
     resolution: {integrity: sha512-JefAn0ljTUPtoEJ47PjEfcLQb9BVt3OH1R6aD8qZ7bNYwZH+xystXpVJ3pW+1iDnOXjfpLgc3bsHUZoxlfobpw==}
@@ -4434,7 +4538,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.3.13
       '@vue/shared': 3.3.13
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
 
   /@vue/server-renderer@3.4.21(vue@3.4.21):
     resolution: {integrity: sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==}
@@ -4443,7 +4547,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.4.21
       '@vue/shared': 3.4.21
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /@vue/shared@3.3.13:
     resolution: {integrity: sha512-/zYUwiHD8j7gKx2argXEMCUXVST6q/21DFU0sTfNX0URJroCe3b1UF6vLJ3lQDfLNIiiRl2ONp7Nh5UVWS6QnA==}
@@ -4714,7 +4818,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4723,7 +4827,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4732,7 +4836,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -4749,6 +4853,9 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.12.0
     dev: true
@@ -5801,6 +5908,27 @@ packages:
     engines: {node: ^12.20.0 || >=14}
     dev: true
 
+  /commitizen@4.3.0:
+    resolution: {integrity: sha512-H0iNtClNEhT0fotHvGV3E9tDejDeS04sN1veIebsKYGMuGscFaswRoYJKmT3eW85eIJAs0F28bG2+a/9wCOfPw==}
+    engines: {node: '>= 12'}
+    hasBin: true
+    dependencies:
+      cachedir: 2.3.0
+      cz-conventional-changelog: 3.3.0(@types/node@18.19.24)(typescript@5.3.3)
+      dedent: 0.7.0
+      detect-indent: 6.1.0
+      find-node-modules: 2.1.3
+      find-root: 1.1.0
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      inquirer: 8.2.5
+      is-utf8: 0.2.1
+      lodash: 4.17.21
+      minimist: 1.2.7
+      strip-bom: 4.0.0
+      strip-json-comments: 3.1.1
+    dev: true
+
   /commitizen@4.3.0(@types/node@18.19.24)(typescript@5.3.3):
     resolution: {integrity: sha512-H0iNtClNEhT0fotHvGV3E9tDejDeS04sN1veIebsKYGMuGscFaswRoYJKmT3eW85eIJAs0F28bG2+a/9wCOfPw==}
     engines: {node: '>= 12'}
@@ -6263,7 +6391,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.0(@types/node@18.19.24)(typescript@5.3.3)
+      commitizen: 4.3.0
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
@@ -6349,6 +6477,17 @@ packages:
     dependencies:
       ms: 2.0.0
 
+  /debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
   /debug@3.2.7(supports-color@8.1.1):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -6359,6 +6498,18 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 8.1.1
+    dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
     dev: true
 
   /debug@4.3.4(supports-color@8.1.1):
@@ -6961,7 +7112,7 @@ packages:
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       is-core-module: 2.13.1
       resolve: 1.22.4
     transitivePeerDependencies:
@@ -6971,7 +7122,7 @@ packages:
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       is-core-module: 2.13.1
       resolve: 1.22.4
     transitivePeerDependencies:
@@ -7000,7 +7151,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -7053,7 +7204,7 @@ packages:
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -7196,7 +7347,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -7693,6 +7844,14 @@ packages:
       tabbable: 6.2.0
     dev: false
 
+  /focus-trap-vue@4.0.3(focus-trap@7.5.4):
+    resolution: {integrity: sha512-cIX5rybkCAlNZ4IHYJ3nCFIsipDDljJHHjtTO2IgYWkVYg7X9ipUVdab3HzYp88kmHgMwjcB71LYnXRRsF6ZqQ==}
+    peerDependencies:
+      focus-trap: ^7.0.0
+      vue: ^3.0.0
+    dependencies:
+      focus-trap: 7.5.4
+
   /focus-trap-vue@4.0.3(focus-trap@7.5.4)(vue@3.3.13):
     resolution: {integrity: sha512-cIX5rybkCAlNZ4IHYJ3nCFIsipDDljJHHjtTO2IgYWkVYg7X9ipUVdab3HzYp88kmHgMwjcB71LYnXRRsF6ZqQ==}
     peerDependencies:
@@ -7700,7 +7859,7 @@ packages:
       vue: ^3.0.0
     dependencies:
       focus-trap: 7.5.4
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     dev: true
 
   /focus-trap-vue@4.0.3(focus-trap@7.5.4)(vue@3.4.21):
@@ -7710,7 +7869,7 @@ packages:
       vue: ^3.0.0
     dependencies:
       focus-trap: 7.5.4
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /focus-trap@7.5.4:
     resolution: {integrity: sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==}
@@ -8490,7 +8649,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8500,7 +8659,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8549,7 +8708,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8559,7 +8718,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11253,7 +11412,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /pinia@2.1.7(typescript@5.3.3)(vue@3.4.21):
+  /pinia@2.1.7:
     resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
     peerDependencies:
       '@vue/composition-api': ^1.4.0
@@ -11266,8 +11425,23 @@ packages:
         optional: true
     dependencies:
       '@vue/devtools-api': 6.6.1
-      typescript: 5.3.3
-      vue: 3.4.21(typescript@5.3.3)
+      vue-demi: 0.14.7
+    dev: true
+
+  /pinia@2.1.7(vue@3.4.21):
+    resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
+    peerDependencies:
+      '@vue/composition-api': ^1.4.0
+      typescript: '>=4.4.4'
+      vue: ^2.6.14 || ^3.3.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/devtools-api': 6.6.1
+      vue: 3.4.21
       vue-demi: 0.14.7(vue@3.4.21)
     dev: true
 
@@ -12773,7 +12947,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -12784,7 +12958,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -12867,7 +13041,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -12881,7 +13055,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -13235,7 +13409,7 @@ packages:
       cosmiconfig: 9.0.0(typescript@5.3.3)
       css-functions-list: 3.2.1
       css-tree: 2.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 8.0.0
@@ -13390,12 +13564,17 @@ packages:
       - rollup
     dev: false
 
+  /swrv@1.0.4:
+    resolution: {integrity: sha512-zjEkcP8Ywmj+xOJW3lIT65ciY/4AL4e/Or7Gj0MzU3zBJNMdJiT8geVZhINavnlHRMMCcJLHhraLTAiDOTmQ9g==}
+    peerDependencies:
+      vue: '>=3.2.26 < 4'
+
   /swrv@1.0.4(vue@3.3.13):
     resolution: {integrity: sha512-zjEkcP8Ywmj+xOJW3lIT65ciY/4AL4e/Or7Gj0MzU3zBJNMdJiT8geVZhINavnlHRMMCcJLHhraLTAiDOTmQ9g==}
     peerDependencies:
       vue: '>=3.2.26 < 4'
     dependencies:
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     dev: true
 
   /swrv@1.0.4(vue@3.4.21):
@@ -13403,7 +13582,8 @@ packages:
     peerDependencies:
       vue: '>=3.2.26 < 4'
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
+    dev: true
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -13786,7 +13966,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 1.0.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       make-fetch-happen: 11.1.1
     transitivePeerDependencies:
       - supports-color
@@ -13797,7 +13977,7 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
@@ -13949,6 +14129,7 @@ packages:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /ufo@1.3.2:
     resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
@@ -14093,7 +14274,7 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
-  /v-calendar@3.0.0-alpha.8(vue@3.4.21):
+  /v-calendar@3.0.0-alpha.8:
     resolution: {integrity: sha512-T23H5UbK0EomrwArlF/jrT2LFbV/lu+Bp9JroZ1paN6rPoaMyvE+HrLxvAmUgi+pODrdTURDMzM3+WPgeFKEBQ==}
     peerDependencies:
       vue: ^3.1.0
@@ -14103,8 +14284,22 @@ packages:
       date-fns: 2.30.0
       date-fns-tz: 1.3.8(date-fns@2.30.0)
       lodash: 4.17.21
-      vue: 3.4.21(typescript@5.3.3)
     dev: false
+
+  /v-calendar@3.1.2(@popperjs/core@2.11.8):
+    resolution: {integrity: sha512-QDWrnp4PWCpzUblctgo4T558PrHgHzDtQnTeUNzKxfNf29FkCeFpwGd9bKjAqktaa2aJLcyRl45T5ln1ku34kg==}
+    peerDependencies:
+      '@popperjs/core': ^2.0.0
+      vue: ^3.2.0
+    dependencies:
+      '@popperjs/core': 2.11.8
+      '@types/lodash': 4.17.0
+      '@types/resize-observer-browser': 0.1.11
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      lodash: 4.17.21
+      vue-screen-utils: 1.0.0-beta.13
+    dev: true
 
   /v-calendar@3.1.2(@popperjs/core@2.11.8)(vue@3.3.13):
     resolution: {integrity: sha512-QDWrnp4PWCpzUblctgo4T558PrHgHzDtQnTeUNzKxfNf29FkCeFpwGd9bKjAqktaa2aJLcyRl45T5ln1ku34kg==}
@@ -14118,7 +14313,7 @@ packages:
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       lodash: 4.17.21
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
       vue-screen-utils: 1.0.0-beta.13(vue@3.3.13)
     dev: true
 
@@ -14134,7 +14329,7 @@ packages:
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       lodash: 4.17.21
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
       vue-screen-utils: 1.0.0-beta.13(vue@3.4.21)
     dev: true
 
@@ -14199,7 +14394,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.2.6(@types/node@18.19.24)(sass@1.71.1)
@@ -14239,7 +14434,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 10.0.3
@@ -14363,7 +14558,7 @@ packages:
       '@vitest/utils': 1.3.1
       acorn-walk: 8.3.2
       chai: 4.3.10
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       execa: 8.0.1
       jsdom: 24.0.0
       local-pkg: 0.5.0
@@ -14407,11 +14602,24 @@ packages:
       vue: ^3.0.0-0 || ^2.7.0
     dependencies:
       chart.js: 4.4.2
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /vue-component-type-helpers@2.0.7:
     resolution: {integrity: sha512-7e12Evdll7JcTIocojgnCgwocX4WzIYStGClBQ+QuWPinZo/vQolv2EMq4a3lg16TKfwWafLimG77bxb56UauA==}
+    dev: true
+
+  /vue-demi@0.14.7:
+    resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
     dev: true
 
   /vue-demi@0.14.7(vue@3.4.21):
@@ -14426,8 +14634,16 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: true
+
+  /vue-draggable-next@2.2.1(sortablejs@1.15.2):
+    resolution: {integrity: sha512-EAMS1IRHF0kZO0o5PMOinsQsXIqsrKT1hKmbICxG3UEtn7zLFkLxlAtajcCcUTisNvQ6TtCB5COjD9a1raNADw==}
+    peerDependencies:
+      sortablejs: ^1.14.0
+      vue: ^3.2.2
+    dependencies:
+      sortablejs: 1.15.2
 
   /vue-draggable-next@2.2.1(sortablejs@1.15.2)(vue@3.3.13):
     resolution: {integrity: sha512-EAMS1IRHF0kZO0o5PMOinsQsXIqsrKT1hKmbICxG3UEtn7zLFkLxlAtajcCcUTisNvQ6TtCB5COjD9a1raNADw==}
@@ -14436,7 +14652,7 @@ packages:
       vue: ^3.2.2
     dependencies:
       sortablejs: 1.15.2
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     dev: true
 
   /vue-draggable-next@2.2.1(sortablejs@1.15.2)(vue@3.4.21):
@@ -14446,7 +14662,8 @@ packages:
       vue: ^3.2.2
     dependencies:
       sortablejs: 1.15.2
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
+    dev: true
 
   /vue-eslint-parser@9.3.1(eslint@8.57.0):
     resolution: {integrity: sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==}
@@ -14454,7 +14671,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -14472,7 +14689,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -14490,14 +14707,21 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.6.1
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
+    dev: true
+
+  /vue-screen-utils@1.0.0-beta.13:
+    resolution: {integrity: sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==}
+    peerDependencies:
+      vue: ^3.2.0
+    dev: true
 
   /vue-screen-utils@1.0.0-beta.13(vue@3.3.13):
     resolution: {integrity: sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     dev: true
 
   /vue-screen-utils@1.0.0-beta.13(vue@3.4.21):
@@ -14505,7 +14729,7 @@ packages:
     peerDependencies:
       vue: ^3.2.0
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: true
 
   /vue-template-compiler@2.7.14:
@@ -14527,7 +14751,7 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /vue@3.3.13(typescript@5.3.3):
+  /vue@3.3.13:
     resolution: {integrity: sha512-LDnUpQvDgsfc0u/YgtAgTMXJlJQqjkxW1PVcOnJA5cshPleULDjHi7U45pl2VJYazSSvLH8UKcid/kzH8I0a0Q==}
     peerDependencies:
       typescript: '*'
@@ -14540,7 +14764,20 @@ packages:
       '@vue/runtime-dom': 3.3.13
       '@vue/server-renderer': 3.3.13(vue@3.3.13)
       '@vue/shared': 3.3.13
-      typescript: 5.3.3
+
+  /vue@3.4.21:
+    resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-sfc': 3.4.21
+      '@vue/runtime-dom': 3.4.21
+      '@vue/server-renderer': 3.4.21(vue@3.4.21)
+      '@vue/shared': 3.4.21
 
   /vue@3.4.21(typescript@5.3.3):
     resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
@@ -14556,6 +14793,7 @@ packages:
       '@vue/server-renderer': 3.4.21(vue@3.4.21)
       '@vue/shared': 3.4.21
       typescript: 5.3.3
+    dev: true
 
   /w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -15130,3 +15368,7 @@ packages:
   /zenscroll@4.0.2:
     resolution: {integrity: sha512-jEA1znR7b4C/NnaycInCU6h/d15ZzCd1jmsruqOKnZP6WXQSMH3W2GL+OXbkruslU4h+Tzuos0HdswzRUk/Vgg==}
     dev: false
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
# Summary

Jira: https://konghq.atlassian.net/browse/KHCP-11172

Phase 10 adoption of components reskinned in alpha version of Kongponents v9 release. Includes these components:

- `KTreeList`
- `KBreadcrumb`
- `KSkeleton`
- `KMenu` (removed)

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
