### PR TITLE
feat(analytics-config-store): export `configResult` and some minor fix

### DIFF
--- a/packages/analytics/analytics-config-store/src/stores/analytics-config.ts
+++ b/packages/analytics/analytics-config-store/src/stores/analytics-config.ts
@@ -10,10 +10,9 @@ export type ConfigStoreState = null | AnalyticsConfigV2
 export const useAnalyticsConfigStore = defineStore('analytics-config', () => {
   let fetchedConfig = false
   const configResult = ref<ConfigStoreState>(null)
+  const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
 
   const getConfig = (): Ref<ConfigStoreState> => {
-    const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
-
     if (!queryBridge) {
       console.warn('Analytics components require a query bridge supplied via provide / inject.')
       console.warn("Please ensure your application has a query bridge provided under the key 'analytics-query-provider', as described in")
@@ -32,10 +31,10 @@ export const useAnalyticsConfigStore = defineStore('analytics-config', () => {
     if (!fetchedConfig) {
       // We haven't tried to fetch the config yet.
       fetchedConfig = true
-
       queryBridge.configFn().then(res => {
         configResult.value = res
       }).catch(err => {
+        fetchedConfig = false
         console.warn('Error fetching analytics config')
         console.warn(err)
       })
@@ -46,5 +45,6 @@ export const useAnalyticsConfigStore = defineStore('analytics-config', () => {
 
   return {
     getConfig,
+    configResult,
   }
 })


### PR DESCRIPTION
# Summary

This commit exports `configResult` to prevent some reactivity issues. After that, `getConfig` could be used as a pure action.
    
Besides, we mark `fetchedConfig` to false when `configFn` returns with error, and hoisting the `queryBridge` out of the `getConfig` to prevent some unintentional behavior


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
