### PR TITLE
fix(entities-plugins): hide ordering for consumer group plugins

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -168,9 +168,9 @@
             :item="getEditDropdownItem(row)"
           />
         </PermissionsWrapper>
-        <!-- Dynamic Plugin Ordering not supported for consumer plugins -->
+        <!-- Dynamic Plugin Ordering not supported for consumer/consumer-group plugins -->
         <PermissionsWrapper
-          v-if="!isConsumerPage && isOrderingSupported"
+          v-if="!isConsumerPage && !isConsumerGroupPage && isOrderingSupported"
           :auth-function="() => canConfigureDynamicOrdering(row)"
         >
           <KDropdownItem
@@ -354,6 +354,7 @@ const router = useRouter()
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const isConsumerPage = computed((): boolean => props.config?.entityType === 'consumers')
+const isConsumerGroupPage = computed((): boolean => props.config?.entityType === 'consumer_groups')
 
 const isOrderingSupported = props.config.app === 'konnect' || useGatewayFeatureSupported({
   gatewayInfo: props.config.gatewayInfo,


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Plugins that are scoped to a consumer group do not support dynamic ordering either.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
