### PR TITLE
feat(analytics): add disabled state support to metric cards

### DIFF
--- a/packages/analytics/analytics-metric-provider/sandbox/App.vue
+++ b/packages/analytics/analytics-metric-provider/sandbox/App.vue
@@ -112,6 +112,7 @@ const globalProviderProps = {
   longCardTitles: false,
   description: 'Generic Description',
   containerTitle: 'Analytics',
+  containerSubtitle: 'Subtitle',
 }
 const globalBridge = makeQueryBridge()
 

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsProvider.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsProvider.vue
@@ -29,8 +29,10 @@ const props = withDefaults(defineProps<{
   refreshInterval: number,
   longCardTitles?: boolean,
   containerTitle?: string,
+  containerSubtitle?: string,
   description?: string,
   abortController?: AbortController,
+  isAnalyticsEnabled?: boolean,
 }>(), {
   maxTimeframe: TimeframeKeys.THIRTY_DAY,
   overrideTimeframe: undefined,
@@ -42,8 +44,10 @@ const props = withDefaults(defineProps<{
   refreshInterval: DEFAULT_REFRESH_INTERVAL,
   longCardTitles: false,
   containerTitle: undefined,
+  containerSubtitle: undefined,
   description: undefined,
   abortController: undefined,
+  isAnalyticsEnabled: true,
 })
 
 // Fail early if there's a programming error.
@@ -127,8 +131,10 @@ provide(METRICS_PROVIDER_KEY, {
     traffic: trafficData,
     latency: latencyData,
   },
-  description: props.description,
-  containerTitle: props.containerTitle,
+  description: toRef(() => props.description),
+  containerTitle: toRef(() => props.containerTitle),
+  containerSubtitle: toRef(() => props.containerSubtitle),
+  isAnalyticsEnabled: toRef(() => props.isAnalyticsEnabled),
   hasTrendAccess,
   longCardTitles: props.longCardTitles,
 })

--- a/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
+++ b/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
@@ -8,13 +8,18 @@ import composables from '../composables'
 import type { MetricFetcherOptions } from '../types'
 import { computed } from 'vue'
 import type { InjectionKey, Ref } from 'vue'
+import type { FetcherResult } from 'src/composables/useMetricFetcher'
 
 interface ProviderData {
   data: {
+    traffic: FetcherResult,
+    latency: FetcherResult,
     [key: string]: any // TODO
   },
-  containerTitle?: string,
-  description?: string,
+  containerTitle?: Ref<string | undefined>,
+  containerSubtitle?: Ref<string | undefined>,
+  isAnalyticsEnabled: Ref<boolean>,
+  description?: Ref<string | undefined>,
   hasTrendAccess: Ref<boolean>,
   longCardTitles: boolean,
 }

--- a/packages/analytics/analytics-metric-provider/src/composables/useMetricCardBuilder.ts
+++ b/packages/analytics/analytics-metric-provider/src/composables/useMetricCardBuilder.ts
@@ -7,13 +7,14 @@ import { DEFAULT_KEY } from './useMetricFetcher'
 export interface BuilderOptions {
   cardType: MetricCardType,
   title: Ref<string>,
-  description?: string,
+  description?: Ref<string | undefined>,
   record: Ref<ChronologicalMappedMetrics>,
   hasError: Ref<boolean>,
   lookupKey?: string,
   sumGroupedValues?: string[],
   increaseIsBad?: boolean,
-  formatValueFn?: (rawValue: number) => string,
+  formatChangeFn?: Ref<((change: number) => string) | undefined>,
+  formatValueFn?: Ref<((rawValue: number) => string) | undefined>,
   trendRange?: Ref<string>,
 }
 
@@ -39,6 +40,7 @@ export default function useMetricCardBuilder(opts: BuilderOptions): Ref<MetricCa
     record,
     hasError,
     increaseIsBad,
+    formatChangeFn,
     formatValueFn,
     trendRange,
   } = opts
@@ -66,10 +68,11 @@ export default function useMetricCardBuilder(opts: BuilderOptions): Ref<MetricCa
       currentValue,
       previousValue,
       title: title.value,
-      description,
+      description: description?.value,
       increaseIsBad: !!increaseIsBad, // Coerce undefined to false
-      formatValueFn,
+      formatChangeFn: formatChangeFn?.value,
+      formatValueFn: formatValueFn?.value,
       trendRange: trendRange?.value,
-    }
+    } satisfies MetricCardDef
   })
 }

--- a/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
@@ -253,6 +253,7 @@ export const summaryDashboardConfig: DashboardConfig = {
         chart: {
           type: ChartTypes.GoldenSignals,
         },
+        noPadding: true,
       },
       layout: {
         position: {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -4,9 +4,14 @@
     title="Dashboard Renderer"
   >
     <div class="sandbox-container">
+      <KInputSwitch
+        v-model="isAnalyticsEnabled"
+        label="Toggle Analytics Enabled Status"
+      />
       <h2>Static Dashboard</h2>
+
       <DashboardRenderer
-        :config="(dashboardConfig as DashboardConfig)"
+        :config="dashboardConfig"
         :context="context"
       >
         <template #slot-1>
@@ -29,13 +34,15 @@
 <script setup lang="ts">
 import type { DashboardConfig, DashboardRendererContext, TileConfig } from '../../src'
 import { ChartTypes, DashboardRenderer } from '../../src'
-import { inject } from 'vue'
+import { computed, inject, ref } from 'vue'
 import { ChartMetricDisplay } from '@kong-ui-public/analytics-chart'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
 import { SandboxLayout } from '@kong-ui-public/sandbox-layout'
 import '@kong-ui-public/sandbox-layout/dist/style.css'
 
 const appLinks: SandboxNavigationItem[] = inject('app-links', [])
+
+const isAnalyticsEnabled = ref(true)
 
 const context: DashboardRendererContext = {
   filters: [],
@@ -46,7 +53,7 @@ const context: DashboardRendererContext = {
   refreshInterval: 0,
 }
 
-const dashboardConfig: DashboardConfig = {
+const dashboardConfig = computed<DashboardConfig>(() => ({
   gridSize: {
     cols: 6,
     rows: 5,
@@ -58,7 +65,9 @@ const dashboardConfig: DashboardConfig = {
         chart: {
           type: ChartTypes.GoldenSignals,
           chartTitle: 'Analytics Golden Signals',
+          isAnalyticsEnabled: isAnalyticsEnabled.value,
         },
+        noPadding: true,
         query: {},
       },
       layout: {
@@ -215,6 +224,6 @@ const dashboardConfig: DashboardConfig = {
       },
     } as TileConfig,
   ],
-}
+}))
 
 </script>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -100,6 +100,7 @@ describe('<DashboardRenderer />', () => {
               chart: {
                 type: ChartTypes.GoldenSignals,
               },
+              noPadding: true,
               query: {},
             },
             layout: {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tile-boundary">
+  <div :class="tileClass">
     <component
       :is="componentData.component"
       v-if="componentData"
@@ -58,10 +58,19 @@ const componentData = computed(() => {
     },
   }
 })
+
+const tileClass = computed(() => ({
+  'tile-boundary': true,
+  'no-padding': props.definition.noPadding,
+}))
 </script>
 
 <style lang="scss" scoped>
 .tile-boundary {
   height: v-bind('`${height}px`');
+
+  &.no-padding {
+    padding: 0 !important;
+  }
 }
 </style>

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -53,8 +53,10 @@ const options = computed<ProviderProps>(() => ({
   additionalFilter: props.context.filters,
   longCardTitles: props.chartOptions.longCardTitles,
   containerTitle: props.chartOptions.chartTitle,
+  containerSubtitle: props.chartOptions.chartSubtitle,
   description: props.chartOptions.description,
   hasTrendAccess: true,
+  isAnalyticsEnabled: props.chartOptions.isAnalyticsEnabled ?? true,
   refreshInterval: props.context.refreshInterval ?? DEFAULT_TILE_REFRESH_INTERVAL_MS,
 }))
 </script>

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -154,6 +154,9 @@ export const metricCardSchema = {
   type: 'object',
   properties: {
     chartTitle,
+    chartSubtitle: {
+      type: 'string',
+    },
     type: {
       type: 'string',
       enum: [ChartTypes.GoldenSignals],
@@ -163,6 +166,9 @@ export const metricCardSchema = {
     },
     description: {
       type: 'string',
+    },
+    isAnalyticsEnabled: {
+      type: 'boolean',
     },
   },
   required: ['type'],
@@ -367,6 +373,10 @@ export const tileDefinitionSchema = {
     query: exploreV4QuerySchema,
     chart: {
       oneOf: [barChartSchema, gaugeChartSchema, timeseriesChartSchema, metricCardSchema, topNTableSchema, slottableSchema],
+    },
+    noPadding: {
+      type: 'boolean',
+      description: 'If true, the tile will not have padding.',
     },
   },
   required: ['query', 'chart'],

--- a/packages/analytics/metric-cards/sandbox/App.vue
+++ b/packages/analytics/metric-cards/sandbox/App.vue
@@ -46,6 +46,13 @@
         />
       </div>
 
+      <h3>Analytics Disabled</h3>
+      <div class="generic-card">
+        <MetricCardContainer
+          v-bind="cardsDisabled"
+        />
+      </div>
+
       <h3>Not Available</h3>
       <div class="generic-card">
         <MetricCardContainer
@@ -179,6 +186,22 @@ const cardsLoading: MetricCardContainerOptions = {
   loading: true,
   hasTrendAccess: true,
   fallbackDisplayText: 'Not available',
+}
+
+const cardsDisabled: MetricCardContainerOptions = {
+  cards: cards.map(c => ({
+    ...c,
+    description: '',
+    trendRange: '',
+    formatChangeFn: () => 'N/A',
+    formatValueFn: () => '',
+  })).slice(0, 3),
+  loading: false,
+  hasTrendAccess: false,
+  containerTitle: 'Analytics',
+  containerSubtitle: 'Enable analytics switch for deeper insights.',
+  fallbackDisplayText: 'Not available',
+  cardSize: MetricCardSize.Large,
 }
 
 const cardsNotAvailable: MetricCardContainerOptions = {

--- a/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
+++ b/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
@@ -8,6 +8,13 @@
       class="container-title"
     >
       {{ props.containerTitle }}
+
+      <div
+        v-if="props.containerSubtitle"
+        class="container-subtitle"
+      >
+        {{ props.containerSubtitle }}
+      </div>
     </div>
     <div
       v-if="allCardsHaveErrors"
@@ -99,6 +106,11 @@ const props = defineProps({
     required: false,
     default: '',
   },
+  containerSubtitle: {
+    type: String,
+    required: false,
+    default: '',
+  },
 })
 
 const allCardsHaveErrors = computed((): boolean => props.cards.every(val => val?.hasError === true))
@@ -129,9 +141,19 @@ const formatCardValues = (card: MetricCardDef): MetricCardDisplayValue => {
   width: 100%;
 
   .container-title {
+    align-items: center;
+    display: flex;
+
     font-size: $kui-font-size-40;
     font-weight: $kui-font-weight-semibold;
+    justify-content: space-between;
     margin-bottom: $kui-space-50;
+
+    .container-subtitle {
+      color: $kui-color-text-neutral-strong;
+      font-size: $kui-font-size-20;
+      font-weight: $kui-font-weight-regular;
+    }
   }
 
   .cards-wrapper {

--- a/packages/analytics/metric-cards/src/types/metric-card.ts
+++ b/packages/analytics/metric-cards/src/types/metric-card.ts
@@ -36,5 +36,6 @@ export interface MetricCardContainerOptions {
   loading: boolean
   cardSize?: MetricCardSize
   containerTitle?: string
+  containerSubtitle?: string
   errorMessage?: string
 }


### PR DESCRIPTION
Changes include:
## For `@kong-ui-public/metric-cards`
* Add `containerSubtitle` to `<MetricCardContainer />` props and support subtitle in container

## For `@kong-ui-public/analytics-metric-provider`
* Add `containerSubtitle` and `isAnalyticsEnabled` to `<MetricsProvider />` props
* `<MetricsProvider />` now provides `containerSubtitle` and `isAnalyticsEnabled` to child components
* `description`, `containerTitle`, `containerSubtitle` and `isAnalyticsEnabled` are now provided with reactive data structure
* `<MetricsConsumer />` now has its own padding and has a gary background when analytics is disabled
* Remove `trendRange`, `description` and metrics value, change percentable text to 'N/A' in analytics disabled mode

## For `@kong-ui-public/dashboard-renderer`
* Add `chartSubtitle` and `isAnalyticsEnabled` to both metric card schema and `GoldenSignalsRenderer`
* Add `noPadding` to the tile definition schema to remove the padding. This would be useful while setting the tile's background style

Jira: KM-14
