### PR TITLE
fix(vaultform): fix compatibility of STS endpoint url in Konnect

### DIFF
--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -640,7 +640,6 @@ const configFields = reactive<ConfigFields>({
     endpoint_url: '',
     assume_role_arn: '',
     role_session_name: 'KongVault',
-    sts_endpoint_url: '',
   } as AWSVaultConfig,
   [VaultProviders.GCP]: {
     project_id: '',
@@ -683,7 +682,6 @@ const originalConfigFields = reactive<ConfigFields>({
     endpoint_url: '',
     assume_role_arn: '',
     role_session_name: 'KongVault',
-    sts_endpoint_url: '',
   } as AWSVaultConfig,
   [VaultProviders.GCP]: {
     project_id: '',
@@ -964,7 +962,7 @@ const getPayload = computed((): Record<string, any> => {
     ...configFields[vaultProvider.value],
     endpoint_url: (configFields[vaultProvider.value] as AWSVaultConfig).endpoint_url || null,
     assume_role_arn: (configFields[vaultProvider.value] as AWSVaultConfig).assume_role_arn || null,
-    sts_endpoint_url: (configFields[vaultProvider.value] as AWSVaultConfig).sts_endpoint_url || null,
+    ...(props.config.awsStsEndpointUrlAvailable ? { sts_endpoint_url: (configFields[vaultProvider.value] as AWSVaultConfig).sts_endpoint_url || null } : {}),
   }
 
   let config: VaultPayload['config'] = configFields[vaultProvider.value]


### PR DESCRIPTION
# Summary

Fix compatibility of STS endpoint url field in AWS vault form when saving in Konnect

#### Resources
