### PR TITLE
fix(entities-routes): make paths and hosts copy badges [KHCP-12781]

### DIFF
--- a/packages/entities/entities-routes/src/components/RouteConfigCard.vue
+++ b/packages/entities/entities-routes/src/components/RouteConfigCard.vue
@@ -276,13 +276,13 @@ const configSchema = ref<RouteConfigurationSchema>({
   paths: {
     section: ConfigurationSchemaSection.Basic,
     tooltip: t('form.fields.paths.tooltip'),
-    type: ConfigurationSchemaType.BadgeTag,
+    type: ConfigurationSchemaType.CopyBadge,
     order: 8,
   },
   hosts: {
     section: ConfigurationSchemaSection.Basic,
     tooltip: t('form.fields.hosts.tooltipConfig'),
-    type: ConfigurationSchemaType.BadgeTag,
+    type: ConfigurationSchemaType.CopyBadge,
     order: 9,
   },
   snis: {

--- a/packages/entities/entities-shared/docs/config-card-item.md
+++ b/packages/entities/entities-shared/docs/config-card-item.md
@@ -129,9 +129,9 @@ We support 4 types of badges currently.
 
 The Status Badge (`ConfigurationSchemaType.BadgeStatus`) type is used to display `boolean` values. It will display a green `KBadge` with the text `Enabled` for a `true` value and a grey `KBadge` with the text `Disabled` for a `false` value.
 
-The Tag Badge (`ConfigurationSchemaType.BadgeTag`) type is used to display `string[]` values. Each array value will be rendered in a horizontal line as a `default` styled `KBadge`.
+The Tag Badge (`ConfigurationSchemaType.BadgeTag`) type is used to display `string[]` values. Each array value will be rendered in a horizontal line as a `KBadge appearance="info"`.
 
-The Copy Badge (`ConfigurationSchemaType.CopyBadge`) type is used to display `string[]` values with copy button. Each array value will be rendered on a new a horizontal line as a `default` styled `KCopy :badge="true"`. Content in a badge will be truncated only if there is not enough horizontal room to display the entire string.
+The Copy Badge (`ConfigurationSchemaType.CopyBadge`) type is used to display `string[]` values with copy button. Each array value will be rendered on a new a horizontal line as `KCopy :badge="true"`. Content in a badge will be truncated only if there is not enough horizontal room to display the entire string.
 
 The Method Badge (`ConfigurationSchemaType.BadgeMethod`) type is used to display a `string[]` of API methods in a horizontal line. An instance of `KMethodBadge` is rendered for each array item.
 

--- a/packages/entities/entities-shared/docs/config-card-item.md
+++ b/packages/entities/entities-shared/docs/config-card-item.md
@@ -125,11 +125,13 @@ The External Link (`ConfigurationSchemaType.ExternalLink`) type is used to rende
 
 #### Badge (Tag, Status, Method)
 
-We support 3 types of badges currently.
+We support 4 types of badges currently.
 
 The Status Badge (`ConfigurationSchemaType.BadgeStatus`) type is used to display `boolean` values. It will display a green `KBadge` with the text `Enabled` for a `true` value and a grey `KBadge` with the text `Disabled` for a `false` value.
 
 The Tag Badge (`ConfigurationSchemaType.BadgeTag`) type is used to display `string[]` values. Each array value will be rendered in a horizontal line as a `default` styled `KBadge`.
+
+The Copy Badge (`ConfigurationSchemaType.CopyBadge`) type is used to display `string[]` values with copy button. Each array value will be rendered on a new a horizontal line as a `default` styled `KCopy :badge="true"`. Content in a badge will be truncated only if there is not enough horizontal room to display the entire string.
 
 The Method Badge (`ConfigurationSchemaType.BadgeMethod`) type is used to display a `string[]` of API methods in a horizontal line. An instance of `KMethodBadge` is rendered for each array item.
 

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
@@ -217,7 +217,7 @@ describe('<ConfigCardItem />', () => {
     })
 
     it('renders a JSON field correctly', () => {
-      const obj:Record<string, string> = {
+      const obj: Record<string, string> = {
         name: 'TK Meowstersmith',
         species: 'Awesome cat',
         color: 'All black',
@@ -247,7 +247,7 @@ describe('<ConfigCardItem />', () => {
     })
 
     it('renders a JSON Array field correctly', () => {
-      const obj:Record<string, string>[] = [{
+      const obj: Record<string, string>[] = [{
         name: 'TK Meowstersmith',
         species: 'Awesome cat',
         color: 'All black',
@@ -456,6 +456,30 @@ describe('<ConfigCardItem />', () => {
 
         tags.forEach((tag: string, idx: number) => {
           cy.getTestId(`${item.key}-badge-tag-${idx}`).should('contain.text', tag)
+        })
+      })
+
+      it('renders CopyBadge correctly', () => {
+        const tags = ['cats', 'purr', 'meow']
+        const item: RecordItem = {
+          type: ConfigurationSchemaType.CopyBadge,
+          key: 'tags',
+          label: 'Tags',
+          value: tags,
+        }
+
+        cy.mount(ConfigCardItem, {
+          props: {
+            item,
+          },
+        })
+
+        cy.get('.config-card-details-row').should('be.visible')
+        cy.getTestId(`${item.key}-copy-uuid-array`).should('be.visible')
+
+        tags.forEach((id: string, idx: number) => {
+          cy.getTestId(`${item.key}-copy-uuid-${idx}`).should('be.visible')
+          cy.getTestId(`${item.key}-copy-uuid-${idx}`).should('contain.text', id)
         })
       })
 

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -228,6 +228,18 @@ const componentAttrsData = computed((): ComponentAttrsData => {
         additionalComponent: 'KBadge',
       }
 
+    case ConfigurationSchemaType.CopyBadge:
+      return {
+        tag: 'div',
+        additionalComponent: 'KCopy',
+        childAttrs: {
+          badge: true,
+          truncate: true,
+          truncationLimit: 'auto',
+          text: props.item.value,
+        },
+      }
+
     case ConfigurationSchemaType.BadgeMethod:
       return {
         tag: 'div',

--- a/packages/entities/entities-shared/src/types/entity-base-config-card.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-config-card.ts
@@ -6,10 +6,10 @@ export interface BaseEntityConfig {
 }
 
 /** Konnect base form config */
-export interface KonnectBaseEntityConfig extends KonnectConfig, BaseEntityConfig {}
+export interface KonnectBaseEntityConfig extends KonnectConfig, BaseEntityConfig { }
 
 /** Kong Manager base form config */
-export interface KongManagerBaseEntityConfig extends KongManagerConfig, BaseEntityConfig {}
+export interface KongManagerBaseEntityConfig extends KongManagerConfig, BaseEntityConfig { }
 
 export enum ConfigurationSchemaType {
   ID = 'id',
@@ -21,6 +21,7 @@ export enum ConfigurationSchemaType {
   Json = 'json',
   JsonArray = 'json-array',
   BadgeTag = 'badge-tag',
+  CopyBadge = 'copy-badge',
   BadgeStatus = 'badge-status',
   BadgeMethod = 'badge-method',
   LinkInternal = 'link-internal',


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-12781

Add new value `CopyBadge` to `ConfigurationSchemaType` enum in EntityBaseConfigCard.vue for rendering array of strings as KCopy components. Use new `CopyBadge` schema type in `paths` and `hosts` fields in RouteConfigCard.vue (screenshot).

![Screenshot 2024-08-07 at 5 27 06 PM](https://github.com/user-attachments/assets/7ac14bd8-a71c-4d75-8476-c3d0a74923fa)


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
