### PR TITLE
fix(entities): restore Teleport for new entity button only in Konnect app [KHCP-11277]

### DIFF
--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -27,10 +27,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -45,6 +42,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -27,6 +27,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -42,8 +44,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -27,9 +27,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -44,7 +44,7 @@
               {{ t('ca-certificates.list.toolbar_actions.new_ca_certificate') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -27,8 +27,23 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-ca-certificate"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('ca-certificates.list.toolbar_actions.new_ca_certificate') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -101,22 +116,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-ca-certificate"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('ca-certificates.list.toolbar_actions.new_ca_certificate') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :entity-type="EntityTypes.CACertificate"
@@ -151,6 +150,7 @@ import endpoints from '../ca-certificates-endpoints'
 
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityTypes,

--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -29,21 +29,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-ca-certificate"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('ca-certificates.list.toolbar_actions.new_ca_certificate') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -115,6 +100,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-ca-certificate"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('ca-certificates.list.toolbar_actions.new_ca_certificate') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -27,10 +27,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -45,6 +42,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -27,6 +27,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -42,8 +44,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -27,9 +27,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -44,7 +44,7 @@
               {{ t('certificates.list.toolbar_actions.new_certificate') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -27,8 +27,23 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-certificate"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('certificates.list.toolbar_actions.new_certificate') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -125,22 +140,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-certificate"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('certificates.list.toolbar_actions.new_certificate') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :entity-type="EntityTypes.Certificate"
@@ -175,6 +174,7 @@ import endpoints from '../certificates-endpoints'
 
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityTypes,

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -29,21 +29,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-certificate"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('certificates.list.toolbar_actions.new_certificate') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -139,6 +124,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-certificate"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('certificates.list.toolbar_actions.new_certificate') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -18,6 +18,8 @@
     >
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -33,8 +35,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -20,21 +20,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-credential"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t(`credentials.list.toolbar_actions.${config.plugin}.new`) }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -172,6 +157,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-credential"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t(`credentials.list.toolbar_actions.${config.plugin}.new`) }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -18,8 +18,23 @@
     >
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-credential"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t(`credentials.list.toolbar_actions.${config.plugin}.new`) }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -158,22 +173,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-credential"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t(`credentials.list.toolbar_actions.${config.plugin}.new`) }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :description="t('credentials.delete.description')"
@@ -195,6 +194,7 @@ import composables from '../composables'
 import endpoints from '../consumer-credentials-endpoints'
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityTypes,
   FetcherStatus,

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -18,9 +18,9 @@
     >
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -35,7 +35,7 @@
               {{ t(`credentials.list.toolbar_actions.${config.plugin}.new`) }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -18,10 +18,7 @@
     >
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -36,6 +33,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -31,9 +31,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -49,7 +49,7 @@
               {{ config.consumerId ? t('consumer_groups.actions.add_to_group') : t('consumer_groups.list.toolbar_actions.new_consumer_group') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -31,6 +31,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -47,8 +49,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -33,22 +33,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-consumer-group"
-              icon="plus"
-              size="large"
-              :to="config.consumerId ? undefined : config.createRoute"
-              @click="() => config.consumerId ? handleAddToGroupClick() : undefined"
-            >
-              {{ config.consumerId ? t('consumer_groups.actions.add_to_group') : t('consumer_groups.list.toolbar_actions.new_consumer_group') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -114,6 +98,23 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-consumer-group"
+          icon="plus"
+          size="large"
+          :to="config.consumerId ? undefined : config.createRoute"
+          @click="() => config.consumerId ? handleAddToGroupClick() : undefined"
+        >
+          {{ config.consumerId ? t('consumer_groups.actions.add_to_group') : t('consumer_groups.list.toolbar_actions.new_consumer_group') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -31,10 +31,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -50,6 +47,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -31,8 +31,24 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-consumer-group"
+              icon="plus"
+              size="large"
+              :to="config.consumerId ? undefined : config.createRoute"
+              @click="() => config.consumerId ? handleAddToGroupClick() : undefined"
+            >
+              {{ config.consumerId ? t('consumer_groups.actions.add_to_group') : t('consumer_groups.list.toolbar_actions.new_consumer_group') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -98,23 +114,6 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
-
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-consumer-group"
-          icon="plus"
-          size="large"
-          :to="config.consumerId ? undefined : config.createRoute"
-          @click="() => config.consumerId ? handleAddToGroupClick() : undefined"
-        >
-          {{ config.consumerId ? t('consumer_groups.actions.add_to_group') : t('consumer_groups.list.toolbar_actions.new_consumer_group') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"
@@ -185,6 +184,7 @@ import composables from '../composables'
 import endpoints from '../consumer-groups-endpoints'
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityTypes,

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -31,9 +31,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -49,7 +49,7 @@
               {{ config.consumerGroupId ? t('consumers.actions.add_consumer') : t('consumers.list.toolbar_actions.new_consumer') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -33,22 +33,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-consumer"
-              icon="plus"
-              size="large"
-              :to="config.consumerGroupId ? undefined : config.createRoute"
-              @click="() => config.consumerGroupId ? handleAddConsumerClick() : undefined"
-            >
-              {{ config.consumerGroupId ? t('consumers.actions.add_consumer') : t('consumers.list.toolbar_actions.new_consumer') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -114,6 +98,23 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-consumer"
+          icon="plus"
+          size="large"
+          :to="config.consumerGroupId ? undefined : config.createRoute"
+          @click="() => config.consumerGroupId ? handleAddConsumerClick() : undefined"
+        >
+          {{ config.consumerGroupId ? t('consumers.actions.add_consumer') : t('consumers.list.toolbar_actions.new_consumer') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-button-disabled="isDeletePending"

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -31,6 +31,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -47,8 +49,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -31,10 +31,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -50,6 +47,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -31,8 +31,24 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-consumer"
+              icon="plus"
+              size="large"
+              :to="config.consumerGroupId ? undefined : config.createRoute"
+              @click="() => config.consumerGroupId ? handleAddConsumerClick() : undefined"
+            >
+              {{ config.consumerGroupId ? t('consumers.actions.add_consumer') : t('consumers.list.toolbar_actions.new_consumer') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -98,23 +114,6 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
-
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-consumer"
-          icon="plus"
-          size="large"
-          :to="config.consumerGroupId ? undefined : config.createRoute"
-          @click="() => config.consumerGroupId ? handleAddConsumerClick() : undefined"
-        >
-          {{ config.consumerGroupId ? t('consumers.actions.add_consumer') : t('consumers.list.toolbar_actions.new_consumer') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
 
     <EntityDeleteModal
       :action-button-disabled="isDeletePending"
@@ -185,6 +184,7 @@ import composables from '../composables'
 import endpoints from '../consumers-endpoints'
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityTypes,

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -27,10 +27,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -45,6 +42,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -27,6 +27,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -42,8 +44,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -29,21 +29,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-gateway-service"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('gateway_services.list.toolbar_actions.new_gateway_service') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -134,6 +119,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-gateway-service"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('gateway_services.list.toolbar_actions.new_gateway_service') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityToggleModal
       :action="modalContent.action"

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -27,8 +27,23 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-gateway-service"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('gateway_services.list.toolbar_actions.new_gateway_service') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -120,22 +135,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-gateway-service"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('gateway_services.list.toolbar_actions.new_gateway_service') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityToggleModal
       :action="modalContent.action"
       :entity-id="modalContent.id"
@@ -184,6 +183,7 @@ import type {
 } from '../types'
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityToggleModal,

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -27,9 +27,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -44,7 +44,7 @@
               {{ t('gateway_services.list.toolbar_actions.new_gateway_service') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -27,10 +27,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -45,6 +42,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -27,6 +27,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -42,8 +44,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -27,8 +27,23 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-key-set"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('keySets.list.toolbar_actions.new_key_set') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -98,22 +113,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-key-set"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('keySets.list.toolbar_actions.new_key_set') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :description="t('keySets.delete.description')"
@@ -137,6 +136,7 @@ import composables from '../composables'
 import endpoints from '../key-sets-endpoints'
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityTypes,

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -27,9 +27,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -44,7 +44,7 @@
               {{ t('keySets.list.toolbar_actions.new_key_set') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -29,21 +29,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-key-set"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('keySets.list.toolbar_actions.new_key_set') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -112,6 +97,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-key-set"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('keySets.list.toolbar_actions.new_key_set') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -27,8 +27,23 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-key"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('keys.list.toolbar_actions.new_key') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -101,22 +116,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-key"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('keys.list.toolbar_actions.new_key') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :description="t('keys.delete.description')"
@@ -141,6 +140,7 @@ import composables from '../composables'
 import endpoints from '../keys-endpoints'
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityTypes,

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -27,10 +27,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -45,6 +42,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -27,6 +27,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -42,8 +44,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -27,9 +27,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -44,7 +44,7 @@
               {{ t('keys.list.toolbar_actions.new_key') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -29,21 +29,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-key"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('keys.list.toolbar_actions.new_key') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -115,6 +100,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-key"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('keys.list.toolbar_actions.new_key') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -30,6 +30,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -45,8 +47,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -30,8 +30,23 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-plugin"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('plugins.list.toolbar_actions.new_plugin') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -176,22 +191,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-plugin"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('plugins.list.toolbar_actions.new_plugin') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityToggleModal
       :action="modalContent.action"
       :entity-id="modalContent.id"
@@ -225,6 +224,7 @@ import type { AxiosError } from 'axios'
 
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityToggleModal,
   EntityFilter,

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -30,9 +30,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -47,7 +47,7 @@
               {{ t('plugins.list.toolbar_actions.new_plugin') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -32,21 +32,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-plugin"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('plugins.list.toolbar_actions.new_plugin') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -190,6 +175,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-plugin"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('plugins.list.toolbar_actions.new_plugin') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityToggleModal
       :action="modalContent.action"

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -30,10 +30,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -48,6 +45,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -30,6 +30,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -45,8 +47,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -30,9 +30,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -47,7 +47,7 @@
               {{ t('routes.list.toolbar_actions.new_route') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -32,21 +32,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-route"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('routes.list.toolbar_actions.new_route') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -169,6 +154,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-route"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('routes.list.toolbar_actions.new_route') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -30,8 +30,23 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-route"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('routes.list.toolbar_actions.new_route') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -155,22 +170,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-route"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('routes.list.toolbar_actions.new_route') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :description="t('delete.description')"
@@ -195,6 +194,7 @@ import { BadgeMethodAppearances } from '@kong/kongponents'
 import type { BadgeMethodAppearance, HeaderTag } from '@kong/kongponents'
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityTypes,

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -30,10 +30,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -48,6 +45,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -43,6 +43,12 @@
             v-if="$slots['toolbar-button']"
             class="toolbar-button-container"
           >
+            <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+            <!-- rendering order requires us to render the teleport div before the slots attempt to be rendered -->
+            <div
+              v-if="!useActionOutside"
+              id="kong-ui-app-page-header-action-button-default"
+            />
             <slot name="toolbar-button" />
           </div>
         </div>
@@ -237,6 +243,11 @@ const props = defineProps({
   },
   /** default to false, setting to true will suppress the row click event even if "@click:row" is attached */
   disableRowClick: {
+    type: Boolean,
+    default: false,
+  },
+  /** default to false, setting to true will teleport the toolbar button to the destination in the consuming app */
+  useActionOutside: {
     type: Boolean,
     default: false,
   },

--- a/packages/entities/entities-shared/src/components/entity-base-table/MountedTeleport.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/MountedTeleport.vue
@@ -1,0 +1,27 @@
+<template>
+  <Teleport
+    v-if="isMounted"
+    :to="to"
+  >
+    <slot />
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+defineProps({
+  to: {
+    type: String,
+    required: true,
+  },
+})
+
+const isMounted = ref(false)
+onMounted(() => {
+  isMounted.value = true
+})
+</script>
+
+<style scoped>
+
+</style>

--- a/packages/entities/entities-shared/src/components/entity-base-table/MountedTeleport.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/MountedTeleport.vue
@@ -21,7 +21,3 @@ onMounted(() => {
   isMounted.value = true
 })
 </script>
-
-<style scoped>
-
-</style>

--- a/packages/entities/entities-shared/src/index.ts
+++ b/packages/entities/entities-shared/src/index.ts
@@ -4,6 +4,7 @@ import ConfigCardDisplay from './components/entity-base-config-card/ConfigCardDi
 import InternalLinkItem from './components/entity-base-config-card/InternalLinkItem.vue'
 import EntityBaseForm from './components/entity-base-form/EntityBaseForm.vue'
 import EntityBaseTable from './components/entity-base-table/EntityBaseTable.vue'
+import MountedTeleport from './components/entity-base-table/MountedTeleport.vue'
 import EntityDeleteModal from './components/entity-delete-modal/EntityDeleteModal.vue'
 import EntityFilter from './components/entity-filter/EntityFilter.vue'
 import EntityToggleModal from './components/entity-toggle-modal/EntityToggleModal.vue'
@@ -18,7 +19,7 @@ import composables from './composables'
 const { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators } = composables
 
 // Components
-export { EntityBaseConfigCard, ConfigCardItem, ConfigCardDisplay, InternalLinkItem, EntityBaseForm, EntityBaseTable, EntityDeleteModal, EntityFilter, EntityToggleModal, PermissionsWrapper, EntityFormSection, EntityLink, JsonCodeBlock, YamlCodeBlock }
+export { EntityBaseConfigCard, ConfigCardItem, ConfigCardDisplay, InternalLinkItem, EntityBaseForm, EntityBaseTable, MountedTeleport, EntityDeleteModal, EntityFilter, EntityToggleModal, PermissionsWrapper, EntityFormSection, EntityLink, JsonCodeBlock, YamlCodeBlock }
 
 // Composables
 export { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators }

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -26,10 +26,25 @@
           :config="filterConfig"
         />
       </template>
-      <!-- Create action -->
+
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-sni"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('snis.list.toolbar_actions.new') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -96,22 +111,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-sni"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('snis.list.toolbar_actions.new') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :description="t('delete.description')"
@@ -135,6 +134,7 @@ import composables from '../composables'
 import endpoints from '../snis-endpoints'
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityTypes,

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -30,21 +30,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-sni"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('snis.list.toolbar_actions.new') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -110,6 +95,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-sni"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('snis.list.toolbar_actions.new') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -28,10 +28,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -46,6 +43,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -28,9 +28,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -45,7 +45,7 @@
               {{ t('snis.list.toolbar_actions.new') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -28,6 +28,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -43,8 +45,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-upstreams-targets/sandbox/pages/UpstreamsListPage.vue
+++ b/packages/entities/entities-upstreams-targets/sandbox/pages/UpstreamsListPage.vue
@@ -7,6 +7,7 @@
     @update="handlePermissionsUpdate"
   />
   <h2>Konnect API</h2>
+  <div id="kong-ui-app-page-header-action-button" />
   <UpstreamsList
     v-if="permissions"
     :key="key"
@@ -16,6 +17,7 @@
     :can-edit="permissions.canEdit"
     :can-retrieve="permissions.canRetrieve"
     :config="konnectConfig"
+    use-action-outside
     @copy:error="onCopyIdError"
     @copy:success="onCopyIdSuccess"
     @delete:success="onDeleteSuccess"

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -18,6 +18,8 @@
     >
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -33,8 +35,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column formatting -->

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -18,10 +18,7 @@
     >
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -36,6 +33,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column formatting -->

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -18,9 +18,9 @@
     >
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -35,7 +35,7 @@
               {{ t('targets.list.toolbar_actions.new_target') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column formatting -->

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -20,21 +20,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-new-target"
-              icon="plus"
-              :to="props.config.createRoute ? props.config.createRoute : undefined"
-              @click="() => !props.config.createRoute ? handleCreateTarget() : undefined"
-            >
-              {{ t('targets.list.toolbar_actions.new_target') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column formatting -->
@@ -108,6 +93,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-new-target"
+          icon="plus"
+          :to="props.config.createRoute ? props.config.createRoute : undefined"
+          @click="() => !props.config.createRoute ? handleCreateTarget() : undefined"
+        >
+          {{ t('targets.list.toolbar_actions.new_target') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -26,10 +26,24 @@
         />
       </template>
 
-      <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-upstream"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('upstreams.list.toolbar_actions.new_upstream') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column formatting -->
@@ -92,22 +106,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-upstream"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('upstreams.list.toolbar_actions.new_upstream') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :description="t('upstreams.delete.description')"
@@ -125,6 +123,7 @@
 <script setup lang="ts">
 import {
   EntityBaseTable,
+  MountedTeleport,
   useFetcher,
   EntityFilter,
   FetcherStatus,

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -30,21 +30,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-upstream"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('upstreams.list.toolbar_actions.new_upstream') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column formatting -->
@@ -106,6 +91,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-upstream"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('upstreams.list.toolbar_actions.new_upstream') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -28,10 +28,7 @@
 
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -46,6 +43,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column formatting -->

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -28,6 +28,8 @@
 
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -43,8 +45,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column formatting -->

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -28,9 +28,9 @@
 
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -45,7 +45,7 @@
               {{ t('upstreams.list.toolbar_actions.new_upstream') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column formatting -->

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -27,10 +27,7 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <Teleport
-          :disabled="!useActionOutside || config.app !== 'konnect'"
-          to="#kong-ui-app-page-header-action-button"
-        >
+        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
             <KButton
@@ -45,6 +42,8 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -29,21 +29,6 @@
       <template #toolbar-button>
         <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
         <div id="kong-ui-app-page-header-action-button-default" />
-        <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-          <PermissionsWrapper :auth-function="() => canCreate()">
-            <!-- Hide Create button if table is empty -->
-            <KButton
-              v-show="hasData"
-              appearance="primary"
-              data-testid="toolbar-add-vault"
-              icon="plus"
-              size="large"
-              :to="config.createRoute"
-            >
-              {{ t('vaults.list.toolbar_actions.new_vault') }}
-            </KButton>
-          </PermissionsWrapper>
-        </Teleport>
       </template>
 
       <!-- Column Formatting -->
@@ -116,6 +101,22 @@
         </PermissionsWrapper>
       </template>
     </EntityBaseTable>
+
+    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+      <PermissionsWrapper :auth-function="() => canCreate()">
+        <!-- Hide Create button if table is empty -->
+        <KButton
+          v-show="hasData"
+          appearance="primary"
+          data-testid="toolbar-add-vault"
+          icon="plus"
+          size="large"
+          :to="config.createRoute"
+        >
+          {{ t('vaults.list.toolbar_actions.new_vault') }}
+        </KButton>
+      </PermissionsWrapper>
+    </Teleport>
 
     <EntityDeleteModal
       :action-pending="isDeletePending"

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -27,6 +27,8 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
+        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
+        <div id="kong-ui-app-page-header-action-button-default" />
         <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -42,8 +44,6 @@
             </KButton>
           </PermissionsWrapper>
         </Teleport>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -27,9 +27,9 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <component
-          :is="useActionOutside ? 'Teleport' : 'div'"
-          :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : undefined"
+        <Teleport
+          :disabled="!useActionOutside || config.app !== 'konnect'"
+          to="#kong-ui-app-page-header-action-button"
         >
           <PermissionsWrapper :auth-function="() => canCreate()">
             <!-- Hide Create button if table is empty -->
@@ -44,7 +44,7 @@
               {{ t('vaults.list.toolbar_actions.new_vault') }}
             </KButton>
           </PermissionsWrapper>
-        </component>
+        </Teleport>
       </template>
 
       <!-- Column Formatting -->

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -27,8 +27,23 @@
       </template>
       <!-- Create action -->
       <template #toolbar-button>
-        <!-- render this fallback div for Kong Manager instead, as there is no kong-ui-app-page-header-action-button target to go to in KM -->
-        <div id="kong-ui-app-page-header-action-button-default" />
+        <!-- Render in the button slot because we want to wait until the toolbar is rendered (and the default teleport div) before the Teleport attempts to find the div -->
+        <!-- Do not attempt to render/teleport if toolbar is hidden -->
+        <MountedTeleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
+          <PermissionsWrapper :auth-function="() => canCreate()">
+            <!-- Hide Create button if table is empty -->
+            <KButton
+              v-show="hasData"
+              appearance="primary"
+              data-testid="toolbar-add-vault"
+              icon="plus"
+              size="large"
+              :to="config.createRoute"
+            >
+              {{ t('vaults.list.toolbar_actions.new_vault') }}
+            </KButton>
+          </PermissionsWrapper>
+        </MountedTeleport>
       </template>
 
       <!-- Column Formatting -->
@@ -102,22 +117,6 @@
       </template>
     </EntityBaseTable>
 
-    <Teleport :to="useActionOutside ? '#kong-ui-app-page-header-action-button' : '#kong-ui-app-page-header-action-button-default'">
-      <PermissionsWrapper :auth-function="() => canCreate()">
-        <!-- Hide Create button if table is empty -->
-        <KButton
-          v-show="hasData"
-          appearance="primary"
-          data-testid="toolbar-add-vault"
-          icon="plus"
-          size="large"
-          :to="config.createRoute"
-        >
-          {{ t('vaults.list.toolbar_actions.new_vault') }}
-        </KButton>
-      </PermissionsWrapper>
-    </Teleport>
-
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :description="t('delete.description')"
@@ -140,6 +139,7 @@ import type { AxiosError } from 'axios'
 
 import {
   EntityBaseTable,
+  MountedTeleport,
   EntityDeleteModal,
   EntityFilter,
   EntityTypes,


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/KHCP-11277

**Consumed in https://github.com/Kong/konnect-ui-apps/pull/3087
Deploy Preview: https://pr-3087--gateway-manager.cloud-preview.konghq.tech/gateway-manager**

~This is an easier solution to avoid the Teleport target warning for Kong Manager by not conditionally rendering this for Kong Manager.~

**Context: This PR introduced the regression https://github.com/Kong/public-ui-components/pull/1001** 
where dynamic component usage for Teleport (instead of constantly using a Teleport component) was resulting in the content being always rendered as a div and never a Teleport 

(seems dynamic component and Teleport just don’t work well together).

**Summary of next steps:** 
cc: @Leopoldthecoder 

1. Add destination div for the Teleport `<div id="kong-ui-app-page-header-action-button"/>`
in all of the Kong Manager GM entities.

2. Disable the Vue warning  [fix(teleport): not throw warning when teleport is disabled by Leopoldthecoder · Pull Request #9818 · vuejs/core](https://github.com/vuejs/core/pull/9818) 
Thanks [@Yi Yang](https://kongstrong.slack.com/team/U03KF49LWP5) for opening this PR up. 
Hopefully we can get this merged soon.

3. Revert the dynamic component PR [#1001](https://github.com/Kong/public-ui-components/pull/1001).

4. Close this PR without merging.
