### PR TITLE
chore(deps): bump kongponents to preview [KHCP-11527]

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^1.6.8",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "@rushstack/eslint-patch": "^1.7.2",
     "@types/flat": "^5.0.5",
     "@types/js-yaml": "^4.0.9",

--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -29,7 +29,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "@types/uuid": "^9.0.8",
     "file-saver": "^2.0.5",
     "lodash.mapkeys": "^4.6.0",

--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -65,7 +65,7 @@
     "@kong-ui-public/analytics-config-store": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "pinia": ">= 2.1.7 < 3"
   }
 }

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -46,7 +46,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "json-schema-to-ts": "^3.0.1",
     "pinia": ">= 2.1.7 < 3",
     "swrv": "^1.0.4",

--- a/packages/analytics/metric-cards/package.json
+++ b/packages/analytics/metric-cards/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "vue": "^3.4.21"
   },
   "dependencies": {

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/core/documentation/package.json
+++ b/packages/core/documentation/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4"
   },

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@kong/atc-router": "1.6.0-rc.1",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "monaco-editor": "0.47.0",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vite-plugin-top-level-await": "^1.4.1",

--- a/packages/core/forms/package.json
+++ b/packages/core/forms/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "@types/lodash": "^4.14.202",
     "pug": "^3.0.2"
   },

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "vue": "^3.4.21"
   },
   "repository": {

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"
   },

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/packages/portal/document-viewer/package.json
+++ b/packages/portal/document-viewer/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "@types/prismjs": "^1.26.3",
     "@vitejs/plugin-vue-jsx": "^3.1.0",
     "vue": "^3.4.21"

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.12.11",
-    "@kong/kongponents": "9.0.0-alpha.124",
+    "@kong/kongponents": "9.0.0-pr.2124.767c6917.0",
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/uuid": "^9.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -27,8 +23,8 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue-router@4.3.0)(vue@3.4.21)
       '@rushstack/eslint-patch':
         specifier: ^1.7.2
         version: 1.7.2
@@ -256,8 +252,8 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue@3.4.21)
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
@@ -278,7 +274,7 @@ importers:
         version: 5.4.1
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/analytics/analytics-config-store:
     devDependencies:
@@ -287,16 +283,16 @@ importers:
         version: link:../analytics-utilities
       pinia:
         specifier: '>= 2.1.7 < 3'
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.21)
+        version: 2.1.7(vue@3.4.21)
       vue:
         specifier: '>= 3.4.21 < 4'
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/analytics/analytics-metric-provider:
     dependencies:
       '@kong-ui-public/core':
         specifier: 1.1.0
-        version: 1.1.0(axios@1.6.8)(swrv@1.0.4)(vue@3.4.21)
+        version: 1.1.0(axios@1.6.8)(swrv@1.0.4)
       '@kong-ui-public/metric-cards':
         specifier: workspace:^
         version: link:../metric-cards
@@ -305,7 +301,7 @@ importers:
         version: 1.6.8
       swrv:
         specifier: ^1.0.4
-        version: 1.0.4(vue@3.4.21)
+        version: 1.0.4
     devDependencies:
       '@kong-ui-public/analytics-config-store':
         specifier: workspace:^
@@ -317,11 +313,11 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)
       pinia:
         specifier: '>= 2.1.7 < 3'
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.21)
+        version: 2.1.7
 
   packages/analytics/analytics-utilities:
     dependencies:
@@ -370,20 +366,20 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue@3.4.21)
       json-schema-to-ts:
         specifier: ^3.0.1
         version: 3.0.1
       pinia:
         specifier: '>= 2.1.7 < 3'
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.21)
+        version: 2.1.7(vue@3.4.21)
       swrv:
         specifier: ^1.0.4
         version: 1.0.4(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/analytics/metric-cards:
     dependencies:
@@ -398,11 +394,11 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/core/app-layout:
     dependencies:
@@ -423,14 +419,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue-router@4.3.0)(vue@3.4.21)
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -470,7 +466,7 @@ importers:
         version: 1.6.8
       swrv:
         specifier: ^1.0.4
-        version: 1.0.4(vue@3.4.21)
+        version: 1.0.4
 
   packages/core/documentation:
     dependencies:
@@ -491,14 +487,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.3.13)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue@3.3.13)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: '>= 3.3.13 < 4'
-        version: 3.3.13(typescript@5.3.3)
+        version: 3.3.13
 
   packages/core/error-boundary:
     devDependencies:
@@ -510,7 +506,7 @@ importers:
         version: 1.8.16(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/core/expressions:
     dependencies:
@@ -525,8 +521,8 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue@3.4.21)
       monaco-editor:
         specifier: 0.47.0
         version: 0.47.0
@@ -535,19 +531,19 @@ importers:
         version: 1.1.0(monaco-editor@0.47.0)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(vite@5.2.8)
+        version: 1.4.1
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.2.8)
+        version: 3.3.0
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/core/forms:
     dependencies:
       '@kong/icons':
         specifier: ^1.8.16
-        version: 1.8.16(vue@3.4.21)
+        version: 1.8.16
       fecha:
         specifier: ^4.2.3
         version: 4.2.3
@@ -562,8 +558,8 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
@@ -575,7 +571,7 @@ importers:
     dependencies:
       '@formatjs/intl':
         specifier: ^2.10.1
-        version: 2.10.1(typescript@5.3.3)
+        version: 2.10.1
       flat:
         specifier: ^6.0.1
         version: 6.0.1
@@ -589,11 +585,11 @@ importers:
         specifier: workspace:^
         version: link:../i18n
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/core/sandbox-layout:
     dependencies:
@@ -605,11 +601,11 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue-router@4.3.0)(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -630,14 +626,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -655,14 +651,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -680,14 +676,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -705,14 +701,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -730,14 +726,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -752,14 +748,14 @@ importers:
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -777,14 +773,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -823,14 +819,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -848,14 +844,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -879,14 +875,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -904,14 +900,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -929,14 +925,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -954,14 +950,14 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
       axios:
         specifier: ^1.6.8
         version: 1.6.8
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -979,17 +975,17 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue@3.4.21)
       '@types/prismjs':
         specifier: ^1.26.3
         version: 1.26.3
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.1.0
-        version: 3.1.0(vite@5.2.8)(vue@3.4.21)
+        version: 3.1.0(vue@3.4.21)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/portal/spec-renderer:
     dependencies:
@@ -1013,11 +1009,11 @@ importers:
         specifier: 1.12.11
         version: 1.12.11
       '@kong/kongponents':
-        specifier: 9.0.0-alpha.124
-        version: 9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+        specifier: 9.0.0-pr.2124.767c6917.0
+        version: 9.0.0-pr.2124.767c6917.0(vue@3.4.21)
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.0
-        version: 1.1.0(vite@5.2.8)
+        version: 1.1.0
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -1029,13 +1025,13 @@ importers:
         version: 12.1.3
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
 
   packages/portal/swagger-ui-web-component:
     dependencies:
       '@kong/swagger-ui-kong-theme-universal':
         specifier: ^4.3.3
-        version: 4.3.3(react-dom@17.0.2)(react@17.0.2)(vue-router@4.3.0)(vue@3.4.21)
+        version: 4.3.3(react-dom@17.0.2)(react@17.0.2)
       react:
         specifier: 17.0.2
         version: 17.0.2
@@ -1121,7 +1117,7 @@ packages:
       '@babel/traverse': 7.23.4
       '@babel/types': 7.24.0
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1433,7 +1429,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
       '@babel/types': 7.24.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1451,7 +1447,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
       '@babel/types': 7.24.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2076,7 +2072,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.3.0
@@ -2151,7 +2147,7 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@formatjs/intl@2.10.1(typescript@5.3.3):
+  /@formatjs/intl@2.10.1:
     resolution: {integrity: sha512-dsLG15U7xDi8yzKf4hcAWSsCaez3XrjTO2oaRHPyHtXLm1aEzYbDw6bClo/HMHu+iwS5GbDqT3DV+hYP2ylScg==}
     peerDependencies:
       typescript: ^4.7 || 5
@@ -2166,7 +2162,6 @@ packages:
       '@formatjs/intl-listformat': 7.5.5
       intl-messageformat: 10.5.11
       tslib: 2.6.2
-      typescript: 5.3.3
     dev: false
 
   /@humanwhocodes/config-array@0.11.14:
@@ -2174,7 +2169,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2277,7 +2272,7 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@kong-ui-public/core@1.1.0(axios@1.6.8)(swrv@1.0.4)(vue@3.4.21):
+  /@kong-ui-public/core@1.1.0(axios@1.6.8)(swrv@1.0.4):
     resolution: {integrity: sha512-j1kK07/zDyxwePi1EX1rZ+3iL955VdhZiodzeT5ift7iVQTiPt9VNUFu9+IXJ/AxHfuYu/gaL+gily9TsJTX3w==}
     peerDependencies:
       axios: ^1.4.0
@@ -2286,8 +2281,7 @@ packages:
     dependencies:
       axios: 1.6.8
       date-fns: 2.30.0
-      swrv: 1.0.4(vue@3.4.21)
-      vue: 3.4.21(typescript@5.3.3)
+      swrv: 1.0.4
     dev: false
 
   /@kong/atc-router@1.6.0-rc.1:
@@ -2298,23 +2292,11 @@ packages:
     resolution: {integrity: sha512-+zgR6Ti4Joj85yD/KJzE3ja6Y0khxh9vapNnkOyGtLAUnCLstkH7WfLLhM22Qi7K5q/J2R1kWuR3X+XMp6U2mQ==}
     dev: true
 
-  /@kong/icons@1.8.14(vue@3.3.13):
-    resolution: {integrity: sha512-nJUTtLpqelKCTY8lS8VByWaHYUq1CuB5cBUX/q2FEDu5o6IKH/B7fEDQpb/pB1lLRYTqZXneHR/lGYjxy4u8eQ==}
+  /@kong/icons@1.8.16:
+    resolution: {integrity: sha512-aQvZUrX9Px7SqQkGlZnjlAf7aubW3mFobF9ojJ88lMPZ1XN4gDI0TKBcWtvGCtCqgbvtqe0LJD9gqAjTRqArEg==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       vue: '>= 3.3.4 < 4'
-    dependencies:
-      vue: 3.3.13(typescript@5.3.3)
-    dev: true
-
-  /@kong/icons@1.8.14(vue@3.4.21):
-    resolution: {integrity: sha512-nJUTtLpqelKCTY8lS8VByWaHYUq1CuB5cBUX/q2FEDu5o6IKH/B7fEDQpb/pB1lLRYTqZXneHR/lGYjxy4u8eQ==}
-    engines: {node: '>=18.17.0'}
-    peerDependencies:
-      vue: '>= 3.3.4 < 4'
-    dependencies:
-      vue: 3.4.21(typescript@5.3.3)
-    dev: true
 
   /@kong/icons@1.8.16(vue@3.3.13):
     resolution: {integrity: sha512-aQvZUrX9Px7SqQkGlZnjlAf7aubW3mFobF9ojJ88lMPZ1XN4gDI0TKBcWtvGCtCqgbvtqe0LJD9gqAjTRqArEg==}
@@ -2322,8 +2304,7 @@ packages:
     peerDependencies:
       vue: '>= 3.3.4 < 4'
     dependencies:
-      vue: 3.3.13(typescript@5.3.3)
-    dev: false
+      vue: 3.3.13
 
   /@kong/icons@1.8.16(vue@3.4.21):
     resolution: {integrity: sha512-aQvZUrX9Px7SqQkGlZnjlAf7aubW3mFobF9ojJ88lMPZ1XN4gDI0TKBcWtvGCtCqgbvtqe0LJD9gqAjTRqArEg==}
@@ -2331,9 +2312,9 @@ packages:
     peerDependencies:
       vue: '>= 3.3.4 < 4'
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
-  /@kong/kongponents@8.127.0(vue-router@4.3.0)(vue@3.4.21):
+  /@kong/kongponents@8.127.0:
     resolution: {integrity: sha512-C/MFT+OZtyul62ElgHEggqMYPbLjXiRJg5GE3il8MZpaep2D5QV+F5UQ7frbA98TkZCCVBD4LpR0OmiwXKs+tg==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
@@ -2344,51 +2325,69 @@ packages:
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       focus-trap: 7.5.4
-      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.4.21)
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
       popper.js: 1.16.1
       sortablejs: 1.15.2
-      swrv: 1.0.4(vue@3.4.21)
+      swrv: 1.0.4
       uuid: 9.0.1
-      v-calendar: 3.0.0-alpha.8(vue@3.4.21)
-      vue: 3.4.21(typescript@5.3.3)
-      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.4.21)
-      vue-router: 4.3.0(vue@3.4.21)
+      v-calendar: 3.0.0-alpha.8
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: false
 
-  /@kong/kongponents@9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.3.13):
-    resolution: {integrity: sha512-L+yr60YdcL66Ush7Knx3yaYlJMOcUHj2aH5K5zWykMLcCrgg5L7H+7X7cLeCD+Fw+DyJvv9RgR/Cn/2ZTIxKCQ==}
+  /@kong/kongponents@9.0.0-pr.2124.767c6917.0:
+    resolution: {integrity: sha512-IfhTbct00An2MYLnAILgkrLbcBF5UBd9xrLQvwRl7688OvsZpNCN0+xsjT1poFoE74FsqKf+66UCzZwGQYeQMg==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
-      axios: ^1.6.7
+      axios: ^1.6.8
       vue: '>= 3.3.4 < 4'
       vue-router: ^4.3.0
     dependencies:
-      '@kong/icons': 1.8.14(vue@3.3.13)
+      '@kong/icons': 1.8.16
+      '@popperjs/core': 2.11.8
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      focus-trap: 7.5.4
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
+      popper.js: 1.16.1
+      sortablejs: 1.15.2
+      swrv: 1.0.4
+      uuid: 9.0.1
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
+    dev: true
+
+  /@kong/kongponents@9.0.0-pr.2124.767c6917.0(axios@1.6.8):
+    resolution: {integrity: sha512-IfhTbct00An2MYLnAILgkrLbcBF5UBd9xrLQvwRl7688OvsZpNCN0+xsjT1poFoE74FsqKf+66UCzZwGQYeQMg==}
+    engines: {node: '>=v16.20.2'}
+    peerDependencies:
+      axios: ^1.6.8
+      vue: '>= 3.3.4 < 4'
+      vue-router: ^4.3.0
+    dependencies:
+      '@kong/icons': 1.8.16
       '@popperjs/core': 2.11.8
       axios: 1.6.8
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       focus-trap: 7.5.4
-      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.3.13)
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)
       popper.js: 1.16.1
       sortablejs: 1.15.2
-      swrv: 1.0.4(vue@3.3.13)
+      swrv: 1.0.4
       uuid: 9.0.1
-      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.3.13)
-      vue: 3.3.13(typescript@5.3.3)
-      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.3.13)
-      vue-router: 4.3.0(vue@3.4.21)
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)
     dev: true
 
-  /@kong/kongponents@9.0.0-alpha.124(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21):
-    resolution: {integrity: sha512-L+yr60YdcL66Ush7Knx3yaYlJMOcUHj2aH5K5zWykMLcCrgg5L7H+7X7cLeCD+Fw+DyJvv9RgR/Cn/2ZTIxKCQ==}
+  /@kong/kongponents@9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-IfhTbct00An2MYLnAILgkrLbcBF5UBd9xrLQvwRl7688OvsZpNCN0+xsjT1poFoE74FsqKf+66UCzZwGQYeQMg==}
     engines: {node: '>=v16.20.2'}
     peerDependencies:
-      axios: ^1.6.7
+      axios: ^1.6.8
       vue: '>= 3.3.4 < 4'
       vue-router: ^4.3.0
     dependencies:
-      '@kong/icons': 1.8.14(vue@3.4.21)
+      '@kong/icons': 1.8.16(vue@3.4.21)
       '@popperjs/core': 2.11.8
       axios: 1.6.8
       date-fns: 2.30.0
@@ -2400,9 +2399,80 @@ packages:
       swrv: 1.0.4(vue@3.4.21)
       uuid: 9.0.1
       v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.4.21)
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
       vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.4.21)
       vue-router: 4.3.0(vue@3.4.21)
+    dev: true
+
+  /@kong/kongponents@9.0.0-pr.2124.767c6917.0(axios@1.6.8)(vue@3.3.13):
+    resolution: {integrity: sha512-IfhTbct00An2MYLnAILgkrLbcBF5UBd9xrLQvwRl7688OvsZpNCN0+xsjT1poFoE74FsqKf+66UCzZwGQYeQMg==}
+    engines: {node: '>=v16.20.2'}
+    peerDependencies:
+      axios: ^1.6.8
+      vue: '>= 3.3.4 < 4'
+      vue-router: ^4.3.0
+    dependencies:
+      '@kong/icons': 1.8.16(vue@3.3.13)
+      '@popperjs/core': 2.11.8
+      axios: 1.6.8
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      focus-trap: 7.5.4
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.3.13)
+      popper.js: 1.16.1
+      sortablejs: 1.15.2
+      swrv: 1.0.4(vue@3.3.13)
+      uuid: 9.0.1
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.3.13)
+      vue: 3.3.13
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.3.13)
+    dev: true
+
+  /@kong/kongponents@9.0.0-pr.2124.767c6917.0(vue-router@4.3.0)(vue@3.4.21):
+    resolution: {integrity: sha512-IfhTbct00An2MYLnAILgkrLbcBF5UBd9xrLQvwRl7688OvsZpNCN0+xsjT1poFoE74FsqKf+66UCzZwGQYeQMg==}
+    engines: {node: '>=v16.20.2'}
+    peerDependencies:
+      axios: ^1.6.8
+      vue: '>= 3.3.4 < 4'
+      vue-router: ^4.3.0
+    dependencies:
+      '@kong/icons': 1.8.16(vue@3.4.21)
+      '@popperjs/core': 2.11.8
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      focus-trap: 7.5.4
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.4.21)
+      popper.js: 1.16.1
+      sortablejs: 1.15.2
+      swrv: 1.0.4(vue@3.4.21)
+      uuid: 9.0.1
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.4.21)
+      vue: 3.4.21
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.4.21)
+      vue-router: 4.3.0(vue@3.4.21)
+    dev: true
+
+  /@kong/kongponents@9.0.0-pr.2124.767c6917.0(vue@3.4.21):
+    resolution: {integrity: sha512-IfhTbct00An2MYLnAILgkrLbcBF5UBd9xrLQvwRl7688OvsZpNCN0+xsjT1poFoE74FsqKf+66UCzZwGQYeQMg==}
+    engines: {node: '>=v16.20.2'}
+    peerDependencies:
+      axios: ^1.6.8
+      vue: '>= 3.3.4 < 4'
+      vue-router: ^4.3.0
+    dependencies:
+      '@kong/icons': 1.8.16(vue@3.4.21)
+      '@popperjs/core': 2.11.8
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      focus-trap: 7.5.4
+      focus-trap-vue: 4.0.3(focus-trap@7.5.4)(vue@3.4.21)
+      popper.js: 1.16.1
+      sortablejs: 1.15.2
+      swrv: 1.0.4(vue@3.4.21)
+      uuid: 9.0.1
+      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.4.21)
+      vue: 3.4.21
+      vue-draggable-next: 2.2.1(sortablejs@1.15.2)(vue@3.4.21)
     dev: true
 
   /@kong/markdown@1.3.4(vue@3.3.13):
@@ -2432,20 +2502,20 @@ packages:
       markdown-it-textual-uml: 0.17.1
       mermaid: 10.9.0
       uuid: 9.0.1
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     transitivePeerDependencies:
       - '@types/markdown-it'
       - '@vue/composition-api'
       - supports-color
     dev: false
 
-  /@kong/swagger-ui-kong-theme-universal@4.3.3(react-dom@17.0.2)(react@17.0.2)(vue-router@4.3.0)(vue@3.4.21):
+  /@kong/swagger-ui-kong-theme-universal@4.3.3(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-g89NLf7Vu19BJ157fVUkLIrjzTmNE74zGfzktK2rxdZgIUegt4VBDsG8K0MAxDwQELQqSK3kPkamgdD9j1eV3Q==}
     peerDependencies:
       react: 17.0.2
     dependencies:
       '@braintree/sanitize-url': 6.0.2
-      '@kong/kongponents': 8.127.0(vue-router@4.3.0)(vue@3.4.21)
+      '@kong/kongponents': 8.127.0
       '@kyleshockey/xml': 1.0.2
       classnames: 2.3.2
       curl-to-har: 1.0.1
@@ -2583,7 +2653,7 @@ packages:
     resolution: {integrity: sha512-1BeEB+DbtmDMUAfvbNUj5Hso8cSl2sBVK2iTyOMAqhfDVLdh+/9+D0JmQHaCeUk/vuJoMhOwbweZvh55wHxm4w==}
     dev: false
 
-  /@modyfi/vite-plugin-yaml@1.1.0(vite@5.2.8):
+  /@modyfi/vite-plugin-yaml@1.1.0:
     resolution: {integrity: sha512-L26xfzkSo1yamODCAtk/ipVlL6OEw2bcJ92zunyHu8zxi7+meV0zefA9xscRMDCsMY8xL3C3wi3DhMiPxcbxbw==}
     peerDependencies:
       vite: ^3.2.7 || ^4.0.5 || ^5.0.5
@@ -2591,7 +2661,6 @@ packages:
       '@rollup/pluginutils': 5.1.0
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
-      vite: 5.2.8(@types/node@18.19.29)(sass@1.71.1)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -4243,7 +4312,7 @@ packages:
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.0
@@ -4269,7 +4338,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -4296,7 +4365,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       ts-api-utils: 1.0.1(typescript@5.3.3)
       typescript: 5.3.3
@@ -4320,7 +4389,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -4374,6 +4443,21 @@ packages:
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.3)
       vite: 5.2.8(@types/node@18.19.29)(sass@1.71.1)
       vue: 3.4.21(typescript@5.3.3)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vitejs/plugin-vue-jsx@3.1.0(vue@3.4.21):
+    resolution: {integrity: sha512-w9M6F3LSEU5kszVb9An2/MmXNxocAnUb3WhRr8bHlimhDrXNt6n6D2nJQR3UXpGlZHh/EsgouOHCsM8V3Ln+WA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
+    dependencies:
+      '@babel/core': 7.23.3
+      '@babel/plugin-transform-typescript': 7.23.4(@babel/core@7.23.3)
+      '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.3)
+      vue: 3.4.21
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4555,6 +4639,7 @@ packages:
 
   /@vue/devtools-api@6.6.1:
     resolution: {integrity: sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA==}
+    dev: true
 
   /@vue/devtools-core@7.0.25(vite@5.2.8)(vue@3.4.21):
     resolution: {integrity: sha512-aCsY4J6SvSBDuGdYADszByT0wy0GgpgdCApxcZzQEqYlyVchX7vqznJQrm7Y1GCLqAvoLaxsQqew7Cz+KQ3Idg==}
@@ -4703,7 +4788,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.3.13
       '@vue/shared': 3.3.13
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
 
   /@vue/server-renderer@3.4.21(vue@3.4.21):
     resolution: {integrity: sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==}
@@ -4712,7 +4797,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.4.21
       '@vue/shared': 3.4.21
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /@vue/shared@3.3.13:
     resolution: {integrity: sha512-/zYUwiHD8j7gKx2argXEMCUXVST6q/21DFU0sTfNX0URJroCe3b1UF6vLJ3lQDfLNIiiRl2ONp7Nh5UVWS6QnA==}
@@ -5008,7 +5093,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5017,7 +5102,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5026,7 +5111,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -5043,6 +5128,9 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.12.0
     dev: true
@@ -6110,6 +6198,27 @@ packages:
     engines: {node: ^12.20.0 || >=14}
     dev: true
 
+  /commitizen@4.3.0:
+    resolution: {integrity: sha512-H0iNtClNEhT0fotHvGV3E9tDejDeS04sN1veIebsKYGMuGscFaswRoYJKmT3eW85eIJAs0F28bG2+a/9wCOfPw==}
+    engines: {node: '>= 12'}
+    hasBin: true
+    dependencies:
+      cachedir: 2.3.0
+      cz-conventional-changelog: 3.3.0(@types/node@18.19.29)(typescript@5.3.3)
+      dedent: 0.7.0
+      detect-indent: 6.1.0
+      find-node-modules: 2.1.3
+      find-root: 1.1.0
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      inquirer: 8.2.5
+      is-utf8: 0.2.1
+      lodash: 4.17.21
+      minimist: 1.2.7
+      strip-bom: 4.0.0
+      strip-json-comments: 3.1.1
+    dev: true
+
   /commitizen@4.3.0(@types/node@18.19.29)(typescript@5.3.3):
     resolution: {integrity: sha512-H0iNtClNEhT0fotHvGV3E9tDejDeS04sN1veIebsKYGMuGscFaswRoYJKmT3eW85eIJAs0F28bG2+a/9wCOfPw==}
     engines: {node: '>= 12'}
@@ -6595,7 +6704,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.0(@types/node@18.19.29)(typescript@5.3.3)
+      commitizen: 4.3.0
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
@@ -6963,6 +7072,17 @@ packages:
     dependencies:
       ms: 2.0.0
 
+  /debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
   /debug@3.2.7(supports-color@8.1.1):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -6975,6 +7095,17 @@ packages:
       supports-color: 8.1.1
     dev: true
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -6986,6 +7117,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -7600,7 +7732,7 @@ packages:
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       is-core-module: 2.13.1
       resolve: 1.22.4
     transitivePeerDependencies:
@@ -7610,7 +7742,7 @@ packages:
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       is-core-module: 2.13.1
       resolve: 1.22.4
     transitivePeerDependencies:
@@ -7639,7 +7771,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -7692,7 +7824,7 @@ packages:
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -7835,7 +7967,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -8338,6 +8470,14 @@ packages:
       tabbable: 6.2.0
     dev: false
 
+  /focus-trap-vue@4.0.3(focus-trap@7.5.4):
+    resolution: {integrity: sha512-cIX5rybkCAlNZ4IHYJ3nCFIsipDDljJHHjtTO2IgYWkVYg7X9ipUVdab3HzYp88kmHgMwjcB71LYnXRRsF6ZqQ==}
+    peerDependencies:
+      focus-trap: ^7.0.0
+      vue: ^3.0.0
+    dependencies:
+      focus-trap: 7.5.4
+
   /focus-trap-vue@4.0.3(focus-trap@7.5.4)(vue@3.3.13):
     resolution: {integrity: sha512-cIX5rybkCAlNZ4IHYJ3nCFIsipDDljJHHjtTO2IgYWkVYg7X9ipUVdab3HzYp88kmHgMwjcB71LYnXRRsF6ZqQ==}
     peerDependencies:
@@ -8345,7 +8485,7 @@ packages:
       vue: ^3.0.0
     dependencies:
       focus-trap: 7.5.4
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     dev: true
 
   /focus-trap-vue@4.0.3(focus-trap@7.5.4)(vue@3.4.21):
@@ -8355,7 +8495,7 @@ packages:
       vue: ^3.0.0
     dependencies:
       focus-trap: 7.5.4
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /focus-trap@7.5.4:
     resolution: {integrity: sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==}
@@ -9139,7 +9279,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9149,7 +9289,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9198,7 +9338,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9208,7 +9348,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10999,7 +11139,7 @@ packages:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -12254,7 +12394,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /pinia@2.1.7(typescript@5.3.3)(vue@3.4.21):
+  /pinia@2.1.7:
     resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
     peerDependencies:
       '@vue/composition-api': ^1.4.0
@@ -12267,8 +12407,23 @@ packages:
         optional: true
     dependencies:
       '@vue/devtools-api': 6.6.1
-      typescript: 5.3.3
-      vue: 3.4.21(typescript@5.3.3)
+      vue-demi: 0.14.7
+    dev: true
+
+  /pinia@2.1.7(vue@3.4.21):
+    resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
+    peerDependencies:
+      '@vue/composition-api': ^1.4.0
+      typescript: '>=4.4.4'
+      vue: ^2.6.14 || ^3.3.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/devtools-api': 6.6.1
+      vue: 3.4.21
       vue-demi: 0.14.7(vue@3.4.21)
     dev: true
 
@@ -13783,7 +13938,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -13794,7 +13949,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -13878,7 +14033,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -13892,7 +14047,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -14251,7 +14406,7 @@ packages:
       cosmiconfig: 9.0.0(typescript@5.3.3)
       css-functions-list: 3.2.1
       css-tree: 2.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 8.0.0
@@ -14312,6 +14467,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-hyperlinks@3.0.0:
     resolution: {integrity: sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==}
@@ -14409,12 +14565,17 @@ packages:
       - rollup
     dev: false
 
+  /swrv@1.0.4:
+    resolution: {integrity: sha512-zjEkcP8Ywmj+xOJW3lIT65ciY/4AL4e/Or7Gj0MzU3zBJNMdJiT8geVZhINavnlHRMMCcJLHhraLTAiDOTmQ9g==}
+    peerDependencies:
+      vue: '>=3.2.26 < 4'
+
   /swrv@1.0.4(vue@3.3.13):
     resolution: {integrity: sha512-zjEkcP8Ywmj+xOJW3lIT65ciY/4AL4e/Or7Gj0MzU3zBJNMdJiT8geVZhINavnlHRMMCcJLHhraLTAiDOTmQ9g==}
     peerDependencies:
       vue: '>=3.2.26 < 4'
     dependencies:
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     dev: true
 
   /swrv@1.0.4(vue@3.4.21):
@@ -14422,7 +14583,8 @@ packages:
     peerDependencies:
       vue: '>=3.2.26 < 4'
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
+    dev: true
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -14810,7 +14972,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 1.0.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       make-fetch-happen: 11.1.1
     transitivePeerDependencies:
       - supports-color
@@ -14821,7 +14983,7 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
@@ -14973,6 +15135,7 @@ packages:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
@@ -15138,7 +15301,7 @@ packages:
       sade: 1.8.1
     dev: false
 
-  /v-calendar@3.0.0-alpha.8(vue@3.4.21):
+  /v-calendar@3.0.0-alpha.8:
     resolution: {integrity: sha512-T23H5UbK0EomrwArlF/jrT2LFbV/lu+Bp9JroZ1paN6rPoaMyvE+HrLxvAmUgi+pODrdTURDMzM3+WPgeFKEBQ==}
     peerDependencies:
       vue: ^3.1.0
@@ -15148,8 +15311,22 @@ packages:
       date-fns: 2.30.0
       date-fns-tz: 1.3.8(date-fns@2.30.0)
       lodash: 4.17.21
-      vue: 3.4.21(typescript@5.3.3)
     dev: false
+
+  /v-calendar@3.1.2(@popperjs/core@2.11.8):
+    resolution: {integrity: sha512-QDWrnp4PWCpzUblctgo4T558PrHgHzDtQnTeUNzKxfNf29FkCeFpwGd9bKjAqktaa2aJLcyRl45T5ln1ku34kg==}
+    peerDependencies:
+      '@popperjs/core': ^2.0.0
+      vue: ^3.2.0
+    dependencies:
+      '@popperjs/core': 2.11.8
+      '@types/lodash': 4.17.0
+      '@types/resize-observer-browser': 0.1.11
+      date-fns: 2.30.0
+      date-fns-tz: 2.0.1(date-fns@2.30.0)
+      lodash: 4.17.21
+      vue-screen-utils: 1.0.0-beta.13
+    dev: true
 
   /v-calendar@3.1.2(@popperjs/core@2.11.8)(vue@3.3.13):
     resolution: {integrity: sha512-QDWrnp4PWCpzUblctgo4T558PrHgHzDtQnTeUNzKxfNf29FkCeFpwGd9bKjAqktaa2aJLcyRl45T5ln1ku34kg==}
@@ -15163,7 +15340,7 @@ packages:
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       lodash: 4.17.21
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
       vue-screen-utils: 1.0.0-beta.13(vue@3.3.13)
     dev: true
 
@@ -15179,7 +15356,7 @@ packages:
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       lodash: 4.17.21
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
       vue-screen-utils: 1.0.0-beta.13(vue@3.4.21)
     dev: true
 
@@ -15244,7 +15421,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.2.8(@types/node@18.19.29)(sass@1.71.1)
@@ -15284,7 +15461,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 10.0.3
@@ -15305,7 +15482,7 @@ packages:
       monaco-editor: 0.47.0
     dev: true
 
-  /vite-plugin-top-level-await@1.4.1(vite@5.2.8):
+  /vite-plugin-top-level-await@1.4.1:
     resolution: {integrity: sha512-hogbZ6yT7+AqBaV6lK9JRNvJDn4/IJvHLu6ET06arNfo0t2IsyCaon7el9Xa8OumH+ESuq//SDf8xscZFE0rWw==}
     peerDependencies:
       vite: '>=2.8'
@@ -15313,7 +15490,6 @@ packages:
       '@rollup/plugin-virtual': 3.0.2
       '@swc/core': 1.4.11
       uuid: 9.0.1
-      vite: 5.2.8(@types/node@18.19.29)(sass@1.71.1)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
@@ -15359,12 +15535,10 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-wasm@3.3.0(vite@5.2.8):
+  /vite-plugin-wasm@3.3.0:
     resolution: {integrity: sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==}
     peerDependencies:
       vite: ^2 || ^3 || ^4 || ^5
-    dependencies:
-      vite: 5.2.8(@types/node@18.19.29)(sass@1.71.1)
     dev: true
 
   /vite@5.2.8(@types/node@18.19.29)(sass@1.71.1):
@@ -15438,7 +15612,7 @@ packages:
       '@vitest/utils': 1.3.1
       acorn-walk: 8.3.2
       chai: 4.3.10
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       execa: 8.0.1
       jsdom: 24.0.0
       local-pkg: 0.5.0
@@ -15482,11 +15656,24 @@ packages:
       vue: ^3.0.0-0 || ^2.7.0
     dependencies:
       chart.js: 4.4.2
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /vue-component-type-helpers@2.0.7:
     resolution: {integrity: sha512-7e12Evdll7JcTIocojgnCgwocX4WzIYStGClBQ+QuWPinZo/vQolv2EMq4a3lg16TKfwWafLimG77bxb56UauA==}
+    dev: true
+
+  /vue-demi@0.14.7:
+    resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
     dev: true
 
   /vue-demi@0.14.7(vue@3.3.13):
@@ -15501,7 +15688,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     dev: false
 
   /vue-demi@0.14.7(vue@3.4.21):
@@ -15516,8 +15703,16 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: true
+
+  /vue-draggable-next@2.2.1(sortablejs@1.15.2):
+    resolution: {integrity: sha512-EAMS1IRHF0kZO0o5PMOinsQsXIqsrKT1hKmbICxG3UEtn7zLFkLxlAtajcCcUTisNvQ6TtCB5COjD9a1raNADw==}
+    peerDependencies:
+      sortablejs: ^1.14.0
+      vue: ^3.2.2
+    dependencies:
+      sortablejs: 1.15.2
 
   /vue-draggable-next@2.2.1(sortablejs@1.15.2)(vue@3.3.13):
     resolution: {integrity: sha512-EAMS1IRHF0kZO0o5PMOinsQsXIqsrKT1hKmbICxG3UEtn7zLFkLxlAtajcCcUTisNvQ6TtCB5COjD9a1raNADw==}
@@ -15526,7 +15721,7 @@ packages:
       vue: ^3.2.2
     dependencies:
       sortablejs: 1.15.2
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     dev: true
 
   /vue-draggable-next@2.2.1(sortablejs@1.15.2)(vue@3.4.21):
@@ -15536,7 +15731,8 @@ packages:
       vue: ^3.2.2
     dependencies:
       sortablejs: 1.15.2
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
+    dev: true
 
   /vue-eslint-parser@9.3.1(eslint@8.57.0):
     resolution: {integrity: sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==}
@@ -15544,7 +15740,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -15562,7 +15758,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.57.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -15580,14 +15776,21 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.6.1
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
+    dev: true
+
+  /vue-screen-utils@1.0.0-beta.13:
+    resolution: {integrity: sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==}
+    peerDependencies:
+      vue: ^3.2.0
+    dev: true
 
   /vue-screen-utils@1.0.0-beta.13(vue@3.3.13):
     resolution: {integrity: sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
-      vue: 3.3.13(typescript@5.3.3)
+      vue: 3.3.13
     dev: true
 
   /vue-screen-utils@1.0.0-beta.13(vue@3.4.21):
@@ -15595,7 +15798,7 @@ packages:
     peerDependencies:
       vue: ^3.2.0
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: true
 
   /vue-template-compiler@2.7.14:
@@ -15617,7 +15820,7 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /vue@3.3.13(typescript@5.3.3):
+  /vue@3.3.13:
     resolution: {integrity: sha512-LDnUpQvDgsfc0u/YgtAgTMXJlJQqjkxW1PVcOnJA5cshPleULDjHi7U45pl2VJYazSSvLH8UKcid/kzH8I0a0Q==}
     peerDependencies:
       typescript: '*'
@@ -15630,7 +15833,20 @@ packages:
       '@vue/runtime-dom': 3.3.13
       '@vue/server-renderer': 3.3.13(vue@3.3.13)
       '@vue/shared': 3.3.13
-      typescript: 5.3.3
+
+  /vue@3.4.21:
+    resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-sfc': 3.4.21
+      '@vue/runtime-dom': 3.4.21
+      '@vue/server-renderer': 3.4.21(vue@3.4.21)
+      '@vue/shared': 3.4.21
 
   /vue@3.4.21(typescript@5.3.3):
     resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
@@ -15646,6 +15862,7 @@ packages:
       '@vue/server-renderer': 3.4.21(vue@3.4.21)
       '@vue/shared': 3.4.21
       typescript: 5.3.3
+    dev: true
 
   /w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -16211,3 +16428,7 @@ packages:
   /zenscroll@4.0.2:
     resolution: {integrity: sha512-jEA1znR7b4C/NnaycInCU6h/d15ZzCd1jmsruqOKnZP6WXQSMH3W2GL+OXbkruslU4h+Tzuos0HdswzRUk/Vgg==}
     dev: false
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
# Summary

Jira: https://konghq.atlassian.net/browse/KHCP-11527

Phase 10 adoption of components reskinned in alpha version of Kongponents v9 release. Includes these components:
- `KCodeBlock`
- `KCatalog`
- `KCollapse`
- `KStepper`

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
