### PR TITLE
fix: set the max bounds to prevent zooming out too far

### DIFF
--- a/packages/analytics/analytics-geo-map/README.md
+++ b/packages/analytics/analytics-geo-map/README.md
@@ -74,27 +74,19 @@ npm install @kong-ui-public/analytics-geo-map
 - **default:** `true`
 - **description:** Display value in the tooltip.
 
-#### `center`
-
-- **type:** `Object` (`LongLat`)
-- **required:** `false`
-- **default:** `null`
-- **description:** Initial center of the map. Expects an object with `lat` and `lng` properties.
-
 #### `fitToCountry`
 
 - **type:** `Object` (`CountryISOA2 | null`)
 - **required:** `false`
 - **default:** `null`
-- **description:** Country code to fit the map bounds to. Overrides initial center and zoom.
+- **description:** Country code to zoom in on.
 
-#### `initialZoom`
+#### `bounds`
 
-- **type:** `Number | null`
+- **type:** `Object` (`LngLatBoundsLike`)
 - **required:** `false`
 - **default:** `null`
-- **validator:** `value => value >= 0 && value <= 24`
-- **description:** Initial zoom level of the map.
+- **description:** Longitudinal/Latitudinal bounds to initially fit the map to.
 
 ### Example
 
@@ -103,9 +95,18 @@ npm install @kong-ui-public/analytics-geo-map
   <AnalyticsGeoMap
     :countryMetrics="countryMetrics"
     :geoJsonData="geoJsonData"
-    :center="{ lat: 0, lng: 0 }"
     :fitToCountry="'US'"
-    :initialZoom="2"
+    metricUnit="%"
+  />
+
+  <!-- bounds to europe -->
+  <AnalyticsGeoMap
+    :countryMetrics="countryMetrics"
+    :geoJsonData="geoJsonData"
+    :bounds="[
+      [-10, 35],
+      [65, 72]
+    ]"
     metricUnit="%"
   />
 </template>

--- a/packages/analytics/analytics-geo-map/sandbox/App.vue
+++ b/packages/analytics/analytics-geo-map/sandbox/App.vue
@@ -9,11 +9,13 @@
     />
     <div class="map-container">
       <AnalyticsGeoMap
-        :center="{ lng: 0, lat: 0 }"
+        :bounds="[
+          [-10, 35],
+          [65, 72]
+        ]"
         :country-metrics="countryMetrics"
         :fit-to-country="fitToCountry"
         :geo-json-data="(countryGeoJson as FeatureCollection)"
-        :initial-zoom="1"
         :metric="'request_count'"
         :metric-unit="'requests'"
       />
@@ -58,8 +60,8 @@ const countryMetrics = computed(() => {
     height: 900px;
 
     .map-container {
-      height: 500px;
-      width: 700px;
+      height: 700px;
+      width: 900px;
     }
   }
 </style>

--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
@@ -34,8 +34,8 @@
 import { ref, onMounted, watch, computed } from 'vue'
 import { Map, Popup } from 'maplibre-gl'
 import type { PropType } from 'vue'
-import type { ColorSpecification, DataDrivenPropertyValueSpecification, ExpressionSpecification, LngLatLike, MapOptions } from 'maplibre-gl'
-import type { CountryISOA2, LongLat, MapFeatureCollection, MetricUnits } from '../types'
+import type { ColorSpecification, DataDrivenPropertyValueSpecification, ExpressionSpecification, LngLatBoundsLike, MapOptions } from 'maplibre-gl'
+import type { CountryISOA2, MapFeatureCollection, MetricUnits } from '../types'
 import type { Feature, MultiPolygon, Geometry, GeoJsonProperties } from 'geojson'
 import composables from '../composables'
 import 'maplibre-gl/dist/maplibre-gl.css'
@@ -70,21 +70,15 @@ const props = defineProps({
     required: false,
     default: true,
   },
-  center: {
-    type: Object as PropType<LongLat>,
-    required: false,
-    default: null,
-  },
   fitToCountry: {
     type: String as PropType<CountryISOA2 | null>,
     required: false,
     default: null,
   },
-  initialZoom: {
-    type: [Number, null] as PropType<number | null>,
+  bounds: {
+    type: Object as PropType<LngLatBoundsLike>,
     required: false,
-    default: null,
-    validator: (value: number) => value >= 0 && value <= 24,
+    default: () => null,
   },
 })
 const map = ref<Map>()
@@ -225,19 +219,15 @@ const mapOptions = computed(() => {
     container: 'mapContainer',
     style: { version: 8, sources: {}, layers: [] },
     attributionControl: false,
+    // fit bounds for whole world minus antarctica
+    maxBounds: [
+      [-179, -83], // -83 south tip of south america
+      [179, 90],
+    ],
   }
-  if (!props.center && !props.initialZoom) {
-    options.bounds = [
-      [-180, -90],
-      [180, 90],
-    ]
-  } else {
-    if (props.center) {
-      options.center = props.center as LngLatLike
-    }
-    if (props.initialZoom) {
-      options.zoom = props.initialZoom
-    }
+
+  if (props.bounds) {
+    options.bounds = props.bounds
   }
 
   return options


### PR DESCRIPTION
# Summary

Remove the `initial-zoom` and `centre` props in favour of a `bounds` prop

Set the maxBounds of the map by default

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
