### PR TITLE
fix(entities-plugins): omit redis cluster/sentinel addresses if empty [KAG-4328]

### DIFF
--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -35,6 +35,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.12.11",
     "@kong/kongponents": "9.0.0-alpha.146",
+    "@types/lodash-es": "^4.17.12",
     "axios": "^1.6.8",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"
@@ -80,6 +81,7 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/forms": "^3.1.0",
     "@kong/icons": "^1.9.1",
+    "lodash-es": "^4.17.21",
     "marked": "^12.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,6 +840,9 @@ importers:
       '@kong/icons':
         specifier: ^1.9.1
         version: 1.9.1(vue@3.4.21)
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       marked:
         specifier: ^12.0.1
         version: 12.0.1
@@ -853,6 +856,9 @@ importers:
       '@kong/kongponents':
         specifier: 9.0.0-alpha.146
         version: 9.0.0-alpha.146(axios@1.6.8)(vue-router@4.3.0)(vue@3.4.21)
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       axios:
         specifier: ^1.6.8
         version: 1.6.8


### PR DESCRIPTION
# Summary

This PR fixed an issue where plugins with `config.redis.cluster_addresses` and `config.redis.sentinel_addresses` cannot be created or edited if the user tried to add some addresses but removed all addresses before submitting the form.

This bug affects the following four plugins:

- graphql-proxy-cache-advanced
- graphql-rate-limiting-advanced
- proxy-cache-advanced
- rate-limiting-advanced

This fix should be a temporary and straightforward workaround since we should ultimately fix it in the `core/forms` package.

KAG-4328