### PR TITLE
fix(dashboard-renderer): resize observer callback [KHCP-12507]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
@@ -48,8 +48,15 @@ const gridContainer = ref(null)
 const containerWidth = ref(0)
 
 const resizeObserver = new ResizeObserver(entries => {
-  // Only observing one element
-  containerWidth.value = entries[0].contentRect.width
+  // Wrapper 'window.requestAnimationFrame' is needed for disabling "ResizeObserver loop limit exceeded" error in DD
+  window.requestAnimationFrame(() => {
+    if (!Array.isArray(entries) || !entries.length) {
+      return
+    }
+
+    // Only observing one element
+    containerWidth.value = entries[0].contentRect.width
+  })
 })
 
 onMounted(() => {


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-12507

Wrap `ResizeObserver` callback in `window.requestAnimationFrame` to reduce number of "ResizeObserver loop limit exceeded" errors in DD

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
