### PR TITLE
fix(entities-plugins): allow ACL to be scoped to consumers and consumer groups

### DIFF
--- a/packages/entities/entities-plugins/src/definitions/metadata.ts
+++ b/packages/entities/entities-plugins/src/definitions/metadata.ts
@@ -167,7 +167,7 @@ export const PLUGIN_METADATA: Record<string, Omit<PluginMetaData<I18nMessageSour
     group: PluginGroup.TRAFFIC_CONTROL,
     isEnterprise: false,
     nameKey: 'plugins.meta.acl.name',
-    scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE],
+    scope: [PluginScope.GLOBAL, PluginScope.SERVICE, PluginScope.ROUTE, PluginScope.CONSUMER, PluginScope.CONSUMER_GROUP],
     fieldRules: {
       onlyOneOf: [['config.allow', 'config.deny']],
     },


### PR DESCRIPTION
# Summary

Allowing the ACL plugin to be scoped to consumers and consumer groups.

Note: We should also update the schema for this plugin at [Kong/kong](https://github.com/Kong/kong/blob/b5716b1155044a79fceaa4b10a8349643c7a8d34/kong/plugins/acl/schema.lua#L7) and [Kong/kong-ee](https://github.com/Kong/kong-ee/blob/c3273ad1f067b8ddc567a3b435a9494e4a528964/kong/plugins/acl/schema.lua#L14-L15).


KM-350