### PR TITLE
fix(entities-plugins): keep dynamic ordering in edit payload [KM-148]

### DIFF
--- a/packages/entities/entities-plugins/src/types/plugin.ts
+++ b/packages/entities/entities-plugins/src/types/plugin.ts
@@ -155,3 +155,12 @@ export type PluginCardList = {
 export type TriggerLabels = {
   [key in PluginGroup]?: string // [plugin.group]: label
 }
+
+export type PluginOrdering = {
+  before: {
+    access: string[]
+  }
+  after: {
+    access: string[]
+  }
+}


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This PR fixes a Konnect bug where dynamic ordering configuration is lost when editing a plugin.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
