### PR TITLE
refactor(entities): remove config.requestHeaders [KM-43]

### DIFF
--- a/packages/entities/entities-certificates/docs/ca-certificate-config-card.md
+++ b/packages/entities/entities-certificates/docs/ca-certificate-config-card.md
@@ -43,11 +43,11 @@ A config card component for CA certificates.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-certificates/docs/ca-certificate-form.md
+++ b/packages/entities/entities-certificates/docs/ca-certificate-form.md
@@ -43,11 +43,11 @@ A form component for CA Certificates.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-certificates/docs/ca-certificate-list.md
+++ b/packages/entities/entities-certificates/docs/ca-certificate-list.md
@@ -43,11 +43,11 @@ A table component for ca-certificates.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-certificates/docs/certificate-config-card.md
+++ b/packages/entities/entities-certificates/docs/certificate-config-card.md
@@ -43,11 +43,11 @@ A form component for Certificate.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-certificates/docs/certificate-form.md
+++ b/packages/entities/entities-certificates/docs/certificate-form.md
@@ -43,11 +43,11 @@ A form component for Certificates.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-certificates/docs/certificate-list.md
+++ b/packages/entities/entities-certificates/docs/certificate-list.md
@@ -43,11 +43,11 @@ A table component for certificates.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-certificates/src/components/CACertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateForm.vue
@@ -107,9 +107,7 @@ const router = useRouter()
 const { i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = useErrors()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const fetchUrl = computed<string>(() => endpoints.form[props.config.app].edit)
 const formType = computed((): EntityBaseFormType => props.certificateId ? EntityBaseFormType.Edit : EntityBaseFormType.Create)

--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -234,9 +234,7 @@ const props = defineProps({
 const { i18n: { t, formatUnixTimeStamp }, i18nT } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 
 /**

--- a/packages/entities/entities-certificates/src/components/CertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.vue
@@ -169,9 +169,7 @@ const router = useRouter()
 const { i18nT, i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = useErrors()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const fetchUrl = computed<string>(() => endpoints.form[props.config.app].edit)
 const formType = computed((): EntityBaseFormType => props.certificateId ? EntityBaseFormType.Edit : EntityBaseFormType.Create)

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -264,9 +264,7 @@ const props = defineProps({
 const { i18n: { t, formatUnixTimeStamp }, i18nT } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 
 /**

--- a/packages/entities/entities-consumer-credentials/docs/consumer-credential-list.md
+++ b/packages/entities/entities-consumer-credentials/docs/consumer-credential-list.md
@@ -43,11 +43,11 @@ A table component for consumer credentials.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -268,9 +268,7 @@ const props = defineProps({
 
 const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
 
-const { axiosInstance } = useAxios({
-  headers: props.config.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 
 /**

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-config-card.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-config-card.md
@@ -43,11 +43,11 @@ A config card component for consumer groups.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-form.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-form.md
@@ -40,11 +40,11 @@ A form component to create/edit Consumer Group.
         - required: `true`
         - default: `undefined`
         - Base URL for API requests.
-    - `requestHeaders`:
-        - type: `RawAxiosRequestHeaders | AxiosHeaders`
+    - `axiosRequestConfig`:
+        - type: `AxiosRequestConfig`
         - required: `false`
         - default: `undefined`
-        - Additional headers to send with all Axios requests.
+        - An optional configuration object for the underlying Axios request.
     - `cancelRoute`:
         - type: `RouteLocationRaw`
         - required: `true`

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
@@ -43,11 +43,11 @@ A table component for consumer groups.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-consumer-groups/src/components/AddToGroupModal.vue
+++ b/packages/entities/entities-consumer-groups/src/components/AddToGroupModal.vue
@@ -92,9 +92,7 @@ const emit = defineEmits<{
   (e: 'error', msg: string): void
 }>()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 /**
  * ------------------------------

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
@@ -160,9 +160,7 @@ const {
   searchKeys: ['username', 'custom_id', 'id'],
 })
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { getMessageFromError } = useErrors()
 const validators = useValidators()
 

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -271,9 +271,7 @@ const props = defineProps({
 const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 const isConsumerPage = computed<boolean>(() => !!props.config.consumerId)
 const preferencesStorageKey = computed<string>(

--- a/packages/entities/entities-consumers/docs/consumer-config-card.md
+++ b/packages/entities/entities-consumers/docs/consumer-config-card.md
@@ -43,11 +43,11 @@ A form component for consumer.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-consumers/docs/consumer-form.md
+++ b/packages/entities/entities-consumers/docs/consumer-form.md
@@ -40,11 +40,11 @@ A form component to create/edit Consumer.
         - required: `true`
         - default: `undefined`
         - Base URL for API requests.
-    - `requestHeaders`:
-        - type: `RawAxiosRequestHeaders | AxiosHeaders`
+    - `axiosRequestConfig`:
+        - type: `AxiosRequestConfig`
         - required: `false`
         - default: `undefined`
-        - Additional headers to send with all Axios requests.
+        - An optional configuration object for the underlying Axios request.
     - `cancelRoute`:
       - type: `RouteLocationRaw`
       - required: `true`

--- a/packages/entities/entities-consumers/docs/consumer-list.md
+++ b/packages/entities/entities-consumers/docs/consumer-list.md
@@ -43,11 +43,11 @@ A table component for consumers.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-consumers/src/components/AddConsumerModal.vue
+++ b/packages/entities/entities-consumers/src/components/AddConsumerModal.vue
@@ -104,9 +104,7 @@ const emit = defineEmits<{
   (e: 'error', msg: string): void
 }>()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 /**
  * ------------------------------

--- a/packages/entities/entities-consumers/src/components/ConsumerForm.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerForm.vue
@@ -150,9 +150,7 @@ const emit = defineEmits<{
 
 const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { getMessageFromError } = useErrors()
 const uuid = uuidv4()
 

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -271,9 +271,7 @@ const props = defineProps({
 const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 const isConsumerGroupPage = computed<boolean>(() => !!props.config.consumerGroupId)
 const preferencesStorageKey = computed<string>(

--- a/packages/entities/entities-gateway-services/docs/gateway-service-config-card.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-config-card.md
@@ -43,11 +43,11 @@ A config card component for gateway services.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-gateway-services/docs/gateway-service-form.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-form.md
@@ -44,11 +44,11 @@ A form component for gateway services.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-gateway-services/docs/gateway-service-list.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-list.md
@@ -43,11 +43,11 @@ A table component for gateway services.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -406,9 +406,7 @@ const isCollapsed = ref(true)
 const router = useRouter()
 const { i18nT, i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = useErrors()
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const validators = useValidators()
 
 const fetchUrl = computed<string>(() => endpoints.form[props.config.app].edit)

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -257,9 +257,7 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetchCacheKey = ref<number>(1)
 
 /**

--- a/packages/entities/entities-key-sets/docs/key-set-config-card.md
+++ b/packages/entities/entities-key-sets/docs/key-set-config-card.md
@@ -43,11 +43,11 @@ A config card component for Key Sets.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-key-sets/docs/key-set-form.md
+++ b/packages/entities/entities-key-sets/docs/key-set-form.md
@@ -43,11 +43,11 @@ A form component for Key Sets.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-key-sets/docs/key-set-list.md
+++ b/packages/entities/entities-key-sets/docs/key-set-list.md
@@ -43,11 +43,11 @@ A table component for key sets.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-key-sets/src/components/KeySetForm.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetForm.vue
@@ -97,9 +97,7 @@ const router = useRouter()
 const { i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = useErrors()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const fetchUrl = computed<string>(() => endpoints.form[props.config.app].edit)
 const formType = computed((): EntityBaseFormType => props.keySetId ? EntityBaseFormType.Edit : EntityBaseFormType.Create)

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -221,9 +221,7 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 
 /**

--- a/packages/entities/entities-keys/docs/key-config-card.md
+++ b/packages/entities/entities-keys/docs/key-config-card.md
@@ -43,11 +43,11 @@ A config card component for Keys.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-keys/docs/key-form.md
+++ b/packages/entities/entities-keys/docs/key-form.md
@@ -43,11 +43,11 @@ A form component for Keys.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-keys/docs/key-list.md
+++ b/packages/entities/entities-keys/docs/key-list.md
@@ -43,11 +43,11 @@ A table component for keys.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-keys/src/components/KeyConfigCard.vue
+++ b/packages/entities/entities-keys/src/components/KeyConfigCard.vue
@@ -147,9 +147,7 @@ interface Key {
   pem?: PemKey;
 }
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { convertKeyToTitle } = useStringHelpers()
 const { i18n: { t } } = composables.useI18n()
 

--- a/packages/entities/entities-keys/src/components/KeyForm.vue
+++ b/packages/entities/entities-keys/src/components/KeyForm.vue
@@ -217,9 +217,7 @@ const router = useRouter()
 const { i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = useErrors()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const fetchUrl = computed<string>(() => {
   return props.keySetId

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -225,9 +225,7 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 
 /**

--- a/packages/entities/entities-plugins/docs/plugin-config-card.md
+++ b/packages/entities/entities-plugins/docs/plugin-config-card.md
@@ -43,11 +43,11 @@ A config card component for plugins. Configuration section properties will be or
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-plugins/docs/plugin-form.md
+++ b/packages/entities/entities-plugins/docs/plugin-form.md
@@ -43,11 +43,11 @@ A form component for Plugins.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-plugins/docs/plugin-list.md
+++ b/packages/entities/entities-plugins/docs/plugin-list.md
@@ -41,11 +41,11 @@ A table component for plugins.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-plugins/docs/plugin-select.md
+++ b/packages/entities/entities-plugins/docs/plugin-select.md
@@ -42,11 +42,11 @@ A grid component for selecting Plugins.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `getCreateRoute`:
     - type: `(plugin: string) => RouteLocationRaw`

--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
@@ -301,9 +301,7 @@ const pluginConfigSchema = computed((): PluginConfigurationSchema => {
 })
 
 const { getMessageFromError } = useErrors()
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const schemaUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.form[props.config.app].pluginSchema}`

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -116,9 +116,7 @@ const props = defineProps({
   },
 })
 
-const { axiosInstance } = useAxios({
-  headers: props.config.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const { parseSchema } = composables.useSchemas(props.entityMap.focusedEntity?.id || undefined, {
   groupFields: props.config.groupFields,

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -246,9 +246,7 @@ const { getMessageFromError } = useErrors()
 const { capitalize } = useStringHelpers()
 const { objectsAreEqual } = useHelpers()
 
-const { axiosInstance } = useAxios({
-  headers: props.config.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const isToggled = ref(false)
 const formType = computed((): EntityBaseFormType => props.pluginId ? EntityBaseFormType.Edit : EntityBaseFormType.Create)

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -361,9 +361,7 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const isConsumerPage = computed((): boolean => props.config?.entityType === 'consumers')
 

--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -252,9 +252,7 @@ const availablePlugins = ref<string[]>([])
 const pluginsList = ref<PluginCardList>({})
 const existingEntityPlugins = ref<string[]>([])
 
-const { axiosInstance } = useAxios({
-  headers: props.config.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const flattenPluginMap = computed(() => {
   if (!pluginsList.value) {

--- a/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
+++ b/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
@@ -81,9 +81,7 @@ const emit = defineEmits(['closed', 'proceed'])
 const { i18nT, i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = useErrors()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const title = computed((): string => {
   return isPluginSchemaInUse.value

--- a/packages/entities/entities-routes/docs/route-config-card.md
+++ b/packages/entities/entities-routes/docs/route-config-card.md
@@ -43,11 +43,11 @@ A config card component for routes.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -44,11 +44,11 @@ A form component for Routes.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-routes/docs/route-list.md
+++ b/packages/entities/entities-routes/docs/route-list.md
@@ -41,11 +41,11 @@ A table component for routes.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-routes/src/components/RouteConfigCard.vue
+++ b/packages/entities/entities-routes/src/components/RouteConfigCard.vue
@@ -207,9 +207,7 @@ const props = defineProps({
   },
 })
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { i18n: { t }, i18nT } = composables.useI18n()
 const internalServiceId = ref('')
 const serviceName = ref('')

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -410,9 +410,7 @@ const emit = defineEmits<{
 const { i18nT, i18n, i18n: { t } } = composables.useI18n()
 const protocolsLabels = i18n.source.form.protocols as Record<string, string>
 const router = useRouter()
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { getMessageFromError } = useErrors()
 
 const showGeneralInfoSection = computed<boolean>(() => !(props.hideNameField && (props.hideServiceField || !!props.serviceId) && props.showTagsFiledUnderAdvanced))

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -284,9 +284,7 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 
 /**

--- a/packages/entities/entities-shared/docs/entity-base-config-card.md
+++ b/packages/entities/entities-shared/docs/entity-base-config-card.md
@@ -44,11 +44,11 @@ A base display component for an entity's record data.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-shared/docs/entity-base-form.md
+++ b/packages/entities/entities-shared/docs/entity-base-form.md
@@ -43,11 +43,11 @@ A base form component for entity create/edit views.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-shared/docs/use-axios.md
+++ b/packages/entities/entities-shared/docs/use-axios.md
@@ -29,9 +29,7 @@ Additional Axios request config settings.
 <script setup lang="ts">
 import { useAxios } from '@kong-ui-public/entities-shared'
 
-const { axiosInstance } = useAxios({
-  headers: props.config.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config.axiosRequestConfig)
 
 const fetcher = async ({ page, pageSize, offset, sortColumnKey, sortColumnOrder, query }) => {
   try {

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -203,9 +203,7 @@ const { i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = composables.useErrors()
 const { convertKeyToTitle } = composables.useStringHelpers()
 
-const { axiosInstance } = composables.useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = composables.useAxios(props.config?.axiosRequestConfig)
 
 const configFormatItems = [
   {

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -180,9 +180,7 @@ const router = useRouter()
 const { i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = composables.useErrors()
 
-const { axiosInstance } = composables.useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = composables.useAxios(props.config?.axiosRequestConfig)
 
 const isLoading = ref(false)
 const fetchDetailsError = ref(false)

--- a/packages/entities/entities-shared/src/composables/useDebouncedFilter.ts
+++ b/packages/entities/entities-shared/src/composables/useDebouncedFilter.ts
@@ -26,10 +26,7 @@ export default function useDebouncedFilter(
     size = '1000'
   }
 
-  // Is this reactive?
-  const { axiosInstance } = useAxios({
-    headers: config.requestHeaders,
-  })
+  const { axiosInstance } = useAxios(config.axiosRequestConfig)
 
   const { i18n: { t } } = useI18n()
   const { debounce } = useDebounce()

--- a/packages/entities/entities-shared/src/composables/useFetcher.ts
+++ b/packages/entities/entities-shared/src/composables/useFetcher.ts
@@ -24,14 +24,7 @@ export default function useFetcher(
 ) {
   const _baseUrl = unref(baseUrl)
 
-  // Combine any config.requestHeaders with the optional axiosRequestConfig.headers
-
-  // Is this reactive?
-  const { axiosInstance } = useAxios({
-    ...config.axiosRequestConfig,
-    ...{ headers: { ...config.axiosRequestConfig?.headers, ...config.requestHeaders } },
-  })
-
+  const { axiosInstance } = useAxios(config.axiosRequestConfig)
   const buildFetchUrl = useFetchUrlBuilder(config, _baseUrl)
 
   const state = ref<FetcherState>({

--- a/packages/entities/entities-shared/src/types/app-config.ts
+++ b/packages/entities/entities-shared/src/types/app-config.ts
@@ -1,4 +1,4 @@
-import type { RawAxiosRequestHeaders, AxiosHeaders, AxiosRequestConfig } from 'axios'
+import type { AxiosRequestConfig } from 'axios'
 
 /** Shared config properties for all app entities */
 interface BaseAppConfig {
@@ -6,10 +6,6 @@ interface BaseAppConfig {
   apiBaseUrl: string
   /** App name. One of 'konnect' | 'kongManager' */
   app: 'konnect' | 'kongManager'
-  // TODO: Remove requestHeaders and in host apps use axiosRequestConfig.headers instead
-  // Ticket: https://konghq.atlassian.net/browse/KM-43
-  /** Additional headers to send with all Axios requests */
-  requestHeaders?: RawAxiosRequestHeaders | AxiosHeaders
   /** An optional configuration object for the underlying Axios request */
   axiosRequestConfig?: AxiosRequestConfig
 }

--- a/packages/entities/entities-snis/docs/sni-form.md
+++ b/packages/entities/entities-snis/docs/sni-form.md
@@ -43,11 +43,11 @@ A form component for SNIs.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-snis/docs/sni-list.md
+++ b/packages/entities/entities-snis/docs/sni-list.md
@@ -43,11 +43,11 @@ A table component for SNIs.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-snis/src/components/SniForm.vue
+++ b/packages/entities/entities-snis/src/components/SniForm.vue
@@ -143,9 +143,7 @@ const router = useRouter()
 const { i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = useErrors()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const fetchUrl = computed<string>(() => endpoints.form[props.config.app].edit)
 const formType = computed((): EntityBaseFormType => props.sniId ? EntityBaseFormType.Edit : EntityBaseFormType.Create)

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -218,9 +218,7 @@ const props = defineProps({
 
 const { i18n: { t } } = composables.useI18n()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetchCacheKey = ref<number>(1)
 
 /**

--- a/packages/entities/entities-upstreams-targets/docs/target-form.md
+++ b/packages/entities/entities-upstreams-targets/docs/target-form.md
@@ -44,11 +44,11 @@ A form component for targets. Comes with [`TargetsList` component](../src/compon
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-upstreams-targets/docs/targets-list.md
+++ b/packages/entities/entities-upstreams-targets/docs/targets-list.md
@@ -45,11 +45,11 @@ A table component for targets. Includes target create/edit form modal out of the
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-upstreams-targets/docs/upstreams-config-card.md
+++ b/packages/entities/entities-upstreams-targets/docs/upstreams-config-card.md
@@ -43,11 +43,11 @@ A config card component for Upstream.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-upstreams-targets/docs/upstreams-form.md
+++ b/packages/entities/entities-upstreams-targets/docs/upstreams-form.md
@@ -40,11 +40,11 @@ A form component to create/edit Upstreams.
         - required: `true`
         - default: `undefined`
         - Base URL for API requests.
-    - `requestHeaders`:
-        - type: `RawAxiosRequestHeaders | AxiosHeaders`
+    - `axiosRequestConfig`:
+        - type: `AxiosRequestConfig`
         - required: `false`
         - default: `undefined`
-        - Additional headers to send with all Axios requests.
+        - An optional configuration object for the underlying Axios request.
     - `cancelRoute`:
         - type: `RouteLocationRaw`
         - required: `true`

--- a/packages/entities/entities-upstreams-targets/docs/upstreams-list.md
+++ b/packages/entities/entities-upstreams-targets/docs/upstreams-list.md
@@ -44,11 +44,11 @@ A table component for upstreams.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
@@ -128,9 +128,7 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = useErrors()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const fetchUrl = computed<string>(() => endpoints.form[props.config.app].edit.replace(/{upstreamId}/gi, props.config?.upstreamId || ''))
 const formType = computed((): EntityBaseFormType => props.targetId ? EntityBaseFormType.Edit : EntityBaseFormType.Create)

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -227,9 +227,7 @@ const props = defineProps({
 
 const { i18n: { t } } = composables.useI18n()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 
 /**
@@ -460,6 +458,7 @@ const formConfig = computed((): KonnectTargetFormConfig | KongManagerTargetFormC
     app: props.config.app,
     apiBaseUrl: props.config.apiBaseUrl,
     upstreamId: props.config.upstreamId,
+    axiosRequestConfig: props.config.axiosRequestConfig,
     ...{
       // Depending on the app, we need to pass in the control plane ID or workspace
       // see KonnectTargetFormConfig and KongManagerTargetFormConfig types
@@ -468,7 +467,6 @@ const formConfig = computed((): KonnectTargetFormConfig | KongManagerTargetFormC
       }),
       ...(props.config.app === 'kongManager' && {
         workspace: props.config.workspace,
-        requestHeaders: props.config.requestHeaders,
       }),
     },
   } as KonnectTargetFormConfig | KongManagerTargetFormConfig

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
@@ -143,9 +143,7 @@ const emit = defineEmits<{
 
 const { inRange, stringToNumberArray, upstreamsResponseToFields, getDefaultUpstreamFields, objectsAreEqual, cloneDeep } =
   useHelpers()
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { getMessageFromError } = useErrors()
 const router = useRouter()
 

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -215,9 +215,7 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetcherCacheKey = ref<number>(1)
 
 /**

--- a/packages/entities/entities-vaults/docs/vault-config-card.md
+++ b/packages/entities/entities-vaults/docs/vault-config-card.md
@@ -43,11 +43,11 @@ A config card component for Vaults.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
     - type: `string`

--- a/packages/entities/entities-vaults/docs/vault-form.md
+++ b/packages/entities/entities-vaults/docs/vault-form.md
@@ -43,11 +43,11 @@ A form component for Vaults.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `cancelRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-vaults/docs/vault-list.md
+++ b/packages/entities/entities-vaults/docs/vault-list.md
@@ -41,11 +41,11 @@ A table component for vaults.
     - default: `undefined`
     - Base URL for API requests.
 
-  - `requestHeaders`:
-    - type: `RawAxiosRequestHeaders | AxiosHeaders`
+  - `axiosRequestConfig`:
+    - type: `AxiosRequestConfig`
     - required: `false`
     - default: `undefined`
-    - Additional headers to send with all Axios requests.
+    - An optional configuration object for the underlying Axios request.
 
   - `createRoute`:
     - type: `RouteLocationRaw`

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -555,9 +555,7 @@ const emit = defineEmits<{
 
 const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { getMessageFromError } = useErrors()
 
 const form = reactive<VaultState>({

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -230,9 +230,7 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
-const { axiosInstance } = useAxios({
-  headers: props.config?.requestHeaders,
-})
+const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 /**
  * Table Headers


### PR DESCRIPTION
BREAKING CHANGE: Now `config.requestHeaders` is removed. Use `config.axiosRequestConfig` instead.

# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

KM-43

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
