### PR TITLE
fix(forms): required indicator style

### DIFF
--- a/packages/core/forms/src/components/FormGroup.vue
+++ b/packages/core/forms/src/components/FormGroup.vue
@@ -232,15 +232,19 @@ $errorColor: #f00;
     }
   }
 
-  &.required {
-    > label:after {
-      color: red;
-      content: "*";
-      font-size: 14px;
-      font-weight: normal;
-      // position: absolute;
-      padding-left: 3px;
-    }
+  &.required > label:before {
+    background-color: $kui-color-background-danger;
+    border-radius: $kui-border-radius-circle;
+    content: "";
+    height: 6px;
+    margin-right: $kui-space-40;
+    width: 6px;
+  }
+
+  // hide the required indicator for checkboxes
+  // because it may be misleading that the checkbox must be checked
+  &.field-checkbox.required > label:before {
+    display: none;
   }
 
   &.disabled {


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Unifying the style of required indicators in plugin forms with other entity forms.

| Before | After |
| - | - |
| <img width="704" alt="image" src="https://github.com/user-attachments/assets/66ef3576-e5f7-48c0-b302-63fadb59a6da"> | <img width="686" alt="image" src="https://github.com/user-attachments/assets/16e53fd9-7e8e-4a7d-b7d6-b54768e328e4"> |

This PR also removes required indicators for checkbox fields.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
