### PR TITLE
refactor(entities-routes): make expressions and monaco as optionalDependencies

### DIFF
--- a/packages/entities/entities-routes/README.md
+++ b/packages/entities/entities-routes/README.md
@@ -48,7 +48,7 @@ import '@kong-ui-public/entities-routes/dist/style.css'
 
 This package installs `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/)-related features. However, this will add several megabytes to your bundle size.
 
-If you don't need Expressions features, but have imported the components (e.g., `<RouteForm.vue />`) with these features in your host app, add the following configuration to your Vite config to avoid bundling them with your build result:
+If you don't need Expressions features, but have imported the components with support for these features (e.g., `routeFlavor` in `<RouteForm.vue />`) in your host app, add the following configuration to your Vite config to avoid bundling them with your build result:
 
 > As of now, only `<RouteForm.vue />` has Expressions features. You should ensure you are not using Expressions features in your host app before adding this configuration.
 

--- a/packages/entities/entities-routes/README.md
+++ b/packages/entities/entities-routes/README.md
@@ -15,17 +15,17 @@ Route entity components.
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 - `axios` must be installed as a dependency in the host application
-- `@kong-ui-public/expressions` and `monaco-editor` must be installed as **`devDependencies`**. If you don't need to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/)-related features, you will need to add the following configuration to your Vite config to avoid them to be bundled with your build result:
+- `@kong-ui-public/expressions` and `monaco-editor` must be installed as **`dependencies`** to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/)-related features. If you don't need the Expressions support, install them as **`devDependencies`**, and add the following configuration to your Vite config to avoid bundling them with your build result:
 
-```ts
-defineConfig({
-  build: {
-    rollupOptions: {
-      external: ['@kong-ui-public/expressions', 'monaco-editor'],
+  ```ts
+  defineConfig({
+    build: {
+      rollupOptions: {
+        external: ['@kong-ui-public/expressions', 'monaco-editor'],
+      },
     },
-  },
-})
-```
+  })
+  ```
 
 ## Included components
 

--- a/packages/entities/entities-routes/README.md
+++ b/packages/entities/entities-routes/README.md
@@ -3,7 +3,6 @@
 Route entity components.
 
 - [Requirements](#requirements)
-  - [Expressions features](#expressions-features)
 - [Included components](#included-components)
 - [Usage](#usage)
   - [Install](#install)
@@ -16,12 +15,7 @@ Route entity components.
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 - `axios` must be installed as a dependency in the host application
-
-### Expressions features
-
-Some components (e.g., RouteForm with `expressions` route flavor enabled) in this package use `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/), you will need to install `@kong-ui-public/expressions` and `monaco-editor` in your host app to use Expressions features.
-
-If you don't use Expressions features, you will need to add the following to your Vite config:
+- `@kong-ui-public/expressions` and `monaco-editor` must be installed as **`devDependencies`**. If you don't need to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/)-related features, you will need to add the following configuration to your Vite config to avoid them to be bundled with your build result:
 
 ```ts
 defineConfig({

--- a/packages/entities/entities-routes/README.md
+++ b/packages/entities/entities-routes/README.md
@@ -3,6 +3,7 @@
 Route entity components.
 
 - [Requirements](#requirements)
+  - [Expressions features](#expressions-features)
 - [Included components](#included-components)
 - [Usage](#usage)
   - [Install](#install)
@@ -15,6 +16,22 @@ Route entity components.
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 - `axios` must be installed as a dependency in the host application
+
+### Expressions features
+
+Some components (e.g., RouteForm with `expressions` route flavor enabled) in this package use `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/), you will need to install `@kong-ui-public/expressions` and `monaco-editor` in your host app to use Expressions features.
+
+If you don't use Expressions features but have non-type imports from this package in your host app, you will need to add the following to your Vite config:
+
+```ts
+defineConfig({
+  build: {
+    rollupOptions: {
+      external: ['@kong-ui-public/expressions', 'monaco-editor'],
+    },
+  },
+})
+```
 
 ## Included components
 

--- a/packages/entities/entities-routes/README.md
+++ b/packages/entities/entities-routes/README.md
@@ -19,19 +19,7 @@ Route entity components.
 
 ### Expressions features
 
-Some components (e.g., RouteForm with `expressions` route flavor enabled) in this package use `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/), you will need to install `@kong-ui-public/expressions` and `monaco-editor` in your host app to use Expressions features.
-
-If you don't use Expressions features but have non-type imports from this package in your host app, you will need to add the following to your Vite config:
-
-```ts
-defineConfig({
-  build: {
-    rollupOptions: {
-      external: ['@kong-ui-public/expressions', 'monaco-editor'],
-    },
-  },
-})
-```
+Some components (e.g., RouteForm with `expressions` route flavor enabled) in this package use `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/). These dependencies are optional, you will need to install `@kong-ui-public/expressions` and `monaco-editor` in your host app as `dependencies` to use Expressions features.
 
 ## Included components
 

--- a/packages/entities/entities-routes/README.md
+++ b/packages/entities/entities-routes/README.md
@@ -7,15 +7,16 @@ Route entity components.
 - [Usage](#usage)
   - [Install](#install)
   - [Registration](#registration)
-  - [Reduce the bundle size (Optional)](#reduce-the-bundle-size-optional)
+- [Expressions features](#expressions-features)
 - [Individual component documentation](#individual-component-documentation)
 
 ## Requirements
 
-- `vue` and `vue-router` must be initialized in the host application
+- `vue` and `vue-router` must be initialized in the host application.
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
-- `axios` must be installed as a dependency in the host application
+- `axios` must be installed as a dependency in the host application.
+- If you want to enable [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/)-related [features](#expressions-features) in your host app, `@kong-ui-public/expressions` and `monaco-editor` must be installed as dependencies in the host application.
 
 ## Included components
 
@@ -44,23 +45,11 @@ import { RouteList, RouteForm, RouteConfigCard } from '@kong-ui-public/entities-
 import '@kong-ui-public/entities-routes/dist/style.css'
 ```
 
-### Reduce the bundle size (Optional)
+## Expressions features
 
-This package installs `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/)-related features. However, this will add several megabytes to your bundle size.
+This package utilizes `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/)-related features. You will need to ensure these dependencies are installed in your host application to enable these features.
 
-If you don't need Expressions features, but have imported the components with support for these features (e.g., `routeFlavor` in `<RouteForm.vue />`) in your host app, add the following configuration to your Vite config to avoid bundling them with your build result:
-
-> As of now, only `<RouteForm.vue />` has Expressions features. You should ensure you are not using Expressions features in your host app before adding this configuration.
-
-```ts
-defineConfig({
-  build: {
-    rollupOptions: {
-      external: ['@kong-ui-public/expressions', 'monaco-editor'],
-    },
-  },
-})
-```
+As of now, `<RouteForm.vue />` is the only component with Expressions features(controlled via the `routeFlavor` prop).
 
 ## Individual component documentation
 

--- a/packages/entities/entities-routes/README.md
+++ b/packages/entities/entities-routes/README.md
@@ -7,6 +7,7 @@ Route entity components.
 - [Usage](#usage)
   - [Install](#install)
   - [Registration](#registration)
+  - [Reduce the bundle size (Optional)](#reduce-the-bundle-size-optional)
 - [Individual component documentation](#individual-component-documentation)
 
 ## Requirements
@@ -15,17 +16,6 @@ Route entity components.
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 - `axios` must be installed as a dependency in the host application
-- `@kong-ui-public/expressions` and `monaco-editor` must be installed as **`dependencies`** to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/)-related features. If you don't need the Expressions support, install them as **`devDependencies`**, and add the following configuration to your Vite config to avoid bundling them with your build result:
-
-  ```ts
-  defineConfig({
-    build: {
-      rollupOptions: {
-        external: ['@kong-ui-public/expressions', 'monaco-editor'],
-      },
-    },
-  })
-  ```
 
 ## Included components
 
@@ -52,6 +42,24 @@ Import the component(s) in your host application as well as the package styles
 ```ts
 import { RouteList, RouteForm, RouteConfigCard } from '@kong-ui-public/entities-routes'
 import '@kong-ui-public/entities-routes/dist/style.css'
+```
+
+### Reduce the bundle size (Optional)
+
+This package installs `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/)-related features. However, this will add several megabytes to your bundle size.
+
+If you don't need Expressions features, but have imported the components (e.g., `<RouteForm.vue />`) with these features in your host app, add the following configuration to your Vite config to avoid bundling them with your build result:
+
+> As of now, only `<RouteForm.vue />` has Expressions features. You should ensure you are not using Expressions features in your host app before adding this configuration.
+
+```ts
+defineConfig({
+  build: {
+    rollupOptions: {
+      external: ['@kong-ui-public/expressions', 'monaco-editor'],
+    },
+  },
+})
 ```
 
 ## Individual component documentation

--- a/packages/entities/entities-routes/README.md
+++ b/packages/entities/entities-routes/README.md
@@ -19,7 +19,19 @@ Route entity components.
 
 ### Expressions features
 
-Some components (e.g., RouteForm with `expressions` route flavor enabled) in this package use `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/). These dependencies are optional, you will need to install `@kong-ui-public/expressions` and `monaco-editor` in your host app as `dependencies` to use Expressions features.
+Some components (e.g., RouteForm with `expressions` route flavor enabled) in this package use `@kong-ui-public/expressions` and `monaco-editor` to support [Kong's Expressions language](https://docs.konghq.com/gateway/latest/reference/expressions-language/), you will need to install `@kong-ui-public/expressions` and `monaco-editor` in your host app to use Expressions features.
+
+If you don't use Expressions features, you will need to add the following to your Vite config:
+
+```ts
+defineConfig({
+  build: {
+    rollupOptions: {
+      external: ['@kong-ui-public/expressions', 'monaco-editor'],
+    },
+  },
+})
+```
 
 ## Included components
 

--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -13,11 +13,11 @@ A form component for Routes.
 
 ## Requirements
 
-- `vue` and `vue-router` must be initialized in the host application
+- `vue` and `vue-router` must be initialized in the host application.
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
-- `axios` must be installed as a dependency in the host application
-- `@kong-ui-public/expressions` and `monaco-editor` will be installed for Expressions features. If you don't use Expressions features, you can follow [these instructions to reduce the bundle size](../README.md#reduce-the-bundle-size-optional).
+- `axios` must be installed as a dependency in the host application.
+- If you want to use Expressions features, `@kong-ui-public/expressions` and `monaco-editor` must be installed as dependencies in the host application.
 
 ## Usage
 

--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -17,7 +17,7 @@ A form component for Routes.
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 - `axios` must be installed as a dependency in the host application
-- `@kong-ui-public/expressions` and `monaco-editor` are required if the host app uses this component with `expressions` route flavor enabled.
+- `@kong-ui-public/expressions` and `monaco-editor` will be installed for Expressions features. If you don't use Expressions features, you can follow [these instructions to reduce the bundle size](../README.md#reduce-the-bundle-size-optional).
 
 ## Usage
 
@@ -119,7 +119,7 @@ Show/hide Service Select field. Should be used in case of manual adding `service
 
 Show tags field under _Advanced Fields_ collapse or in it's default place (before protocols field).
 
-#### `routeFlavors`
+#### `routeFlavors` (controls Expressions features)
 
 - type: `RouteFlavors`
 - required: `false`
@@ -134,7 +134,7 @@ Show tags field under _Advanced Fields_ collapse or in it's default place (befor
     - type: `boolean`
     - required: `false`
     - default: `false`
-    - Whether to show input components for the Expressions route.
+    - Whether to show input components for the Expressions route. (If true, Expressions features will be enabled for this component.)
 
 #### `configTabTooltips`
 

--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -17,6 +17,7 @@ A form component for Routes.
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 - `axios` must be installed as a dependency in the host application
+- `@kong-ui-public/expressions` and `monaco-editor` are required if the host app uses this component with `expressions` route flavor enabled.
 
 ## Usage
 

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -21,6 +21,7 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/expressions": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/kongponents": "^9.0.0-alpha.146",
     "axios": "^1.6.8",
@@ -29,6 +30,7 @@
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
+    "@kong-ui-public/expressions": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
     "@kong/kongponents": "9.0.0-alpha.146",
@@ -69,11 +71,10 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "5000KB"
+    "errorLimit": "700KB"
   },
   "dependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong-ui-public/expressions": "workspace:^",
     "@kong/icons": "^1.9.0",
     "lodash.isequal": "^4.5.0"
   }

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -21,22 +21,18 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@kong-ui-public/expressions": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/kongponents": "^9.0.0-alpha.146",
     "axios": "^1.6.8",
-    "monaco-editor": "0.21.3",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
-    "@kong-ui-public/expressions": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
     "@kong/kongponents": "9.0.0-alpha.146",
     "@types/lodash.isequal": "^4.5.8",
     "axios": "^1.6.8",
-    "monaco-editor": "0.21.3",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"
@@ -77,5 +73,9 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong/icons": "^1.9.0",
     "lodash.isequal": "^4.5.0"
+  },
+  "optionalDependencies": {
+    "@kong-ui-public/expressions": "workspace:^",
+    "monaco-editor": "0.21.3"
   }
 }

--- a/packages/entities/entities-routes/vite.config.ts
+++ b/packages/entities/entities-routes/vite.config.ts
@@ -18,7 +18,10 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       fileName: (format) => `${sanitizedPackageName}.${format}.js`,
     },
     rollupOptions: {
-      external: ['monaco-editor'], // Do not bundle monaco-editor with this package. Provide as a peer dependency
+      external: [
+        '@kong-ui-public/expressions', // This is optional if we do not use Expressions features
+        'monaco-editor', // This is optional if we do not use Expressions features
+      ],
     },
   },
   server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -846,10 +846,14 @@ importers:
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0
-    devDependencies:
+    optionalDependencies:
       '@kong-ui-public/expressions':
         specifier: workspace:^
         version: link:../../core/expressions
+      monaco-editor:
+        specifier: 0.21.3
+        version: 0.21.3
+    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
@@ -865,9 +869,6 @@ importers:
       axios:
         specifier: ^1.6.8
         version: 1.6.8
-      monaco-editor:
-        specifier: 0.21.3
-        version: 0.21.3
       vite-plugin-monaco-editor:
         specifier: ^1.1.0
         version: 1.1.0(monaco-editor@0.21.3)
@@ -11208,7 +11209,6 @@ packages:
 
   /monaco-editor@0.21.3:
     resolution: {integrity: sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==}
-    dev: true
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,9 +840,6 @@ importers:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong-ui-public/expressions':
-        specifier: workspace:^
-        version: link:../../core/expressions
       '@kong/icons':
         specifier: ^1.9.0
         version: 1.9.0(vue@3.4.21)
@@ -850,6 +847,9 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0
     devDependencies:
+      '@kong-ui-public/expressions':
+        specifier: workspace:^
+        version: link:../../core/expressions
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
@@ -4982,9 +4982,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.12.0
     dev: true


### PR DESCRIPTION
# Summary

This PR moves `@kong-ui-public/expressions` to `peerDependencies` so that we can provide `@kong-ui-public/expressions` and `monaco-editor` in host apps. This allows us to reduce the bundle size of `@kong-ui-public/entities-routes` (several megabytes smaller) as the Expressions features are not always necessary (e.g., Konnect API Products/Overview).

In host apps with non-type imports from `@kong-ui-public/entities-routes` but without the need to use Expressions features, they will need to mark these peer dependencies as `external` (as https://github.com/Kong/konnect-ui-apps/pull/3018 demonstrated):

```ts
defineConfig({
  build: {
    rollupOptions: {
      external: ['@kong-ui-public/expressions', 'monaco-editor'],
    },
  },
})
```

I've also updated the documentation for that package to note this.