### PR TITLE
chore: loosen peer dependency ranges

### DIFF
--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -59,7 +59,7 @@
     "@kong-ui-public/analytics-config-store": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.0.0-alpha.113"
+    "@kong/kongponents": "^9.0.0-alpha.113"
   },
   "devDependencies": {
     "@kong-ui-public/analytics-config-store": "workspace:^",

--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -59,7 +59,7 @@
     "@kong-ui-public/analytics-config-store": "workspace:^",
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "^9.0.0-alpha.113"
+    "@kong/kongponents": "^9.0.0-alpha.146"
   },
   "devDependencies": {
     "@kong-ui-public/analytics-config-store": "workspace:^",

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -64,8 +64,8 @@
     "errorLimit": "2048KB"
   },
   "peerDependencies": {
-    "@kong/atc-router": "1.6.0-rc.1",
-    "@kong/kongponents": "9.0.0-alpha.105",
+    "@kong/atc-router": "^1.6.0-rc.1",
+    "@kong/kongponents": "^9.0.0-alpha.105",
     "monaco-editor": "0.21.3",
     "vue": "^3.4.21"
   },

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@kong/atc-router": "^1.6.0-rc.1",
-    "@kong/kongponents": "^9.0.0-alpha.105",
+    "@kong/kongponents": "^9.0.0-alpha.146",
     "monaco-editor": "0.21.3",
     "vue": "^3.4.21"
   },


### PR DESCRIPTION
# Summary

Loosen the peer dependency versions from exact versions to "current minor" by adding the `^` prefix.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: Running `pnpm install` after these changes didn’t produce any other changes.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
