### PR TITLE
feat(analytics): improved dashboard time spec handling [MA-2759]

### DIFF
--- a/packages/analytics/analytics-config-store/src/components/AnalyticsConfigCheck.cy.ts
+++ b/packages/analytics/analytics-config-store/src/components/AnalyticsConfigCheck.cy.ts
@@ -44,6 +44,7 @@ const makeQueryBridge = (level: 'networkFail' | 'none' | 'analytics' | 'percenti
 
       return Promise.resolve(config)
     },
+    evaluateFeatureFlagFn: () => true as any,
   }
 }
 

--- a/packages/analytics/analytics-config-store/src/components/AnalyticsConfigCheck.vue
+++ b/packages/analytics/analytics-config-store/src/components/AnalyticsConfigCheck.vue
@@ -1,19 +1,20 @@
 <template>
   <slot
     v-if="!loading && passThrough"
-    :has-analytics="hasAnalytics"
-    :has-percentiles="hasPercentiles"
+    :has-analytics="analytics"
+    :has-percentiles="percentiles"
   />
   <slot
     v-else-if="!loading"
-    :has-analytics="hasAnalytics"
-    :has-percentiles="hasPercentiles"
+    :has-analytics="analytics"
+    :has-percentiles="percentiles"
     name="fallback"
   />
 </template>
 <script setup lang="ts">
-import { type ConfigStoreState, useAnalyticsConfigStore } from '../stores'
-import { computed, type Ref } from 'vue'
+import { useAnalyticsConfigStore } from '../stores'
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
 
 const props = defineProps<{
   requireAnalytics?: boolean
@@ -21,14 +22,11 @@ const props = defineProps<{
 }>()
 
 const analyticsConfigStore = useAnalyticsConfigStore()
-const analyticsConfig: Ref<ConfigStoreState> = analyticsConfigStore.getConfig()
+const { analytics, percentiles, loading } = storeToRefs(analyticsConfigStore)
 
-const loading = computed<boolean>(() => !analyticsConfig.value)
-const hasAnalytics = computed<boolean>(() => !!analyticsConfig.value?.analytics)
-const hasPercentiles = computed<boolean>(() => !!analyticsConfig.value?.analytics?.percentiles)
 const passThrough = computed<boolean>(() =>
-  (props.requireAnalytics ? hasAnalytics.value : true) &&
-  (props.requirePercentiles ? hasPercentiles.value : true),
+  (props.requireAnalytics ? analytics.value : true) &&
+  (props.requirePercentiles ? percentiles.value : true),
 )
 
 </script>

--- a/packages/analytics/analytics-config-store/src/constants.ts
+++ b/packages/analytics/analytics-config-store/src/constants.ts
@@ -1,1 +1,1 @@
-export const SEVEN_DAYS_MS = 604800000
+export const THIRTY_DAYS_MS = 2592000000

--- a/packages/analytics/analytics-config-store/src/index.ts
+++ b/packages/analytics/analytics-config-store/src/index.ts
@@ -2,4 +2,3 @@ import AnalyticsConfigCheck from './components/AnalyticsConfigCheck.vue'
 
 export { AnalyticsConfigCheck }
 export * from './stores'
-export * from './constants'

--- a/packages/analytics/analytics-metric-provider/sandbox/App.vue
+++ b/packages/analytics/analytics-metric-provider/sandbox/App.vue
@@ -102,6 +102,8 @@ const makeQueryBridge = (opts?: MockOptions): AnalyticsBridge => {
         },
       })
     },
+
+    evaluateFeatureFlagFn: () => true as any,
   }
 }
 

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsConsumer.vue
@@ -43,7 +43,6 @@ const trafficCard = composables.useMetricCardBuilder({
   title: computed(() => providerData.longCardTitles
     ? i18n.t('metricCard.long.traffic')
     : i18n.t('metricCard.short.traffic')),
-  description: providerData.description,
   record: traffic.mapped,
   hasError: traffic.hasError,
   lookupKey: props.lookupKey,
@@ -75,7 +74,6 @@ const errorRateCard = computed<MetricCardDef>(() => {
     title: providerData.longCardTitles
       ? i18n.t('metricCard.long.errorRate')
       : i18n.t('metricCard.short.errorRate'),
-    description: providerData.description,
     increaseIsBad: true,
     trendRange: traffic.trendRange.value,
   }
@@ -91,7 +89,6 @@ const latencyCard = composables.useMetricCardBuilder({
       ? i18n.t(`metricCard.long.${titleKey}`)
       : i18n.t(`metricCard.short.${titleKey}`)
   }),
-  description: providerData.description,
   hasError: latency.hasError,
   record: latency.mapped,
   lookupKey: props.lookupKey,
@@ -125,12 +122,13 @@ const isLoading = computed<boolean>(() => {
 // TODO: per-card loading?
 const containerOpts = computed(() => ({
   cards: cards.value,
-  containerTitle: providerData.containerTitle,
+  containerTitle: providerData.containerTitle.value,
+  containerDescription: providerData.description.value,
   loading: isLoading.value,
   hasTrendAccess: providerData.hasTrendAccess.value,
   fallbackDisplayText: i18n.t('general.notAvailable'),
   // If the parent container has a title, we enforce a Medium card size; otherwise, pass down provided cardSize
-  cardSize: providerData.containerTitle ? MetricCardSize.Medium : props.cardSize,
+  cardSize: providerData.containerTitle.value ? MetricCardSize.Medium : props.cardSize,
   hideTitle: true,
 }))
 

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsProvider.cy.ts
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsProvider.cy.ts
@@ -215,12 +215,13 @@ describe('<AnalyticsMetricProvider />', () => {
     cy.get('.metricscard-title').eq(2).should('have.text', 'P99 Latency')
   })
 
-  it('displays a card description if provided', () => {
+  it('displays a container description if provided', () => {
     const queryBridge = makeQueryBridge()
 
     cy.mount(MetricsTestHarness, {
       props: {
         render: 'global',
+        containerTitle: 'Analytics',
         description: 'Lorem ipsum golden signal details',
       },
       global: {
@@ -231,7 +232,7 @@ describe('<AnalyticsMetricProvider />', () => {
     })
 
     cy.get('.metricscard').should('exist')
-    cy.get('.metricscard-description').eq(0).should('contain', 'Lorem ipsum golden signal details')
+    cy.get('.container-description').eq(0).should('contain', 'Lorem ipsum golden signal details')
   })
 
   it('displays "30 days" if trend access allows', () => {

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsTestHarness.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsTestHarness.vue
@@ -56,6 +56,7 @@ const props = withDefaults(defineProps<{
   refreshInterval?: number,
   additionalFilter?: ExploreFilter[],
   longCardTitles?: boolean,
+  containerTitle?: string,
   description?: string,
   percentileLatency?: boolean,
 }>(), {
@@ -63,6 +64,7 @@ const props = withDefaults(defineProps<{
   queryReady: true,
   additionalFilter: undefined,
   longCardTitles: undefined,
+  containerTitle: undefined,
   description: undefined,
   percentileLatency: undefined,
 })

--- a/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
+++ b/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
@@ -9,13 +9,15 @@ import composables from '../composables'
 import type { MetricFetcherOptions } from '../types'
 import { computed, ref } from 'vue'
 import type { InjectionKey, Ref } from 'vue'
+import type { FetcherResult } from '../composables/useMetricFetcher'
 
 interface ProviderData {
   data: {
-    [key: string]: any // TODO
+    traffic: FetcherResult,
+    latency: FetcherResult,
   },
-  containerTitle?: string,
-  description?: string,
+  containerTitle: Ref<string | undefined>,
+  description: Ref<string | undefined>,
   hasTrendAccess: Ref<boolean>,
   longCardTitles: boolean,
   averageLatencies: Ref<boolean>,

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -34,6 +34,11 @@ This component only takes two properties:
 
 For context `filters` and `timeSpec` see [here](https://github.com/Kong/public-ui-components/blob/main/packages/analytics/analytics-utilities/src/types/explore-v4.ts).
 
+If a `timeSpec` is not provided in the `context` object, the renderer will determine a default based on the current organization's analytics retention:
+
+- If the org's retention is less than 30 days, the renderer will query 24 hours of data.
+- If the org's retention is greater than or equal to 30 days, the renderer will query 30 days of data.
+
 ### Example
 
 ```html

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/analytics-chart": "workspace:^",
+    "@kong-ui-public/analytics-config-store": "workspace:^",
     "@kong-ui-public/analytics-metric-provider": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
@@ -70,6 +71,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/analytics-chart": "workspace:^",
+    "@kong-ui-public/analytics-config-store": "workspace:^",
     "@kong-ui-public/analytics-metric-provider": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",

--- a/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
@@ -252,6 +252,8 @@ export const summaryDashboardConfig: DashboardConfig = {
       definition: {
         chart: {
           type: ChartTypes.GoldenSignals,
+          chartTitle: 'Analytics',
+          description: '{timeframe}',
         },
       },
       layout: {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -39,10 +39,6 @@ const appLinks: SandboxNavigationItem[] = inject('app-links', [])
 
 const context: DashboardRendererContext = {
   filters: [],
-  timeSpec: {
-    type: 'relative',
-    time_range: '24h',
-  },
   refreshInterval: 0,
 }
 
@@ -58,6 +54,7 @@ const dashboardConfig: DashboardConfig = {
         chart: {
           type: ChartTypes.GoldenSignals,
           chartTitle: 'Analytics Golden Signals',
+          description: '{timeframe}',
         },
         query: {},
       },
@@ -77,7 +74,7 @@ const dashboardConfig: DashboardConfig = {
         chart: {
           type: ChartTypes.TopN,
           chartTitle: 'Top N chart of mock data',
-          description: 'Description',
+          description: '{timeframe}',
         },
         query: { limit: 1 },
       },

--- a/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
@@ -12,6 +12,7 @@ const delayedResponse = <T>(response: T): Promise<T> => {
 }
 
 const queryFn = async (query: ExploreQuery): Promise<ExploreResultV4> => {
+  console.log('Querying data:', query)
   if (query.dimensions && query.dimensions.findIndex(d => d === 'time') > -1) {
     return await delayedResponse(
       generateSingleMetricTimeSeriesData(
@@ -34,19 +35,28 @@ const queryFn = async (query: ExploreQuery): Promise<ExploreResultV4> => {
   return await delayedResponse(nonTsExploreResponse)
 }
 
-const configFn = (): Promise<AnalyticsConfigV2> => Promise.resolve({
-  analytics: {
-    percentiles: true,
-    retention_ms: 2592000000, // 30d
-  },
-  requests: {
-    retention_ms: 86400000,
-  },
-})
+const configFn = (): Promise<AnalyticsConfigV2> => {
+  return new Promise(resolve => {
+    window.setTimeout(() => {
+      console.log('Analytics config resolved')
+      resolve({
+        analytics: {
+          percentiles: true,
+          retention_ms: 2592000000, // 30d
+        },
+        requests: {
+          retention_ms: 86400000,
+        },
+      })
+    }, 1000)
+  })
+}
+
+const evaluateFeatureFlagFn = () => true
 
 const sandboxQueryProvider: Plugin = {
   install(app) {
-    app.provide(INJECT_QUERY_PROVIDER, { queryFn, configFn } as AnalyticsBridge)
+    app.provide(INJECT_QUERY_PROVIDER, { queryFn, configFn, evaluateFeatureFlagFn } as AnalyticsBridge)
   },
 }
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -8,7 +8,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ChartTypes, type DashboardRendererContext, type TileDefinition } from '../types'
+import { ChartTypes, type DashboardRendererContextInternal, type TileDefinition } from '../types'
 import type {
   Component,
 } from 'vue'
@@ -27,8 +27,9 @@ const PADDING_SIZE = parseInt(KUI_SPACE_70, 10)
 
 const props = withDefaults(defineProps<{
   definition: TileDefinition,
-  context: DashboardRendererContext,
-  height?: number
+  context: DashboardRendererContextInternal,
+  height?: number,
+  queryReady: boolean,
 }>(), {
   height: DEFAULT_TILE_HEIGHT,
 })
@@ -52,7 +53,7 @@ const componentData = computed(() => {
     rendererProps: {
       query: props.definition.query,
       context: props.context,
-      queryReady: true, // TODO: Pipelining
+      queryReady: props.queryReady,
       chartOptions: props.definition.chart,
       height: props.height - PADDING_SIZE * 2,
     },

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -10,7 +10,6 @@ import type { MetricCardOptions, RendererProps } from '../types'
 import { MetricsProvider, MetricsConsumer } from '@kong-ui-public/analytics-metric-provider'
 import { computed, type Ref } from 'vue'
 import { GranularityKeys, Timeframe, TimePeriods } from '@kong-ui-public/analytics-utilities'
-import { DEFAULT_TILE_REFRESH_INTERVAL_MS } from '../constants'
 
 // Unlike AnalyticsChart, the metric card package doesn't currently expose its options
 // in a convenient interface.
@@ -55,7 +54,8 @@ const options = computed<ProviderProps>(() => ({
   containerTitle: props.chartOptions.chartTitle,
   description: props.chartOptions.description,
   percentileLatency: props.chartOptions.percentileLatency,
-  refreshInterval: props.context.refreshInterval ?? DEFAULT_TILE_REFRESH_INTERVAL_MS,
+  refreshInterval: props.context.refreshInterval,
+  queryReady: props.queryReady,
 }))
 </script>
 

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
@@ -35,11 +35,11 @@ import useSWRV from 'swrv'
 import { useSwrvState } from '@kong-ui-public/core'
 import composables from '../composables'
 import type { AnalyticsBridge, ExploreFilter, ExploreQuery } from '@kong-ui-public/analytics-utilities'
-import { DEFAULT_TILE_REFRESH_INTERVAL_MS, INJECT_QUERY_PROVIDER } from '../constants'
-import type { DashboardRendererContext } from '../types'
+import { INJECT_QUERY_PROVIDER } from '../constants'
+import type { DashboardRendererContextInternal } from '../types'
 
 const props = defineProps<{
-  context: DashboardRendererContext
+  context: DashboardRendererContextInternal
   query: ExploreQuery
   queryReady: boolean
 }>()
@@ -96,7 +96,7 @@ const { data: v4Data, error, isValidating } = useSWRV(queryKey, async () => {
     emit('queryComplete')
   }
 }, {
-  refreshInterval: props.context.refreshInterval ?? DEFAULT_TILE_REFRESH_INTERVAL_MS,
+  refreshInterval: props.context.refreshInterval,
   revalidateOnFocus: false,
 })
 

--- a/packages/analytics/dashboard-renderer/src/constants.ts
+++ b/packages/analytics/dashboard-renderer/src/constants.ts
@@ -3,4 +3,5 @@ export const DEFAULT_TILE_HEIGHT = 170
 export const INJECT_QUERY_PROVIDER = 'analytics-query-provider'
 export const ENTITY_ID_TOKEN = '{entity-id}'
 export const CP_ID_TOKEN = '{cp-id}'
+export const TIMEFRAME_TOKEN = '{timeframe}'
 export const DEFAULT_TILE_REFRESH_INTERVAL_MS = 30 * 1000 // 30 seconds

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -1,6 +1,10 @@
 {
   "renderer": {
-    "noQueryBridge": "No query bridge provided.  Unable to render dashboard."
+    "noQueryBridge": "No query bridge provided.  Unable to render dashboard.",
+    "trendRange": {
+      "24h": "Last 24-Hour Summary",
+      "30d": "Last 30-Day Summary"
+    }
   },
   "queryDataProvider": {
     "timeRangeExceeded":  "The time range for this report is outside of your organization's data retention period"

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -5,10 +5,13 @@ import type { ExploreFilter, ExploreQuery, TimeRangeV4 } from '@kong-ui-public/a
 
 export interface DashboardRendererContext {
   filters: ExploreFilter[]
-  timeSpec: TimeRangeV4
+  timeSpec?: TimeRangeV4
   tz?: string,
   refreshInterval?: number
 }
+
+// The DashboardRenderer component fills in optional values before passing them down to the tile renderers.
+export type DashboardRendererContextInternal = Required<DashboardRendererContext>
 
 export enum ChartTypes {
   HorizontalBar = 'horizontal_bar',
@@ -466,7 +469,7 @@ export type DashboardConfig = FromSchema<typeof dashboardConfigSchema>
 
 export interface RendererProps<T> {
   query: ExploreQuery
-  context: DashboardRendererContext
+  context: DashboardRendererContextInternal
   queryReady: boolean
   chartOptions: T
   height: number

--- a/packages/analytics/dashboard-renderer/vite.config.ts
+++ b/packages/analytics/dashboard-renderer/vite.config.ts
@@ -20,6 +20,7 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       // Make sure to externalize deps that shouldn't be bundled into your library
       external: [
         '@kong-ui-public/analytics-chart',
+        '@kong-ui-public/analytics-config-store',
         '@kong-ui-public/analytics-metric-provider',
         '@kong-ui-public/analytics-utilities',
         'swrv',
@@ -28,6 +29,7 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
         // Provide global variables to use in the UMD build for externalized deps
         globals: {
           '@kong-ui-public/analytics-chart': 'kong-ui-public-analytics-chart',
+          '@kong-ui-public/analytics-config-store': 'kong-ui-public-analytics-config-store',
           '@kong-ui-public/analytics-metric-provider': 'kong-ui-public-analytics-metric-provider',
           '@kong-ui-public/analytics-utilities': 'kong-ui-public-analytics-utilities',
           swrv: 'swrv',

--- a/packages/analytics/metric-cards/sandbox/App.vue
+++ b/packages/analytics/metric-cards/sandbox/App.vue
@@ -152,6 +152,7 @@ const cardsSmall: MetricCardContainerOptions = {
 const cardsRegular: MetricCardContainerOptions = {
   cards: [...cards].slice(0, 3),
   containerTitle: 'Analytics Golden Signals',
+  containerDescription: 'Last 30-Day Summary',
   loading: false,
   hasTrendAccess: true,
   fallbackDisplayText: 'Not available',

--- a/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
+++ b/packages/analytics/metric-cards/src/components/MetricCardContainer.vue
@@ -8,6 +8,12 @@
       class="container-title"
     >
       {{ props.containerTitle }}
+      <div
+        v-if="props.containerDescription"
+        class="container-description"
+      >
+        {{ props.containerDescription }}
+      </div>
     </div>
     <div
       v-if="allCardsHaveErrors"
@@ -99,6 +105,11 @@ const props = defineProps({
     required: false,
     default: '',
   },
+  containerDescription: {
+    type: String,
+    required: false,
+    default: '',
+  },
 })
 
 const allCardsHaveErrors = computed((): boolean => props.cards.every(val => val?.hasError === true))
@@ -129,9 +140,18 @@ const formatCardValues = (card: MetricCardDef): MetricCardDisplayValue => {
   width: 100%;
 
   .container-title {
+    align-items: center;
+    display: flex;
     font-size: $kui-font-size-40;
     font-weight: $kui-font-weight-semibold;
+    justify-content: space-between;
     margin-bottom: $kui-space-50;
+
+    .container-description {
+      color: $kui-color-text-neutral;
+      font-size: $kui-font-size-20;
+      font-weight: $kui-font-weight-regular;
+    }
   }
 
   .cards-wrapper {

--- a/packages/analytics/metric-cards/src/types/metric-card.ts
+++ b/packages/analytics/metric-cards/src/types/metric-card.ts
@@ -36,5 +36,6 @@ export interface MetricCardContainerOptions {
   loading: boolean
   cardSize?: MetricCardSize
   containerTitle?: string
+  containerDescription?: string
   errorMessage?: string
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,9 @@ importers:
       '@kong-ui-public/analytics-chart':
         specifier: workspace:^
         version: link:../analytics-chart
+      '@kong-ui-public/analytics-config-store':
+        specifier: workspace:^
+        version: link:../analytics-config-store
       '@kong-ui-public/analytics-metric-provider':
         specifier: workspace:^
         version: link:../analytics-metric-provider


### PR DESCRIPTION
BREAKING CHANGE: refactor interface for analytics config store

- Change analytics config store to fetch config when first instantiated and expose refs rather than functions.
- Update dashboard renderer to fill in a default time spec based on the org's retention if one isn't provided.
- Don't issue queries until a time spec is determined.
- Fix missing feature flag functions in tests.
- Fix display of "description" property in metric cards: show in container rather than broadcasting to all cards.
- Fix title and description reactivity in metrics provider.
- Replace special timeframe token in tile descriptions.
- Fill in missing context values in the top-level renderer to save code in the tile renderers.

# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
