### PR TITLE
feat(entities-plugins): remove back button in the form [KM-273]

### DIFF
--- a/packages/entities/entities-plugins/docs/plugin-form.md
+++ b/packages/entities/entities-plugins/docs/plugin-form.md
@@ -55,12 +55,6 @@ A form component for Plugins.
     - default: `undefined`
     - Route to return to when canceling creation/edit of a plugin.
 
-  - `backRoute`:
-    - type: `RouteLocationRaw`
-    - required: `false`
-    - default: `undefined`
-    - Route to return to the plugin selection page if clicking back when creating a plugin.
-
   - `workspace`:
     - type: `string`
     - required: `true`

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -48,7 +48,6 @@ const konnectConfig = ref<KonnectPluginFormConfig>({
   // force the scope
   // entityType: 'services',
   // entityId: '6f1ef200-d3d4-4979-9376-726f2216d90c',
-  backRoute: { name: 'select-plugin' },
   cancelRoute: { name: 'home' },
 })
 
@@ -59,7 +58,6 @@ const kongManagerConfig = ref<KongManagerPluginFormConfig>({
   // force the scope
   // entityType: 'consumers',
   // entityId: '123-abc-i-lover-cats',
-  backRoute: { name: 'select-plugin' },
   cancelRoute: { name: 'home' },
 })
 

--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -20,7 +20,6 @@ const baseConfigKonnect: KonnectPluginFormConfig = {
   app: 'konnect',
   apiBaseUrl: '/us/kong-api',
   controlPlaneId: 'abc-123-i-love-cats',
-  backRoute: { name: 'select-plugin' },
   cancelRoute: { name: 'home' },
 }
 
@@ -28,7 +27,6 @@ const baseConfigKM:KongManagerPluginFormConfig = {
   app: 'kongManager',
   workspace: 'default',
   apiBaseUrl: '/kong-manager',
-  backRoute: { name: 'select-plugin' },
   cancelRoute: { name: 'home' },
 }
 
@@ -191,8 +189,6 @@ describe('<PluginForm />', () => {
       // button state
       cy.getTestId('form-submit').should('be.visible')
       cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('form-back').should('be.visible')
-      cy.getTestId('form-back').should('be.enabled')
       cy.getTestId('form-cancel').should('be.visible')
 
       // pinned fields (but they should not be under a KCollapse)
@@ -264,8 +260,6 @@ describe('<PluginForm />', () => {
       // button state
       cy.getTestId('form-submit').should('be.visible')
       cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('form-back').should('be.visible')
-      cy.getTestId('form-back').should('be.enabled')
       cy.getTestId('form-cancel').should('be.visible')
 
       // pinned fields (but they should not be under a KCollapse)
@@ -347,8 +341,6 @@ describe('<PluginForm />', () => {
       // button state
       cy.getTestId('form-submit').should('be.visible')
       cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('form-back').should('be.visible')
-      cy.getTestId('form-back').should('be.enabled')
       cy.getTestId('form-cancel').should('be.visible')
 
       // scope fields
@@ -435,7 +427,6 @@ describe('<PluginForm />', () => {
       cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
 
       cy.getTestId('form-submit').should('not.exist')
-      cy.getTestId('form-back').should('not.exist')
       cy.getTestId('form-cancel').should('not.exist')
     })
 
@@ -461,7 +452,6 @@ describe('<PluginForm />', () => {
       // button state
       cy.getTestId('form-submit').should('be.visible')
       cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('form-back').should('be.visible')
       cy.getTestId('form-cancel').should('be.visible')
 
       // scope & global fields
@@ -587,7 +577,6 @@ describe('<PluginForm />', () => {
         // button state
         cy.getTestId('form-submit').should('be.visible')
         cy.getTestId('form-submit').should('be.disabled')
-        cy.getTestId('form-back').should('not.exist')
         cy.getTestId('form-cancel').should('be.visible')
 
         // reveal advanced fields
@@ -1054,8 +1043,6 @@ describe('<PluginForm />', () => {
       // button state
       cy.getTestId('form-submit').should('be.visible')
       cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('form-back').should('be.visible')
-      cy.getTestId('form-back').should('be.enabled')
       cy.getTestId('form-cancel').should('be.visible')
 
       // pinned fields (but they should not be under a KCollapse)
@@ -1128,8 +1115,6 @@ describe('<PluginForm />', () => {
       // button state
       cy.getTestId('form-submit').should('be.visible')
       cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('form-back').should('be.visible')
-      cy.getTestId('form-back').should('be.enabled')
       cy.getTestId('form-cancel').should('be.visible')
 
       // pinned fields (but they should not be under a KCollapse)
@@ -1212,8 +1197,6 @@ describe('<PluginForm />', () => {
       // button state
       cy.getTestId('form-submit').should('be.visible')
       cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('form-back').should('be.visible')
-      cy.getTestId('form-back').should('be.enabled')
       cy.getTestId('form-cancel').should('be.visible')
 
       // scope fields
@@ -1303,7 +1286,6 @@ describe('<PluginForm />', () => {
       cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
 
       cy.getTestId('form-submit').should('not.exist')
-      cy.getTestId('form-back').should('not.exist')
       cy.getTestId('form-cancel').should('not.exist')
     })
 
@@ -1346,7 +1328,6 @@ describe('<PluginForm />', () => {
       // button state
       cy.getTestId('form-submit').should('be.visible')
       cy.getTestId('form-submit').should('be.enabled')
-      cy.getTestId('form-back').should('be.visible')
       cy.getTestId('form-cancel').should('be.visible')
 
       // scope & global fields
@@ -1473,7 +1454,6 @@ describe('<PluginForm />', () => {
         // button state
         cy.getTestId('form-submit').should('be.visible')
         cy.getTestId('form-submit').should('be.disabled')
-        cy.getTestId('form-back').should('not.exist')
         cy.getTestId('form-cancel').should('be.visible')
 
         // reveal advanced fields

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -82,16 +82,6 @@
               {{ t('actions.cancel') }}
             </KButton>
             <KButton
-              v-if="formType === EntityBaseFormType.Create && config.backRoute"
-              appearance="secondary"
-              class="form-action-button"
-              data-testid="form-back"
-              :disabled="form.isReadonly"
-              @click="handleClickBack"
-            >
-              {{ t('actions.back') }}
-            </KButton>
-            <KButton
               appearance="primary"
               data-testid="form-submit"
               :disabled="!canSubmit || form.isReadonly"
@@ -972,12 +962,6 @@ const handleClickCancel = (): void => {
     router.push(props.config.cancelRoute)
   } else {
     emit('cancel')
-  }
-}
-
-const handleClickBack = (): void => {
-  if (props.config.backRoute) {
-    router.push(props.config.backRoute)
   }
 }
 

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -1,6 +1,5 @@
 {
   "actions": {
-    "back": "Back",
     "cancel": "Cancel",
     "view_configuration": "View Configuration",
     "create": "New Plugin",

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -29,8 +29,6 @@ export interface BasePluginSelectConfig {
 }
 
 export interface BasePluginFormConfig {
-  /** Route to return to if canceling create a Plugin (go back to plugin selection page) */
-  backRoute?: RouteLocationRaw
   /** Current entity type and id for plugins for specific entity */
   entityType?: EntityType
   entityId?: string


### PR DESCRIPTION
> **BREAKING CHANGE:**  The Back button on the form has been removed, and `backRoute` no longer exists in the form configuration

# Summary

According to our discussion on Slack, we decided to remove the Back button on the plugin form page due to its low usage.

KM-273