### PR TITLE
fix(entities): remove the label next to the enabled switch

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -73,7 +73,6 @@
                 v-model="row.enabled"
                 :data-testid="`row-${row.id}-toggle-input`"
                 :disabled="!isAllowed"
-                :label="row.enabled ? t('actions.enable.enabled_label') : t('actions.enable.disabled_label')"
                 @click.prevent="toggleEnableStatus(row)"
               />
             </div>

--- a/packages/entities/entities-gateway-services/src/locales/en.json
+++ b/packages/entities/entities-gateway-services/src/locales/en.json
@@ -6,10 +6,6 @@
     "edit": "Edit",
     "clear": "Clear",
     "view": "View Details",
-    "enable": {
-      "enabled_label": "Enabled",
-      "disabled_label": "Disabled"
-    },
     "delete": {
       "title": "Delete a Gateway Service",
       "description": "Deleting this Gateway Service will also remove any associated routes and plugins. This action cannot be reversed.",

--- a/packages/entities/entities-plugins/src/components/PluginList.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginList.cy.ts
@@ -167,8 +167,8 @@ describe('<PluginList />', () => {
         },
       })
 
-      cy.getTestId('basic-auth').find('[data-testid="enabled"]').should('contain.text', 'Disabled')
-      cy.getTestId('acl').find('[data-testid="enabled"]').should('contain.text', 'Enabled')
+      cy.getTestId('basic-auth').find('[data-testid="enabled"] input').should('not.be.checked')
+      cy.getTestId('acl').find('[data-testid="enabled"] input').should('be.checked')
     })
 
     it('should render "Dynamic" / "Static" ordering badge', () => {

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -106,20 +106,9 @@
               <KInputSwitch
                 :disabled="!isAllowed"
                 :disabled-tooltip-text="!isAllowed && config.getToggleDisabledTooltip?.(row) || undefined"
-                label-before
                 :model-value="row.enabled"
                 @click.stop.prevent="isAllowed && toggleEnableStatus(row)"
-              >
-                <template #label>
-                  <div class="toggle-label">
-                    {{
-                      row.enabled
-                        ? t('plugins.list.table_headers.status_label.enabled')
-                        : t('plugins.list.table_headers.status_label.disabled')
-                    }}
-                  </div>
-                </template>
-              </KInputSwitch>
+              />
             </div>
           </template>
         </PermissionsWrapper>
@@ -385,7 +374,7 @@ if (!props.config?.entityId) {
   fields.appliedTo = { label: t('plugins.list.table_headers.applied_to'), sortable: false }
 }
 
-fields.enabled = { label: t('plugins.list.table_headers.status'), searchable: true, sortable: true }
+fields.enabled = { label: t('plugins.list.table_headers.enabled'), searchable: true, sortable: true }
 
 if (isOrderingSupported) {
   fields.ordering = { label: t('plugins.list.table_headers.ordering'), sortable: true }
@@ -812,10 +801,6 @@ onBeforeMount(async () => {
         margin-top: 4px;
       }
     }
-  }
-
-  .toggle-label {
-    font-size: $kui-font-size-30;
   }
 
   .k-badge.disabled {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -85,11 +85,7 @@
           "dynamic": "Dynamic",
           "static": "Static"
         },
-        "status": "Status",
-        "status_label": {
-          "enabled": "Enabled",
-          "disabled": "Disabled"
-        },
+        "enabled": "Enabled",
         "tags": "Tags"
       },
       "empty_state": {


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This PR removes the label next to the `Enabled` switch for `GatewayServiceList` and `PluginList`.

`GatewayServiceList`:
<img width="1657" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/fc83e282-f84d-48ec-bc36-8c68b0d77eaf">

`PluginList`:
<img width="1664" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/f63bcd1b-e40d-48ce-ae02-f220729bbd83">


KM-65

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
