### PR TITLE
feat(plugins): rollout redesigned RLA form [KM-233]

### DIFF
--- a/packages/core/forms/src/forms/RLAForm.vue
+++ b/packages/core/forms/src/forms/RLAForm.vue
@@ -331,12 +331,7 @@ const scopingSchema = computed(() => {
     return undefined
   }
 
-  return {
-    fields: [{
-      ...selectionGroup,
-      horizontalRadios: true,
-    }],
-  }
+  return { fields: [selectionGroup] }
 })
 
 const advancedSchema = computed(() => {

--- a/packages/core/forms/src/generator/fields/advanced/FieldSelectionGroup.vue
+++ b/packages/core/forms/src/generator/fields/advanced/FieldSelectionGroup.vue
@@ -1,60 +1,13 @@
 <template>
   <div class="selection-group">
-    <template v-if="schema.horizontalRadios">
-      <!-- Radio button -->
-      <div class="form-group horizontal-radios">
-        <div class="radio-group">
-          <div
-            v-for="(option, i) in schema.fields"
-            :key="i"
-            class="option-group"
-          >
-            <label
-              class="k-label"
-              :class="`${option.label}-check`"
-            >
-              <input
-                v-model="checkedGroup"
-                class="k-input"
-                type="radio"
-                :value="i"
-              >
-              {{ option.label }}
-              <div class="control-help">{{ option.description }}</div>
-            </label>
-          </div>
-        </div>
-      </div>
-
-      <div
-        v-for="(option, i) in schema.fields"
-        :key="i"
-        class="option-group"
-      >
-        <!-- Selected Field -->
+    <!-- Radio button -->
+    <div class="form-group horizontal-radios">
+      <div class="radio-group">
         <div
-          v-show="option.fields && checkedGroup === i"
-          class="option-field"
+          v-for="(option, i) in schema.fields"
+          :key="i"
+          class="option-group"
         >
-          <div class="option-field-container">
-            <vue-form-generator
-              :model="model"
-              :options="{ helpAsHtml: true }"
-              :schema="{ fields: option.fields }"
-              @model-updated="updateModel"
-            />
-          </div>
-        </div>
-      </div>
-    </template>
-    <template v-else>
-      <div
-        v-for="(option, i) in schema.fields"
-        :key="i"
-        class="option-group"
-      >
-        <!-- Radio button -->
-        <div class="form-group">
           <label
             class="k-label"
             :class="`${option.label}-check`"
@@ -69,23 +22,29 @@
             <div class="control-help">{{ option.description }}</div>
           </label>
         </div>
+      </div>
+    </div>
 
-        <!-- Selected Field -->
-        <div
-          v-show="option.fields && checkedGroup === i"
-          class="option-field"
-        >
-          <div class="option-field-container">
-            <vue-form-generator
-              :model="model"
-              :options="{ helpAsHtml: true }"
-              :schema="{ fields: option.fields }"
-              @model-updated="updateModel"
-            />
-          </div>
+    <div
+      v-for="(option, i) in schema.fields"
+      :key="i"
+      class="option-group"
+    >
+      <!-- Selected Field -->
+      <div
+        v-show="option.fields && checkedGroup === i"
+        class="option-field"
+      >
+        <div class="option-field-container">
+          <vue-form-generator
+            :model="model"
+            :options="{ helpAsHtml: true }"
+            :schema="{ fields: option.fields }"
+            @model-updated="updateModel"
+          />
         </div>
       </div>
-    </template>
+    </div>
   </div>
 </template>
 

--- a/packages/core/forms/src/index.ts
+++ b/packages/core/forms/src/index.ts
@@ -12,18 +12,14 @@ export default {
 export { customFields } from './generator/fields/advanced/exports'
 export { VueFormGenerator, sharedForms }
 
-export interface GetSharedFormNameOptions {
-  useRLARedesignedForm?: boolean
-}
-
-export const getSharedFormName = (modelName: string, options?: GetSharedFormNameOptions): string => {
+export const getSharedFormName = (modelName: string): string => {
   const mapping:Record<string, string> = {
     'openid-connect': 'OIDCForm',
     'post-function': 'PostFunction',
     // Pre and Post function plugins are using same component
     'pre-function': 'PostFunction',
     'exit-transformer': 'ExitTransformer',
-    ...(options?.useRLARedesignedForm && { 'rate-limiting-advanced': 'RLAForm' }),
+    'rate-limiting-advanced': 'RLAForm',
   }
 
   return mapping[modelName]

--- a/packages/entities/entities-plugins/docs/plugin-form.md
+++ b/packages/entities/entities-plugins/docs/plugin-form.md
@@ -91,18 +91,6 @@ A form component for Plugins.
     - default: `false`
     - *Specific to Kong Manager*. Whether or not to hide the consumer group scope field.
 
-  - `useRLARedesignedForm`:
-    - type: `boolean`
-    - required: `false`
-    - default: `false`
-    - Whether to use the redesigned form for the RLA plugin.
-
-  - `useHorizontalRadiosForPluginScoping`:
-    - type: `boolean`
-    - required: `false`
-    - default: `false`
-    - Whether to use the horizontal radios in the plugin scoping section.
-
 The base konnect or kongManger config.
 
 #### `pluginType`

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -50,7 +50,6 @@ const konnectConfig = ref<KonnectPluginFormConfig>({
   // entityId: '6f1ef200-d3d4-4979-9376-726f2216d90c',
   backRoute: { name: 'select-plugin' },
   cancelRoute: { name: 'home' },
-  useRLARedesignedForm: true,
 })
 
 const kongManagerConfig = ref<KongManagerPluginFormConfig>({
@@ -62,7 +61,6 @@ const kongManagerConfig = ref<KongManagerPluginFormConfig>({
   // entityId: '123-abc-i-lover-cats',
   backRoute: { name: 'select-plugin' },
   cancelRoute: { name: 'home' },
-  useRLARedesignedForm: true,
 })
 
 const onUpdate = (payload: Record<string, any>) => {

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -137,7 +137,6 @@ const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { parseSchema } = composables.useSchemas({
   entityId: props.entityMap.focusedEntity?.id || undefined,
   credential: props.credential,
-  useRLARedesignedForm: props.config.useRLARedesignedForm,
 })
 const { convertToDotNotation, unFlattenObject, isObjectEmpty, unsetNullForeignKey } = composables.usePluginHelpers()
 
@@ -608,7 +607,7 @@ watch(() => props.schema, (newSchema, oldSchema) => {
     return { ...r, disabled: r.disabled || false }
   }) }
   Object.assign(originalModel, JSON.parse(JSON.stringify(form.model)))
-  sharedFormName.value = getSharedFormName(form.model.name, { useRLARedesignedForm: props.config.useRLARedesignedForm })
+  sharedFormName.value = getSharedFormName(form.model.name)
 
   initFormModel()
 }, { immediate: true, deep: true })

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -440,7 +440,6 @@ const defaultFormSchema: DefaultPluginsSchemaRecord = reactive({
       },
     ],
     pinned: true,
-    horizontalRadios: props.config.useHorizontalRadiosForPluginScoping, // KM-136-RLA-Redesign: While enabled, this new horizontal radio design will be applied for ALL plugins
   },
   protocols: {
     id: 'protocols',

--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -59,12 +59,6 @@ export interface UseSchemasOptions {
    * @defaultValue false
    */
   credential?: boolean
-
-  /**
-   * Whether to enable the redesigned form for the RLA plugin (KM-136).
-   * @defaultValue false
-   */
-  useRLARedesignedForm?: boolean
 }
 
 /** Sorts non-config fields and place them at the top */
@@ -251,7 +245,7 @@ export const useSchemas = (options?: UseSchemasOptions) => {
     const pluginName = formModel.name
     const metadata = PLUGIN_METADATA[pluginName]
 
-    if (getSharedFormName(pluginName, { useRLARedesignedForm: options?.useRLARedesignedForm }) || metadata?.useLegacyForm || options?.credential) {
+    if (getSharedFormName(pluginName) || metadata?.useLegacyForm || options?.credential) {
       /**
        * Do not generate grouped schema when:
        * - The plugin has a custom layout

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -36,10 +36,6 @@ export interface BasePluginFormConfig {
   entityId?: string
   /** Whether to hide the consumer group scope field. For Kong Manager OSS, this is true */
   disableConsumerGroupScope?: boolean
-  /** Whether to use the redesigned form for the RLA plugin. Default: false */
-  useRLARedesignedForm?: boolean
-  /** Whether to use the horizontal radios in the plugin scoping section. Default: false */
-  useHorizontalRadiosForPluginScoping?: boolean
 }
 
 export interface KongManagerPluginSelectConfig extends BasePluginSelectConfig, KongManagerBaseFormConfig {}


### PR DESCRIPTION
# Summary

### ⚠️  BREAKING CHANGE

`useRLARedesignedForm` and `useHorizontalRadiosForPluginScoping` are no longer used and the redesigned RLA form will be available for all


This pull request rolls out the redesigned RLA form and cleans the unnecessary props.

- [x] Branch created: https://github.com/Kong/public-ui-components/tree/entities-plugins-5.x
- [x] _Adoption PR is linked_

KM-233