### PR TITLE
feat(entities-vaults): disable secret key input when editing

### DIFF
--- a/packages/entities/entities-vaults/src/components/SecretForm.cy.ts
+++ b/packages/entities/entities-vaults/src/components/SecretForm.cy.ts
@@ -94,6 +94,7 @@ describe('<SecretForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       cy.getTestId('form-cancel').should('be.enabled')
       cy.getTestId('form-submit').should('be.disabled')
       // form fields
+      cy.getTestId('secret-form-key').should('be.disabled')
       cy.getTestId('secret-form-key').should('have.value', secret.key)
       cy.getTestId('secret-form-value').should('have.value', '')
     })
@@ -117,13 +118,10 @@ describe('<SecretForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       cy.getTestId('form-cancel').should('be.enabled')
       cy.getTestId('form-submit').should('be.disabled')
       // enables save when form has changes
-      cy.getTestId('secret-form-key').type('ubiquitous')
       cy.getTestId('secret-form-value').type('ubiquitous')
       cy.getTestId('form-submit').should('be.enabled')
       // disables save when form changes are undone
-      cy.getTestId('secret-form-key').clear()
       cy.getTestId('secret-form-value').clear()
-      cy.getTestId('secret-form-key').type(secret.key)
       cy.getTestId('form-submit').should('be.disabled')
     })
 

--- a/packages/entities/entities-vaults/src/components/SecretForm.vue
+++ b/packages/entities/entities-vaults/src/components/SecretForm.vue
@@ -25,6 +25,7 @@
             autocomplete="off"
             class="key-field"
             data-testid="secret-form-key"
+            :disabled="formType === EntityBaseFormType.Edit"
             :label="t('secrets.form.fields.key.label')"
             :placeholder="t('secrets.form.fields.key.placeholder')"
             :readonly="state.readonly"


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

The `key` field in the secret edit form should be disabled.

KM-343

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
