### PR TITLE
fix(entities-plugins): incorrect icons caused by v-for keys [KM-113]

### DIFF
--- a/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
@@ -32,10 +32,10 @@
       @plugin-clicked="(plugin: PluginType) => emitPluginData(plugin)"
     />
 
-    <template v-for="(group, idx) in PluginGroupArray">
+    <template v-for="group in PluginGroupArray">
       <div
         v-if="displayedPlugins[group]"
-        :key="idx"
+        :key="group"
       >
         <PluginSelectGroup
           v-model="shouldCollapsed[group]"

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectGroup.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectGroup.vue
@@ -17,8 +17,8 @@
     <template #visible-content>
       <div class="plugin-card-container">
         <PluginSelectCard
-          v-for="(plugin, index) in getPluginCards('visible', props.plugins, props.pluginsPerRow)"
-          :key="`plugin-card-${index}`"
+          v-for="plugin in getPluginCards('visible', props.plugins, props.pluginsPerRow)"
+          :key="`plugin-card-${plugin.id}`"
           :config="config"
           :navigate-on-click="navigateOnClick"
           :plugin="plugin"
@@ -29,8 +29,8 @@
 
     <div class="plugin-card-container">
       <PluginSelectCard
-        v-for="(plugin, index) in getPluginCards('hidden', props.plugins, props.pluginsPerRow)"
-        :key="`plugin-card-${index}`"
+        v-for="plugin in getPluginCards('hidden', props.plugins, props.pluginsPerRow)"
+        :key="`plugin-card-${plugin.id}`"
         :config="config"
         :navigate-on-click="navigateOnClick"
         :plugin="plugin"


### PR DESCRIPTION
# Summary

This PR fixes an issue where incorrect plugin icons were displayed while filtering plugins in `PluginSelect`. After inspecting the build result, the plugin icon mapping is deemed correct. I suspect this was caused by the index-based `key` in `v-for` being reused.

Plugin icons are correct without filtering:

<img width="1728" alt="Screenshot 2024-04-18 at 10 55 25" src="https://github.com/Kong/public-ui-components/assets/5277268/d1c20d04-6de0-40f6-a7fe-3a21345bf357">

Some plugin icons are incorrect while filtering:

<img width="1109" alt="Screenshot 2024-04-18 at 11 06 52" src="https://github.com/Kong/public-ui-components/assets/5277268/7e4960fa-3c7e-40ee-be9c-0394f7030daa">

<img width="1520" alt="Screenshot 2024-04-18 at 11 04 45" src="https://github.com/Kong/public-ui-components/assets/5277268/1578c9b7-e2a7-4083-b5b7-aa872dd4ab89">

KM-113
