### PR TITLE
fix(entities-plugins): nested array for custom schema [KM-213/FTI-6014]

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -606,9 +606,9 @@ const buildFormSchema = (parentKey: string, response: Record<string, any>, initi
     if (scheme.elements && scheme.type === 'array') {
       const elements = scheme.elements
       if (elements.type === 'string' && !elements.one_of) {
-        const { help, label, hint } = initialFormSchema[field]
+        const { id, help, label, hint } = initialFormSchema[field]
         const { help: helpOverride, ...overrides } = JSON.parse(JSON.stringify(ArrayStringFieldSchema))
-        initialFormSchema[field] = { help, label, hint, ...overrides }
+        initialFormSchema[field] = { id, help, label, hint, ...overrides }
         // Only replace the help text when it is not defined because ArrayStringFieldSchema is more generic
         if (initialFormSchema[field].help === undefined && typeof helpOverride === 'string') {
           initialFormSchema[field].help = marked.parse(helpOverride, { mangle: false, headerIds: false } as MarkedOptions)


### PR DESCRIPTION
# Summary

This pull request fixes the nested array for custom plugins. An example schema looks like the following:

```json
{
  "fields": [
    {
      "some_items": {
        "elements": {
          "fields": [
            {
              "some_nested_items": {
                "elements": {
                  "type": "string"
                },
                "type": "array"
              }
            }
          ],
          "type": "record"
        },
        "type": "array"
      }
    }
  ]
}
```

KM-213 / FTI-6014