### PR TITLE
fix(entities-shared): table toolbar width

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -371,6 +371,7 @@ const handleUpdateTablePreferences = (tablePreferences: UserTablePreferences): v
 .kong-ui-entity-base-table {
   .toolbar-container {
     align-items: center;
+    width: 100%;
   }
 
   .toolbar-button-container {


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Due to recent `KTable` changes, we need to explicitly set the toolbar width now:

| Before | After |
| - | - |
| <img width="1443" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/96a48fa8-5dc2-48a6-a26f-0d22af924036"> | <img width="1446" alt="image" src="https://github.com/Kong/public-ui-components/assets/10095631/57785783-3ccd-49bc-81cd-e39757466109"> |

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
