### PR TITLE
fix: fix sorting for cross sectional datasets (bar charts)

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
@@ -288,7 +288,7 @@ const dimensionItems = [{
 
 // Short labels
 const statusCodeLabels = [
-  '200', '300', '400', '123123213asa-asdasdf', 'asdfasdfasdfasdfadsfasdf',
+  '500', '200', '300', '400',
 ]
 
 const statusCodeDimensionValues = ref(new Set(statusCodeLabels))

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
@@ -176,8 +176,8 @@ describe('<AnalyticsChart />', () => {
     cy.get('[data-testid="doughnut-chart-parent"]').should('be.visible')
     cy.get('.chart-header').should('contain.text', 'Doughnut chart')
     cy.get('[data-testid="legend"]').children().should('have.length', 6)
-    cy.get('.label').eq(0).should('include.text', 'dp-mock-msg-per-sec-us-dev')
-    cy.get('.label').eq(1).should('include.text', '8b1db7eb-5c3c-489c-9344-eb0b272019ca')
+    cy.get('.label').eq(0).should('include.text', 'dp-mock-us-dev')
+    cy.get('.label').eq(1).should('include.text', 'GetMeAKongDefault')
   })
 
   it('renders a doughnut chart with sigle dimension data', () => {

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -305,7 +305,7 @@ const chartLegendSortFn = computed(() => {
     }
 
     // Status codes (if label is numeric)
-    if (typeof parseInt(a.text, 10) === 'number' && typeof parseInt(b.text, 10) === 'number') {
+    if (!isNaN(parseInt(a.text, 10)) && !isNaN(parseInt(b.text, 10))) {
       return a.text < b.text ? -1 : 1
     }
 
@@ -329,7 +329,7 @@ const chartTooltipSortFn = computed(() => {
     }
 
     // Status codes (if label is numeric)
-    if (typeof parseInt(a.label, 10) === 'number' && typeof parseInt(b.label, 10) === 'number') {
+    if (!isNaN(parseInt(a.label, 10)) && !isNaN(parseInt(b.label, 10))) {
       return a.label < b.label ? -1 : 1
     }
 

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
@@ -167,12 +167,12 @@ describe('useVitalsExploreDatasets', () => {
 
     expect(result.value).toEqual(
       {
-        labels: ['GroupBy1', 'GroupBy2'],
+        labels: ['GroupBy2', 'GroupBy1'],
         datasets: [
-          { label: 'ThenBy1', backgroundColor: '#a86cd5', data: [100, null] },
-          { label: 'ThenBy2', backgroundColor: '#6a86d2', data: [150, null] },
-          { label: 'ThenBy3', backgroundColor: '#00bbf9', data: [null, 200] },
-          { label: 'ThenBy4', backgroundColor: '#00c4b0', data: [null, 250] },
+          { label: 'ThenBy1', backgroundColor: '#a86cd5', data: [null, 100] },
+          { label: 'ThenBy2', backgroundColor: '#6a86d2', data: [null, 150] },
+          { label: 'ThenBy3', backgroundColor: '#00bbf9', data: [200, null] },
+          { label: 'ThenBy4', backgroundColor: '#00c4b0', data: [250, null] },
         ],
       },
     )
@@ -297,10 +297,10 @@ it('handles multiple metrics with dimension', () => {
 
   expect(result.value).toEqual(
     {
-      labels: ['service1', 'service2'],
+      labels: ['service2', 'service1'],
       datasets: [
-        { label: 'metric1', backgroundColor: '#a86cd5', data: [1, 3] },
-        { label: 'metric2', backgroundColor: '#6a86d2', data: [2, 4] },
+        { label: 'metric1', backgroundColor: '#a86cd5', data: [3, 1] },
+        { label: 'metric2', backgroundColor: '#6a86d2', data: [4, 2] },
       ],
     },
   )

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
@@ -30,7 +30,7 @@ function generateDatasets(dataSetGenerationParams: BarChartDatasetGenerationPara
     })
   }
 
-  return Array.from(barSegmentLabels).flatMap((dimension, i) => {
+  const datasets = Array.from(barSegmentLabels).flatMap((dimension, i) => {
     if (!dimension) {
       return []
     }
@@ -47,11 +47,17 @@ function generateDatasets(dataSetGenerationParams: BarChartDatasetGenerationPara
       // @ts-ignore - dynamic i18n key
       label: (i18n && i18n.te(`chartLabels.${dimension.name}`) && i18n.t(`chartLabels.${dimension.name}`)) || dimension.name,
       backgroundColor: baseColor,
+      total: rowLabels.reduce((acc, row) => {
+        const value = pivotRecords[`${row.id},${dimension.id}`] || 0
+        return acc + Number(value)
+      }, 0),
       data: rowLabels.map(rowPosition => {
         return pivotRecords[`${rowPosition.id},${dimension.id}`] || null
       }),
     } as Dataset
   })
+
+  return datasets
 }
 
 export default function useExploreResultToDatasets(
@@ -60,7 +66,6 @@ export default function useExploreResultToDatasets(
 ): Ref<KChartData> {
 
   const { i18n } = composables.useI18n()
-
   const chartData: Ref<KChartData> = computed(() => {
 
     try {
@@ -98,32 +103,41 @@ export default function useExploreResultToDatasets(
             return [label, value]
           }))
 
+        const sortedDatasetIds = Object.entries(pivotRecords).sort(([, a], [, b]) => Number(b) - Number(a)).map(([key]) => (key.split(',')[0]))
         const primaryDimensionDisplay = display[primaryDimension]
         const secondaryDimensionDisplay = display[secondaryDimension]
         const rowLabels: DatasetLabel[] = (hasDimensions && primaryDimensionDisplay && Object.entries(primaryDimensionDisplay).map(([id, val]) => ({ id, name: val.name }))) || metricNames.map(name => ({ id: name, name }))
-
         const barSegmentLabels: DatasetLabel[] = (hasDimensions && secondaryDimensionDisplay && Object.entries(secondaryDimensionDisplay).map(([id, val]) => ({ id, name: val.name }))) || metricNames.map(name => ({ id: name, name }))
+
+        if (primaryDimension !== 'status_code' && primaryDimension !== 'status_code_grouped') {
+          rowLabels.sort((a, b) => sortedDatasetIds.indexOf(a.id) - sortedDatasetIds.indexOf(b.id))
+          barSegmentLabels.sort((a, b) => sortedDatasetIds.indexOf(a.id) - sortedDatasetIds.indexOf(b.id))
+        }
 
         if (!rowLabels || !barSegmentLabels) {
           return { labels: [], datasets: [] }
         }
 
+        const datasets = generateDatasets({
+          isMultiMetric,
+          hasDimensions,
+          metricNames,
+          dimensionFieldNames,
+          barSegmentLabels,
+          pivotRecords,
+          rowLabels,
+          colorPalette: deps.colorPalette || datavisPalette,
+        })
+
+        const labels = !hasDimensions
+          // @ts-ignore - dynamic i18n key
+          ? metricNames.map(name => (i18n && i18n.te(`chartLabels.${name}`) && i18n.t(`chartLabels.${name}`)) || name)
+          // @ts-ignore - dynamic i18n key
+          : rowLabels.map(label => (i18n && i18n.te(`chartLabels.${label.name}`) && i18n.t(`chartLabels.${label.name}`)) || label.name)
+
         const data: KChartData = {
-          labels: !hasDimensions
-            // @ts-ignore - dynamic i18n key
-            ? metricNames.map(name => (i18n && i18n.te(`chartLabels.${name}`) && i18n.t(`chartLabels.${name}`)) || name)
-            // @ts-ignore - dynamic i18n key
-            : Object.entries(display[primaryDimension]).map(([, val]) => (i18n && i18n.te(`chartLabels.${val.name}`) && i18n.t(`chartLabels.${val.name}`)) || val.name),
-          datasets: generateDatasets({
-            isMultiMetric,
-            hasDimensions,
-            metricNames,
-            dimensionFieldNames,
-            barSegmentLabels,
-            pivotRecords,
-            rowLabels,
-            colorPalette: deps.colorPalette || datavisPalette,
-          }),
+          labels,
+          datasets,
         }
 
         return data

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
@@ -47,10 +47,6 @@ function generateDatasets(dataSetGenerationParams: BarChartDatasetGenerationPara
       // @ts-ignore - dynamic i18n key
       label: (i18n && i18n.te(`chartLabels.${dimension.name}`) && i18n.t(`chartLabels.${dimension.name}`)) || dimension.name,
       backgroundColor: baseColor,
-      total: rowLabels.reduce((acc, row) => {
-        const value = pivotRecords[`${row.id},${dimension.id}`] || 0
-        return acc + Number(value)
-      }, 0),
       data: rowLabels.map(rowPosition => {
         return pivotRecords[`${rowPosition.id},${dimension.id}`] || null
       }),


### PR DESCRIPTION
# Summary

 Explore result meta used to contain an array `dimensions: []`. We use this to generate the resulting ChartJS datasets. It was an array so the order in which it came back from druid was maintained, we didn't have to use `Object.entries`. 
Now it's an object `display: {}`. Now we need to call Object.entries() in order to iterate over it to create datasets, order is not guaranteed, need to do manual sorting.

  - Sort the pivot records lookup table by value and extract an array of entity IDs to keep track of the order in which the datasets should appear in the chart
  - Sort the rowLabels by the index in which they appear in the sorted list by value. (rowLabels is used to then generate the chartJS datsets and labels array)


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
