### PR TITLE
feat(metric-card-container): add optional title [MA-2726]

### DIFF
--- a/packages/analytics/analytics-metric-provider/sandbox/App.vue
+++ b/packages/analytics/analytics-metric-provider/sandbox/App.vue
@@ -111,6 +111,7 @@ const globalProviderProps = {
   overrideTimeframe: TimePeriods.get(TimeframeKeys.SIX_HOUR),
   longCardTitles: false,
   description: 'Generic Description',
+  containerTitle: 'Analytics',
 }
 const globalBridge = makeQueryBridge()
 

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
@@ -125,7 +125,8 @@ const containerOpts = computed(() => ({
   loading: isLoading.value,
   hasTrendAccess: providerData.hasTrendAccess.value,
   fallbackDisplayText: i18n.t('general.notAvailable'),
-  cardSize: props.cardSize,
+  // If the parent container has a title, we enforce a Medium card size; otherwise, pass down provided cardSize
+  cardSize: providerData.containerTitle ? MetricCardSize.Medium : props.cardSize,
   hideTitle: true,
 }))
 

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
@@ -121,6 +121,7 @@ const isLoading = computed<boolean>(() => {
 // TODO: per-card loading?
 const containerOpts = computed(() => ({
   cards: cards.value,
+  containerTitle: providerData.containerTitle,
   loading: isLoading.value,
   hasTrendAccess: providerData.hasTrendAccess.value,
   fallbackDisplayText: i18n.t('general.notAvailable'),

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsProviderInternal.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsProviderInternal.vue
@@ -28,6 +28,7 @@ const props = withDefaults(defineProps<{
   queryReady?: boolean,
   refreshInterval: number,
   longCardTitles?: boolean,
+  containerTitle?: string,
   description?: string,
   abortController?: AbortController,
 }>(), {
@@ -39,6 +40,7 @@ const props = withDefaults(defineProps<{
   additionalFilter: undefined,
   queryReady: true,
   longCardTitles: false,
+  containerTitle: undefined,
   description: undefined,
   abortController: undefined,
 })
@@ -125,6 +127,7 @@ provide(METRICS_PROVIDER_KEY, {
     latency: latencyData,
   },
   description: props.description,
+  containerTitle: props.containerTitle,
   hasTrendAccess,
   longCardTitles: props.longCardTitles,
 })

--- a/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
+++ b/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
@@ -13,6 +13,7 @@ interface ProviderData {
   data: {
     [key: string]: any // TODO
   },
+  containerTitle?: string,
   description?: string,
   hasTrendAccess: Ref<boolean>,
   longCardTitles: boolean,

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -28,7 +28,7 @@
 
 <script setup lang="ts">
 import type { DashboardConfig, DashboardRendererContext, TileConfig } from '../../src'
-import { CP_ID_TOKEN, ChartTypes, DashboardRenderer, ENTITY_ID_TOKEN } from '../../src'
+import { ChartTypes, DashboardRenderer } from '../../src'
 import { inject } from 'vue'
 import { ChartMetricDisplay } from '@kong-ui-public/analytics-chart'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
@@ -57,6 +57,7 @@ const dashboardConfig: DashboardConfig = {
       definition: {
         chart: {
           type: ChartTypes.GoldenSignals,
+          chartTitle: 'Analytics Golden Signals',
         },
         query: {},
       },

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -52,7 +52,7 @@ const options = computed<ProviderProps>(() => ({
   tz: props.context.tz,
   additionalFilter: props.context.filters,
   longCardTitles: props.chartOptions.longCardTitles,
-  containerTitle: props.chartOptions?.chartTitle,
+  containerTitle: props.chartOptions.chartTitle,
   description: props.chartOptions.description,
   hasTrendAccess: true,
   refreshInterval: props.context.refreshInterval ?? DEFAULT_TILE_REFRESH_INTERVAL_MS,

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -52,6 +52,7 @@ const options = computed<ProviderProps>(() => ({
   tz: props.context.tz,
   additionalFilter: props.context.filters,
   longCardTitles: props.chartOptions.longCardTitles,
+  containerTitle: props.chartOptions?.chartTitle,
   description: props.chartOptions.description,
   hasTrendAccess: true,
   refreshInterval: props.context.refreshInterval ?? DEFAULT_TILE_REFRESH_INTERVAL_MS,

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -76,14 +76,6 @@ const options = computed<ProviderProps>(() => ({
           border-right: $kui-border-width-10 solid $kui-color-border;
         }
       }
-
-      // These overrides are here because, for now, we only want the bolder metric titles
-      // on dashboards.  In other places, the golden signal cards tend to be embedded into KCards which
-      // already have titles.
-      .metricscard-title.lg {
-        font-size: $kui-font-size-40;
-        font-weight: $kui-font-weight-semibold;
-      }
     }
   }
 }

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -153,6 +153,7 @@ export type TopNTableOptions = FromSchema<typeof topNTableSchema>
 export const metricCardSchema = {
   type: 'object',
   properties: {
+    chartTitle,
     type: {
       type: 'string',
       enum: [ChartTypes.GoldenSignals],

--- a/packages/analytics/metric-cards/sandbox/App.vue
+++ b/packages/analytics/metric-cards/sandbox/App.vue
@@ -151,6 +151,7 @@ const cardsSmall: MetricCardContainerOptions = {
 
 const cardsRegular: MetricCardContainerOptions = {
   cards: [...cards].slice(0, 3),
+  containerTitle: 'Analytics Golden Signals',
   loading: false,
   hasTrendAccess: true,
   fallbackDisplayText: 'Not available',

--- a/packages/analytics/metric-cards/src/components/MetricCardContainer.cy.ts
+++ b/packages/analytics/metric-cards/src/components/MetricCardContainer.cy.ts
@@ -44,7 +44,7 @@ const cards = [
   },
 ]
 
-const container = '.kong-ui-public-metric-card-container'
+const container = '.kong-ui-public-metric-card-container .cards-wrapper'
 
 describe('<MetricCardContainer />', () => {
   it('layout updates on desktop vs mobile ', () => {

--- a/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
+++ b/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
@@ -4,6 +4,12 @@
     :class="cardSize"
   >
     <div
+      v-if="props.containerTitle"
+      class="container-title"
+    >
+      {{ props.containerTitle }}
+    </div>
+    <div
       v-if="allCardsHaveErrors"
       class="error-display"
     >
@@ -15,30 +21,32 @@
         {{ errorMessage }}
       </div>
     </div>
-    <template
-      v-for="(card, index) in cards"
+    <div
       v-else
+      class="cards-wrapper"
     >
-      <MetricCardLoadingSkeleton
-        v-if="loading"
-        :key="`skeleton-${index}`"
-        :class="cardSize === MetricCardSize.Small ? 'loading-tabs-small' : 'loading-tabs-large'"
-      />
-      <MetricsCard
-        v-else
-        :key="index"
-        v-bind="formatCardValues(card)"
-        :card-size="cardSize"
-        :card-type="card.cardType"
-        :description="card.description"
-        :error-message="errorMessage"
-        :has-error="card.hasError"
-        :title="card.title"
-        :title-tag="card.titleTag"
-        :tooltip="card.tooltip"
-        :trend-range="card.trendRange"
-      />
-    </template>
+      <template v-for="(card, index) in cards">
+        <MetricCardLoadingSkeleton
+          v-if="loading"
+          :key="`skeleton-${index}`"
+          :class="cardSize === MetricCardSize.Small ? 'loading-tabs-small' : 'loading-tabs-large'"
+        />
+        <MetricsCard
+          v-else
+          :key="index"
+          v-bind="formatCardValues(card)"
+          :card-size="cardSize"
+          :card-type="card.cardType"
+          :description="card.description"
+          :error-message="errorMessage"
+          :has-error="card.hasError"
+          :title="card.title"
+          :title-tag="card.titleTag"
+          :tooltip="card.tooltip"
+          :trend-range="card.trendRange"
+        />
+      </template>
+    </div>
   </div>
 </template>
 
@@ -86,6 +94,11 @@ const props = defineProps({
     required: false,
     default: () => MetricCardSize.Large,
   },
+  containerTitle: {
+    type: String,
+    required: false,
+    default: '',
+  },
 })
 
 const allCardsHaveErrors = computed((): boolean => props.cards.every(val => val?.hasError === true))
@@ -100,6 +113,7 @@ const formatCardValues = (card: MetricCardDef): MetricCardDisplayValue => {
     changePolarity: polarity,
     trendIcon: defineIcon(polarity, card.increaseIsBad) as typeof GenericIcon,
     cardSize: props.cardSize,
+    hasContainerTitle: !!props.containerTitle,
   }
 }
 </script>
@@ -110,14 +124,25 @@ const formatCardValues = (card: MetricCardDef): MetricCardDisplayValue => {
 .kong-ui-public-metric-card-container {
   background-color: var(--kong-ui-metric-card-background, transparent);
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: space-between;
   width: 100%;
-  @include flex-gap(24px, 16px);
 
-  @media (max-width: ($kui-breakpoint-phablet - 1px)) {
-    @include flex-gap(16px, 16px);
-    flex-direction: column;
+  .container-title {
+    font-size: $kui-font-size-50;
+    font-weight: $kui-font-weight-semibold;
+    margin-bottom: $kui-space-40;
+  }
+
+  .cards-wrapper {
+    display: flex;
+    flex-direction: row;
+    @include flex-gap(24px, 16px);
+
+    @media (max-width: ($kui-breakpoint-phablet - 1px)) {
+      @include flex-gap(16px, 16px);
+      flex-direction: column;
+    }
   }
 
   // Ensure tightest possible spacing

--- a/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
+++ b/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
@@ -129,14 +129,15 @@ const formatCardValues = (card: MetricCardDef): MetricCardDisplayValue => {
   width: 100%;
 
   .container-title {
-    font-size: $kui-font-size-50;
+    font-size: $kui-font-size-40;
     font-weight: $kui-font-weight-semibold;
-    margin-bottom: $kui-space-40;
+    margin-bottom: $kui-space-50;
   }
 
   .cards-wrapper {
     display: flex;
     flex-direction: row;
+    flex-grow: 1;
     @include flex-gap(24px, 16px);
 
     @media (max-width: ($kui-breakpoint-phablet - 1px)) {

--- a/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
+++ b/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
@@ -2,7 +2,7 @@
   <div class="metricscard">
     <div
       class="metricscard-title"
-      :class="cardSize"
+      :class="[ cardSize, {'small-heading': hasContainerTitle }]"
     >
       <component
         :is="iconMap.get(cardType)"
@@ -184,7 +184,12 @@ const props = defineProps({
   cardSize: {
     type: String as PropType<MetricCardSize>,
     required: false,
-    default: () => 'lg',
+    default: () => MetricCardSize.Large,
+  },
+  hasContainerTitle: {
+    type: Boolean,
+    required: false,
+    default: false,
   },
   titleTag: {
     type: String as PropType<HeaderTag>,
@@ -280,6 +285,11 @@ $row-gap-size: 12px;
     &.sm {
       font-size: $kui-font-size-20;
     }
+
+    &.small-heading {
+      font-size: $kui-font-size-30 !important;
+      font-weight: $kui-font-weight-semibold;
+    }
   }
 
   &-description {
@@ -290,7 +300,7 @@ $row-gap-size: 12px;
   }
 
   &-icon {
-    margin-right: 6px;
+    margin-right: $kui-space-20;
   }
 
   &-value {

--- a/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
+++ b/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
@@ -2,7 +2,7 @@
   <div class="metricscard">
     <div
       class="metricscard-title"
-      :class="[ cardSize, {'small-heading': hasContainerTitle }]"
+      :class="cardSize"
     >
       <component
         :is="iconMap.get(cardType)"
@@ -54,7 +54,6 @@
         class="metricscard-value"
         :class="cardSize"
         data-testid="metric-value"
-        :style="`font-size:${metricFontSize}`"
       >
         {{ metricValue }}
       </div>
@@ -102,14 +101,11 @@ import type { PropType } from 'vue'
 import { computed } from 'vue'
 import {
   KUI_COLOR_BORDER_DANGER_STRONG,
-  KUI_FONT_SIZE_30, // 14px
-  KUI_FONT_SIZE_100, // 48px
   KUI_ICON_SIZE_30,
   KUI_ICON_SIZE_40,
   KUI_COLOR_TEXT_SUCCESS, // Positive trend
   KUI_COLOR_TEXT_NEUTRAL_STRONG, // Neutral trend
   KUI_COLOR_TEXT_NEUTRAL,
-  KUI_FONT_SIZE_70,
 } from '@kong/design-tokens'
 import { MetricCardType } from '../../enums'
 import { MetricCardSize } from '../../constants'
@@ -221,10 +217,6 @@ const textColor = (polarity: number): string => {
 
 const cardDisplayFull = [MetricCardSize.Medium, MetricCardSize.Large, MetricCardSize.LargeCompact].includes(props.cardSize)
 
-const metricFontSize = props.cardSize === MetricCardSize.ExtraLarge
-  ? KUI_FONT_SIZE_100
-  : cardDisplayFull ? KUI_FONT_SIZE_70 : KUI_FONT_SIZE_30
-
 // TODO: remove size variant as part of Dashboards epic - MA-2193
 const isLargeCompact = computed((): boolean => props.cardSize === MetricCardSize.LargeCompact)
 
@@ -278,17 +270,22 @@ $row-gap-size: 12px;
     display: flex;
     flex-direction: row;
     font-size: $kui-font-size-30;
-    font-weight: $kui-font-weight-medium;
+    font-weight: $kui-font-weight-semibold;
     line-height: $kui-line-height-20;
     margin: $kui-space-0;
 
     &.sm {
       font-size: $kui-font-size-20;
+      font-weight: $kui-font-weight-medium;
     }
-
-    &.small-heading {
-      font-size: $kui-font-size-30 !important;
-      font-weight: $kui-font-weight-semibold;
+    &.md {
+      font-size: $kui-font-size-30;
+    }
+    &.lg {
+      font-size: $kui-font-size-40;
+    }
+    &.xl {
+      font-size: $kui-font-size-30;
     }
   }
 
@@ -313,6 +310,9 @@ $row-gap-size: 12px;
 
     &.sm {
       line-height: $kui-line-height-40;
+    }
+    &.xl {
+      font-size: $kui-font-size-70;
     }
   }
 

--- a/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
+++ b/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
@@ -270,19 +270,20 @@ $row-gap-size: 12px;
     display: flex;
     flex-direction: row;
     font-size: $kui-font-size-30;
-    font-weight: $kui-font-weight-semibold;
+    font-weight: $kui-font-weight-medium;
     line-height: $kui-line-height-20;
     margin: $kui-space-0;
 
+    // The metric card title is always 14px; the "small" variant is the exception
     &.sm {
       font-size: $kui-font-size-20;
-      font-weight: $kui-font-weight-medium;
     }
     &.md {
       font-size: $kui-font-size-30;
+      font-weight: $kui-font-weight-semibold;
     }
     &.lg {
-      font-size: $kui-font-size-40;
+      font-size: $kui-font-size-30;
     }
     &.xl {
       font-size: $kui-font-size-30;
@@ -343,7 +344,7 @@ $row-gap-size: 12px;
       flex-direction: row;
       font-size: $kui-font-size-20;
       font-weight: $kui-font-weight-semibold;
-      padding: 4px 8px;
+      padding: $kui-space-20 $kui-space-40;
 
       .kui-icon {
         margin-right: 4px;

--- a/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
+++ b/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
@@ -310,8 +310,8 @@ $row-gap-size: 12px;
     line-height: $kui-line-height-60;
 
     &.sm {
-      line-height: $kui-line-height-40;
       font-size: $kui-font-size-30;
+      line-height: $kui-line-height-40;
     }
     &.xl {
       font-size: $kui-font-size-100;

--- a/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
+++ b/packages/analytics/metric-cards/src/components/display/MetricsCard.vue
@@ -304,15 +304,17 @@ $row-gap-size: 12px;
     color: var(--kong-ui-metric-card-value, $kui-color-text);
     display: flex;
     flex-direction: row;
+    font-size: $kui-font-size-70;
     font-weight: $kui-font-weight-semibold;
     justify-content: space-between;
     line-height: $kui-line-height-60;
 
     &.sm {
       line-height: $kui-line-height-40;
+      font-size: $kui-font-size-30;
     }
     &.xl {
-      font-size: $kui-font-size-70;
+      font-size: $kui-font-size-100;
     }
   }
 

--- a/packages/analytics/metric-cards/src/types/metric-card.ts
+++ b/packages/analytics/metric-cards/src/types/metric-card.ts
@@ -26,6 +26,7 @@ export interface MetricCardDisplayValue {
   changePolarity: number
   trendIcon?: typeof GenericIcon
   cardSize?: MetricCardSize
+  hasContainerTitle?: boolean
 }
 
 export interface MetricCardContainerOptions {
@@ -34,5 +35,6 @@ export interface MetricCardContainerOptions {
   hasTrendAccess: boolean
   loading: boolean
   cardSize?: MetricCardSize
+  containerTitle?: string
   errorMessage?: string
 }


### PR DESCRIPTION
# Summary
https://konghq.atlassian.net/browse/MA-2726

Allows us to add a Golden Signals card title in a Dashboard definition.

### Preview links for consuming repositories:
#### GM MFE
https://pr-2819--gateway-manager.cloud-preview.konghq.tech/gateway-manager

#### Konnect (check Overview page + Analytics Dashboard)

https://pr-7818--khcp-ui.cloud-preview.konghq.tech/us/overview/
https://pr-7818--khcp-ui.cloud-preview.konghq.tech/us/analytics/summary

### Decisions (which are up for discussion):

- [ ] extend `metricCardSchema` to allow `chartTitle`; this gets mapped to `containerTitle` down the line
- [x] add a [new custom class in MetricsCard.vue](https://github.com/Kong/public-ui-components/pull/1298/files#diff-5da7413b7371afe63776bd6389ffeb769e125e8171a84b6f69f320de1705d52fR289) to force the font size to be smaller; had to use `!important` to override the `lg` card size font :(


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
