### PR TITLE
fix(entities-plugins): watch formModel (Plan B) [KAG-4328]

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -448,6 +448,14 @@ const onModelUpdated = (model: any, schema: string) => {
   })
 }
 
+watch(formModel, (model) => {
+  emit('model-updated', {
+    model,
+    originalModel: model,
+    data: getModel(),
+  })
+})
+
 // special handling for problematic fields before we emit
 const updateModel = (data: Record<string, any>, parent?: string) => {
   Object.keys(data).forEach(key => {


### PR DESCRIPTION
# Summary

Plan B for the issue mentioned in https://github.com/Kong/public-ui-components/pull/1375: Adding a `watch` on `formModel` to catch the removal of array items.

KAG-4328