### PR TITLE
fix(plugin-icon): use default icon when plugin icon name is undefined [KHCP-11396]

### DIFF
--- a/packages/entities/entities-plugins/README.md
+++ b/packages/entities/entities-plugins/README.md
@@ -11,6 +11,9 @@ Plugin entity components.
 
 ## Requirements
 
+> [!CAUTION]
+> A string of 'undefined' is disallowed in Plugin icon names
+
 - `vue` and `vue-router` must be initialized in the host application
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.

--- a/packages/entities/entities-plugins/README.md
+++ b/packages/entities/entities-plugins/README.md
@@ -11,13 +11,12 @@ Plugin entity components.
 
 ## Requirements
 
-> [!CAUTION]
-> A string of 'undefined' is disallowed in Plugin icon names
-
 - `vue` and `vue-router` must be initialized in the host application
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 - `axios` must be installed as a dependency in the host application
+> [!CAUTION]
+> A string of 'undefined' is disallowed in Plugin icon names
 
 ## Included components
 

--- a/packages/entities/entities-plugins/src/components/PluginIcon.vue
+++ b/packages/entities/entities-plugins/src/components/PluginIcon.vue
@@ -2,17 +2,15 @@
   <img
     ref="img"
     :alt="alt"
-    :src="iconSrc || defaultIcon"
+    :src="iconSrc"
     :width="size"
     @error="onError"
   >
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import { getPluginIconURL } from '../definitions/metadata'
-
-const defaultIcon = new URL('../assets/images/plugin-icons/missing.png', import.meta.url).href
 
 const props = defineProps({
   name: {
@@ -32,9 +30,10 @@ const props = defineProps({
 })
 
 const img = ref<HTMLImageElement>()
-const iconSrc = computed((): string => props.name ? getPluginIconURL(props.name) : '')
+const iconSrc = getPluginIconURL(props.name)
 
 const onError = () => {
+  const defaultIcon = new URL('../assets/images/plugin-icons/missing.png', import.meta.url).href // ? only need to compute it when plugin URL is invalid
   if (img.value) {
     img.value.src = defaultIcon
   }

--- a/packages/entities/entities-plugins/src/components/PluginIcon.vue
+++ b/packages/entities/entities-plugins/src/components/PluginIcon.vue
@@ -33,7 +33,7 @@ const img = ref<HTMLImageElement>()
 const iconSrc = getPluginIconURL(props.name)
 
 const onError = () => {
-  const defaultIcon = new URL('../assets/images/plugin-icons/missing.png', import.meta.url).href // ? only need to compute it when plugin URL is invalid
+  const defaultIcon = new URL('../assets/images/plugin-icons/missing.png', import.meta.url).href // only need to compute it when icon URL is invalid
   if (img.value) {
     img.value.src = defaultIcon
   }

--- a/packages/entities/entities-plugins/src/definitions/metadata.spec.ts
+++ b/packages/entities/entities-plugins/src/definitions/metadata.spec.ts
@@ -3,29 +3,43 @@ import { PLUGIN_METADATA, getPluginIconURL } from './metadata'
 
 describe('metadata', () => {
   describe('getPluginIconURL', () => {
-    const defaultIconURL = 'file:///src/assets/images/plugin-icons/missing.png'
+    const defaultIconURL = 'missing.png'
 
-    it('generates default icon URL when icon name provided is empty', () => {
-      expect(getPluginIconURL('')).toBe(defaultIconURL)
+    it('generates default icon URL when icon name provided is not provided or is empty string', () => {
+      expect(getPluginIconURL('')).toContain(defaultIconURL)
     })
 
-    it('generates icon URL using PLUGIN_METADATA when icon name provided is a valid key of PLUGIN_METADATA', () => {
-      // this is for the case when icon name provided is a key of PLUGIN_METADATA, and also has `imageName` field defined
+    it('generates icon URL using PLUGIN_METADATA', () => {
+      // when icon name provided is a key of PLUGIN_METADATA, and also has `imageName` field defined
       const pluginMetadataKey = 'exit-transformer'
       const exitTransformerImageName = PLUGIN_METADATA[pluginMetadataKey].imageName
 
-      expect(getPluginIconURL(pluginMetadataKey)).toContain(`file:///src/assets/images/plugin-icons/${exitTransformerImageName}.png`)
+      expect(getPluginIconURL(pluginMetadataKey)).toContain(`${exitTransformerImageName}.png`)
     })
 
     it('generates icon URL with the provided icon name', () => {
       /**
-       * this is for the case when:
+       * when:
        * - icon name provided is a valid key of PLUGIN_METADATA, but the `imageName` field is undefined for it
+       * OR
        * - icon name provided is NOT a valid key of PLUGIN_METADATA
+       * we directly use the provided icon name to generate a URL (assuming an icon exists, with the same name, in assets directory)
        */
       const iconName = 'acme'
 
-      expect(getPluginIconURL(iconName)).toBe(`file:///src/assets/images/plugin-icons/${iconName}.png`)
+      expect(getPluginIconURL(iconName)).toContain(`${iconName}.png`)
+    })
+
+    it('generates icon URL with the provided icon name but no such icon exists', () => {
+      /**
+       * when icon name is provided, but it's:
+       * - neither a key in PLUGIN_METADATA
+       * - nor a icon of the same name exists in assets directory
+       * we then instead use the default icon
+       */
+      const iconName = 'random-icon-that-doesn`t-exist'
+
+      expect(getPluginIconURL(iconName)).toContain(defaultIconURL)
     })
   })
 })

--- a/packages/entities/entities-plugins/src/definitions/metadata.spec.ts
+++ b/packages/entities/entities-plugins/src/definitions/metadata.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { PLUGIN_METADATA, getPluginIconURL } from './metadata'
+
+describe('metadata', () => {
+  describe('getPluginIconURL', () => {
+    const defaultIconURL = 'file:///src/assets/images/plugin-icons/missing.png'
+
+    it('generates default icon URL when icon name provided is empty', () => {
+      expect(getPluginIconURL('')).toBe(defaultIconURL)
+    })
+
+    it('generates icon URL using PLUGIN_METADATA when icon name provided is a valid key of PLUGIN_METADATA', () => {
+      // this is for the case when icon name provided is a key of PLUGIN_METADATA, and also has `imageName` field defined
+      const pluginMetadataKey = 'exit-transformer'
+      const exitTransformerImageName = PLUGIN_METADATA[pluginMetadataKey].imageName
+
+      expect(getPluginIconURL(pluginMetadataKey)).toContain(`file:///src/assets/images/plugin-icons/${exitTransformerImageName}.png`)
+    })
+
+    it('generates icon URL with the provided icon name', () => {
+      /**
+       * this is for the case when:
+       * - icon name provided is a valid key of PLUGIN_METADATA, but the `imageName` field is undefined for it
+       * - icon name provided is NOT a valid key of PLUGIN_METADATA
+       */
+      const iconName = 'acme'
+
+      expect(getPluginIconURL(iconName)).toBe(`file:///src/assets/images/plugin-icons/${iconName}.png`)
+    })
+  })
+})

--- a/packages/entities/entities-plugins/src/definitions/metadata.ts
+++ b/packages/entities/entities-plugins/src/definitions/metadata.ts
@@ -767,6 +767,6 @@ export const CREDENTIAL_SCHEMAS: Record<string, any> = {
  * @returns URL for the plugin icon
  */
 export const getPluginIconURL = (name: string) => {
-  const imageName = PLUGIN_METADATA[name]?.imageName || name
+  const imageName = PLUGIN_METADATA[name]?.imageName || name || 'missing' // ? default icon is 'missing'
   return new URL(`../assets/images/plugin-icons/${imageName}.png`, import.meta.url).href
 }

--- a/packages/entities/entities-plugins/src/definitions/metadata.ts
+++ b/packages/entities/entities-plugins/src/definitions/metadata.ts
@@ -767,6 +767,6 @@ export const CREDENTIAL_SCHEMAS: Record<string, any> = {
  * @returns URL for the plugin icon
  */
 export const getPluginIconURL = (name: string) => {
-  const imageName = PLUGIN_METADATA[name]?.imageName || name || 'missing' // ? default icon is 'missing'
+  const imageName = PLUGIN_METADATA[name]?.imageName || name || 'missing' // default icon is 'missing'
   return new URL(`../assets/images/plugin-icons/${imageName}.png`, import.meta.url).href
 }

--- a/packages/entities/entities-plugins/src/definitions/metadata.ts
+++ b/packages/entities/entities-plugins/src/definitions/metadata.ts
@@ -767,10 +767,10 @@ export const CREDENTIAL_SCHEMAS: Record<string, any> = {
  * @returns URL for the plugin icon
  */
 export const getPluginIconURL = (name: string) => {
-  const imageName = PLUGIN_METADATA[name]?.imageName || name // default icon is 'missing'
+  const imageName = PLUGIN_METADATA[name]?.imageName || name || 'missing' // default icon is 'missing'
   const iconURL = new URL(`../assets/images/plugin-icons/${imageName}.png`, import.meta.url).href
 
-  if (iconURL.endsWith('/undefined.png') || iconURL.endsWith('/undefined')) {
+  if (iconURL.includes('undefined')) {
     // if URL ends with /undefined or /undefined.png, return default icon
     return new URL('../assets/images/plugin-icons/missing.png', import.meta.url).href
   }

--- a/packages/entities/entities-plugins/src/definitions/metadata.ts
+++ b/packages/entities/entities-plugins/src/definitions/metadata.ts
@@ -767,6 +767,12 @@ export const CREDENTIAL_SCHEMAS: Record<string, any> = {
  * @returns URL for the plugin icon
  */
 export const getPluginIconURL = (name: string) => {
-  const imageName = PLUGIN_METADATA[name]?.imageName || name || 'missing' // default icon is 'missing'
-  return new URL(`../assets/images/plugin-icons/${imageName}.png`, import.meta.url).href
+  const imageName = PLUGIN_METADATA[name]?.imageName || name // default icon is 'missing'
+  const iconURL = new URL(`../assets/images/plugin-icons/${imageName}.png`, import.meta.url).href
+
+  if (iconURL.endsWith('/undefined.png') || iconURL.endsWith('/undefined')) {
+    // if URL ends with /undefined or /undefined.png, return default icon
+    return new URL('../assets/images/plugin-icons/missing.png', import.meta.url).href
+  }
+  return iconURL
 }


### PR DESCRIPTION
## Summary

- if the `getPluginIconURL` method is not provided any icon name, default to `missing` icon
- move check for empty icon name from `PluginIcon` component to `getPluginIconURL` method
- only compute and use default icon URL in `PluginIcon` component if the URL passed in `src` attribute was invalid and the `img` tag emitted an error

## Resources

- [Slack thread discussion](https://kongstrong.slack.com/archives/C05UE909XU5/p1712172404522979?thread_ts=1712153356.330669&cid=C05UE909XU5)
- [KHCP-11396](https://konghq.atlassian.net/browse/KHCP-11396?atlOrigin=eyJpIjoiOGQxMTNjOWJjNzQzNDQxNDkwNmUyNDA0ZDI4NjU3NDIiLCJwIjoiaiJ9)

## ToDo

- [x] add unit tests for `getPluginIconURL`


[KHCP-11396]: https://konghq.atlassian.net/browse/KHCP-11396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ