### PR TITLE
fix(swagger-ui-web-component): ensure there are 4 grid columns for each operation

### DIFF
--- a/packages/portal/swagger-ui-web-component/src/styles/essentialsOnly.css
+++ b/packages/portal/swagger-ui-web-component/src/styles/essentialsOnly.css
@@ -8,6 +8,10 @@
 .opblock-body .right-side-wrapper .code-snippet {
   display: none !important;
 }
+/* ensure there are 4 columns to match the number of elements in the current version of swagger */
+.swagger-ui .opblock-tag-section .opblock .opblock-summary {
+  grid-template-columns: 80px auto 30px auto;
+}
 /* fix copy button width */
 .swagger-ui .opblock .opblock-summary:hover .view-line-link.copy-to-clipboard {
   width: 24px;


### PR DESCRIPTION
# Summary

Currently there is some CSS that has 3 columns, but a recently upgraded version of Swagger UI regrouped the elements so that it is now necessary to have 4 columns to prevent the open/collapse toggle button from flowing into the next row.

The current CSS rule that is offending is:
```css
.swagger-ui .opblock .opblock-summary {
  grid-template-columns: 80px auto 30px;
}

before:
<img width="980" alt="Screenshot 2024-05-23 at 3 27 45 PM" src="https://github.com/Kong/public-ui-components/assets/8764246/42bf22fc-97ce-48bf-ace2-747750ce821a">

after:
<img width="900" alt="Screenshot 2024-05-23 at 3 28 02 PM" src="https://github.com/Kong/public-ui-components/assets/8764246/b0504b1c-e852-49a6-9c5f-3fa976939035">

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
