### PR TITLE
fix(forms): partially use KInput in FieldArray [KM-185]

### DIFF
--- a/packages/core/forms/src/forms/RLAForm.vue
+++ b/packages/core/forms/src/forms/RLAForm.vue
@@ -354,8 +354,9 @@ const advancedSchema = computed(() => {
 
     if (model.startsWith('config-redis-')) {
       if (field.model === 'config-redis-cluster_addresses' || field.model === 'config-redis-sentinel_addresses') {
-        field.hint = t('rla.redis.address_example')
+        field.inputAttributes.help = t('rla.redis.address_example')
       }
+
       redis.push(field)
       continue
     }

--- a/packages/core/forms/src/generator/FormGenerator.vue
+++ b/packages/core/forms/src/generator/FormGenerator.vue
@@ -401,7 +401,7 @@ export default {
     width: 100%;
   }
 
-  .form-control {
+  :not(.k-input).form-control {
     background-color: #fff;
     background-image: none;
     border: none;

--- a/packages/core/forms/src/generator/fields/advanced/FieldArray.vue
+++ b/packages/core/forms/src/generator/fields/advanced/FieldArray.vue
@@ -42,13 +42,21 @@
         @remove-item="removeElement(index)"
       >
         <FieldTextArea
-          v-if=" schema.inputAttributes?.type === 'textarea'"
+          v-if="schema.inputAttributes && schema.inputAttributes.type === 'textarea'"
           :aria-labelledby="getLabelId(schema)"
           class="k-input"
           :form-options="formOptions"
           :model="item"
           :schema="generateSchema(value, schema.items, index)"
           @model-updated="modelUpdated"
+        />
+
+        <KInput
+          v-else-if="!schema.inputAttributes || !schema.inputAttributes.type || schema.inputAttributes.type === 'text'"
+          v-model="value[index]"
+          :aria-labelledby="getLabelId(schema)"
+          v-bind="schema.inputAttributes"
+          :type="schema.inputAttributes && schema.inputAttributes.type || 'text'"
         />
 
         <input
@@ -58,6 +66,7 @@
           v-bind="schema.inputAttributes"
           :type="schema.inputAttributes?.type || 'text'"
         >
+
         <input
           v-if="schema.showRemoveButton"
           v-bind="schema.removeElementButtonAttributes"


### PR DESCRIPTION
# Summary

This pull request updates the FieldArray to use partially KInput as array items to show the help text right below the input

|Before|After|
|:-:|:-:|
|<img width="796" alt="Screenshot 2024-05-29 at 12 44 25" src="https://github.com/Kong/public-ui-components/assets/5277268/f46c5464-c263-4ab8-b2fc-7912a1bb803e">|<img width="688" alt="Screenshot 2024-05-29 at 12 38 45" src="https://github.com/Kong/public-ui-components/assets/5277268/49f4fce4-443e-43ce-9567-6931f100dfae">|


KM-185