### PR TITLE
fix(forms): use KTextArea in array fields [KM-249]

### DIFF
--- a/packages/core/forms/src/generator/FormGenerator.vue
+++ b/packages/core/forms/src/generator/FormGenerator.vue
@@ -401,7 +401,7 @@ export default {
     width: 100%;
   }
 
-  :not(.k-input).form-control {
+  :not(.k-input):not(.k-textarea).form-control {
     background-color: #fff;
     background-image: none;
     border: none;

--- a/packages/core/forms/src/generator/fields/advanced/FieldArray.vue
+++ b/packages/core/forms/src/generator/fields/advanced/FieldArray.vue
@@ -41,14 +41,20 @@
         :schema="generateSchema(value, schema.items, index)"
         @remove-item="removeElement(index)"
       >
-        <FieldTextArea
+        <KTextArea
           v-if="schema.inputAttributes && schema.inputAttributes.type === 'textarea'"
+          v-bind="schema.inputAttributes"
+          :id="getFieldID(schema)"
+          v-model="value[index]"
           :aria-labelledby="getLabelId(schema)"
-          class="k-input"
-          :form-options="formOptions"
-          :model="item"
-          :schema="generateSchema(value, schema.items, index)"
-          @model-updated="modelUpdated"
+          :class="schema.fieldClasses"
+          :maxlength="schema.max"
+          :minlength="schema.min"
+          :name="schema.inputName"
+          :placeholder="schema.placeholder"
+          :readonly="schema.readonly"
+          :required="schema.required"
+          :rows="schema.rows || 2"
         />
 
         <KInput
@@ -90,6 +96,7 @@
         @click="removeElement(index)"
       >
     </div>
+
     <KButton
       appearance="tertiary"
       :class="schema.newElementButtonLabelClasses"
@@ -104,17 +111,16 @@
 
 <script>
 import abstractField from '../abstractField'
+import FieldInput from '../core/FieldInput.vue'
+import FieldSelect from '../core/fieldSelect.vue'
+import FieldArrayCardContainer from './FieldArrayCardContainer.vue'
 import FieldArrayItem from './FieldArrayItem.vue'
 import FieldArrayMultiItem from './FieldArrayMultiItem.vue'
+import FieldAutoSuggest from './FieldAutoSuggest.vue'
 import FieldMetric from './FieldMetric.vue'
 import FieldObject from './FieldObject.vue'
 import FieldObjectAdvanced from './FieldObjectAdvanced.vue'
-import FieldAutoSuggest from './FieldAutoSuggest.vue'
-import FieldArrayCardContainer from './FieldArrayCardContainer.vue'
 import FieldRadio from './FieldRadio.vue'
-import FieldInput from '../core/FieldInput.vue'
-import FieldSelect from '../core/fieldSelect.vue'
-import FieldTextArea from '../core/fieldTextArea.vue'
 
 export default {
   name: 'FieldArray',
@@ -128,7 +134,6 @@ export default {
     FieldAutoSuggest,
     FieldRadio,
     FieldArrayCardContainer,
-    FieldTextArea,
     FieldInput,
   },
   mixins: [abstractField],


### PR DESCRIPTION
# Summary

This PR makes the VFG use `KTextArea` in array fields.

<img width="709" alt="Screenshot 2024-06-19 at 19 16 02" src="https://github.com/Kong/public-ui-components/assets/5277268/717badc7-33a7-4178-91d3-1f5bb40514ef">


`FieldTextArea` is not used anymore, but we will clean it in the refactor PR along with other unused fields.

- [x] Adoption PR linked

KM-249