### PR TITLE
feat(forms): dedicated redis configuration for RLA [KM-178]

### DIFF
--- a/packages/core/forms/src/locales/en.json
+++ b/packages/core/forms/src/locales/en.json
@@ -103,6 +103,9 @@
         "consumer-group": "Consumer Group"
       }
     },
-    "redis_address_example": "e.g. localhost:6379"
+    "redis": {
+      "title": "Configure your Redis",
+      "address_example": "e.g. localhost:6379"
+    }
   }
 }


### PR DESCRIPTION
# Summary

This pull request adds the dedicated section for Redis configuration which will show/hide in the RLA form according to the value of the `config.strategy`.

<img width="789" alt="Screenshot 2024-05-28 at 12 49 29" src="https://github.com/Kong/public-ui-components/assets/5277268/16226743-6fe0-4001-9c91-f487bef79ef5">

<img width="658" alt="Screenshot 2024-05-28 at 12 49 47" src="https://github.com/Kong/public-ui-components/assets/5277268/84b69a0c-3fa8-46ef-aade-80dfac757335">

KM-178