### PR TITLE
fix(EntityFormSection): use aria labels for fieldsets [KHCP-11030]

### DIFF
--- a/packages/entities/entities-shared/docs/entity-form-section.md
+++ b/packages/entities/entities-shared/docs/entity-form-section.md
@@ -29,7 +29,7 @@ Component that provides basic layout and styling for descriptive form section. R
 
 Renders the provided `string` as the `h4` tag content.
 
-> If the `title` prop is not provided, you must set `aria-label` attribute on the component yourself
+> If the `title` prop is not provided, you must set `aria-label` attribute on the component in your host app.
 
 #### `description`
 

--- a/packages/entities/entities-shared/docs/entity-form-section.md
+++ b/packages/entities/entities-shared/docs/entity-form-section.md
@@ -29,6 +29,8 @@ Component that provides basic layout and styling for descriptive form section. R
 
 Renders the provided `string` as the `h4` tag content.
 
+> If the `title` prop is not provided, you must set `aria-label` attribute on the component yourself
+
 #### `description`
 
 - type: `String`

--- a/packages/entities/entities-shared/src/components/entity-form-section/EntityFormSection.vue
+++ b/packages/entities/entities-shared/src/components/entity-form-section/EntityFormSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :aria-labelledby="legendID"
+    :aria-labelledby="title ? legendId : undefined"
     class="kong-ui-entity-form-section"
     :class="{ 'has-divider': hasDivider }"
     role="group"
@@ -14,7 +14,7 @@
         <component
           :is="titleTag"
           v-if="title"
-          :id="legendID"
+          :id="legendId"
           class="form-section-title"
         >
           {{ title }}
@@ -79,7 +79,7 @@ defineProps({
 })
 
 const slots = useSlots()
-const legendID = uuidv4()
+const legendId = uuidv4()
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-shared/src/components/entity-form-section/EntityFormSection.vue
+++ b/packages/entities/entities-shared/src/components/entity-form-section/EntityFormSection.vue
@@ -1,7 +1,9 @@
 <template>
-  <fieldset
+  <div
+    :aria-labelledby="legendID"
     class="kong-ui-entity-form-section"
     :class="{ 'has-divider': hasDivider }"
+    role="group"
   >
     <div class="form-section-wrapper">
       <div
@@ -12,6 +14,7 @@
         <component
           :is="titleTag"
           v-if="title"
+          :id="legendID"
           class="form-section-title"
         >
           {{ title }}
@@ -39,13 +42,14 @@
         <slot />
       </div>
     </div>
-  </fieldset>
+  </div>
 </template>
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
 import { useSlots } from 'vue'
 import type { HeaderTag } from '@kong/kongponents'
+import { v4 as uuidv4 } from 'uuid'
 
 defineProps({
   title: {
@@ -75,6 +79,7 @@ defineProps({
 })
 
 const slots = useSlots()
+const legendID = uuidv4()
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
# Summary

We were using `fieldset` element in `EnitityFormSection` component for a form group, but there was no corresponding `legend` element.
However, we can't use the `legend` element for the form title, since it's deeply nested and is not a direct child of the `fieldset` element ([`legend` need to be direct child of `fieldset`](https://www.accessibility-developer-guide.com/examples/forms/grouping-with-fieldset-legend/#legend-must-be-a-direct-child-of-fieldset)). 
Given how the component was structured, it would be a major breaking change to move the title as the direct child of the `fieldset` element. So instead opted to use ARIA roles ([ref](https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-aria)).
We're generating a unique ID for each `EnitityFormSection` component for the ARIA labels, since there can be multiple instance of the component on the same page.

[LevelAccess ticket](https://kong.hub.essentia11y.com/short-link/asIDs7vakV3cxAjf)
[KHCP-11030](https://konghq.atlassian.net/browse/KHCP-11030)


[KHCP-11030]: https://konghq.atlassian.net/browse/KHCP-11030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ