### PR TITLE
feat(analytics-chart): padding below title, not above subtitle

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
@@ -227,10 +227,10 @@ function handleMouseUp() {
     .title {
       font-size: $kui-font-size-30;
       font-weight: $kui-font-weight-semibold;
+      margin-bottom: $kui-space-20;
     }
     .subtitle {
       font-size: $kui-font-size-20;
-      margin-top: $kui-space-40;
     }
 
     .drag-icon {


### PR DESCRIPTION
# Summary

### Issue
<img width="406" alt="Screenshot 2024-06-25 at 18 34 37" src="https://github.com/Kong/public-ui-components/assets/103061463/548e4656-1fba-4d4c-bc4b-6b7996494043">


### Fix
Looks good if Title prop is not provided
<img width="389" alt="Screenshot 2024-06-25 at 18 57 06" src="https://github.com/Kong/public-ui-components/assets/103061463/e86b2a32-86ee-4a32-b5e6-cd6f7d8d1f08">

<img width="294" alt="Screenshot 2024-06-25 at 18 34 07" src="https://github.com/Kong/public-ui-components/assets/103061463/289b412f-b990-4f03-a429-fa52f415ab37">

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
