### PR TITLE
feat(analytics): add support for basic datasource [MA-2931]

### DIFF
--- a/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
+++ b/packages/analytics/analytics-metric-provider/src/components/metricsProviderUtil.ts
@@ -2,7 +2,7 @@ import type {
   AnalyticsBridge,
   ExploreAggregations,
   ExploreFilter,
-  QueryableExploreDimensions,
+  QueryableExploreDimensions, QueryDatasource,
   Timeframe,
 } from '@kong-ui-public/analytics-utilities'
 import composables from '../composables'
@@ -26,6 +26,7 @@ interface ProviderData {
 export const METRICS_PROVIDER_KEY = Symbol('METRICS_PROVIDER_KEY') as InjectionKey<ProviderData>
 
 interface FetcherOptions {
+  datasource: Ref<QueryDatasource>
   dimension?: QueryableExploreDimensions
   dimensionFilterValue?: string
   additionalFilter: Ref<ExploreFilter[] | undefined>
@@ -41,6 +42,7 @@ interface FetcherOptions {
 
 export const defaultFetcherDefs = (opts: FetcherOptions) => {
   const {
+    datasource,
     dimension,
     dimensionFilterValue,
     additionalFilter,
@@ -80,6 +82,8 @@ export const defaultFetcherDefs = (opts: FetcherOptions) => {
   })
 
   const trafficMetricFetcherOptions: MetricFetcherOptions = {
+    datasource,
+
     metrics: ref([
       'request_count',
     ]),
@@ -105,6 +109,8 @@ export const defaultFetcherDefs = (opts: FetcherOptions) => {
   }
 
   const latencyMetricFetcherOptions: MetricFetcherOptions = {
+    datasource,
+
     metrics: computed<ExploreAggregations[]>(() => [
       averageLatencies.value ? 'response_latency_average' : 'response_latency_p99',
     ]),

--- a/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
+++ b/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
@@ -121,7 +121,12 @@ export default function useMetricFetcher(opts: MetricFetcherOptions): FetcherRes
 
   const { response: raw, error: metricError, isValidating: isMetricDataValidating } = composables.useRequest<ExploreResultV4>(
     () => cacheKey.value,
-    () => opts.queryFn(query.value, opts.abortController ?? new AbortController()),
+    () => opts.queryFn({
+      // TODO: Use a type guard to validate that if the datasource is basic,
+      // the query is a valid basic explore query.
+      datasource: opts.datasource.value as 'advanced',
+      query: query.value,
+    }, opts.abortController ?? new AbortController()),
     {
       refreshInterval: opts.refreshInterval,
       revalidateOnFocus: false,

--- a/packages/analytics/analytics-metric-provider/src/types/fetcher-types.ts
+++ b/packages/analytics/analytics-metric-provider/src/types/fetcher-types.ts
@@ -1,10 +1,11 @@
 import type {
   Timeframe,
-  ExploreAggregations, QueryableExploreDimensions, ExploreFilter, AnalyticsBridge,
+  ExploreAggregations, QueryableExploreDimensions, ExploreFilter, AnalyticsBridge, QueryDatasource,
 } from '@kong-ui-public/analytics-utilities'
 import type { Ref } from 'vue'
 
 export interface MetricFetcherOptions {
+  datasource: Ref<QueryDatasource>
   metrics: Ref<ExploreAggregations[]>
   dimensions?: QueryableExploreDimensions[]
   filter: Ref<ExploreFilter[] | undefined>

--- a/packages/analytics/analytics-utilities/src/types/explore-v4.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore-v4.ts
@@ -1,6 +1,10 @@
 // Query types
 import type { MetricUnit, RecordEvent } from './analytics-data'
 
+export const queryDatasources = ['basic', 'advanced'] as const
+
+export type QueryDatasource = typeof queryDatasources[number]
+
 export const exploreFilterTypesV2 = ['in', 'not_in', 'selector'] as const
 
 export type ExploreFilterTypesV2 = typeof exploreFilterTypesV2[number]
@@ -18,6 +22,8 @@ export const queryableBasicExploreDimensions = [
   'time',
 ] as const
 
+export type QueryableBasicExploreDimensions = typeof queryableBasicExploreDimensions[number]
+
 export const queryableExploreDimensions = [
   ...queryableBasicExploreDimensions,
   'application',
@@ -26,10 +32,14 @@ export const queryableExploreDimensions = [
 
 export type QueryableExploreDimensions = typeof queryableExploreDimensions[number]
 
-export interface ExploreFilter {
+export interface BasicExploreFilter {
   type: ExploreFilterTypesV2
   dimension: QueryableExploreDimensions
   values: (string | number | null)[]
+}
+
+export interface ExploreFilter extends Omit<BasicExploreFilter, 'dimension'> {
+  dimension: QueryableExploreDimensions
 }
 
 export const basicExploreAggregations = [
@@ -38,6 +48,8 @@ export const basicExploreAggregations = [
   'request_per_minute',
   'response_latency_average',
 ] as const
+
+export type BasicExploreAggregations = typeof basicExploreAggregations[number]
 
 export const exploreAggregations = [
   ...basicExploreAggregations,
@@ -114,10 +126,10 @@ export const granularityValues = [
 
 export type GranularityValues = typeof granularityValues[number]
 
-export interface ExploreQuery {
-  metrics?: ExploreAggregations[]
-  dimensions?: QueryableExploreDimensions[]
-  filters?: ExploreFilter[]
+export interface BasicExploreQuery {
+  metrics?: BasicExploreAggregations[]
+  dimensions?: QueryableBasicExploreDimensions[]
+  filters?: BasicExploreFilter[]
   granularity?: GranularityValues
   time_range?: TimeRangeV4
   limit?: number
@@ -125,6 +137,12 @@ export interface ExploreQuery {
   meta?: {
     query_id: string
   }
+}
+
+export interface ExploreQuery extends Omit<BasicExploreQuery, 'metrics' | 'dimensions' | 'filters'> {
+  metrics?: ExploreAggregations[]
+  dimensions?: QueryableExploreDimensions[]
+  filters?: ExploreFilter[]
 }
 
 // Result types

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -1,13 +1,28 @@
-import type { ExploreQuery, ExploreResultV4 } from './explore-v4'
+import type { BasicExploreQuery, ExploreQuery, ExploreResultV4 } from './explore-v4'
 import type { AnalyticsConfigV2 } from './analytics-config'
+
+export interface BasicDatasourceQuery {
+  datasource: 'basic'
+  query: BasicExploreQuery
+}
+
+export interface AdvancedDatasourceQuery {
+  datasource: 'advanced'
+  query: ExploreQuery
+}
+
+export type DatasourceAwareQuery = BasicDatasourceQuery | AdvancedDatasourceQuery
 
 export interface AnalyticsBridge {
   // Issue queries to the KAnalytics API
-  queryFn: (query: ExploreQuery, abortController: AbortController) => Promise<ExploreResultV4>,
+  queryFn: (query: DatasourceAwareQuery, abortController: AbortController) => Promise<ExploreResultV4>,
 
   // Determine the current org's analytics config
   configFn: () => Promise<AnalyticsConfigV2>,
 
   // Evaluate feature flags (if applicable)
+  // TODO: Use `NoInfer` once we upgrade to TS 5.4:
+  //  https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#the-noinfer-utility-type
+  //  See note in DashboardRenderer tests.
   evaluateFeatureFlagFn: <T = boolean>(key: string, defaultValue: T) => T,
 }

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -34,10 +34,7 @@ This component only takes two properties:
 
 For context `filters` and `timeSpec` see [here](https://github.com/Kong/public-ui-components/blob/main/packages/analytics/analytics-utilities/src/types/explore-v4.ts).
 
-If a `timeSpec` is not provided in the `context` object, the renderer will determine a default based on the current organization's analytics retention:
-
-- If the org's retention is less than 30 days, the renderer will query 24 hours of data.
-- If the org's retention is greater than or equal to 30 days, the renderer will query 30 days of data.
+If a `timeSpec` is not provided in the `context` object, the renderer will determine a default, which is currently 7 days.
 
 ### Example
 
@@ -68,7 +65,7 @@ const config: DashboardConfig = {
   gridSize: {
     cols: 4,
     rows: 1,
-  }
+  },
   tiles: [
     {
       definition: {
@@ -159,7 +156,7 @@ const config: DashboardConfig = {
   gridSize: {
     cols: 4,
     rows: 1,
-  }
+  },
   tiles: [
     {
       // Line chart
@@ -235,7 +232,7 @@ const config: DashboardConfig = {
   gridSize: {
     cols: 4,
     rows: 1,
-  }
+  },
   tiles: [
     {
       definition: {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -56,7 +56,9 @@ const dashboardConfig: DashboardConfig = {
           chartTitle: 'Analytics Golden Signals',
           description: '{timeframe}',
         },
-        query: {},
+        query: {
+          datasource: 'basic',
+        },
       },
       layout: {
         position: {
@@ -76,7 +78,10 @@ const dashboardConfig: DashboardConfig = {
           chartTitle: 'Top N chart of mock data',
           description: '{timeframe}',
         },
-        query: { limit: 1 },
+        query: {
+          datasource: 'basic',
+          limit: 1,
+        },
       },
       layout: {
         position: {
@@ -97,7 +102,10 @@ const dashboardConfig: DashboardConfig = {
           chartTitle: 'Top N chart of mock data',
           description: 'Description',
         },
-        query: { limit: 3 },
+        query: {
+          datasource: 'basic',
+          limit: 3,
+        },
       },
       layout: {
         position: {
@@ -118,7 +126,10 @@ const dashboardConfig: DashboardConfig = {
           chartTitle: 'Horizontal bar chart of mock data',
           allowCsvExport: true,
         },
-        query: { dimensions: ['route'] },
+        query: {
+          datasource: 'basic',
+          dimensions: ['route'],
+        },
       },
       layout: {
         position: {
@@ -138,6 +149,7 @@ const dashboardConfig: DashboardConfig = {
           type: ChartTypes.TimeseriesLine,
         },
         query: {
+          datasource: 'basic',
           dimensions: ['time'],
         },
       },
@@ -160,7 +172,9 @@ const dashboardConfig: DashboardConfig = {
           reverseDataset: true,
           numerator: 0,
         },
-        query: {},
+        query: {
+          datasource: 'basic',
+        },
       },
       layout: {
         position: {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
@@ -18,7 +18,9 @@ describe('Dashboard schemas', () => {
             chart: {
               type: 'horizontal_bar',
             },
-            query: {},
+            query: {
+              datasource: 'basic',
+            },
           },
           layout: {
             position: {
@@ -52,7 +54,9 @@ describe('Dashboard schemas', () => {
               reverseDataset: true,
               numerator: 0,
             },
-            query: {},
+            query: {
+              datasource: 'basic',
+            },
           },
           layout: {
             position: {

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -47,6 +47,7 @@ const overrideTimeframe: Ref<Timeframe> = computed(() => {
 })
 
 const options = computed<ProviderProps>(() => ({
+  datasource: props.query?.datasource,
   overrideTimeframe: overrideTimeframe.value,
   tz: props.context.tz,
   additionalFilter: props.context.filters,

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -3,6 +3,7 @@
     "noQueryBridge": "No query bridge provided.  Unable to render dashboard.",
     "trendRange": {
       "24h": "Last 24-Hour Summary",
+      "7d": "Last 7-Day Summary",
       "30d": "Last 30-Day Summary"
     }
   },


### PR DESCRIPTION
BREAKING CHANGE: change signature of `queryFn` in query bridge, and make `datasource` a required property in dashboard definitions.

- Change signature of `queryFn`.
- Add `datasource` parameter to MetricsProvider.
- Add `datasource` property to dashboard query definitions.

# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
