### PR TITLE
fix(document-viewer): ensure document heading slugs are unique

### DIFF
--- a/packages/portal/document-viewer/src/utils/addUniqueHeadingSlugs.ts
+++ b/packages/portal/document-viewer/src/utils/addUniqueHeadingSlugs.ts
@@ -26,9 +26,9 @@ export function addSlug(child: HeadingNode, slugMap: Map<string, number>, prefix
   const text = isTextNode(firstChild)
     ? firstChild.text || defaultText
     : defaultText
-  const slugCount = slugMap.get(text)
-  slugMap.set(text, (slugCount || 0) + 1)
-  const duplicateSuffix = slugCount && slugCount > 1 ? `-${slugCount}` : ''
+  const slugCount = (slugMap.get(text) || 0) + 1
+  slugMap.set(text, slugCount)
+  const duplicateSuffix = slugCount > 1 ? `-${slugCount}` : ''
   // add a hyphen if there are multiple headings with the same text
   const slug = prefix + toSlug(text, duplicateSuffix)
 


### PR DESCRIPTION
# Summary

Currently the logic is get the slugCount, then inserts the count correctly into the slugMap. But when creating the duplicate suffix, it doesn't factor in the "+ 1". The result is the first duplicate heading has a duplicate slug, but each subsequent heading has a unique slug. Resolves #1318.  

```ts
const slugCount = slugMap.get(text)
slugMap.set(text, (slugCount || 0) + 1)
const duplicateSuffix = slugCount && slugCount > 1 ? `-${slugCount}` : ''
```

First, we get `slugCount` which can be either undefined or a number.
Then, we set the slugMap correctly.
But, when we set the suffix, we use the original `slugCount` that hasn't been updated yet, so it's either 1 less than it should be or undefined.

Proposed changes:

```ts
const slugCount = (slugMap.get(text) || 0) + 1
slugMap.set(text, slugCount)
const duplicateSuffix = slugCount > 1 ? `-${slugCount}` : ''
```

Move the math logic to when we initialize `slugCount`. And then we don't need to check if slugCount exists.