### PR TITLE
fix(entities-shared): MutationObserver error in base table

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTableCell.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTableCell.vue
@@ -48,7 +48,7 @@ const isFirst = computed((): boolean => {
   if (cells) {
     return cells[0]?.getAttribute('data-testid') === props.keyName
   } else {
-    return false
+    return true
   }
 })
 


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Fixing a `MutationObserver` error in base table when the first col is wrapped in `KBadge` and `KTruncate`.

KHCP-12242

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
