### PR TITLE
feat(*): expressions routes support [KM-20]

### DIFF
--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -2,7 +2,6 @@
   "name": "@kong-ui-public/expressions",
   "version": "0.1.7",
   "type": "module",
-  "main": "./dist/expressions.umd.js",
   "module": "./dist/expressions.es.js",
   "types": "dist/types/index.d.ts",
   "files": [
@@ -11,7 +10,6 @@
   "exports": {
     ".": {
       "import": "./dist/expressions.es.js",
-      "require": "./dist/expressions.umd.js",
       "types": "./dist/types/index.d.ts"
     },
     "./package.json": "./package.json",

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -42,7 +42,7 @@
     "@kong/atc-router": "1.6.0-rc.1",
     "@kong/design-tokens": "1.12.11",
     "@kong/kongponents": "9.0.0-alpha.146",
-    "monaco-editor": "0.47.0",
+    "monaco-editor": "0.21.3",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vite-plugin-top-level-await": "^1.4.1",
     "vite-plugin-wasm": "^3.3.0",
@@ -68,7 +68,7 @@
   "peerDependencies": {
     "@kong/atc-router": "1.6.0-rc.1",
     "@kong/kongponents": "9.0.0-alpha.105",
-    "monaco-editor": "0.47.0",
+    "monaco-editor": "0.21.3",
     "vue": "^3.4.21"
   },
   "dependencies": {

--- a/packages/core/expressions/src/components/ExpressionsEditor.vue
+++ b/packages/core/expressions/src/components/ExpressionsEditor.vue
@@ -7,23 +7,23 @@
 
 <script setup lang="ts">
 import { useDebounce } from '@kong-ui-public/core'
-import type { ParseResult, Schema } from '@kong/atc-router'
+import type { ParseResult, Schema as AtcSchema } from '@kong/atc-router'
 import { Parser } from '@kong/atc-router'
 import type * as Monaco from 'monaco-editor'
 import * as monaco from 'monaco-editor'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { createSchema, type NamedSchemaDefinition } from '../schema'
+import { createSchema, type Schema } from '../schema'
 import { registerLanguage, registerTheme, theme } from '../monaco'
 
 let editor: Monaco.editor.IStandaloneCodeEditor | undefined
 let editorModel: Monaco.editor.ITextModel
 
-const parse = (expression:string, schema: Schema) => Parser.parse(expression, schema)
+const parse = (expression:string, schema: AtcSchema) => Parser.parse(expression, schema)
 
 const { debounce } = useDebounce()
 
 const props = withDefaults(defineProps<{
-  schema: NamedSchemaDefinition,
+  schema: Schema,
   parseDebounce?: number,
   inactiveUntilFocused?: boolean,
 }>(), {
@@ -45,7 +45,7 @@ const editorClass = computed(() => [
   { invalid: isParsingActive.value && parseResult.value?.status !== 'ok' },
 ])
 
-const registerSchema = (schema: NamedSchemaDefinition) => {
+const registerSchema = (schema: Schema) => {
   const { languageId } = registerLanguage(schema)
   monaco.editor.setModelLanguage(editorModel, languageId)
 }

--- a/packages/core/expressions/src/index.ts
+++ b/packages/core/expressions/src/index.ts
@@ -1,6 +1,6 @@
 import ExpressionsEditor from './components/ExpressionsEditor.vue'
 
-export * from '@kong/atc-router'
+export * as Atc from '@kong/atc-router'
 export * from './schema'
 export { ExpressionsEditor }
 

--- a/packages/core/expressions/src/monaco.ts
+++ b/packages/core/expressions/src/monaco.ts
@@ -1,5 +1,5 @@
 import * as monaco from 'monaco-editor'
-import { type NamedSchemaDefinition, type SchemaDefinition } from './schema'
+import { type Schema, type SchemaDefinition } from './schema'
 
 interface MonarchLanguage extends monaco.languages.IMonarchLanguage {
   keywords: string[];
@@ -54,11 +54,10 @@ export const registerTheme = () => {
   })
 }
 
-export const registerLanguage = (schema: NamedSchemaDefinition) => {
+export const registerLanguage = (schema: Schema) => {
   const languageId = getLanguageId(schema.name)
 
   if (monaco.languages.getEncodedLanguageId(languageId) !== 0) {
-    console.warn(`Language "${languageId}" has already been registered`)
     return { languageId }
   }
 

--- a/packages/core/expressions/src/schema.ts
+++ b/packages/core/expressions/src/schema.ts
@@ -1,16 +1,16 @@
-import { Schema, type AstType } from '@kong/atc-router'
+import { Schema as AtcSchema, type AstType } from '@kong/atc-router'
 
 export type SchemaDefinition = {
   [K in AstType]?: string[];
 };
 
-export interface NamedSchemaDefinition {
+export interface Schema {
   name: string;
   definition: SchemaDefinition;
 }
 
 export const createSchema = (definition: SchemaDefinition) => {
-  const schema = new Schema()
+  const schema = new AtcSchema()
 
   for (const [type, fields] of Object.entries(definition)) {
     for (const field of fields) {
@@ -42,15 +42,16 @@ export const STREAM_SCHEMA_DEFINITION: SchemaDefinition = {
   IpAddr: ['net.src.ip', 'net.dst.ip'],
 }
 
-export const PROTOCOL_TO_SCHEMA_DEFINITION = {
-  http: HTTP_SCHEMA_DEFINITION,
-  https: HTTP_SCHEMA_DEFINITION,
-  grpc: HTTP_SCHEMA_DEFINITION,
-  grpcs: HTTP_SCHEMA_DEFINITION,
+export const PROTOCOL_TO_SCHEMA = (() => {
+  const s: Record<string, Schema> = {}
 
-  tcp: STREAM_SCHEMA_DEFINITION,
-  udp: STREAM_SCHEMA_DEFINITION,
-  tls: STREAM_SCHEMA_DEFINITION,
+  for (const protocol of ['http', 'https', 'grpc', 'grpcs', 'ws', 'wss']) {
+    s[protocol] = { name: protocol, definition: HTTP_SCHEMA_DEFINITION }
+  }
 
-  tls_passthrough: STREAM_SCHEMA_DEFINITION,
-}
+  for (const protocol of ['tcp', 'udp', 'tls', 'tls_passthrough']) {
+    s[protocol] = { name: protocol, definition: STREAM_SCHEMA_DEFINITION }
+  }
+
+  return s
+})()

--- a/packages/core/expressions/vite.config.ts
+++ b/packages/core/expressions/vite.config.ts
@@ -30,8 +30,9 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       promiseExportName: 'asyncInit',
     }),
     // We don't need this plugin to bundle the library. Only for sandbox previews.
+    // See: https://github.com/vdesjs/vite-plugin-monaco-editor/issues/21
     ...process.env.USE_SANDBOX
-      ? [monacoEditorPlugin.default({})]
+      ? [((monacoEditorPlugin as any).default as typeof monacoEditorPlugin)({})]
       : [],
   ],
 }))

--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -118,6 +118,23 @@ Show/hide Service Select field. Should be used in case of manual adding `service
 
 Show tags field under _Advanced Fields_ collapse or in it's default place (before protocols field).
 
+#### `routeFlavors`
+
+- type: `RouteFlavors`
+- required: `false`
+- default: `{ traditional: true }`
+- properties:
+  - `traditional`:
+    - type: `boolean`
+    - required: `false`
+    - default: `true`
+    - Whether to show input components for the traditional route.
+  - `expressions`:
+    - type: `boolean`
+    - required: `false`
+    - default: `false`
+    - Whether to show input components for the Expressions route.
+
 ### Slots
 
 #### `form-actions`

--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -135,6 +135,25 @@ Show tags field under _Advanced Fields_ collapse or in it's default place (befor
     - default: `false`
     - Whether to show input components for the Expressions route.
 
+#### `configTabTooltips`
+
+- type: `Object as PropType<{ traditional?: string; expressions?: string } | undefined>`
+- required: `false`
+- default: `undefined`
+- properties:
+  - `traditional`:
+    - type: `string`
+    - required: `false`
+    - default: `undefined`
+    - Text to show in the tooltip of the traditional config tab.
+
+  - `expressions`:
+    - type: `string`
+    - required: `false`
+    - default: `undefined`
+    - Text to show in the tooltip of the Expressions config tab.
+
+
 ### Slots
 
 #### `form-actions`

--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -171,6 +171,18 @@ Slot props:
   - type: `Function`
   - Cancel handler function.
 
+#### `after-expressions-editor`
+
+Content to be displayed after the Expressions editor.
+
+Slot props:
+- `expression`
+  - type: `[string, (value: string) => void]`
+  - The expression and a function to update the expression. This is useful when slot content is trying to update the expression (e.g., router playground).
+- `state`
+  - type: `ExpressionsEditorState`
+  - The state of the editor.
+
 ### Events
 
 #### error
@@ -210,10 +222,14 @@ import type {
   MethodsFields,
   Sources,
   Destinations,
-  RouteStateFields,
+  BaseRouteStateFields,
+  TraditionalRouteStateFields,
+  ExpressionsRouteStateFields,
   RouteState,
   Headers,
-  RoutePayload,
+  BaseRoutePayload,
+  TraditionalRoutePayload,
+  ExpressionsRoutePayload,
   SelectItem
 } from '@kong-ui-public/entities-routes'
 ```

--- a/packages/entities/entities-routes/docs/route-list.md
+++ b/packages/entities/entities-routes/docs/route-list.md
@@ -65,12 +65,6 @@ A table component for routes.
     - default: `undefined`
     - A function that returns the route for editing a route.
 
-  - `useExpression`:
-    - type: `boolean`
-    - required: `false`
-    - default: `undefined`
-    - Whether to use expression flavored routes.
-
   - `serviceId`:
     - type: `string`
     - required: `false`
@@ -163,6 +157,14 @@ The table is rendered inside a `KCard`. `title` text is displayed in the upper l
 #### `titleTag`
 
 HTML element you want title to be rendered as. Defaults to `h2`.
+
+#### `hasExpressionColumn`
+
+- type: `boolean`
+- required: `false`
+- default: `false`
+
+Whether to show the "Expression" column. Defaults to `false`.
 
 ### Events
 

--- a/packages/entities/entities-routes/fixtures/mockData.ts
+++ b/packages/entities/entities-routes/fixtures/mockData.ts
@@ -59,6 +59,7 @@ export const services = [
   },
 ]
 
+// traditional
 export const route = {
   service: {
     id: services[0].id,
@@ -76,4 +77,21 @@ export const route = {
   strip_path: false,
   paths: ['/foo', '/bar'],
   headers: { Header1: ['cropped-jeans', 'expensive-petroleum'] },
+}
+
+// expressions
+export const routeExpressions = {
+  service: {
+    id: services[0].id,
+  },
+  id: '1',
+  name: 'route-1',
+  methods: ['GET', 'CASTOM'],
+  service_id: '',
+  tags: ['dev', 'test'],
+  preserve_host: true,
+  https_redirect_status_code: 426,
+  protocols: ['http', 'https'],
+  strip_path: false,
+  expression: 'http.path == "/kong"',
 }

--- a/packages/entities/entities-routes/fixtures/mockData.ts
+++ b/packages/entities/entities-routes/fixtures/mockData.ts
@@ -23,31 +23,6 @@ export const routes: FetcherRawResponse = {
   total: 2,
 }
 
-export const routes100: any[] = Array(100)
-  .fill(null)
-  .map((_, i) => ({
-    id: `${i + 1}`,
-    name: `route-${i + 1}`,
-    methods: ['GET'],
-    hosts: [`${i + 1}.example.com`],
-  }))
-
-export const paginate = (
-  routes: any[],
-  size: number,
-  _offset: number,
-): FetcherRawResponse => {
-  const sliced = routes.slice(_offset, _offset + size)
-  const offset =
-    _offset + size < routes.length ? String(_offset + size) : undefined
-
-  return {
-    data: sliced,
-    total: sliced.length,
-    offset,
-  }
-}
-
 export const services = [
   {
     id: '1',
@@ -65,7 +40,7 @@ export const route = {
     id: services[0].id,
   },
   id: '1',
-  name: 'route-1',
+  name: 'route-trad',
   methods: ['GET', 'CASTOM'],
   service_id: '',
   tags: ['dev', 'test'],
@@ -85,7 +60,7 @@ export const routeExpressions = {
     id: services[0].id,
   },
   id: '1',
-  name: 'route-1',
+  name: 'route-expr',
   methods: ['GET', 'CASTOM'],
   service_id: '',
   tags: ['dev', 'test'],
@@ -94,4 +69,31 @@ export const routeExpressions = {
   protocols: ['http', 'https'],
   strip_path: false,
   expression: 'http.path == "/kong"',
+}
+
+export const routesTraditional100: any[] = Array(100)
+  .fill(null)
+  .map((_, i) => ({
+    id: `${i + 1}`,
+    name: `route-${i + 1}`,
+    methods: ['GET'],
+    hosts: [`${i + 1}.example.com`],
+  }))
+
+export const routesTraditionalExpressionsMixed = [route, routeExpressions]
+
+export const paginate = (
+  routes: any[],
+  size: number,
+  _offset: number,
+): FetcherRawResponse => {
+  const sliced = routes.slice(_offset, _offset + size)
+  const offset =
+    _offset + size < routes.length ? String(_offset + size) : undefined
+
+  return {
+    data: sliced,
+    total: sliced.length,
+    offset,
+  }
 }

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -69,7 +69,7 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "2400KB"
+    "errorLimit": "5000KB"
   },
   "dependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -69,7 +69,7 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "5000KB"
+    "errorLimit": "2400KB"
   },
   "dependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -24,6 +24,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/kongponents": "^9.0.0-alpha.146",
     "axios": "^1.6.8",
+    "monaco-editor": "0.21.3",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
   },
@@ -31,7 +32,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
     "@kong/kongponents": "9.0.0-alpha.146",
+    "@types/lodash.isequal": "^4.5.8",
     "axios": "^1.6.8",
+    "monaco-editor": "0.21.3",
+    "vite-plugin-monaco-editor": "^1.1.0",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"
   },
@@ -65,9 +69,11 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "700KB"
+    "errorLimit": "5000KB"
   },
   "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^"
+    "@kong-ui-public/entities-shared": "workspace:^",
+    "@kong-ui-public/expressions": "workspace:^",
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/expressions": "workspace:^",
+    "@kong/icons": "^1.8.16",
     "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/entities/entities-routes/sandbox/pages/RouteFormPage.vue
+++ b/packages/entities/entities-routes/sandbox/pages/RouteFormPage.vue
@@ -1,7 +1,30 @@
 <template>
+  <KCard class="sandbox-route-flavor-control">
+    <KCollapse
+      v-model="isRouteFlavorControlCollapsed"
+      :class="{ 'is-collapsed': isRouteFlavorControlCollapsed }"
+      title="Route flavors"
+    >
+      <div class="wrapper">
+        <KInputSwitch
+          v-model="routeFlavors.traditional"
+          class="route-flavor-toggle"
+          label="Traditional"
+        />
+        <KInputSwitch
+          v-model="routeFlavors.expressions"
+          class="route-flavor-toggle"
+          label="Expressions"
+        />
+      </div>
+      <p><b>Note:</b> Use controls above to enable/disable route flavors.</p>
+    </KCollapse>
+  </KCard>
+
   <h2>Konnect API</h2>
   <RouteForm
     :config="konnectConfig"
+    :route-flavors="routeFlavors"
     :route-id="routeId"
     @error="onError"
     @update="onUpdate"
@@ -26,6 +49,7 @@
   <h2>Kong Manager API</h2>
   <RouteForm
     :config="kongManagerConfig"
+    :route-flavors="routeFlavors"
     :route-id="routeId"
     @error="onError"
     @update="onUpdate"
@@ -49,16 +73,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { AxiosError } from 'axios'
-import type { KonnectRouteFormConfig, KongManagerRouteFormConfig } from '../../src'
+import type { KonnectRouteFormConfig, KongManagerRouteFormConfig, RouteFlavors } from '../../src'
 import { RouteForm } from '../../src'
 
 const route = useRoute()
 const router = useRouter()
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 
+const isRouteFlavorControlCollapsed = ref<boolean>(true)
+const routeFlavors = reactive<RouteFlavors>({ traditional: true, expressions: true })
 const routeId = computed((): string => route?.params?.id as string || '')
 
 const konnectConfig = ref<KonnectRouteFormConfig>({
@@ -91,3 +117,29 @@ const onUpdate = (payload: Record<string, any>) => {
   router.push({ name: 'route-list' })
 }
 </script>
+
+<style lang="scss" scoped>
+.sandbox-route-flavor-control {
+  :deep(.k-collapse) {
+    &.is-collapsed {
+      .k-collapse-heading {
+        margin-bottom: 0 !important;
+        align-items: center;
+      }
+
+      .k-collapse-title {
+        margin-bottom: 0 !important;
+      }
+    }
+  }
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+
+    .route-flavor-toggle {
+      margin-bottom: 10px;
+    }
+  }
+}
+</style>

--- a/packages/entities/entities-routes/sandbox/pages/RouteFormPage.vue
+++ b/packages/entities/entities-routes/sandbox/pages/RouteFormPage.vue
@@ -44,6 +44,10 @@
         Next
       </KButton>
     </template>
+
+    <template #after-expressions-editor="editor">
+      This text will appear after the Expressions editor. Editor state: {{ editor.state }}.
+    </template>
   </RouteForm>
 
   <h2>Kong Manager API</h2>
@@ -69,6 +73,10 @@
         Next
       </KButton>
     </template>
+
+    <template #after-expressions-editor="{ state }">
+      This text will appear after the Expressions editor. Editor state: {{ state }}.
+    </template>
   </RouteForm>
 </template>
 
@@ -84,7 +92,7 @@ const router = useRouter()
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 
 const isRouteFlavorControlCollapsed = ref<boolean>(true)
-const routeFlavors = reactive<RouteFlavors>({ traditional: true, expressions: true })
+const routeFlavors = reactive<Required<RouteFlavors>>({ traditional: true, expressions: true })
 const routeId = computed((): string => route?.params?.id as string || '')
 
 const konnectConfig = ref<KonnectRouteFormConfig>({

--- a/packages/entities/entities-routes/sandbox/pages/RouteFormPage.vue
+++ b/packages/entities/entities-routes/sandbox/pages/RouteFormPage.vue
@@ -123,12 +123,12 @@ const onUpdate = (payload: Record<string, any>) => {
   :deep(.k-collapse) {
     &.is-collapsed {
       .k-collapse-heading {
-        margin-bottom: 0 !important;
+        margin-bottom: $kui-space-0 !important;
         align-items: center;
       }
 
       .k-collapse-title {
-        margin-bottom: 0 !important;
+        margin-bottom: $kui-space-0 !important;
       }
     }
   }
@@ -138,7 +138,7 @@ const onUpdate = (payload: Record<string, any>) => {
     flex-direction: column;
 
     .route-flavor-toggle {
-      margin-bottom: 10px;
+      margin-bottom: $kui-space-50;
     }
   }
 }

--- a/packages/entities/entities-routes/sandbox/pages/RouteListPage.vue
+++ b/packages/entities/entities-routes/sandbox/pages/RouteListPage.vue
@@ -2,6 +2,23 @@
   <SandboxPermissionsControl
     @update="handlePermissionsUpdate"
   />
+
+  <KCard class="sandbox-route-list-control">
+    <KCollapse
+      v-model="isRouteListControlCollapsed"
+      :class="{ 'is-collapsed': isRouteListControlCollapsed }"
+      title="Route list controls"
+    >
+      <div class="wrapper">
+        <KInputSwitch
+          v-model="routeListHasExpressionColumn"
+          class="route-list-expressions-column-toggle"
+          label="Has &quot;Expression&quot; column"
+        />
+      </div>
+    </KCollapse>
+  </KCard>
+
   <h2>Konnect API</h2>
   <RouteList
     v-if="permissions"
@@ -12,6 +29,7 @@
     :can-edit="permissions.canEdit"
     :can-retrieve="permissions.canRetrieve"
     :config="konnectConfig"
+    :has-expression-column="routeListHasExpressionColumn"
     title="Routes"
     @copy:error="onCopyIdError"
     @copy:success="onCopyIdSuccess"
@@ -29,6 +47,7 @@
     :can-edit="permissions.canEdit"
     :can-retrieve="permissions.canRetrieve"
     :config="kongManagerConfig"
+    :has-expression-column="routeListHasExpressionColumn"
     title="Routes"
     @copy:error="onCopyIdError"
     @copy:success="onCopyIdSuccess"
@@ -38,7 +57,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import type { AxiosError } from 'axios'
 import { RouteList } from '../../src'
 import type { KonnectRouteListConfig, KongManagerRouteListConfig, EntityRow, CopyEventPayload } from '../../src'
@@ -87,6 +106,10 @@ const kongManagerConfig = ref<KongManagerRouteListConfig>({
 // Remount the tables in the sandbox when the permission props change; not needed outside of a sandbox
 const key = ref(1)
 const permissions = ref<PermissionsActions | null>(null)
+
+const isRouteListControlCollapsed = ref<boolean>(true)
+const routeListHasExpressionColumn = ref<boolean>(false)
+
 const handlePermissionsUpdate = (newPermissions: PermissionsActions) => {
   permissions.value = newPermissions
   key.value++
@@ -107,4 +130,36 @@ const onDeleteRouteSuccess = (row: EntityRow) => {
 const onError = (error: AxiosError) => {
   console.error(`Error: ${error}`)
 }
+
+watch(routeListHasExpressionColumn, () => {
+  key.value++
+})
 </script>
+
+<style lang="scss" scoped>
+.sandbox-route-list-control {
+  margin-top: $kui-space-80;
+
+  :deep(.k-collapse) {
+    &.is-collapsed {
+      .k-collapse-heading {
+        margin-bottom: $kui-space-0 !important;
+        align-items: center;
+      }
+
+      .k-collapse-title {
+        margin-bottom: $kui-space-0 !important;
+      }
+    }
+  }
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+
+    .route-list-expressions-column-toggle {
+      margin-bottom: $kui-space-50;
+    }
+  }
+}
+</style>

--- a/packages/entities/entities-routes/sandbox/pages/RouteListPage.vue
+++ b/packages/entities/entities-routes/sandbox/pages/RouteListPage.vue
@@ -108,7 +108,7 @@ const key = ref(1)
 const permissions = ref<PermissionsActions | null>(null)
 
 const isRouteListControlCollapsed = ref<boolean>(true)
-const routeListHasExpressionColumn = ref<boolean>(false)
+const routeListHasExpressionColumn = ref<boolean>(true)
 
 const handlePermissionsUpdate = (newPermissions: PermissionsActions) => {
   permissions.value = newPermissions

--- a/packages/entities/entities-routes/src/components/RouteForm.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteForm.cy.ts
@@ -1,7 +1,8 @@
-import type { KonnectRouteFormConfig, KongManagerRouteFormConfig } from '../types'
+import type { KonnectRouteFormConfig, KongManagerRouteFormConfig, RouteFlavors } from '../types'
 import RouteForm from './RouteForm.vue'
-import { route, services } from '../../fixtures/mockData'
+import { route, routeExpressions, services } from '../../fixtures/mockData'
 import { EntityBaseForm } from '@kong-ui-public/entities-shared'
+import type { RouteHandler } from 'cypress/types/net-stubbing'
 
 const cancelRoute = { name: 'route-list' }
 
@@ -17,6 +18,14 @@ const baseConfigKM: KongManagerRouteFormConfig = {
   workspace: 'default',
   apiBaseUrl: '/kong-manager',
   cancelRoute,
+}
+
+const TRADITIONAL_ONLY: RouteFlavors = { traditional: true, expressions: false }
+const EXPRESSIONS_ONLY: RouteFlavors = { traditional: false, expressions: true }
+const TRADITIONAL_EXPRESSIONS: RouteFlavors = { traditional: true, expressions: true }
+
+const formatRouteFlavors = (routeFlavors?: RouteFlavors): string => {
+  return routeFlavors ? [...routeFlavors.traditional ? ['trad'] : [], ...routeFlavors.expressions ? ['expr'] : []].join('+') || 'none' : 'default'
 }
 
 describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
@@ -66,420 +75,715 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       ).as('updateRoute')
     }
 
-    it('should show create form', () => {
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKM,
-        },
+    /**
+     * Stub the POST and PATCH requests with mocked responses where `kind` marks the type of route
+     * being created/edited. This uses the validation steps that are similar to the backend to simply
+     * verify that the mutually exclusive fields are not included.
+     */
+    const stubCreateEdit = () => {
+      const handler: RouteHandler = (req) => {
+        const { body } = req
+
+        // only verify mutually exclusive fields
+        const hasExpressionsFields = Object.hasOwnProperty.call(body, 'expression')
+        const hasTraditionalFields = ['hosts', 'paths', 'headers', 'methods', 'snis', 'sources', 'destinations']
+          .some((prop) => Object.hasOwnProperty.call(body, prop))
+
+        req.reply({
+          statusCode: 400,
+          body: {
+            kind: hasExpressionsFields ? 'expr' : hasTraditionalFields ? 'trad' : undefined,
+          },
+        })
+      }
+
+      cy.intercept('POST', `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/routes`, handler).as('createRoute')
+      cy.intercept('PATCH', `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/routes/*`, handler).as('editRoute')
+    }
+
+    // Tests 4 possible RouteFlavors: <not-set>, <trad only>, <expr only>, <trad+expr>
+    for (const routeFlavors of [undefined, TRADITIONAL_ONLY, EXPRESSIONS_ONLY, TRADITIONAL_EXPRESSIONS]) {
+      const configTabs = `tabs=${formatRouteFlavors(routeFlavors)}`
+
+      it(`should show create form, ${configTabs}`, () => {
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKM,
+            routeFlavors,
+          },
+        })
+
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.get('.kong-ui-entities-route-form form').should('be.visible')
+
+        // button state
+        cy.getTestId('form-cancel').should('be.visible')
+        cy.getTestId('form-submit').should('be.visible')
+        cy.getTestId('form-cancel').should('be.enabled')
+        cy.getTestId('form-submit').should('be.disabled')
+
+        // config tabs is hidden when there is only one tab
+        cy.getTestId('route-form-config-tabs')
+          .should(routeFlavors?.traditional && routeFlavors?.expressions ? 'be.visible' : 'not.exist')
+
+        // base + base advanced fields
+        cy.getTestId('collapse-trigger-content').click()
+        cy.getTestId('route-form-name').should('be.visible')
+        cy.getTestId('route-form-service-id').should('be.visible')
+        cy.getTestId('route-form-tags').should('be.visible')
+        cy.getTestId('route-form-protocols').should('be.visible')
+
+        if (routeFlavors?.traditional && routeFlavors?.expressions) {
+          // trad + expr 2 tabs
+          // switch to trad tab
+          cy.get('#traditional-tab').click()
+        } // else: we will be on the trad tab by default
+
+        if (routeFlavors?.traditional) {
+          // base advanced fields
+          cy.getTestId('route-form-http-redirect-status-code').should('be.visible')
+          cy.getTestId('route-form-preserve-host').should('be.visible')
+          cy.getTestId('route-form-strip-path').should('be.visible')
+          cy.getTestId('route-form-request-buffering').should('be.visible')
+          cy.getTestId('route-form-response-buffering').should('be.visible')
+
+          // other advanced fields
+          cy.getTestId('route-form-path-handling').should('be.visible')
+          cy.getTestId('route-form-regex-priority').should('be.visible')
+
+          // paths
+          cy.getTestId('route-form-paths-input-1').should('be.visible')
+          cy.getTestId('add-paths').should('be.visible').click()
+          cy.getTestId('route-form-paths-input-2').should('be.visible')
+          cy.getTestId('remove-paths').first().should('be.visible').click()
+          cy.getTestId('route-form-paths-input-2').should('not.exist')
+
+          cy.getTestId('route-form-paths-input-1').should('be.visible')
+          cy.getTestId('remove-paths').first().should('be.visible').click()
+          cy.get('.route-form-routing-rules-selector-options').should('be.visible')
+
+          // snis
+          cy.getTestId('routing-rule-snis').should('be.visible').click()
+          cy.getTestId('route-form-snis-input-1').should('be.visible')
+          cy.getTestId('add-snis').should('be.visible').click()
+          cy.getTestId('route-form-snis-input-2').should('be.visible')
+          cy.getTestId('remove-snis').first().should('be.visible').click()
+          cy.getTestId('route-form-snis-input-2').should('not.exist')
+
+          // hosts
+          cy.getTestId('routing-rule-hosts').should('be.visible').click()
+          cy.getTestId('route-form-hosts-input-1').should('be.visible')
+          cy.getTestId('add-hosts').should('be.visible').click()
+          cy.getTestId('route-form-hosts-input-2').should('be.visible')
+          cy.getTestId('remove-hosts').first().should('be.visible').click()
+          cy.getTestId('route-form-hosts-input-2').should('not.exist')
+
+          // methods and custom methods
+          cy.getTestId('routing-rule-methods').should('be.visible').click()
+          cy.getTestId('routing-rule-methods').should('have.attr', 'aria-disabled').and('eq', 'true')
+          cy.getTestId('get-method-toggle').should('exist')
+          cy.getTestId('post-method-toggle').should('exist')
+          cy.getTestId('put-method-toggle').should('exist')
+          cy.getTestId('custom-method-toggle').should('exist').check({ force: true })
+          cy.getTestId('route-form-custom-method-input-1').should('be.visible')
+          cy.getTestId('add-custom-method').should('be.visible').click()
+          cy.getTestId('route-form-custom-method-input-2').should('be.visible')
+          cy.getTestId('remove-custom-method').first().should('be.visible').click()
+          cy.getTestId('route-form-custom-method-input-2').should('not.exist')
+          cy.getTestId('remove-methods').should('be.visible').click()
+          cy.getTestId('get-method-toggle').should('not.exist')
+          cy.getTestId('routing-rule-methods').should('have.attr', 'aria-disabled').and('eq', 'false')
+
+          // headers
+          cy.getTestId('routing-rule-headers').should('be.visible').click()
+          cy.getTestId('route-form-headers-name-input-1').should('be.visible')
+          cy.getTestId('route-form-headers-values-input-1').should('be.visible')
+          cy.getTestId('add-headers').should('be.visible').click()
+          cy.getTestId('route-form-headers-name-input-2').should('be.visible')
+          cy.getTestId('route-form-headers-values-input-2').should('be.visible')
+          cy.getTestId('remove-headers').first().should('be.visible').click()
+          cy.getTestId('route-form-headers-name-input-2').should('not.exist')
+          cy.getTestId('route-form-headers-values-input-2').should('not.exist')
+
+          cy.getTestId('route-form-protocols').click({ force: true })
+          cy.get("[data-testid='select-item-tcp,tls,udp']").click()
+          cy.getTestId('routing-rule-paths').should('not.exist')
+          cy.getTestId('routing-rule-hosts').should('not.exist')
+          cy.getTestId('routing-rule-methods').should('not.exist')
+          cy.getTestId('routing-rule-headers').should('not.exist')
+
+          // sources
+          cy.getTestId('routing-rule-sources').should('be.visible').click()
+          cy.getTestId('route-form-sources-ip-input-1').should('be.visible')
+          cy.getTestId('route-form-sources-port-input-1').should('be.visible')
+          cy.getTestId('add-sources').should('be.visible').click()
+          cy.getTestId('route-form-sources-ip-input-2').should('be.visible')
+          cy.getTestId('route-form-sources-port-input-2').should('be.visible')
+          cy.getTestId('remove-sources').first().should('be.visible').click()
+          cy.getTestId('route-form-sources-ip-input-2').should('not.exist')
+          cy.getTestId('route-form-sources-port-input-2').should('not.exist')
+
+          // destinations
+          cy.getTestId('routing-rule-destinations').should('be.visible').click()
+          cy.getTestId('route-form-destinations-ip-input-1').should('be.visible')
+          cy.getTestId('route-form-destinations-port-input-1').should('be.visible')
+          cy.getTestId('add-destinations').should('be.visible').click()
+          cy.getTestId('route-form-destinations-ip-input-2').should('be.visible')
+          cy.getTestId('route-form-destinations-port-input-2').should('be.visible')
+          cy.getTestId('remove-destinations').first().should('be.visible').click()
+          cy.getTestId('route-form-destinations-ip-input-2').should('not.exist')
+          cy.getTestId('route-form-destinations-port-input-2').should('not.exist')
+        }
+
+        if (routeFlavors?.traditional && routeFlavors?.expressions) {
+          // trad + expr 2 tabs
+          // switch to expr tab
+          cy.get('#expressions-tab').click()
+        }
+
+        if (routeFlavors?.expressions) {
+          // negative: traditional fields should not exist
+          cy.getTestId('route-form-path-handling').should('not.exist')
+          cy.getTestId('route-form-regex-priority').should('not.exist')
+          cy.getTestId('route-form-paths-input-1').should('not.exist')
+          cy.get('.route-form-routing-rules-selector-options').should('not.exist')
+
+          // expressions editor
+          cy.get('.expression-editor .monaco-editor').should('be.visible')
+
+          // base advanced fields
+          cy.getTestId('route-form-http-redirect-status-code').should('be.visible')
+          cy.getTestId('route-form-preserve-host').should('be.visible')
+          cy.getTestId('route-form-strip-path').should('be.visible')
+          cy.getTestId('route-form-request-buffering').should('be.visible')
+          cy.getTestId('route-form-response-buffering').should('be.visible')
+        }
       })
 
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
-      cy.get('.kong-ui-entities-route-form form').should('be.visible')
+      if (!routeFlavors || routeFlavors?.traditional) {
+        // only test when there is trad tab
+        it(`should correctly handle button state - create traditional, ${configTabs}`, () => {
+          interceptKMServices()
+          stubCreateEdit()
 
-      // button state
-      cy.getTestId('form-cancel').should('be.visible')
-      cy.getTestId('form-submit').should('be.visible')
-      cy.getTestId('form-cancel').should('be.enabled')
-      cy.getTestId('form-submit').should('be.disabled')
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKM,
+              routeFlavors,
+            },
+          })
 
-      // form fields - general
-      cy.getTestId('route-form-name').should('be.visible')
-      cy.getTestId('route-form-service-id').should('be.visible')
-      cy.getTestId('route-form-tags').should('be.visible')
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
 
-      // advanced fields
-      cy.getTestId('collapse-trigger-content').should('be.visible').click()
-      cy.getTestId('route-form-path-handling').should('be.visible')
-      cy.getTestId('route-form-http-redirect-status-code').should('be.visible')
-      cy.getTestId('route-form-regex-priority').should('be.visible')
-      cy.getTestId('route-form-strip-path').should('be.visible')
-      cy.getTestId('route-form-preserve-host').should('be.visible')
-      cy.getTestId('route-form-request-buffering').should('be.visible')
-      cy.getTestId('route-form-response-buffering').should('be.visible')
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+          // trad + expr 2 tabs
+          // switch to trad tab
+            cy.get('#traditional-tab').click()
+          } // else: we will be on the trad tab by default
 
-      // routing rules fields
-      cy.getTestId('route-form-protocols').should('be.visible')
+          // default button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
 
-      // paths
-      cy.getTestId('route-form-paths-input-1').should('be.visible')
-      cy.getTestId('add-paths').should('be.visible').click()
-      cy.getTestId('route-form-paths-input-2').should('be.visible')
-      cy.getTestId('remove-paths').first().should('be.visible').click()
-      cy.getTestId('route-form-paths-input-2').should('not.exist')
+          // config tabs is hidden when there is only one tab
+          cy.getTestId('route-form-config-tabs')
+            .should(routeFlavors?.traditional && routeFlavors?.expressions ? 'be.visible' : 'not.exist')
 
-      cy.getTestId('route-form-paths-input-1').should('be.visible')
-      cy.getTestId('remove-paths').first().should('be.visible').click()
-      cy.get('.route-form-routing-rules-selector-options').should('be.visible')
+          // enables save when required fields have values
+          // form fields - general
+          cy.getTestId('route-form-name').should('be.visible')
 
-      // snis
-      cy.getTestId('routing-rule-snis').should('be.visible').click()
-      cy.getTestId('route-form-snis-input-1').should('be.visible')
-      cy.getTestId('add-snis').should('be.visible').click()
-      cy.getTestId('route-form-snis-input-2').should('be.visible')
-      cy.getTestId('remove-snis').first().should('be.visible').click()
-      cy.getTestId('route-form-snis-input-2').should('not.exist')
+          // paths
+          cy.getTestId('route-form-paths-input-1').type(route.paths[0])
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
-      // hosts
-      cy.getTestId('routing-rule-hosts').should('be.visible').click()
-      cy.getTestId('route-form-hosts-input-1').should('be.visible')
-      cy.getTestId('add-hosts').should('be.visible').click()
-      cy.getTestId('route-form-hosts-input-2').should('be.visible')
-      cy.getTestId('remove-hosts').first().should('be.visible').click()
-      cy.getTestId('route-form-hosts-input-2').should('not.exist')
+          cy.getTestId('route-form-paths-input-1').clear()
+          cy.getTestId('form-submit').should('be.disabled')
 
-      // methods and custom methods
-      cy.getTestId('routing-rule-methods').should('be.visible').click()
-      cy.getTestId('routing-rule-methods').should('have.attr', 'aria-disabled').and('eq', 'true')
-      cy.getTestId('get-method-toggle').should('exist')
-      cy.getTestId('post-method-toggle').should('exist')
-      cy.getTestId('put-method-toggle').should('exist')
-      cy.getTestId('custom-method-toggle').should('exist').check({ force: true })
-      cy.getTestId('route-form-custom-method-input-1').should('be.visible')
-      cy.getTestId('add-custom-method').should('be.visible').click()
-      cy.getTestId('route-form-custom-method-input-2').should('be.visible')
-      cy.getTestId('remove-custom-method').first().should('be.visible').click()
-      cy.getTestId('route-form-custom-method-input-2').should('not.exist')
-      cy.getTestId('remove-methods').should('be.visible').click()
-      cy.getTestId('get-method-toggle').should('not.exist')
-      cy.getTestId('routing-rule-methods').should('have.attr', 'aria-disabled').and('eq', 'false')
+          // snis
+          cy.getTestId('routing-rule-snis').click()
+          cy.getTestId('route-form-snis-input-1').type('sni')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
-      // headers
-      cy.getTestId('routing-rule-headers').should('be.visible').click()
-      cy.getTestId('route-form-headers-name-input-1').should('be.visible')
-      cy.getTestId('route-form-headers-values-input-1').should('be.visible')
-      cy.getTestId('add-headers').should('be.visible').click()
-      cy.getTestId('route-form-headers-name-input-2').should('be.visible')
-      cy.getTestId('route-form-headers-values-input-2').should('be.visible')
-      cy.getTestId('remove-headers').first().should('be.visible').click()
-      cy.getTestId('route-form-headers-name-input-2').should('not.exist')
-      cy.getTestId('route-form-headers-values-input-2').should('not.exist')
+          cy.getTestId('route-form-snis-input-1').clear()
+          cy.getTestId('form-submit').should('be.disabled')
 
-      cy.getTestId('route-form-protocols').click({ force: true })
-      cy.get("[data-testid='select-item-tcp,tls,udp']").click()
-      cy.getTestId('routing-rule-paths').should('not.exist')
-      cy.getTestId('routing-rule-hosts').should('not.exist')
-      cy.getTestId('routing-rule-methods').should('not.exist')
-      cy.getTestId('routing-rule-headers').should('not.exist')
+          // hosts
+          cy.getTestId('routing-rule-hosts').click()
+          cy.getTestId('route-form-hosts-input-1').type('host')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
-      // sources
-      cy.getTestId('routing-rule-sources').should('be.visible').click()
-      cy.getTestId('route-form-sources-ip-input-1').should('be.visible')
-      cy.getTestId('route-form-sources-port-input-1').should('be.visible')
-      cy.getTestId('add-sources').should('be.visible').click()
-      cy.getTestId('route-form-sources-ip-input-2').should('be.visible')
-      cy.getTestId('route-form-sources-port-input-2').should('be.visible')
-      cy.getTestId('remove-sources').first().should('be.visible').click()
-      cy.getTestId('route-form-sources-ip-input-2').should('not.exist')
-      cy.getTestId('route-form-sources-port-input-2').should('not.exist')
+          cy.getTestId('route-form-hosts-input-1').clear()
+          cy.getTestId('form-submit').should('be.disabled')
 
-      // destinations
-      cy.getTestId('routing-rule-destinations').should('be.visible').click()
-      cy.getTestId('route-form-destinations-ip-input-1').should('be.visible')
-      cy.getTestId('route-form-destinations-port-input-1').should('be.visible')
-      cy.getTestId('add-destinations').should('be.visible').click()
-      cy.getTestId('route-form-destinations-ip-input-2').should('be.visible')
-      cy.getTestId('route-form-destinations-port-input-2').should('be.visible')
-      cy.getTestId('remove-destinations').first().should('be.visible').click()
-      cy.getTestId('route-form-destinations-ip-input-2').should('not.exist')
-      cy.getTestId('route-form-destinations-port-input-2').should('not.exist')
-    })
+          // methods and custom methods
+          cy.getTestId('routing-rule-methods').click()
+          cy.getTestId('get-method-toggle').check({ force: true })
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
-    it('should correctly handle button state - create', () => {
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKM,
-        },
+          cy.getTestId('get-method-toggle').uncheck({ force: true })
+          cy.getTestId('form-submit').should('be.disabled')
+          cy.getTestId('custom-method-toggle').check({ force: true })
+          cy.getTestId('form-submit').should('be.disabled')
+          cy.getTestId('route-form-custom-method-input-1').type('castom')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('route-form-custom-method-input-1').clear()
+          cy.getTestId('form-submit').should('be.disabled')
+
+          // headers
+          cy.getTestId('routing-rule-headers').click()
+          cy.getTestId('route-form-headers-name-input-1').type(Object.keys(route.headers)[0])
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('route-form-headers-name-input-1').clear()
+          cy.getTestId('route-form-headers-values-input-1').type(route.headers.Header1[0])
+          cy.getTestId('form-submit').should('be.disabled')
+
+          cy.getTestId('route-form-protocols').click({ force: true })
+          cy.get("[data-testid='select-item-tcp,tls,udp']").click()
+
+          // sources
+          cy.getTestId('routing-rule-sources').click()
+          cy.getTestId('route-form-sources-ip-input-1').type('127.0.0.1')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('route-form-sources-ip-input-1').clear()
+          cy.getTestId('route-form-sources-port-input-1').type('8080')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          // destinations
+          cy.getTestId('routing-rule-destinations').click()
+          cy.getTestId('route-form-destinations-ip-input-1').type('127.0.0.2')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('route-form-destinations-ip-input-1').clear()
+          cy.getTestId('route-form-destinations-port-input-1').type('8000')
+          cy.getTestId('form-submit').should('be.disabled')
+        })
+      } // if !routeFlavors || routeFlavors?.traditional
+
+      if (routeFlavors?.expressions) {
+        // only test when there is expr tab
+        it(`should correctly handle button state - create expressions, ${configTabs}`, () => {
+          interceptKMServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKM,
+              routeFlavors,
+            },
+          })
+
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+          // trad + expr 2 tabs
+          // switch to expr tab
+            cy.get('#expressions-tab').click()
+          } // else: we will be on expr tab by default
+
+          // default button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          // enables save when required fields have values
+          // form fields - general
+          cy.getTestId('route-form-name').should('be.visible')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          // the editor shows invalid because it is empty
+          cy.get('.expression-editor').should('have.class', 'invalid')
+
+          // type a valid expression
+          cy.get('.monaco-editor').first().as('monacoEditor').click()
+          cy.get('@monacoEditor').type('http.path == "/kong"')
+
+          // it should be no longer invalid
+          cy.get('.expression-editor').should('not.have.class', 'invalid')
+          // and the submit button is enabled
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'expr')
+
+          // delete the last character
+          cy.get('@monacoEditor').type('{backspace}')
+
+          // invalid again
+          cy.get('.expression-editor').should('have.class', 'invalid')
+          // but the submit button is still enabled because we let the server handle uncaught errors
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'expr')
+        })
+      } // if routeFlavors?.expressions
+
+      if (!routeFlavors || routeFlavors?.traditional) {
+        // only test when there is trad tab
+        it(`should show edit form, traditional ${configTabs}`, () => {
+          interceptKM()
+          interceptKMServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKM,
+              routeId: route.id,
+              routeFlavors,
+            },
+          })
+
+          cy.wait('@getRoute')
+          cy.wait('@getServices')
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          // button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // trad tab should be active by default
+            cy.get('#traditional-tab').should('have.class', 'active')
+          }
+
+          // form fields
+          cy.getTestId('route-form-name').should('have.value', route.name)
+          cy.getTestId('route-form-service-id').should('have.value', route.service.id)
+          cy.getTestId('route-form-tags').should('have.value', route.tags.join(', '))
+
+          cy.getTestId('collapse-trigger-content').click()
+          cy.getTestId('route-form-path-handling').should('have.value', route.path_handling)
+          cy.getTestId('route-form-regex-priority').should('have.value', route.regex_priority)
+          cy.getTestId('route-form-strip-path').should(`${route.strip_path ? '' : 'not.'}be.checked`)
+          cy.getTestId('route-form-preserve-host').should(`${route.preserve_host ? '' : 'not.'}be.checked`)
+
+          cy.getTestId('route-form-paths-input-1').should('have.value', route.paths[0])
+          cy.getTestId('route-form-paths-input-2').should('have.value', route.paths[1])
+          cy.getTestId(`${route.methods[0].toLowerCase()}-method-toggle`).should('be.checked')
+          cy.getTestId(`${route.methods[1].toLowerCase()}-method-toggle`).should('be.checked')
+          cy.getTestId('route-form-headers-name-input-1').should('have.value', Object.keys(route.headers)[0])
+          cy.getTestId('route-form-headers-values-input-1').should('have.value', route.headers.Header1.join(','))
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // switch to expr tab
+            cy.get('#expressions-tab').click()
+            // should not see the expression editor
+            cy.get('.expression-editor').should('not.exist')
+            // should be reminded that the route type cannot be changed
+            cy.getTestId('route-config-type-immutable-alert').should('contain.text', 'cannot be changed after creation')
+          }
+        })
+
+        it(`should correctly handle button state - edit traditional, ${configTabs}`, () => {
+          interceptKM()
+          interceptKMServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKM,
+              routeId: route.id,
+              routeFlavors,
+            },
+          })
+
+          cy.wait('@getRoute')
+          cy.wait('@getServices')
+
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          // default button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // trad tab should be active by default
+            cy.get('#traditional-tab').should('have.class', 'active')
+          }
+
+          cy.getTestId('routing-rules-warning').should('not.exist')
+
+          // enables save when form has changes
+          cy.getTestId('route-form-service-id').click({ force: true })
+          cy.get("[data-testid='select-item-2']").click()
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@editRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('remove-methods').click()
+          cy.getTestId('remove-paths').first().click()
+          cy.getTestId('remove-paths').click()
+          cy.getTestId('remove-headers').click()
+          cy.getTestId('routing-rules-warning').should('be.visible')
+          cy.getTestId('form-submit').should('be.disabled')
+        })
+      } // if !routeFlavors || routeFlavors?.traditional
+
+      if (routeFlavors?.expressions) {
+        // only test when there is trad tab
+        it(`should show edit form, expressions ${configTabs}`, () => {
+          interceptKM({ mockData: routeExpressions })
+          interceptKMServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKM,
+              routeId: route.id,
+              routeFlavors,
+            },
+          })
+
+          cy.wait('@getRoute')
+          cy.wait('@getServices')
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          // button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // expr tab should be active by default
+            cy.get('#expressions-tab').should('have.class', 'active')
+          }
+
+          // form fields
+          cy.getTestId('route-form-name').should('have.value', route.name)
+          cy.getTestId('route-form-service-id').should('have.value', route.service.id)
+          cy.getTestId('route-form-tags').should('have.value', route.tags.join(', '))
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            cy.getTestId('collapse-trigger-content').click()
+            // switch to trad tab
+            cy.get('#traditional-tab').click()
+            // should not see trad fields
+            cy.getTestId('route-form-path-handling').should('not.exist')
+            cy.getTestId('route-form-regex-priority').should('not.exist')
+            // should be reminded that the route type cannot be changed
+            cy.getTestId('route-config-type-immutable-alert').should('contain.text', 'cannot be changed after creation')
+          }
+        })
+
+        it(`should correctly handle button state - edit expressions, ${configTabs}`, () => {
+          interceptKM({ mockData: routeExpressions })
+          interceptKMServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKM,
+              routeId: route.id,
+              routeFlavors,
+            },
+          })
+
+          cy.wait('@getRoute')
+          cy.wait('@getServices')
+
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          // default button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // trad tab should be active by default
+            cy.get('#expressions-tab').should('have.class', 'active')
+          }
+
+          // enables save when form has changes
+          cy.getTestId('route-form-service-id').click({ force: true })
+          cy.get("[data-testid='select-item-2']").click()
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@editRoute').then((res) => res.response?.body?.kind).should('eq', 'expr')
+
+          // type a valid expression
+          cy.get('.monaco-editor').first().as('monacoEditor').click()
+          // delete the last character
+          cy.get('@monacoEditor').type('{backspace}')
+
+          // the editor should become invalid
+          cy.get('.expression-editor').should('have.class', 'invalid')
+          // but the submit button is still enabled because we let the server handle uncaught errors
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@editRoute').then((res) => res.response?.body?.kind).should('eq', 'expr')
+        })
+      } // if routeFlavors?.expressions
+
+      it(`should handle error state - failed to load route, ${configTabs}`, () => {
+        interceptKMServices()
+
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/routes/*`,
+          },
+          {
+            statusCode: 404,
+            body: {},
+          },
+        ).as('getRoute')
+
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKM,
+            routeId: route.id,
+            routeFlavors,
+          },
+        })
+
+        cy.wait('@getRoute')
+        cy.wait('@getServices')
+
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+        // error state is displayed
+        cy.getTestId('form-fetch-error').should('be.visible')
+
+        // buttons and form hidden
+        cy.getTestId('form-cancel').should('not.exist')
+        cy.getTestId('form-submit').should('not.exist')
+        cy.get('.kong-ui-entities-route-form form').should('not.exist')
       })
 
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
+      it(`should allow exact match filtering of services, ${configTabs}`, () => {
+        interceptKMServices()
 
-      // default button state
-      cy.getTestId('form-cancel').should('be.visible')
-      cy.getTestId('form-submit').should('be.visible')
-      cy.getTestId('form-cancel').should('be.enabled')
-      cy.getTestId('form-submit').should('be.disabled')
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKM,
+            routeFlavors,
+          },
+        })
 
-      // enables save when required fields have values
-      // form fields - general
-      cy.getTestId('route-form-name').should('be.visible')
+        cy.wait('@getServices')
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
 
-      // paths
-      cy.getTestId('route-form-paths-input-1').type(route.paths[0])
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-paths-input-1').clear()
-      cy.getTestId('form-submit').should('be.disabled')
+        // config tabs is hidden when there is only one tab
+        cy.getTestId('route-form-config-tabs')
+          .should(routeFlavors?.traditional && routeFlavors?.expressions ? 'be.visible' : 'not.exist')
 
-      // snis
-      cy.getTestId('routing-rule-snis').click()
-      cy.getTestId('route-form-snis-input-1').type('sni')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-snis-input-1').clear()
-      cy.getTestId('form-submit').should('be.disabled')
+        // search
+        cy.getTestId('route-form-service-id').should('be.visible')
+        cy.getTestId('route-form-service-id').type(services[1].name)
 
-      // hosts
-      cy.getTestId('routing-rule-hosts').click()
-      cy.getTestId('route-form-hosts-input-1').type('host')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-hosts-input-1').clear()
-      cy.getTestId('form-submit').should('be.disabled')
-
-      // methods and custom methods
-      cy.getTestId('routing-rule-methods').click()
-      cy.getTestId('get-method-toggle').check({ force: true })
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('get-method-toggle').uncheck({ force: true })
-      cy.getTestId('form-submit').should('be.disabled')
-      cy.getTestId('custom-method-toggle').check({ force: true })
-      cy.getTestId('form-submit').should('be.disabled')
-      cy.getTestId('route-form-custom-method-input-1').type('castom')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-custom-method-input-1').clear()
-      cy.getTestId('form-submit').should('be.disabled')
-
-      // headers
-      cy.getTestId('routing-rule-headers').click()
-      cy.getTestId('route-form-headers-name-input-1').type(Object.keys(route.headers)[0])
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-headers-name-input-1').clear()
-      cy.getTestId('route-form-headers-values-input-1').type(route.headers.Header1[0])
-      cy.getTestId('form-submit').should('be.disabled')
-
-      cy.getTestId('route-form-protocols').click({ force: true })
-      cy.get("[data-testid='select-item-tcp,tls,udp']").click()
-
-      // sources
-      cy.getTestId('routing-rule-sources').click()
-      cy.getTestId('route-form-sources-ip-input-1').type('127.0.0.1')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-sources-ip-input-1').clear()
-      cy.getTestId('route-form-sources-port-input-1').type('8080')
-      cy.getTestId('form-submit').should('be.disabled')
-
-      // destinations
-      cy.getTestId('routing-rule-destinations').click()
-      cy.getTestId('route-form-destinations-ip-input-1').type('127.0.0.2')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-destinations-ip-input-1').clear()
-      cy.getTestId('route-form-destinations-port-input-1').type('8000')
-      cy.getTestId('form-submit').should('be.disabled')
-    })
-
-    it('should show edit form', () => {
-      interceptKM()
-      interceptKMServices()
-
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKM,
-          routeId: route.id,
-        },
+        // click kselect item
+        cy.getTestId(`select-item-${services[1].id}`).should('be.visible')
+        cy.get(`[data-testid="select-item-${services[1].id}"] button`).click()
+        cy.getTestId('route-form-service-id').should('have.value', services[1].id)
       })
 
-      cy.wait('@getRoute')
-      cy.wait('@getServices')
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
+      it(`should handle error state - failed to load services, ${configTabs}`, () => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/services*`,
+          },
+          {
+            statusCode: 500,
+            body: {},
+          },
+        ).as('getServices')
 
-      // button state
-      cy.getTestId('form-cancel').should('be.visible')
-      cy.getTestId('form-submit').should('be.visible')
-      cy.getTestId('form-cancel').should('be.enabled')
-      cy.getTestId('form-submit').should('be.disabled')
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKM,
+            routeFlavors,
+          },
+        })
 
-      // form fields
-      cy.getTestId('route-form-name').should('have.value', route.name)
-      cy.getTestId('route-form-service-id').should('have.value', route.service.id)
-      cy.getTestId('route-form-tags').should('have.value', route.tags.join(', '))
-      cy.getTestId('route-form-paths-input-1').should('have.value', route.paths[0])
-      cy.getTestId('route-form-paths-input-2').should('have.value', route.paths[1])
-      cy.getTestId(`${route.methods[0].toLowerCase()}-method-toggle`).should('be.checked')
-      cy.getTestId(`${route.methods[1].toLowerCase()}-method-toggle`).should('be.checked')
-      cy.getTestId('route-form-headers-name-input-1').should('have.value', Object.keys(route.headers)[0])
-      cy.getTestId('route-form-headers-values-input-1').should('have.value', route.headers.Header1.join(','))
-
-      cy.getTestId('collapse-trigger-content').click()
-      cy.getTestId('route-form-path-handling').should('have.value', route.path_handling)
-      cy.getTestId('route-form-regex-priority').should('have.value', route.regex_priority)
-      cy.getTestId('route-form-strip-path').should(`${route.strip_path ? '' : 'not.'}be.checked`)
-      cy.getTestId('route-form-preserve-host').should(`${route.preserve_host ? '' : 'not.'}be.checked`)
-    })
-
-    it('should correctly handle button state - edit', () => {
-      interceptKM()
-      interceptKMServices()
-
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKM,
-          routeId: route.id,
-        },
+        cy.wait('@getServices')
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.getTestId('form-error').should('be.visible')
       })
 
-      cy.wait('@getRoute')
-      cy.wait('@getServices')
+      it(`should correctly render with all props and slot content, ${configTabs}`, () => {
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKM,
+            serviceId: services[0].id,
+            hideSectionsInfo: true,
+            hideNameField: true,
+            showTagsFiledUnderAdvanced: true,
+            routeFlavors,
+          },
+          slots: {
+            'form-actions': '<button data-testid="slotted-cancel-button">Cancel</button><button data-testid="slotted-submit-button">Submit</button>',
+          },
+        })
 
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.get('.kong-ui-entities-route-form form').should('be.visible')
 
-      // default button state
-      cy.getTestId('form-cancel').should('be.visible')
-      cy.getTestId('form-submit').should('be.visible')
-      cy.getTestId('form-cancel').should('be.enabled')
-      cy.getTestId('form-submit').should('be.disabled')
-      cy.getTestId('routing-rules-warning').should('not.exist')
+        // config tabs is hidden when there is only one tab
+        cy.getTestId('route-form-config-tabs')
+          .should(routeFlavors?.traditional && routeFlavors?.expressions ? 'be.visible' : 'not.exist')
 
-      // enables save when form has changes
-      cy.getTestId('route-form-service-id').click({ force: true })
-      cy.get("[data-testid='select-item-2']").click()
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('remove-methods').click()
-      cy.getTestId('remove-paths').first().click()
-      cy.getTestId('remove-paths').click()
-      cy.getTestId('remove-headers').click()
-      cy.getTestId('routing-rules-warning').should('be.visible')
-      cy.getTestId('form-submit').should('be.disabled')
-    })
+        // name field should be hidden when hideNameField is true
+        cy.getTestId('route-form-name').should('not.exist')
 
-    it('should handle error state - failed to load route', () => {
-      interceptKMServices()
+        // tags field should render under advanced fields
+        cy.getTestId('route-form-tags').should('not.be.visible')
+        cy.getTestId('collapse-trigger-content').click()
+        cy.getTestId('route-form-tags').should('be.visible')
 
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/routes/*`,
-        },
-        {
-          statusCode: 404,
-          body: {},
-        },
-      ).as('getRoute')
+        // service id field should be hidden when serviceId is provided
+        cy.getTestId('route-form-service-id').should('not.exist')
 
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKM,
-          routeId: route.id,
-        },
+        // sections info should be hidden when hideSectionsInfo is true
+        cy.get('.form-section-info sticky').should('not.exist')
+
+        // default buttons should be replaced with slotted content
+        cy.getTestId('form-cancel').should('not.exist')
+        cy.getTestId('form-submit').should('not.exist')
+        cy.getTestId('slotted-cancel-button').should('be.visible')
+        cy.getTestId('slotted-submit-button').should('be.visible')
       })
 
-      cy.wait('@getRoute')
-      cy.wait('@getServices')
+      it(`update event should be emitted when Route was edited, ${configTabs}`, () => {
+        interceptKM()
+        interceptUpdate()
 
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKM,
+            routeId: route.id,
+            onUpdate: cy.spy().as('onUpdateSpy'),
+            routeFlavors,
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
 
-      // error state is displayed
-      cy.getTestId('form-fetch-error').should('be.visible')
+        cy.wait('@getRoute')
+        cy.getTestId('route-form-tags').clear()
+        cy.getTestId('route-form-tags').type('tag1,tag2')
 
-      // buttons and form hidden
-      cy.getTestId('form-cancel').should('not.exist')
-      cy.getTestId('form-submit').should('not.exist')
-      cy.get('.kong-ui-entities-route-form form').should('not.exist')
-    })
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+          .vm.$emit('submit'))
 
-    it('should allow exact match filtering of services', () => {
-      interceptKMServices()
+        cy.wait('@updateRoute')
 
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKM,
-        },
+        cy.get('@onUpdateSpy').should('have.been.calledOnce')
       })
-
-      cy.wait('@getServices')
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
-
-      // search
-      cy.getTestId('route-form-service-id').should('be.visible')
-      cy.getTestId('route-form-service-id').type(services[1].name)
-
-      // click kselect item
-      cy.getTestId(`select-item-${services[1].id}`).should('be.visible')
-      cy.get(`[data-testid="select-item-${services[1].id}"] button`).click()
-      cy.getTestId('route-form-service-id').should('have.value', services[1].id)
-    })
-
-    it('should handle error state - failed to load services', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/services*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getServices')
-
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKM,
-        },
-      })
-
-      cy.wait('@getServices')
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
-      cy.getTestId('form-error').should('be.visible')
-    })
-
-    it('should correctly render with all props and slot content', () => {
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKM,
-          serviceId: services[0].id,
-          hideSectionsInfo: true,
-          hideNameField: true,
-          showTagsFiledUnderAdvanced: true,
-        },
-        slots: {
-          'form-actions': '<button data-testid="slotted-cancel-button">Cancel</button><button data-testid="slotted-submit-button">Submit</button>',
-        },
-      })
-
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
-      cy.get('.kong-ui-entities-route-form form').should('be.visible')
-
-      // name field should be hidden when hideNameField is true
-      cy.getTestId('route-form-name').should('not.exist')
-
-      // tags field should render under advanced fields
-      cy.getTestId('route-form-tags').should('not.be.visible')
-      cy.getTestId('collapse-trigger-content').click()
-      cy.getTestId('route-form-tags').should('be.visible')
-
-      // service id field should be hidden when serviceId is provided
-      cy.getTestId('route-form-service-id').should('not.exist')
-
-      // sections info should be hidden when hideSectionsInfo is true
-      cy.get('.form-section-info sticky').should('not.exist')
-
-      // default buttons should be replaced with slotted content
-      cy.getTestId('form-cancel').should('not.exist')
-      cy.getTestId('form-submit').should('not.exist')
-      cy.getTestId('slotted-cancel-button').should('be.visible')
-      cy.getTestId('slotted-submit-button').should('be.visible')
-    })
-
-    it('update event should be emitted when Route was edited', () => {
-      interceptKM()
-      interceptUpdate()
-
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKM,
-          routeId: route.id,
-          onUpdate: cy.spy().as('onUpdateSpy'),
-        },
-      }).then(({ wrapper }) => wrapper)
-        .as('vueWrapper')
-
-      cy.wait('@getRoute')
-      cy.getTestId('route-form-tags').clear()
-      cy.getTestId('route-form-tags').type('tag1,tag2')
-
-      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
-        .vm.$emit('submit'))
-
-      cy.wait('@updateRoute')
-
-      cy.get('@onUpdateSpy').should('have.been.calledOnce')
-    })
+    } // for RouteFlavors[]
 
     it('should hide `ws` options when not supported', () => {
       cy.mount(RouteForm, {
@@ -495,6 +799,9 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       })
 
       cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+      // config tabs is hidden when there is only one tab
+      cy.getTestId('route-form-config-tabs').should('not.exist')
 
       cy.getTestId('route-form-protocols').click({ force: true })
       cy.getTestId('select-item-http').should('exist')
@@ -549,417 +856,736 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       ).as('updateRoute')
     }
 
-    it('should show create form', () => {
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKonnect,
-        },
+    /**
+     * Stub the POST and PATCH requests with mocked responses where `kind` marks the type of route
+     * being created/edited. This uses the validation steps that are similar to the backend to simply
+     * verify that the mutually exclusive fields are not included.
+     */
+    const stubCreateEdit = () => {
+      const handler: RouteHandler = (req) => {
+        const { body } = req
+
+        // only verify mutually exclusive fields
+        const hasExpressionsFields = Object.hasOwnProperty.call(body, 'expression')
+        const hasTraditionalFields = ['hosts', 'paths', 'headers', 'methods', 'snis', 'sources', 'destinations']
+          .some((prop) => Object.hasOwnProperty.call(body, prop))
+
+        req.reply({
+          statusCode: 400,
+          body: {
+            kind: hasExpressionsFields ? 'expr' : hasTraditionalFields ? 'trad' : undefined,
+          },
+        })
+      }
+
+      cy.intercept('POST', `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/routes`, handler).as('createRoute')
+      cy.intercept('PUT', `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/routes/*`, handler).as('editRoute')
+    }
+
+    // Tests 2 possible RouteFlavors: <not-set>, <trad only>
+    for (const routeFlavors of [undefined, TRADITIONAL_ONLY]) {
+      const configTabs = `tabs=${formatRouteFlavors(routeFlavors)}`
+
+      it(`should show create form, ${configTabs}`, () => {
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKonnect,
+            routeFlavors,
+          },
+        })
+
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.get('.kong-ui-entities-route-form form').should('be.visible')
+
+        // button state
+        cy.getTestId('form-cancel').should('be.visible')
+        cy.getTestId('form-submit').should('be.visible')
+        cy.getTestId('form-cancel').should('be.enabled')
+        cy.getTestId('form-submit').should('be.disabled')
+
+        // config tabs is hidden when there is only one tab
+        cy.getTestId('route-form-config-tabs')
+          .should(routeFlavors?.traditional && routeFlavors?.expressions ? 'be.visible' : 'not.exist')
+
+        // base + base advanced fields
+        cy.getTestId('collapse-trigger-content').click()
+        cy.getTestId('route-form-name').should('be.visible')
+        cy.getTestId('route-form-service-id').should('be.visible')
+        cy.getTestId('route-form-tags').should('be.visible')
+        cy.getTestId('route-form-protocols').should('be.visible')
+
+        if (routeFlavors?.traditional && routeFlavors?.expressions) {
+          // trad + expr 2 tabs
+          // switch to trad tab
+          cy.get('#traditional-tab').click()
+        } // else: we will be on the trad tab by default
+
+        if (routeFlavors?.traditional) {
+          // base advanced fields
+          cy.getTestId('route-form-http-redirect-status-code').should('be.visible')
+          cy.getTestId('route-form-preserve-host').should('be.visible')
+          cy.getTestId('route-form-strip-path').should('be.visible')
+          cy.getTestId('route-form-request-buffering').should('be.visible')
+          cy.getTestId('route-form-response-buffering').should('be.visible')
+
+          // other advanced fields
+          cy.getTestId('route-form-path-handling').should('be.visible')
+          cy.getTestId('route-form-regex-priority').should('be.visible')
+
+          // paths
+          cy.getTestId('route-form-paths-input-1').should('be.visible')
+          cy.getTestId('add-paths').should('be.visible').click()
+          cy.getTestId('route-form-paths-input-2').should('be.visible')
+          cy.getTestId('remove-paths').first().should('be.visible').click()
+          cy.getTestId('route-form-paths-input-2').should('not.exist')
+
+          cy.getTestId('route-form-paths-input-1').should('be.visible')
+          cy.getTestId('remove-paths').first().should('be.visible').click()
+          cy.get('.route-form-routing-rules-selector-options').should('be.visible')
+
+          // snis
+          cy.getTestId('routing-rule-snis').should('be.visible').click()
+          cy.getTestId('route-form-snis-input-1').should('be.visible')
+          cy.getTestId('add-snis').should('be.visible').click()
+          cy.getTestId('route-form-snis-input-2').should('be.visible')
+          cy.getTestId('remove-snis').first().should('be.visible').click()
+          cy.getTestId('route-form-snis-input-2').should('not.exist')
+
+          // hosts
+          cy.getTestId('routing-rule-hosts').should('be.visible').click()
+          cy.getTestId('route-form-hosts-input-1').should('be.visible')
+          cy.getTestId('add-hosts').should('be.visible').click()
+          cy.getTestId('route-form-hosts-input-2').should('be.visible')
+          cy.getTestId('remove-hosts').first().should('be.visible').click()
+          cy.getTestId('route-form-hosts-input-2').should('not.exist')
+
+          // methods and custom methods
+          cy.getTestId('routing-rule-methods').should('be.visible').click()
+          cy.getTestId('routing-rule-methods').should('have.attr', 'aria-disabled').and('eq', 'true')
+          cy.getTestId('get-method-toggle').should('exist')
+          cy.getTestId('post-method-toggle').should('exist')
+          cy.getTestId('put-method-toggle').should('exist')
+          cy.getTestId('custom-method-toggle').should('exist').check({ force: true })
+          cy.getTestId('route-form-custom-method-input-1').should('be.visible')
+          cy.getTestId('add-custom-method').should('be.visible').click()
+          cy.getTestId('route-form-custom-method-input-2').should('be.visible')
+          cy.getTestId('remove-custom-method').first().should('be.visible').click()
+          cy.getTestId('route-form-custom-method-input-2').should('not.exist')
+          cy.getTestId('remove-methods').should('be.visible').click()
+          cy.getTestId('get-method-toggle').should('not.exist')
+          cy.getTestId('routing-rule-methods').should('have.attr', 'aria-disabled').and('eq', 'false')
+
+          // headers
+          cy.getTestId('routing-rule-headers').should('be.visible').click()
+          cy.getTestId('route-form-headers-name-input-1').should('be.visible')
+          cy.getTestId('route-form-headers-values-input-1').should('be.visible')
+          cy.getTestId('add-headers').should('be.visible').click()
+          cy.getTestId('route-form-headers-name-input-2').should('be.visible')
+          cy.getTestId('route-form-headers-values-input-2').should('be.visible')
+          cy.getTestId('remove-headers').first().should('be.visible').click()
+          cy.getTestId('route-form-headers-name-input-2').should('not.exist')
+          cy.getTestId('route-form-headers-values-input-2').should('not.exist')
+
+          cy.getTestId('route-form-protocols').click({ force: true })
+          cy.get("[data-testid='select-item-tcp,tls,udp']").click()
+          cy.getTestId('routing-rule-paths').should('not.exist')
+          cy.getTestId('routing-rule-hosts').should('not.exist')
+          cy.getTestId('routing-rule-methods').should('not.exist')
+          cy.getTestId('routing-rule-headers').should('not.exist')
+
+          // sources
+          cy.getTestId('routing-rule-sources').should('be.visible').click()
+          cy.getTestId('route-form-sources-ip-input-1').should('be.visible')
+          cy.getTestId('route-form-sources-port-input-1').should('be.visible')
+          cy.getTestId('add-sources').should('be.visible').click()
+          cy.getTestId('route-form-sources-ip-input-2').should('be.visible')
+          cy.getTestId('route-form-sources-port-input-2').should('be.visible')
+          cy.getTestId('remove-sources').first().should('be.visible').click()
+          cy.getTestId('route-form-sources-ip-input-2').should('not.exist')
+          cy.getTestId('route-form-sources-port-input-2').should('not.exist')
+
+          // destinations
+          cy.getTestId('routing-rule-destinations').should('be.visible').click()
+          cy.getTestId('route-form-destinations-ip-input-1').should('be.visible')
+          cy.getTestId('route-form-destinations-port-input-1').should('be.visible')
+          cy.getTestId('add-destinations').should('be.visible').click()
+          cy.getTestId('route-form-destinations-ip-input-2').should('be.visible')
+          cy.getTestId('route-form-destinations-port-input-2').should('be.visible')
+          cy.getTestId('remove-destinations').first().should('be.visible').click()
+          cy.getTestId('route-form-destinations-ip-input-2').should('not.exist')
+          cy.getTestId('route-form-destinations-port-input-2').should('not.exist')
+        } // if routeFlavors?.traditional
+
+        if (routeFlavors?.traditional && routeFlavors?.expressions) {
+          // trad + expr 2 tabs
+          // switch to expr tab
+          cy.get('#expressions-tab').click()
+        }
+
+        if (routeFlavors?.expressions) {
+          // negative: traditional fields should not exist
+          cy.getTestId('route-form-path-handling').should('not.exist')
+          cy.getTestId('route-form-regex-priority').should('not.exist')
+          cy.getTestId('route-form-paths-input-1').should('not.exist')
+          cy.get('.route-form-routing-rules-selector-options').should('not.exist')
+
+          // expressions editor
+          cy.get('.expression-editor .monaco-editor').should('be.visible')
+
+          // base advanced fields
+          cy.getTestId('route-form-http-redirect-status-code').should('be.visible')
+          cy.getTestId('route-form-preserve-host').should('be.visible')
+          cy.getTestId('route-form-strip-path').should('be.visible')
+          cy.getTestId('route-form-request-buffering').should('be.visible')
+          cy.getTestId('route-form-response-buffering').should('be.visible')
+        } // if routeFlavors?.expressions
       })
 
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
-      cy.get('.kong-ui-entities-route-form form').should('be.visible')
+      if (!routeFlavors || routeFlavors?.traditional) {
+        // only test when there is trad tab
+        it(`should correctly handle button state - create traditional, ${configTabs}`, () => {
+          interceptKonnectServices()
+          stubCreateEdit()
 
-      // button state
-      cy.getTestId('form-cancel').should('be.visible')
-      cy.getTestId('form-submit').should('be.visible')
-      cy.getTestId('form-cancel').should('be.enabled')
-      cy.getTestId('form-submit').should('be.disabled')
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKonnect,
+              routeFlavors,
+            },
+          })
 
-      // form fields - general
-      cy.getTestId('route-form-name').should('be.visible')
-      cy.getTestId('route-form-service-id').should('be.visible')
-      cy.getTestId('route-form-tags').should('be.visible')
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
 
-      // advanced fields
-      cy.getTestId('collapse-trigger-content').should('be.visible').click()
-      cy.getTestId('route-form-path-handling').should('be.visible')
-      cy.getTestId('route-form-http-redirect-status-code').should('be.visible')
-      cy.getTestId('route-form-regex-priority').should('be.visible')
-      cy.getTestId('route-form-strip-path').should('be.visible')
-      cy.getTestId('route-form-preserve-host').should('be.visible')
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+          // trad + expr 2 tabs
+          // switch to trad tab
+            cy.get('#traditional-tab').click()
+          } // else: we will be on the trad tab by default
 
-      // routing rules fields
-      cy.getTestId('route-form-protocols').should('be.visible')
+          // default button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
 
-      // paths
-      cy.getTestId('route-form-paths-input-1').should('be.visible')
-      cy.getTestId('add-paths').should('be.visible').click()
-      cy.getTestId('route-form-paths-input-2').should('be.visible')
-      cy.getTestId('remove-paths').first().should('be.visible').click()
-      cy.getTestId('route-form-paths-input-2').should('not.exist')
+          // config tabs is hidden when there is only one tab
+          cy.getTestId('route-form-config-tabs')
+            .should(routeFlavors?.traditional && routeFlavors?.expressions ? 'be.visible' : 'not.exist')
 
-      cy.getTestId('route-form-paths-input-1').should('be.visible')
-      cy.getTestId('remove-paths').first().should('be.visible').click()
-      cy.get('.route-form-routing-rules-selector-options').should('be.visible')
+          // enables save when required fields have values
+          // form fields - general
+          cy.getTestId('route-form-name').should('be.visible')
 
-      // snis
-      cy.getTestId('routing-rule-snis').should('be.visible').click()
-      cy.getTestId('route-form-snis-input-1').should('be.visible')
-      cy.getTestId('add-snis').should('be.visible').click()
-      cy.getTestId('route-form-snis-input-2').should('be.visible')
-      cy.getTestId('remove-snis').first().should('be.visible').click()
-      cy.getTestId('route-form-snis-input-2').should('not.exist')
+          // paths
+          cy.getTestId('route-form-paths-input-1').type(route.paths[0])
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
-      // hosts
-      cy.getTestId('routing-rule-hosts').should('be.visible').click()
-      cy.getTestId('route-form-hosts-input-1').should('be.visible')
-      cy.getTestId('add-hosts').should('be.visible').click()
-      cy.getTestId('route-form-hosts-input-2').should('be.visible')
-      cy.getTestId('remove-hosts').first().should('be.visible').click()
-      cy.getTestId('route-form-hosts-input-2').should('not.exist')
+          cy.getTestId('route-form-paths-input-1').clear()
+          cy.getTestId('form-submit').should('be.disabled')
 
-      // methods and custom methods
-      cy.getTestId('routing-rule-methods').should('be.visible').click()
-      cy.getTestId('routing-rule-methods').should('have.attr', 'aria-disabled').and('eq', 'true')
-      cy.getTestId('get-method-toggle').should('exist')
-      cy.getTestId('post-method-toggle').should('exist')
-      cy.getTestId('put-method-toggle').should('exist')
-      cy.getTestId('custom-method-toggle').should('exist').check({ force: true })
-      cy.getTestId('route-form-custom-method-input-1').should('be.visible')
-      cy.getTestId('add-custom-method').should('be.visible').click()
-      cy.getTestId('route-form-custom-method-input-2').should('be.visible')
-      cy.getTestId('remove-custom-method').first().should('be.visible').click()
-      cy.getTestId('route-form-custom-method-input-2').should('not.exist')
-      cy.getTestId('remove-methods').should('be.visible').click()
-      cy.getTestId('get-method-toggle').should('not.exist')
-      cy.getTestId('routing-rule-methods').should('have.attr', 'aria-disabled').and('eq', 'false')
+          // snis
+          cy.getTestId('routing-rule-snis').click()
+          cy.getTestId('route-form-snis-input-1').type('sni')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
-      // headers
-      cy.getTestId('routing-rule-headers').should('be.visible').click()
-      cy.getTestId('route-form-headers-name-input-1').should('be.visible')
-      cy.getTestId('route-form-headers-values-input-1').should('be.visible')
-      cy.getTestId('add-headers').should('be.visible').click()
-      cy.getTestId('route-form-headers-name-input-2').should('be.visible')
-      cy.getTestId('route-form-headers-values-input-2').should('be.visible')
-      cy.getTestId('remove-headers').first().should('be.visible').click()
-      cy.getTestId('route-form-headers-name-input-2').should('not.exist')
-      cy.getTestId('route-form-headers-values-input-2').should('not.exist')
+          cy.getTestId('route-form-snis-input-1').clear()
+          cy.getTestId('form-submit').should('be.disabled')
 
-      cy.getTestId('route-form-protocols').click({ force: true })
-      cy.get("[data-testid='select-item-tcp,tls,udp']").click()
-      cy.getTestId('routing-rule-paths').should('not.exist')
-      cy.getTestId('routing-rule-hosts').should('not.exist')
-      cy.getTestId('routing-rule-methods').should('not.exist')
-      cy.getTestId('routing-rule-headers').should('not.exist')
+          // hosts
+          cy.getTestId('routing-rule-hosts').click()
+          cy.getTestId('route-form-hosts-input-1').type('host')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
-      // sources
-      cy.getTestId('routing-rule-sources').should('be.visible').click()
-      cy.getTestId('route-form-sources-ip-input-1').should('be.visible')
-      cy.getTestId('route-form-sources-port-input-1').should('be.visible')
-      cy.getTestId('add-sources').should('be.visible').click()
-      cy.getTestId('route-form-sources-ip-input-2').should('be.visible')
-      cy.getTestId('route-form-sources-port-input-2').should('be.visible')
-      cy.getTestId('remove-sources').first().should('be.visible').click()
-      cy.getTestId('route-form-sources-ip-input-2').should('not.exist')
-      cy.getTestId('route-form-sources-port-input-2').should('not.exist')
+          cy.getTestId('route-form-hosts-input-1').clear()
+          cy.getTestId('form-submit').should('be.disabled')
 
-      // destinations
-      cy.getTestId('routing-rule-destinations').should('be.visible').click()
-      cy.getTestId('route-form-destinations-ip-input-1').should('be.visible')
-      cy.getTestId('route-form-destinations-port-input-1').should('be.visible')
-      cy.getTestId('add-destinations').should('be.visible').click()
-      cy.getTestId('route-form-destinations-ip-input-2').should('be.visible')
-      cy.getTestId('route-form-destinations-port-input-2').should('be.visible')
-      cy.getTestId('remove-destinations').first().should('be.visible').click()
-      cy.getTestId('route-form-destinations-ip-input-2').should('not.exist')
-      cy.getTestId('route-form-destinations-port-input-2').should('not.exist')
-    })
+          // methods and custom methods
+          cy.getTestId('routing-rule-methods').click()
+          cy.getTestId('get-method-toggle').check({ force: true })
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
-    it('should correctly handle button state - create', () => {
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKonnect,
-        },
+          cy.getTestId('get-method-toggle').uncheck({ force: true })
+          cy.getTestId('form-submit').should('be.disabled')
+          cy.getTestId('custom-method-toggle').check({ force: true })
+          cy.getTestId('form-submit').should('be.disabled')
+          cy.getTestId('route-form-custom-method-input-1').type('castom')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('route-form-custom-method-input-1').clear()
+          cy.getTestId('form-submit').should('be.disabled')
+
+          // headers
+          cy.getTestId('routing-rule-headers').click()
+          cy.getTestId('route-form-headers-name-input-1').type(Object.keys(route.headers)[0])
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('route-form-headers-name-input-1').clear()
+          cy.getTestId('route-form-headers-values-input-1').type(route.headers.Header1[0])
+          cy.getTestId('form-submit').should('be.disabled')
+
+          cy.getTestId('route-form-protocols').click({ force: true })
+          cy.get("[data-testid='select-item-tcp,tls,udp']").click()
+
+          // sources
+          cy.getTestId('routing-rule-sources').click()
+          cy.getTestId('route-form-sources-ip-input-1').type('127.0.0.1')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('route-form-sources-ip-input-1').clear()
+          cy.getTestId('route-form-sources-port-input-1').type('8080')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          // destinations
+          cy.getTestId('routing-rule-destinations').click()
+          cy.getTestId('route-form-destinations-ip-input-1').type('127.0.0.2')
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('route-form-destinations-ip-input-1').clear()
+          cy.getTestId('route-form-destinations-port-input-1').type('8000')
+          cy.getTestId('form-submit').should('be.disabled')
+        })
+      } // if !routeFlavors || routeFlavors?.traditional
+
+      if (routeFlavors?.expressions) {
+        // only test when there is expr tab
+        it(`should correctly handle button state - create expressions, ${configTabs}`, () => {
+          interceptKonnectServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKonnect,
+              routeFlavors,
+            },
+          })
+
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+          // trad + expr 2 tabs
+          // switch to expr tab
+            cy.get('#expressions-tab').click()
+          } // else: we will be on expr tab by default
+
+          // default button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          // enables save when required fields have values
+          // form fields - general
+          cy.getTestId('route-form-name').should('be.visible')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          // the editor shows invalid because it is empty
+          cy.get('.expression-editor').should('have.class', 'invalid')
+
+          // type a valid expression
+          cy.get('.monaco-editor').first().as('monacoEditor').click()
+          cy.get('@monacoEditor').type('http.path == "/kong"')
+
+          // it should be no longer invalid
+          cy.get('.expression-editor').should('not.have.class', 'invalid')
+          // and the submit button is enabled
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'expr')
+
+          // delete the last character
+          cy.get('@monacoEditor').type('{backspace}')
+
+          // invalid again
+          cy.get('.expression-editor').should('have.class', 'invalid')
+          // but the submit button is still enabled because we let the server handle uncaught errors
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'expr')
+        })
+      } // if routeFlavors?.expressions
+
+      if (!routeFlavors || routeFlavors?.traditional) {
+        // only test when there is trad tab
+        it(`should show edit form, traditional ${configTabs}`, () => {
+          interceptKonnect()
+          interceptKonnectServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKonnect,
+              routeId: route.id,
+              routeFlavors,
+            },
+          })
+
+          cy.wait('@getRoute')
+          cy.wait('@getServices')
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          // button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // trad tab should be active by default
+            cy.get('#traditional-tab').should('have.class', 'active')
+          }
+
+          // form fields
+          cy.getTestId('route-form-name').should('have.value', route.name)
+          cy.getTestId('route-form-service-id').should('have.value', route.service.id)
+          cy.getTestId('route-form-tags').should('have.value', route.tags.join(', '))
+
+          cy.getTestId('collapse-trigger-content').click()
+          cy.getTestId('route-form-path-handling').should('have.value', route.path_handling)
+          cy.getTestId('route-form-regex-priority').should('have.value', route.regex_priority)
+          cy.getTestId('route-form-strip-path').should(`${route.strip_path ? '' : 'not.'}be.checked`)
+          cy.getTestId('route-form-preserve-host').should(`${route.preserve_host ? '' : 'not.'}be.checked`)
+
+          cy.getTestId('route-form-paths-input-1').should('have.value', route.paths[0])
+          cy.getTestId('route-form-paths-input-2').should('have.value', route.paths[1])
+          cy.getTestId(`${route.methods[0].toLowerCase()}-method-toggle`).should('be.checked')
+          cy.getTestId(`${route.methods[1].toLowerCase()}-method-toggle`).should('be.checked')
+          cy.getTestId('route-form-headers-name-input-1').should('have.value', Object.keys(route.headers)[0])
+          cy.getTestId('route-form-headers-values-input-1').should('have.value', route.headers.Header1.join(','))
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // switch to expr tab
+            cy.get('#expressions-tab').click()
+            // should not see the expression editor
+            cy.get('.expression-editor').should('not.exist')
+            // should be reminded that the route type cannot be changed
+            cy.getTestId('route-config-type-immutable-alert').should('contain.text', 'cannot be changed after creation')
+          }
+        })
+
+        it(`should correctly handle button state - edit traditional, ${configTabs}`, () => {
+          interceptKonnect()
+          interceptKonnectServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKonnect,
+              routeId: route.id,
+              routeFlavors,
+            },
+          })
+
+          cy.wait('@getRoute')
+          cy.wait('@getServices')
+
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          // default button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // trad tab should be active by default
+            cy.get('#traditional-tab').should('have.class', 'active')
+          }
+
+          cy.getTestId('routing-rules-warning').should('not.exist')
+
+          // enables save when form has changes
+          cy.getTestId('route-form-service-id').click({ force: true })
+          cy.get("[data-testid='select-item-2']").click()
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@editRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
+
+          cy.getTestId('remove-methods').click()
+          cy.getTestId('remove-paths').first().click()
+          cy.getTestId('remove-paths').click()
+          cy.getTestId('remove-headers').click()
+          cy.getTestId('routing-rules-warning').should('be.visible')
+          cy.getTestId('form-submit').should('be.disabled')
+        })
+      } // if !routeFlavors || routeFlavors?.traditional
+
+      if (routeFlavors?.expressions) {
+        // only test when there is trad tab
+        it(`should show edit form, expressions ${configTabs}`, () => {
+          interceptKonnect({ mockData: routeExpressions })
+          interceptKonnectServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKonnect,
+              routeId: route.id,
+              routeFlavors,
+            },
+          })
+
+          cy.wait('@getRoute')
+          cy.wait('@getServices')
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          // button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // expr tab should be active by default
+            cy.get('#expressions-tab').should('have.class', 'active')
+          }
+
+          // form fields
+          cy.getTestId('route-form-name').should('have.value', route.name)
+          cy.getTestId('route-form-service-id').should('have.value', route.service.id)
+          cy.getTestId('route-form-tags').should('have.value', route.tags.join(', '))
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            cy.getTestId('collapse-trigger-content').click()
+            // switch to trad tab
+            cy.get('#traditional-tab').click()
+            // should not see trad fields
+            cy.getTestId('route-form-path-handling').should('not.exist')
+            cy.getTestId('route-form-regex-priority').should('not.exist')
+            // should be reminded that the route type cannot be changed
+            cy.getTestId('route-config-type-immutable-alert').should('contain.text', 'cannot be changed after creation')
+          }
+        })
+
+        it(`should correctly handle button state - edit expressions, ${configTabs}`, () => {
+          interceptKonnect({ mockData: routeExpressions })
+          interceptKonnectServices()
+          stubCreateEdit()
+
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKonnect,
+              routeId: route.id,
+              routeFlavors,
+            },
+          })
+
+          cy.wait('@getRoute')
+          cy.wait('@getServices')
+
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+          // default button state
+          cy.getTestId('form-cancel').should('be.visible')
+          cy.getTestId('form-submit').should('be.visible')
+          cy.getTestId('form-cancel').should('be.enabled')
+          cy.getTestId('form-submit').should('be.disabled')
+
+          if (routeFlavors?.traditional && routeFlavors?.expressions) {
+            // trad tab should be active by default
+            cy.get('#expressions-tab').should('have.class', 'active')
+          }
+
+          // enables save when form has changes
+          cy.getTestId('route-form-service-id').click({ force: true })
+          cy.get("[data-testid='select-item-2']").click()
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@editRoute').then((res) => res.response?.body?.kind).should('eq', 'expr')
+
+          // type a valid expression
+          cy.get('.monaco-editor').first().as('monacoEditor').click()
+          // delete the last character
+          cy.get('@monacoEditor').type('{backspace}')
+
+          // the editor should become invalid
+          cy.get('.expression-editor').should('have.class', 'invalid')
+          // but the submit button is still enabled because we let the server handle uncaught errors
+          cy.getTestId('form-submit').should('be.enabled').click()
+          cy.wait('@editRoute').then((res) => res.response?.body?.kind).should('eq', 'expr')
+        })
+      } // if routeFlavors?.expressions
+
+      it('should correctly handle button state - edit', () => {
+        interceptKonnect()
+        interceptKonnectServices()
+
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKonnect,
+            routeId: route.id,
+          },
+        })
+
+        cy.wait('@getRoute')
+        cy.wait('@getServices')
+
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
+
+        // default button state
+        cy.getTestId('form-cancel').should('be.visible')
+        cy.getTestId('form-submit').should('be.visible')
+        cy.getTestId('form-cancel').should('be.enabled')
+        cy.getTestId('form-submit').should('be.disabled')
+        cy.getTestId('routing-rules-warning').should('not.exist')
+
+        // enables save when form has changes
+        cy.getTestId('route-form-service-id').click({ force: true })
+        cy.get("[data-testid='select-item-2']").click()
+        cy.getTestId('form-submit').should('be.enabled')
+        cy.getTestId('remove-methods').click()
+        cy.getTestId('remove-paths').first().click()
+        cy.getTestId('remove-paths').click()
+        cy.getTestId('remove-headers').click()
+        cy.getTestId('routing-rules-warning').should('be.visible')
+        cy.getTestId('form-submit').should('be.disabled')
       })
 
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
+      it('should handle error state - failed to load route', () => {
+        interceptKonnectServices()
 
-      // default button state
-      cy.getTestId('form-cancel').should('be.visible')
-      cy.getTestId('form-submit').should('be.visible')
-      cy.getTestId('form-cancel').should('be.enabled')
-      cy.getTestId('form-submit').should('be.disabled')
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/routes/*`,
+          },
+          {
+            statusCode: 404,
+            body: {},
+          },
+        ).as('getRoute')
 
-      // enables save when required fields have values
-      // form fields - general
-      cy.getTestId('route-form-name').should('be.visible')
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKonnect,
+            routeId: route.id,
+          },
+        })
 
-      // paths
-      cy.getTestId('route-form-paths-input-1').type(route.paths[0])
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-paths-input-1').clear()
-      cy.getTestId('form-submit').should('be.disabled')
+        cy.wait('@getRoute')
+        cy.wait('@getServices')
 
-      // snis
-      cy.getTestId('routing-rule-snis').click()
-      cy.getTestId('route-form-snis-input-1').type('sni')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-snis-input-1').clear()
-      cy.getTestId('form-submit').should('be.disabled')
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
 
-      // hosts
-      cy.getTestId('routing-rule-hosts').click()
-      cy.getTestId('route-form-hosts-input-1').type('host')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-hosts-input-1').clear()
-      cy.getTestId('form-submit').should('be.disabled')
+        // error state is displayed
+        cy.getTestId('form-fetch-error').should('be.visible')
 
-      // methods and custom methods
-      cy.getTestId('routing-rule-methods').click()
-      cy.getTestId('get-method-toggle').check({ force: true })
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('get-method-toggle').uncheck({ force: true })
-      cy.getTestId('form-submit').should('be.disabled')
-      cy.getTestId('custom-method-toggle').check({ force: true })
-      cy.getTestId('form-submit').should('be.disabled')
-      cy.getTestId('route-form-custom-method-input-1').type('castom')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-custom-method-input-1').clear()
-      cy.getTestId('form-submit').should('be.disabled')
-
-      // headers
-      cy.getTestId('routing-rule-headers').click()
-      cy.getTestId('route-form-headers-name-input-1').type(Object.keys(route.headers)[0])
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-headers-name-input-1').clear()
-      cy.getTestId('route-form-headers-values-input-1').type(route.headers.Header1[0])
-      cy.getTestId('form-submit').should('be.disabled')
-
-      cy.getTestId('route-form-protocols').click({ force: true })
-      cy.get("[data-testid='select-item-tcp,tls,udp']").click()
-
-      // sources
-      cy.getTestId('routing-rule-sources').click()
-      cy.getTestId('route-form-sources-ip-input-1').type('127.0.0.1')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-sources-ip-input-1').clear()
-      cy.getTestId('route-form-sources-port-input-1').type('8080')
-      cy.getTestId('form-submit').should('be.disabled')
-
-      // destinations
-      cy.getTestId('routing-rule-destinations').click()
-      cy.getTestId('route-form-destinations-ip-input-1').type('127.0.0.2')
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('route-form-destinations-ip-input-1').clear()
-      cy.getTestId('route-form-destinations-port-input-1').type('8000')
-      cy.getTestId('form-submit').should('be.disabled')
-    })
-
-    it('should show edit form', () => {
-      interceptKonnect()
-      interceptKonnectServices()
-
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKonnect,
-          routeId: route.id,
-        },
+        // buttons and form hidden
+        cy.getTestId('form-cancel').should('not.exist')
+        cy.getTestId('form-submit').should('not.exist')
+        cy.get('.kong-ui-entities-route-form form').should('not.exist')
       })
 
-      cy.wait('@getRoute')
-      cy.wait('@getServices')
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
+      it('should allow exact match filtering of certs', () => {
+        interceptKonnectServices()
 
-      // button state
-      cy.getTestId('form-cancel').should('be.visible')
-      cy.getTestId('form-submit').should('be.visible')
-      cy.getTestId('form-cancel').should('be.enabled')
-      cy.getTestId('form-submit').should('be.disabled')
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKonnect,
+          },
+        })
 
-      // form fields
-      cy.getTestId('route-form-name').should('have.value', route.name)
-      cy.getTestId('route-form-service-id').should('have.value', route.service.id)
-      cy.getTestId('route-form-tags').should('have.value', route.tags.join(', '))
-      cy.getTestId('route-form-paths-input-1').should('have.value', route.paths[0])
-      cy.getTestId('route-form-paths-input-2').should('have.value', route.paths[1])
-      cy.getTestId(`${route.methods[0].toLowerCase()}-method-toggle`).should('be.checked')
-      cy.getTestId(`${route.methods[0].toLowerCase()}-method-toggle`).should('be.checked')
-      cy.getTestId('route-form-headers-name-input-1').should('have.value', Object.keys(route.headers)[0])
-      cy.getTestId('route-form-headers-values-input-1').should('have.value', route.headers.Header1.join(','))
+        cy.wait('@getServices')
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
 
-      cy.getTestId('collapse-trigger-content').click()
-      cy.getTestId('route-form-path-handling').should('have.value', route.path_handling)
-      cy.getTestId('route-form-regex-priority').should('have.value', route.regex_priority)
-      cy.getTestId('route-form-strip-path').should(`${route.strip_path ? '' : 'not.'}be.checked`)
-      cy.getTestId('route-form-preserve-host').should(`${route.preserve_host ? '' : 'not.'}be.checked`)
-    })
+        // search
+        cy.getTestId('route-form-service-id').should('be.visible')
+        cy.getTestId('route-form-service-id').type(services[1].name)
 
-    it('should correctly handle button state - edit', () => {
-      interceptKonnect()
-      interceptKonnectServices()
-
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKonnect,
-          routeId: route.id,
-        },
+        // click kselect item
+        cy.getTestId(`select-item-${services[1].id}`).should('be.visible')
+        cy.get(`[data-testid="select-item-${services[1].id}"] button`).click()
+        cy.getTestId('route-form-service-id').should('have.value', services[1].id)
       })
 
-      cy.wait('@getRoute')
-      cy.wait('@getServices')
+      it('should handle error state - failed to load services', () => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/services*`,
+          },
+          {
+            statusCode: 500,
+            body: {},
+          },
+        ).as('getServices')
 
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKonnect,
+          },
+        })
 
-      // default button state
-      cy.getTestId('form-cancel').should('be.visible')
-      cy.getTestId('form-submit').should('be.visible')
-      cy.getTestId('form-cancel').should('be.enabled')
-      cy.getTestId('form-submit').should('be.disabled')
-      cy.getTestId('routing-rules-warning').should('not.exist')
-
-      // enables save when form has changes
-      cy.getTestId('route-form-service-id').click({ force: true })
-      cy.get("[data-testid='select-item-2']").click()
-      cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('remove-methods').click()
-      cy.getTestId('remove-paths').first().click()
-      cy.getTestId('remove-paths').click()
-      cy.getTestId('remove-headers').click()
-      cy.getTestId('routing-rules-warning').should('be.visible')
-      cy.getTestId('form-submit').should('be.disabled')
-    })
-
-    it('should handle error state - failed to load route', () => {
-      interceptKonnectServices()
-
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/routes/*`,
-        },
-        {
-          statusCode: 404,
-          body: {},
-        },
-      ).as('getRoute')
-
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKonnect,
-          routeId: route.id,
-        },
+        cy.wait('@getServices')
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.getTestId('form-error').should('be.visible')
       })
 
-      cy.wait('@getRoute')
-      cy.wait('@getServices')
+      it('should correctly render with all props and slot content', () => {
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKonnect,
+            serviceId: services[0].id,
+            hideSectionsInfo: true,
+            hideNameField: true,
+            showTagsFiledUnderAdvanced: true,
+          },
+          slots: {
+            'form-actions': '<button data-testid="slotted-cancel-button">Cancel</button><button data-testid="slotted-submit-button">Submit</button>',
+          },
+        })
 
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.get('.kong-ui-entities-route-form').should('be.visible')
+        cy.get('.kong-ui-entities-route-form form').should('be.visible')
 
-      // error state is displayed
-      cy.getTestId('form-fetch-error').should('be.visible')
+        // name field should be hidden when hideNameField is true
+        cy.getTestId('route-form-name').should('not.exist')
 
-      // buttons and form hidden
-      cy.getTestId('form-cancel').should('not.exist')
-      cy.getTestId('form-submit').should('not.exist')
-      cy.get('.kong-ui-entities-route-form form').should('not.exist')
-    })
+        // tags field should render under advanced fields
+        cy.getTestId('route-form-tags').should('not.be.visible')
+        cy.getTestId('collapse-trigger-content').click()
+        cy.getTestId('route-form-tags').should('be.visible')
 
-    it('should allow exact match filtering of certs', () => {
-      interceptKonnectServices()
+        // service id field should be hidden when serviceId is provided
+        cy.getTestId('route-form-service-id').should('not.exist')
 
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKonnect,
-        },
+        // sections info should be hidden when hideSectionsInfo is true
+        cy.get('.form-section-info sticky').should('not.exist')
+
+        // default buttons should be replaced with slotted content
+        cy.getTestId('form-cancel').should('not.exist')
+        cy.getTestId('form-submit').should('not.exist')
+        cy.getTestId('slotted-cancel-button').should('be.visible')
+        cy.getTestId('slotted-submit-button').should('be.visible')
       })
 
-      cy.wait('@getServices')
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
+      it('update event should be emitted when Route was edited', () => {
+        interceptKonnect()
+        interceptUpdate()
 
-      // search
-      cy.getTestId('route-form-service-id').should('be.visible')
-      cy.getTestId('route-form-service-id').type(services[1].name)
+        cy.mount(RouteForm, {
+          props: {
+            config: baseConfigKonnect,
+            routeId: route.id,
+            onUpdate: cy.spy().as('onUpdateSpy'),
+          },
+        }).then(({ wrapper }) => wrapper)
+          .as('vueWrapper')
 
-      // click kselect item
-      cy.getTestId(`select-item-${services[1].id}`).should('be.visible')
-      cy.get(`[data-testid="select-item-${services[1].id}"] button`).click()
-      cy.getTestId('route-form-service-id').should('have.value', services[1].id)
-    })
+        cy.wait('@getRoute')
+        cy.getTestId('route-form-tags').clear()
+        cy.getTestId('route-form-tags').type('tag1,tag2')
 
-    it('should handle error state - failed to load services', () => {
-      cy.intercept(
-        {
-          method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/services*`,
-        },
-        {
-          statusCode: 500,
-          body: {},
-        },
-      ).as('getServices')
+        cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
+          .vm.$emit('submit'))
 
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKonnect,
-        },
+        cy.wait('@updateRoute')
+
+        cy.get('@onUpdateSpy').should('have.been.calledOnce')
       })
-
-      cy.wait('@getServices')
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
-      cy.getTestId('form-error').should('be.visible')
-    })
-
-    it('should correctly render with all props and slot content', () => {
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKonnect,
-          serviceId: services[0].id,
-          hideSectionsInfo: true,
-          hideNameField: true,
-          showTagsFiledUnderAdvanced: true,
-        },
-        slots: {
-          'form-actions': '<button data-testid="slotted-cancel-button">Cancel</button><button data-testid="slotted-submit-button">Submit</button>',
-        },
-      })
-
-      cy.get('.kong-ui-entities-route-form').should('be.visible')
-      cy.get('.kong-ui-entities-route-form form').should('be.visible')
-
-      // name field should be hidden when hideNameField is true
-      cy.getTestId('route-form-name').should('not.exist')
-
-      // tags field should render under advanced fields
-      cy.getTestId('route-form-tags').should('not.be.visible')
-      cy.getTestId('collapse-trigger-content').click()
-      cy.getTestId('route-form-tags').should('be.visible')
-
-      // service id field should be hidden when serviceId is provided
-      cy.getTestId('route-form-service-id').should('not.exist')
-
-      // sections info should be hidden when hideSectionsInfo is true
-      cy.get('.form-section-info sticky').should('not.exist')
-
-      // default buttons should be replaced with slotted content
-      cy.getTestId('form-cancel').should('not.exist')
-      cy.getTestId('form-submit').should('not.exist')
-      cy.getTestId('slotted-cancel-button').should('be.visible')
-      cy.getTestId('slotted-submit-button').should('be.visible')
-    })
-
-    it('update event should be emitted when Route was edited', () => {
-      interceptKonnect()
-      interceptUpdate()
-
-      cy.mount(RouteForm, {
-        props: {
-          config: baseConfigKonnect,
-          routeId: route.id,
-          onUpdate: cy.spy().as('onUpdateSpy'),
-        },
-      }).then(({ wrapper }) => wrapper)
-        .as('vueWrapper')
-
-      cy.wait('@getRoute')
-      cy.getTestId('route-form-tags').clear()
-      cy.getTestId('route-form-tags').type('tag1,tag2')
-
-      cy.get('@vueWrapper').then((wrapper: any) => wrapper.findComponent(EntityBaseForm)
-        .vm.$emit('submit'))
-
-      cy.wait('@updateRoute')
-
-      cy.get('@onUpdateSpy').should('have.been.calledOnce')
-    })
+    } // for RouteFlavors[]
   })
 })

--- a/packages/entities/entities-routes/src/components/RouteForm.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteForm.cy.ts
@@ -565,7 +565,7 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
           cy.mount(RouteForm, {
             props: {
               config: baseConfigKM,
-              routeId: route.id,
+              routeId: routeExpressions.id,
               routeFlavors,
             },
           })
@@ -586,9 +586,9 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
           }
 
           // form fields
-          cy.getTestId('route-form-name').should('have.value', route.name)
-          cy.getTestId('route-form-service-id').should('have.value', route.service.id)
-          cy.getTestId('route-form-tags').should('have.value', route.tags.join(', '))
+          cy.getTestId('route-form-name').should('have.value', routeExpressions.name)
+          cy.getTestId('route-form-service-id').should('have.value', routeExpressions.service.id)
+          cy.getTestId('route-form-tags').should('have.value', routeExpressions.tags.join(', '))
 
           if (routeFlavors?.traditional && routeFlavors?.expressions) {
             cy.getTestId('collapse-trigger-content').click()
@@ -610,7 +610,7 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
           cy.mount(RouteForm, {
             props: {
               config: baseConfigKM,
-              routeId: route.id,
+              routeId: routeExpressions.id,
               routeFlavors,
             },
           })
@@ -629,6 +629,7 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
           if (routeFlavors?.traditional && routeFlavors?.expressions) {
             // trad tab should be active by default
             cy.get('#expressions-tab').should('have.class', 'active')
+            cy.getTestId('route-form-expressions-editor-loader-loading').should('not.exist')
           }
 
           // enables save when form has changes
@@ -1346,7 +1347,7 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
           cy.mount(RouteForm, {
             props: {
               config: baseConfigKonnect,
-              routeId: route.id,
+              routeId: routeExpressions.id,
               routeFlavors,
             },
           })
@@ -1367,9 +1368,9 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
           }
 
           // form fields
-          cy.getTestId('route-form-name').should('have.value', route.name)
-          cy.getTestId('route-form-service-id').should('have.value', route.service.id)
-          cy.getTestId('route-form-tags').should('have.value', route.tags.join(', '))
+          cy.getTestId('route-form-name').should('have.value', routeExpressions.name)
+          cy.getTestId('route-form-service-id').should('have.value', routeExpressions.service.id)
+          cy.getTestId('route-form-tags').should('have.value', routeExpressions.tags.join(', '))
 
           if (routeFlavors?.traditional && routeFlavors?.expressions) {
             cy.getTestId('collapse-trigger-content').click()
@@ -1391,7 +1392,7 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
           cy.mount(RouteForm, {
             props: {
               config: baseConfigKonnect,
-              routeId: route.id,
+              routeId: routeExpressions.id,
               routeFlavors,
             },
           })

--- a/packages/entities/entities-routes/src/components/RouteForm.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteForm.cy.ts
@@ -260,6 +260,28 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
         }
       })
 
+      if (routeFlavors?.traditional && routeFlavors?.expressions) {
+        // only test when both trad & expr tabs present
+        it('should show tooltips', () => {
+          cy.mount(RouteForm, {
+            props: {
+              config: baseConfigKM,
+              routeFlavors,
+              configTabTooltips: {
+                traditional: 'For traditional routes',
+                expressions: 'For expressions routes',
+              },
+            },
+          })
+
+          cy.get('.kong-ui-entities-route-form').should('be.visible')
+          cy.get('.kong-ui-entities-route-form form').should('be.visible')
+
+          cy.get('#traditional-tab .route-form-config-tabs-tooltip').should('contain.text', 'For traditional routes')
+          cy.get('#expressions-tab .route-form-config-tabs-tooltip').should('contain.text', 'For expressions routes')
+        })
+      }
+
       if (!routeFlavors || routeFlavors?.traditional) {
         // only test when there is trad tab
         it(`should correctly handle button state - create traditional, ${configTabs}`, () => {

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -98,6 +98,7 @@
           v-model="currentConfigTab"
           data-testid="route-form-config-tabs"
           :route-flavors="routeFlavors"
+          :tooltips="configTabTooltips"
         >
           <template
             v-if="routeFlavors.traditional && routeFlavors.expressions && (!recordFlavor || recordFlavor !== currentConfigTab)"
@@ -544,12 +545,22 @@ const props = defineProps({
     required: false,
     default: false,
   },
+  /** Route flavors to be enabled for this form */
   routeFlavors: {
     type: Object as PropType<RouteFlavors>,
     required: false,
     default: () => ({
       traditional: true,
     }),
+  },
+  /** Tooltips to show on config tabs */
+  configTabTooltips: {
+    type: Object as PropType<{
+      [RouteFlavor.TRADITIONAL]?: string,
+      [RouteFlavor.EXPRESSIONS]?: string,
+    } | undefined>,
+    required: false,
+    default: () => undefined,
   },
 })
 

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -1367,7 +1367,7 @@ defineExpose({ saveFormData, getPayload })
   }
 
   .k-select-selected-item-label {
-    margin-left: 30px;
+    margin-left: $kui-space-90;
   }
 
   .k-checkbox {

--- a/packages/entities/entities-routes/src/components/RouteFormConfigTabs.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormConfigTabs.vue
@@ -7,6 +7,25 @@
   >
     <template
       v-if="routeFlavors.traditional"
+      #[`${RouteFlavor.TRADITIONAL}-anchor`]
+    >
+      {{ t('form.flavors.traditional') }}
+
+      <KTooltip
+        v-if="tooltips && tooltips[RouteFlavor.TRADITIONAL]"
+        class="route-form-config-tabs-tooltip"
+        :text="tooltips[RouteFlavor.TRADITIONAL]"
+        tooltip-id="route-form-config-tabs-tooltip-traditional"
+      >
+        <InfoIcon
+          :color="KUI_COLOR_TEXT_NEUTRAL"
+          :size="KUI_ICON_SIZE_30"
+          tabindex="0"
+        />
+      </KTooltip>
+    </template>
+    <template
+      v-if="routeFlavors.traditional"
       #[RouteFlavor.TRADITIONAL]
     >
       <slot name="before-content" />
@@ -14,6 +33,25 @@
       <slot :name="RouteFlavor.TRADITIONAL" />
     </template>
 
+    <template
+      v-if="routeFlavors.expressions"
+      #[`${RouteFlavor.EXPRESSIONS}-anchor`]
+    >
+      {{ t('form.flavors.expressions') }}
+
+      <KTooltip
+        v-if="tooltips && tooltips[RouteFlavor.EXPRESSIONS]"
+        class="route-form-config-tabs-tooltip"
+        :text="tooltips[RouteFlavor.EXPRESSIONS]"
+        tooltip-id="route-form-config-tabs-tooltip-expressions"
+      >
+        <InfoIcon
+          :color="KUI_COLOR_TEXT_NEUTRAL"
+          :size="KUI_ICON_SIZE_30"
+          tabindex="0"
+        />
+      </KTooltip>
+    </template>
     <template
       v-if="routeFlavors.expressions"
       #[RouteFlavor.EXPRESSIONS]
@@ -40,27 +78,44 @@
 </template>
 
 <script setup lang="ts">
+import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { InfoIcon } from '@kong/icons'
 import { computed } from 'vue'
-import { type RouteFlavors, RouteFlavor } from '../types'
+import useI18n from '../composables/useI18n'
+import { RouteFlavor, type RouteFlavors } from '../types'
+
+const { i18n: { t } } = useI18n()
 
 const tab = defineModel<string>()
 
 const props = defineProps<{
-  routeFlavors: RouteFlavors
+  routeFlavors: RouteFlavors,
+  tooltips?: {
+    [RouteFlavor.TRADITIONAL]?: string,
+    [RouteFlavor.EXPRESSIONS]?: string,
+  }
 }>()
 
 const tabs = computed(() => [
   ...props.routeFlavors.traditional
     ? [{
       hash: RouteFlavor.TRADITIONAL,
-      title: 'Traditional',
+      title: t('form.flavors.traditional'),
     }]
     : [],
   ...props.routeFlavors.expressions
     ? [{
       hash: RouteFlavor.EXPRESSIONS,
-      title: 'Expressions',
+      title: t('form.flavors.expressions'),
     }]
     : [],
 ])
 </script>
+
+<style lang="scss" scoped>
+.route-form-config-tabs-tooltip {
+  display: inline-flex;
+  margin: $kui-space-auto $kui-space-0 $kui-space-auto $kui-space-20;
+  vertical-align: middle;
+}
+</style>

--- a/packages/entities/entities-routes/src/components/RouteFormConfigTabs.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormConfigTabs.vue
@@ -2,8 +2,8 @@
   <KTabs
     v-if="tabs.length > 1"
     v-model="tab"
+    data-testid="route-form-config-tabs"
     :tabs="tabs"
-    @change="(t: string) => tab = t"
   >
     <template
       v-if="routeFlavors.traditional"
@@ -80,13 +80,12 @@
 <script setup lang="ts">
 import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { InfoIcon } from '@kong/icons'
+import { type Tab } from '@kong/kongponents'
 import { computed } from 'vue'
 import useI18n from '../composables/useI18n'
 import { RouteFlavor, type RouteFlavors } from '../types'
 
-const { i18n: { t } } = useI18n()
-
-const tab = defineModel<string>()
+const tab = defineModel<string>({ required: true })
 
 const props = defineProps<{
   routeFlavors: RouteFlavors,
@@ -96,16 +95,18 @@ const props = defineProps<{
   }
 }>()
 
-const tabs = computed(() => [
+const { i18n: { t } } = useI18n()
+
+const tabs = computed<Tab[]>(() => [
   ...props.routeFlavors.traditional
     ? [{
-      hash: RouteFlavor.TRADITIONAL,
+      hash: `#${RouteFlavor.TRADITIONAL}`,
       title: t('form.flavors.traditional'),
     }]
     : [],
   ...props.routeFlavors.expressions
     ? [{
-      hash: RouteFlavor.EXPRESSIONS,
+      hash: `#${RouteFlavor.EXPRESSIONS}`,
       title: t('form.flavors.expressions'),
     }]
     : [],

--- a/packages/entities/entities-routes/src/components/RouteFormConfigTabs.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormConfigTabs.vue
@@ -1,0 +1,66 @@
+<template>
+  <KTabs
+    v-if="tabs.length > 1"
+    v-model="tab"
+    :tabs="tabs"
+    @change="(t: string) => tab = t"
+  >
+    <template
+      v-if="routeFlavors.traditional"
+      #[RouteFlavor.TRADITIONAL]
+    >
+      <slot name="before-content" />
+
+      <slot :name="RouteFlavor.TRADITIONAL" />
+    </template>
+
+    <template
+      v-if="routeFlavors.expressions"
+      #[RouteFlavor.EXPRESSIONS]
+    >
+      <slot name="before-content" />
+
+      <slot :name="RouteFlavor.EXPRESSIONS" />
+    </template>
+  </KTabs>
+
+  <template v-else>
+    <slot name="before-content" />
+
+    <slot
+      v-if="routeFlavors.traditional"
+      :name="RouteFlavor.TRADITIONAL"
+    />
+
+    <slot
+      v-else-if="routeFlavors.expressions"
+      :name="RouteFlavor.EXPRESSIONS"
+    />
+  </template>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { type RouteFlavors, RouteFlavor } from '../types'
+
+const tab = defineModel<string>()
+
+const props = defineProps<{
+  routeFlavors: RouteFlavors
+}>()
+
+const tabs = computed(() => [
+  ...props.routeFlavors.traditional
+    ? [{
+      hash: RouteFlavor.TRADITIONAL,
+      title: 'Traditional',
+    }]
+    : [],
+  ...props.routeFlavors.expressions
+    ? [{
+      hash: RouteFlavor.EXPRESSIONS,
+      title: 'Expressions',
+    }]
+    : [],
+])
+</script>

--- a/packages/entities/entities-routes/src/components/RouteFormExpressionsEditor.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormExpressionsEditor.vue
@@ -1,0 +1,24 @@
+<template>
+  <ExpressionsEditor
+    v-if="schema !== undefined"
+    v-model="expression"
+    :schema="schema"
+  />
+</template>
+
+<script setup lang="ts">
+/**
+ * This component assumes that @kong-ui-public/expressions has been initialized.
+ */
+import { ExpressionsEditor, PROTOCOL_TO_SCHEMA, type Schema } from '@kong-ui-public/expressions'
+import { computed } from 'vue'
+
+import '@kong-ui-public/expressions/dist/style.css'
+
+const props = defineProps<{ protocol?: string }>()
+const expression = defineModel<string>({ required: true })
+
+const schema = computed<Schema | undefined>(() => {
+  return PROTOCOL_TO_SCHEMA[props.protocol as keyof typeof PROTOCOL_TO_SCHEMA]
+})
+</script>

--- a/packages/entities/entities-routes/src/components/RouteFormExpressionsEditorLoader.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormExpressionsEditorLoader.vue
@@ -1,0 +1,55 @@
+<template>
+  <component
+    :is="errorComponent"
+    v-if="expressionInitError"
+  />
+  <component
+    :is="loadingComponent"
+    v-else-if="!expressionInitialized"
+  />
+  <RouteFormExpressionsEditor
+    v-else
+    v-model="expression"
+    :protocol="props.protocol"
+  />
+</template>
+
+<script setup lang="ts">
+/**
+ * This is a loader component to lazy-load the @kong-ui-public/expressions and RouteFormExpressionsEditor,
+ * which depends on @kong-ui-public/expressions, to avoid loading the Expressions language support and the
+ * editor until they are used.
+ */
+import { defineAsyncComponent, onMounted, ref, type Component, h } from 'vue'
+
+const loadingComponent: Component = {
+  render: () => h('div', 'Loading...'),
+}
+
+const errorComponent: Component = {
+  render: () => h('div', 'Error occurred while loading the editor. Please view the console for more details.'),
+}
+
+const RouteFormExpressionsEditor = defineAsyncComponent({
+  loader: async () => {
+    return import('./RouteFormExpressionsEditor.vue')
+  },
+  loadingComponent,
+  errorComponent,
+})
+
+const props = defineProps<{ protocol?: string }>()
+const expression = defineModel<string>({ required: true })
+const expressionInitialized = ref(false)
+const expressionInitError = ref(false)
+
+onMounted(async () => {
+  try {
+    await (await import('@kong-ui-public/expressions')).asyncInit
+    expressionInitialized.value = true
+  } catch (e) {
+    expressionInitError.value = true
+    console.error(e)
+  }
+})
+</script>

--- a/packages/entities/entities-routes/src/components/RouteFormExpressionsEditorLoader.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormExpressionsEditorLoader.vue
@@ -20,14 +20,17 @@
  * which depends on @kong-ui-public/expressions, to avoid loading the Expressions language support and the
  * editor until they are used.
  */
+import useI18n from '../composables/useI18n'
 import { defineAsyncComponent, onMounted, ref, type Component, h } from 'vue'
 
+const { i18n: { t } } = useI18n()
+
 const loadingComponent: Component = {
-  render: () => h('div', 'Loading...'),
+  render: () => h('div', t('form.expressions_editor.loading')),
 }
 
 const errorComponent: Component = {
-  render: () => h('div', 'Error occurred while loading the editor. Please view the console for more details.'),
+  render: () => h('div', t('form.expressions_editor.error')),
 }
 
 const RouteFormExpressionsEditor = defineAsyncComponent({

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -2,6 +2,7 @@
   <div class="kong-ui-entities-routes-list">
     <EntityBaseTable
       :cache-identifier="cacheIdentifier"
+      :cell-attributes="getCellAttrs"
       disable-pagination-page-jump
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
@@ -121,7 +122,9 @@
         <span v-else>-</span>
       </template>
       <template #expression="{ rowValue }">
-        <span class="route-list-cell-expression">{{ rowValue || '-' }}</span>
+        <span class="route-list-cell-expression">
+          {{ rowValue || '-' }}
+        </span>
       </template>
 
       <!-- Row actions -->
@@ -305,7 +308,7 @@ const fields: BaseTableHeaders = {
   methods: { label: t('routes.list.table_headers.methods'), searchable: true },
   paths: { label: t('routes.list.table_headers.paths'), searchable: true },
   ...props.hasExpressionColumn && {
-    expression: { label: t('routes.list.table_headers.expression') },
+    expression: { label: t('routes.list.table_headers.expression'), tooltip: true },
   },
   tags: { label: t('routes.list.table_headers.tags'), sortable: false },
 }
@@ -354,6 +357,18 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
 })
 
 const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+
+const getCellAttrs = (params: Record<string, any>) => {
+  if (params.headerKey === 'expression') {
+    return {
+      style: {
+        maxWidth: '250px',
+        overflowX: 'hidden',
+        textOverflow: 'ellipsis',
+      },
+    }
+  }
+}
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -120,6 +120,9 @@
         </KTruncate>
         <span v-else>-</span>
       </template>
+      <template #expression="{ rowValue }">
+        <span class="route-list-cell-expression">{{ rowValue || '-' }}</span>
+      </template>
 
       <!-- Row actions -->
       <template #actions="{ row }">
@@ -279,6 +282,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  hasExpressionColumn: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const { i18n: { t } } = composables.useI18n()
@@ -294,15 +301,12 @@ const disableSorting = computed((): boolean => props.config.app !== 'kongManager
 const fields: BaseTableHeaders = {
   name: { label: t('routes.list.table_headers.name'), searchable: true, sortable: true },
   protocols: { label: t('routes.list.table_headers.protocols'), searchable: true },
-  ...props.config.useExpression
-    ? {
-      expression: { label: t('routes.list.table_headers.expression') },
-    }
-    : {
-      hosts: { label: t('routes.list.table_headers.hosts'), searchable: true },
-      methods: { label: t('routes.list.table_headers.methods'), searchable: true },
-      paths: { label: t('routes.list.table_headers.paths'), searchable: true },
-    },
+  hosts: { label: t('routes.list.table_headers.hosts'), searchable: true },
+  methods: { label: t('routes.list.table_headers.methods'), searchable: true },
+  paths: { label: t('routes.list.table_headers.paths'), searchable: true },
+  ...props.hasExpressionColumn && {
+    expression: { label: t('routes.list.table_headers.expression') },
+  },
   tags: { label: t('routes.list.table_headers.tags'), sortable: false },
 }
 const tableHeaders: BaseTableHeaders = fields
@@ -338,9 +342,9 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   }
 
   const { name, protocols, hosts, methods, paths, expression } = fields
-  const filterFields: FilterFields = props.config.useExpression
-    ? { name, protocols, expression }
-    : { name, protocols, hosts, methods, paths }
+  const filterFields: FilterFields = {
+    name, protocols, hosts, methods, paths, ...props.hasExpressionColumn && { expression },
+  }
 
   return {
     isExactMatch,
@@ -546,6 +550,10 @@ onBeforeMount(async () => {
 
   .kong-ui-entity-filter-input {
     margin-right: $kui-space-50;
+  }
+
+  .route-list-cell-expression {
+    font-family: $kui-font-family-code;
   }
 }
 </style>

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -358,7 +358,7 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
 
 const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
 
-const getCellAttrs = (params: Record<string, any>) => {
+const getCellAttrs = (params: Record<string, any>): Object => {
   if (params.headerKey === 'expression') {
     return {
       style: {
@@ -368,6 +368,8 @@ const getCellAttrs = (params: Record<string, any>) => {
       },
     }
   }
+
+  return {}
 }
 
 const clearFilter = (): void => {

--- a/packages/entities/entities-routes/src/locales/en.json
+++ b/packages/entities/entities-routes/src/locales/en.json
@@ -85,6 +85,9 @@
       },
       "routingRules": {
         "title": "Routing Rules"
+      },
+      "routingExpression": {
+        "title": "Routing Expression"
       }
     },
     "fields": {
@@ -217,14 +220,30 @@
       "request_buffering": {
         "label": "Request buffering",
         "tooltip": "Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding."
+      },
+      "expression": {
+        "label": "Expression",
+        "tooltip": "The route expression."
+      },
+      "priority": {
+        "label": "Priority",
+        "tooltip": "A number used to choose which route resolves a given request when several routes match it using expression simultaneously."
       }
+    },
+    "flavors": {
+      "traditional": "Traditional",
+      "expressions": "Expressions"
     },
     "viewAdvancedFields": "View Advanced Fields",
     "addNewRule": "Add New Rule",
     "warning": {
       "rulesMessage": "For {protocol}, at least one of {routingRules} must be set.",
       "singleRule": "{routingRules}",
-      "multipleRules": "{routingRules} or {lastRoutingRule}"
+      "multipleRules": "{routingRules} or {lastRoutingRule}",
+      "cannotChangeFlavor": {
+        "create": "The format of the route cannot be changed once created.",
+        "edit": "This route was configured in the {format} format. It cannot be changed after creation, please switch to the {format} tab or create a new route instead."
+      }
     }
   }
 }

--- a/packages/entities/entities-routes/src/locales/en.json
+++ b/packages/entities/entities-routes/src/locales/en.json
@@ -244,6 +244,10 @@
         "create": "The format of the route cannot be changed once created.",
         "edit": "This route was configured in the {format} format. It cannot be changed after creation, please switch to the {format} tab or create a new route instead."
       }
+    },
+    "expressions_editor": {
+      "loading": "Loading the Expressions editor…",
+      "error": "Error occurred while loading the Expressions editor. Please view the console for more details."
     }
   }
 }

--- a/packages/entities/entities-routes/src/locales/en.json
+++ b/packages/entities/entities-routes/src/locales/en.json
@@ -242,7 +242,7 @@
       "multipleRules": "{routingRules} or {lastRoutingRule}",
       "cannotChangeFlavor": {
         "create": "The format of the route cannot be changed once created.",
-        "edit": "This route was configured in the {format} format. It cannot be changed after creation, please switch to the {format} tab or create a new route instead."
+        "edit": "This route was configured in the {format} format, and cannot be changed after creation. You can switch to the {format} tab to edit, or create a new route in a different format instead."
       }
     },
     "expressions_editor": {

--- a/packages/entities/entities-routes/src/types/route-form.ts
+++ b/packages/entities/entities-routes/src/types/route-form.ts
@@ -35,6 +35,12 @@ export enum RoutingRulesEntities {
   CUSTOM_METHOD = 'custom-method'
 }
 
+export enum ExpressionsEditorState {
+  LOADING = 'loading',
+  ERROR = 'error',
+  READY = 'ready'
+}
+
 export type RoutingRuleEntity = Exclude<`${RoutingRulesEntities}`, 'custom-method'>
 
 export type PathHandlingVersion = 'v0' | 'v1'

--- a/packages/entities/entities-routes/src/types/route-list.ts
+++ b/packages/entities/entities-routes/src/types/route-list.ts
@@ -4,8 +4,6 @@ import type { FilterSchema, KongManagerBaseTableConfig, KonnectBaseTableConfig }
 export interface BaseRouteListConfig {
   /** Current service id if the RouteList in nested in the routes tab on a service detail page */
   serviceId?: string
-  /** Whether to use expression flavored routes */
-  useExpression?: boolean
   /** Route for creating a route */
   createRoute: RouteLocationRaw
   /** A function that returns the route for viewing a route */

--- a/packages/entities/entities-routes/tsconfig.json
+++ b/packages/entities/entities-routes/tsconfig.json
@@ -10,7 +10,8 @@
       "cypress",
       "cypress/vue",
       "../../../cypress/support"
-    ]
+    ],
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*",

--- a/packages/entities/entities-routes/vite.config.ts
+++ b/packages/entities/entities-routes/vite.config.ts
@@ -1,6 +1,7 @@
-import sharedViteConfig, { getApiProxies, sanitizePackageName } from '../../../vite.config.shared'
 import { resolve } from 'path'
 import { defineConfig, mergeConfig } from 'vite'
+import sharedViteConfig, { getApiProxies, sanitizePackageName } from '../../../vite.config.shared'
+import monacoEditorPlugin from 'vite-plugin-monaco-editor'
 
 // Package name MUST always match the kebab-case package name inside the component's package.json file and the name of your `/packages/{package-name}` directory
 const packageName = 'entities-routes'
@@ -16,12 +17,21 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       entry: resolve(__dirname, './src/index.ts'),
       fileName: (format) => `${sanitizedPackageName}.${format}.js`,
     },
+    rollupOptions: {
+      external: ['monaco-editor'], // Do not bundle monaco-editor with this package. Provide as a peer dependency
+    },
   },
   server: {
     proxy: {
       // Add the API proxies to inject the Authorization header
       ...getApiProxies(),
     },
+  },
+  ...process.env.USE_SANDBOX && {
+    plugins: [
+      // See: https://github.com/vdesjs/vite-plugin-monaco-editor/issues/21
+      ((monacoEditorPlugin as any).default as typeof monacoEditorPlugin)({}),
+    ],
   },
 }))
 

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -48,13 +48,14 @@
         </div>
       </template>
       <template
-        v-for="(_, key) in tableHeaders"
+        v-for="(header, key) in tableHeaders"
         :key="key"
         #[key]="{ row, rowKey, rowValue }"
       >
         <EntityBaseTableCell
           :key-name="String(key)"
           :row-el="getRowEl(row)"
+          :tooltip="header.tooltip"
         >
           <slot
             :name="key"

--- a/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
+++ b/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
@@ -176,7 +176,7 @@ const searchableFields = computed<{ label: string, value: string, expanded: bool
   const fields = (props.config as FuzzyMatchFilterConfig).fields
   return Object
     .keys(fields)
-    .filter((key: string) => fields[key].searchable)
+    .filter((key: string) => fields?.[key]?.searchable)
     .map((key: string) => ({
       label: fields[key].label || key,
       value: key,

--- a/packages/entities/entities-shared/src/components/entity-form-section/EntityFormSection.vue
+++ b/packages/entities/entities-shared/src/components/entity-form-section/EntityFormSection.vue
@@ -85,6 +85,7 @@ const legendId = uuidv4()
 <style lang="scss" scoped>
 fieldset {
   margin: 0;
+  min-width: 0;
   padding: 0;
 }
 

--- a/packages/entities/entities-shared/src/types/base.ts
+++ b/packages/entities/entities-shared/src/types/base.ts
@@ -6,4 +6,9 @@ export interface Field {
   searchable?: boolean
   /** Determines if the field is sortable */
   sortable?: boolean
+  /**
+   * Determines if cells of this field should be wrapped inside KTooltips.
+   * Need to use with max-width with EntityBaseTable's cellAttributes prop.
+   */
+  tooltip?: boolean
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,11 +528,11 @@ importers:
         specifier: 9.0.0-alpha.146
         version: 9.0.0-alpha.146(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       monaco-editor:
-        specifier: 0.47.0
-        version: 0.47.0
+        specifier: 0.21.3
+        version: 0.21.3
       vite-plugin-monaco-editor:
         specifier: ^1.1.0
-        version: 1.1.0(monaco-editor@0.47.0)
+        version: 1.1.0(monaco-editor@0.21.3)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
         version: 1.4.1(vite@5.2.8)
@@ -840,6 +840,12 @@ importers:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
+      '@kong-ui-public/expressions':
+        specifier: workspace:^
+        version: link:../../core/expressions
+      lodash.isequal:
+        specifier: ^4.5.0
+        version: 4.5.0
     devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
@@ -850,9 +856,18 @@ importers:
       '@kong/kongponents':
         specifier: 9.0.0-alpha.146
         version: 9.0.0-alpha.146(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+      '@types/lodash.isequal':
+        specifier: ^4.5.8
+        version: 4.5.8
       axios:
         specifier: ^1.6.8
         version: 1.6.8
+      monaco-editor:
+        specifier: 0.21.3
+        version: 0.21.3
+      vite-plugin-monaco-editor:
+        specifier: ^1.1.0
+        version: 1.1.0(monaco-editor@0.21.3)
       vue:
         specifier: ^3.4.21
         version: 3.4.21(typescript@5.3.3)
@@ -1044,7 +1059,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       swagger-client:
         specifier: ^3.26.6
-        version: 3.26.8
+        version: 3.26.6
       swagger-ui:
         specifier: ^5.1.3
         version: 5.1.3
@@ -3999,6 +4014,12 @@ packages:
     resolution: {integrity: sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==}
     dependencies:
       '@types/lodash': 4.14.202
+    dev: true
+
+  /@types/lodash.isequal@4.5.8:
+    resolution: {integrity: sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==}
+    dependencies:
+      '@types/lodash': 4.17.0
     dev: true
 
   /@types/lodash.mapkeys@4.6.9:
@@ -10358,6 +10379,10 @@ packages:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: false
 
+  /lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    dev: false
+
   /lodash.isfunction@3.0.9:
     resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
     dev: true
@@ -11238,8 +11263,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /monaco-editor@0.47.0:
-    resolution: {integrity: sha512-VabVvHvQ9QmMwXu4du008ZDuyLnHs9j7ThVFsiJoXSOQk18+LF89N4ADzPbFenm0W4V2bGHnFBztIRQTgBfxzw==}
+  /monaco-editor@0.21.3:
+    resolution: {integrity: sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==}
     dev: true
 
   /mri@1.2.0:
@@ -14305,8 +14330,8 @@ packages:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
     dev: true
 
-  /swagger-client@3.26.8:
-    resolution: {integrity: sha512-NzvHWpWLeNVJAFrH+cRyzCzYrKNYG5AuaTDwaL/sqHRDMxjj8SN9Ua84EbfsUqrUnI50sW270dgQphp0TorAcg==}
+  /swagger-client@3.26.6:
+    resolution: {integrity: sha512-PYYca8BsamZaOjlKr5ombOTeDje1ddiYAKGstpmAU3iU+mBKgqHiw5G2J77SC9+chKU5y0aJzmQX4hNu3p2y5A==}
     dependencies:
       '@babel/runtime-corejs3': 7.22.15
       '@swagger-api/apidom-core': 0.99.1
@@ -14362,7 +14387,7 @@ packages:
       reselect: 4.1.8
       serialize-error: 8.1.0
       sha.js: 2.4.11
-      swagger-client: 3.26.8
+      swagger-client: 3.26.6
       url-parse: 1.5.10
       xml: 1.0.1
       xml-but-prettier: 1.0.1
@@ -15272,12 +15297,12 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-monaco-editor@1.1.0(monaco-editor@0.47.0):
+  /vite-plugin-monaco-editor@1.1.0(monaco-editor@0.21.3):
     resolution: {integrity: sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==}
     peerDependencies:
       monaco-editor: '>=0.33.0'
     dependencies:
-      monaco-editor: 0.47.0
+      monaco-editor: 0.21.3
     dev: true
 
   /vite-plugin-top-level-await@1.4.1(vite@5.2.8):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,6 +843,9 @@ importers:
       '@kong-ui-public/expressions':
         specifier: workspace:^
         version: link:../../core/expressions
+      '@kong/icons':
+        specifier: ^1.8.16
+        version: 1.8.16(vue@3.4.21)
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,7 +845,7 @@ importers:
         version: link:../../core/expressions
       '@kong/icons':
         specifier: ^1.8.16
-        version: 1.8.16(vue@3.4.21)
+        version: 1.9.0(vue@3.4.21)
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0


### PR DESCRIPTION
# Summary

This PR adds support for creating/editing the Expressions routes in `@kong-ui-public/entities-routes`, and also:

- Adds Expressions schemas for the WS and WSS protocols
- Adds test cases to cover creating and editing both traditional and Expressions routes
- Updates the route form page in the sandbox to support testing the combination of different route flavors

KM-20