### PR TITLE
fix(entities-routes): add prop to hide traditional columns

### DIFF
--- a/packages/entities/entities-routes/sandbox/pages/RouteListPage.vue
+++ b/packages/entities/entities-routes/sandbox/pages/RouteListPage.vue
@@ -11,6 +11,11 @@
     >
       <div class="wrapper">
         <KInputSwitch
+          v-model="routeListHideTraditionalColumns"
+          class="route-list-traditional-columns-toggle"
+          label="Hide traditional columns"
+        />
+        <KInputSwitch
           v-model="routeListHasExpressionColumn"
           class="route-list-expressions-column-toggle"
           label="Has &quot;Expression&quot; column"
@@ -30,6 +35,7 @@
     :can-retrieve="permissions.canRetrieve"
     :config="konnectConfig"
     :has-expression-column="routeListHasExpressionColumn"
+    :hide-traditional-columns="routeListHideTraditionalColumns"
     title="Routes"
     @copy:error="onCopyIdError"
     @copy:success="onCopyIdSuccess"
@@ -48,6 +54,7 @@
     :can-retrieve="permissions.canRetrieve"
     :config="kongManagerConfig"
     :has-expression-column="routeListHasExpressionColumn"
+    :hide-traditional-columns="routeListHideTraditionalColumns"
     title="Routes"
     @copy:error="onCopyIdError"
     @copy:success="onCopyIdSuccess"
@@ -108,6 +115,7 @@ const key = ref(1)
 const permissions = ref<PermissionsActions | null>(null)
 
 const isRouteListControlCollapsed = ref<boolean>(true)
+const routeListHideTraditionalColumns = ref<boolean>(false)
 const routeListHasExpressionColumn = ref<boolean>(true)
 
 const handlePermissionsUpdate = (newPermissions: PermissionsActions) => {
@@ -131,7 +139,7 @@ const onError = (error: AxiosError) => {
   console.error(`Error: ${error}`)
 }
 
-watch(routeListHasExpressionColumn, () => {
+watch([routeListHideTraditionalColumns, routeListHasExpressionColumn], () => {
   key.value++
 })
 </script>
@@ -157,7 +165,7 @@ watch(routeListHasExpressionColumn, () => {
     display: flex;
     flex-direction: column;
 
-    .route-list-expressions-column-toggle {
+    .route-list-traditional-columns-toggle, .route-list-expressions-column-toggle {
       margin-bottom: $kui-space-50;
     }
   }

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -285,6 +285,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  hideTraditionalColumns: {
+    type: Boolean,
+    default: false,
+  },
   hasExpressionColumn: {
     type: Boolean,
     default: false,
@@ -304,9 +308,11 @@ const disableSorting = computed((): boolean => props.config.app !== 'kongManager
 const fields: BaseTableHeaders = {
   name: { label: t('routes.list.table_headers.name'), searchable: true, sortable: true },
   protocols: { label: t('routes.list.table_headers.protocols'), searchable: true },
-  hosts: { label: t('routes.list.table_headers.hosts'), searchable: true },
-  methods: { label: t('routes.list.table_headers.methods'), searchable: true },
-  paths: { label: t('routes.list.table_headers.paths'), searchable: true },
+  ...!props.hideTraditionalColumns && {
+    hosts: { label: t('routes.list.table_headers.hosts'), searchable: true },
+    methods: { label: t('routes.list.table_headers.methods'), searchable: true },
+    paths: { label: t('routes.list.table_headers.paths'), searchable: true },
+  },
   ...props.hasExpressionColumn && {
     expression: { label: t('routes.list.table_headers.expression'), tooltip: true },
   },


### PR DESCRIPTION
# Summary

Adding a prop to allow hiding traditional columns in the route list.