### PR TITLE
ci: skip secrets for pr forks [KHCP-11575]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ on:
       - labeled
     branches:
       - main
+      # TODO: Remove before merge
+      - ci/no-secrets
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
       # if previous run did create comment with the reference to PR preview package
       # this comment is removed in this step
       - name: Remove preview consumption comment
+        if: ${{ github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'OWNER' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr_preview_consumption
@@ -48,7 +49,7 @@ jobs:
       # see 'run-test' step and variable bellow
       - name: Check if PR Up to Date
         id: 'up-to-date'
-        if: ${{github.event_name == 'push'}}
+        if: ${{ github.event_name == 'push' }}
         uses: Kong/public-shared-actions/pr-previews/up-to-date@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -221,7 +222,7 @@ jobs:
         uses: Kong/github-action-dist-size-checker@main
 
       - name: Publish Previews
-        if: ${{ github.event_name == 'pull_request' && steps.changed_packages.outputs.filter != '' && (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'create preview package')) }}
+        if: ${{ github.event_name == 'pull_request' && steps.changed_packages.outputs.filter != '' && (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'create preview package')) && (github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'OWNER') }}
         run: |
           git config user.email "konnectx-engineers+kongponents-bot@konghq.com"
           git config user.name "Kong UI Bot"
@@ -265,7 +266,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}
 
       - name: Provide preview link info
-        if: ${{ env.npm_instructions != '' }}
+        if: ${{ env.npm_instructions != '' && (github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'OWNER') }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr_preview_consumption

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,6 @@ on:
       - labeled
     branches:
       - main
-      # TODO: Remove before merge
-      - ci/no-secrets
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/packages/core/app-layout/README.md
+++ b/packages/core/app-layout/README.md
@@ -1,6 +1,6 @@
 # @kong-ui-public/app-layout
 
-A Kong UI application layout component that provides a responsive navbar, sidebar, and main content area.
+A set of Kong UI application layout components that provides a responsive navbar, sidebar, and main content area.
 
 - [Features](#features)
 - [Requirements](#requirements)


### PR DESCRIPTION
# Summary

Skip CI job actions that run on a Pull Request that require `secrets` if the author is not a `COLLABORATOR` or `OWNER`