### PR TITLE
feat(analytics): allow checking feature flags in bridge [MA-2738]

### DIFF
--- a/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
@@ -84,9 +84,13 @@ const errorRateCard = computed<MetricCardDef>(() => {
 const formatLatency = (val: number) => `${val}ms`
 const latencyCard = composables.useMetricCardBuilder({
   cardType: MetricCardType.LATENCY,
-  title: computed(() => providerData.longCardTitles
-    ? i18n.t('metricCard.long.latency')
-    : i18n.t('metricCard.short.latency')),
+  title: computed(() => {
+    const { longCardTitles, averageLatencies } = providerData
+    const titleKey = averageLatencies.value ? 'averageLatency' : 'p99Latency'
+    return longCardTitles
+      ? i18n.t(`metricCard.long.${titleKey}`)
+      : i18n.t(`metricCard.short.${titleKey}`)
+  }),
   description: providerData.description,
   hasError: latency.hasError,
   record: latency.mapped,

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsTestHarness.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsTestHarness.vue
@@ -57,12 +57,14 @@ const props = withDefaults(defineProps<{
   additionalFilter?: ExploreFilter[],
   longCardTitles?: boolean,
   description?: string,
+  percentileLatency?: boolean,
 }>(), {
   refreshInterval: 60 * 1000,
   queryReady: true,
   additionalFilter: undefined,
   longCardTitles: undefined,
   description: undefined,
+  percentileLatency: undefined,
 })
 
 // Query stats for an entire org, no grouping or filtering.

--- a/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
+++ b/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
@@ -97,7 +97,7 @@ export default function useMetricFetcher(opts: MetricFetcherOptions): FetcherRes
   const { i18n } = composables.useI18n()
 
   const query: Ref<ExploreQuery> = computed(() => ({
-    metrics: opts.metrics,
+    metrics: opts.metrics.value,
     dimensions: [
       ...(opts.dimensions?.length ? [...opts.dimensions] : []),
       ...(opts.withTrend.value ? ['time'] : []),
@@ -108,7 +108,7 @@ export default function useMetricFetcher(opts: MetricFetcherOptions): FetcherRes
   } as ExploreQuery))
 
   const cacheKey: Ref<string | null> = computed(() => {
-    if (!opts.queryReady?.value || (opts.featureFlags && !opts.featureFlags.every(e => e))) {
+    if (!opts.queryReady?.value) {
       return null
     }
 
@@ -116,7 +116,7 @@ export default function useMetricFetcher(opts: MetricFetcherOptions): FetcherRes
     // need to have some uniqueness in the cache key to avoid collisions.
     // this was happening when there are multiple providers on the same page with the same dimensions and metrics.
     // For example the singleProvider and multiProvider that appear in the test harness.
-    return `metric-fetcher-${opts.timeframe.value.cacheKey()}-${opts.dimensions?.join('-')}-${opts.metrics?.join('-')}-${additionalFilterKey}`
+    return `metric-fetcher-${opts.timeframe.value.cacheKey()}-${opts.dimensions?.join('-')}-${opts.metrics.value?.join('-')}-${additionalFilterKey}`
   })
 
   const { response: raw, error: metricError, isValidating: isMetricDataValidating } = composables.useRequest<ExploreResultV4>(

--- a/packages/analytics/analytics-metric-provider/src/locales/en.json
+++ b/packages/analytics/analytics-metric-provider/src/locales/en.json
@@ -6,12 +6,14 @@
     "short": {
       "traffic": "Requests",
       "errorRate": "Error Rate",
-      "latency": "P99 Latency"
+      "averageLatency": "Average Latency",
+      "p99Latency": "P99 Latency"
     },
     "long": {
       "traffic": "Number of Requests",
       "errorRate": "Average Error Rate",
-      "latency": "P99 Latency"
+      "averageLatency": "Average Latency",
+      "p99Latency": "P99 Latency"
     }
   },
   "trendRange": {

--- a/packages/analytics/analytics-metric-provider/src/types/fetcher-types.ts
+++ b/packages/analytics/analytics-metric-provider/src/types/fetcher-types.ts
@@ -5,14 +5,13 @@ import type {
 import type { Ref } from 'vue'
 
 export interface MetricFetcherOptions {
-  metrics: ExploreAggregations[]
+  metrics: Ref<ExploreAggregations[]>
   dimensions?: QueryableExploreDimensions[]
   filter: Ref<ExploreFilter[] | undefined>
   timeframe: Ref<Timeframe>
   tz: Ref<string>
   refreshInterval: number
   withTrend: Ref<boolean>
-  featureFlags?: boolean[]
   queryReady: Ref<boolean>
   queryFn: AnalyticsBridge['queryFn']
   abortController?: AbortController

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -2,6 +2,12 @@ import type { ExploreQuery, ExploreResultV4 } from './explore-v4'
 import type { AnalyticsConfigV2 } from './analytics-config'
 
 export interface AnalyticsBridge {
+  // Issue queries to the KAnalytics API
   queryFn: (query: ExploreQuery, abortController: AbortController) => Promise<ExploreResultV4>,
+
+  // Determine the current org's analytics config
   configFn: () => Promise<AnalyticsConfigV2>,
+
+  // Evaluate feature flags (if applicable)
+  evaluateFeatureFlagFn: <T = boolean>(key: string, defaultValue: T) => T,
 }

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -74,9 +74,12 @@ describe('<DashboardRenderer />', () => {
       },
     })
 
+    const evaluateFeatureFlagFn: AnalyticsBridge['evaluateFeatureFlagFn'] = () => true as any
+
     return {
       queryFn: cy.spy(queryFn).as('fetcher'),
       configFn,
+      evaluateFeatureFlagFn,
     }
   }
 

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -54,7 +54,7 @@ const options = computed<ProviderProps>(() => ({
   longCardTitles: props.chartOptions.longCardTitles,
   containerTitle: props.chartOptions.chartTitle,
   description: props.chartOptions.description,
-  hasTrendAccess: true,
+  percentileLatency: props.chartOptions.percentileLatency,
   refreshInterval: props.context.refreshInterval ?? DEFAULT_TILE_REFRESH_INTERVAL_MS,
 }))
 </script>

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -164,6 +164,9 @@ export const metricCardSchema = {
     description: {
       type: 'string',
     },
+    percentileLatency: {
+      type: 'boolean',
+    },
   },
   required: ['type'],
 } as const satisfies JSONSchema


### PR DESCRIPTION
- Add new `evaluateFeatureFlagFn` to query bridge [MA-2738]
- Use feature flag to determine whether to query average latencies [MA-2739]
- Add override property to force querying percentile latencies [MA-2740]

# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)


[MA-2738]: https://konghq.atlassian.net/browse/MA-2738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MA-2739]: https://konghq.atlassian.net/browse/MA-2739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MA-2740]: https://konghq.atlassian.net/browse/MA-2740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ