### PR TITLE
chore(renovate): pin monaco-editor `expressions` and `entities-routes`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,14 @@
   ],
   "constraints": {
     "pnpm": "8.6.11"
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Pin monaco-editor for @kong-ui-public/expressions and @kong-ui-public/entities-routes",
+      "matchFileNames": ["packages/core/expressions/package.json", "packages/entities/entities-routes/package.json"],
+      "groupName": "expressions-monaco-editor",
+      "matchPackageNames": ["monaco-editor"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
# Summary

This PR tries to pin `monaco-editor` by excluding it for `@kong-ui-public/expressions` and `@kong-ui-public/entities-routes` via `packageRules` in `renovate.json`.

### Why?

`monaco-editor` is currently only used for the Expressions routes support in `@kong-ui-public/expressions` and `@kong-ui-public/entities-routes`. We encountered several issues while consuming the latest `monaco-editor` in the host app during the development. To deliver the Expressions routes support in time, we decided to downgrade it to [`v0.21.3`–which we used previously in Kong Manager](https://github.com/Kong/kong-admin/blob/9bae765787d9ea28cfa48e16bd3c56b65e82a2c7/package.json#L85) to prevent [the Renovate bot from bumping it](https://github.com/Kong/public-ui-components/pull/1352). 

We will try to update it to the latest possible minor release after Kong Gateway 3.7's release.

