### PR TITLE
chore(deps): revert pinning monaco in core/expressions

### DIFF
--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -73,7 +73,7 @@
     "@kong-ui-public/forms": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.15.1",
-    "monaco-editor": "0.21.3",
+    "monaco-editor": "0.50.0",
     "uuid": "^9.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,8 +558,8 @@ importers:
         specifier: ^1.15.1
         version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       monaco-editor:
-        specifier: 0.21.3
-        version: 0.21.3
+        specifier: 0.50.0
+        version: 0.50.0
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -578,7 +578,7 @@ importers:
         version: 9.0.8
       vite-plugin-monaco-editor:
         specifier: ^1.1.0
-        version: 1.1.0(monaco-editor@0.21.3)
+        version: 1.1.0(monaco-editor@0.50.0)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
         version: 1.4.1(rollup@4.13.0)(vite@5.3.3(@types/node@18.19.39)(sass@1.77.8)(terser@5.26.0))
@@ -964,7 +964,7 @@ importers:
         version: 1.6.8
       vite-plugin-monaco-editor:
         specifier: ^1.1.0
-        version: 1.1.0(monaco-editor@0.21.3)
+        version: 1.1.0(monaco-editor@0.50.0)
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.3.3)
@@ -6426,8 +6426,8 @@ packages:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
 
-  monaco-editor@0.21.3:
-    resolution: {integrity: sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==}
+  monaco-editor@0.50.0:
+    resolution: {integrity: sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -15624,7 +15624,7 @@ snapshots:
 
   modify-values@1.0.1: {}
 
-  monaco-editor@0.21.3: {}
+  monaco-editor@0.50.0: {}
 
   mri@1.2.0: {}
 
@@ -18020,9 +18020,9 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-monaco-editor@1.1.0(monaco-editor@0.21.3):
+  vite-plugin-monaco-editor@1.1.0(monaco-editor@0.50.0):
     dependencies:
-      monaco-editor: 0.21.3
+      monaco-editor: 0.50.0
 
   vite-plugin-top-level-await@1.4.1(rollup@4.13.0)(vite@5.3.3(@types/node@18.19.39)(sass@1.77.8)(terser@5.26.0)):
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,7 @@
   "ignorePaths": [
     "packages/core/cli/src/__template__/package.json"
   ],
-  "packageRules": [
-    {
-      "description": "Pin monaco-editor for @kong-ui-public/expressions and @kong-ui-public/entities-routes",
-      "matchFileNames": ["packages/core/expressions/package.json", "packages/entities/entities-routes/package.json"],
-      "groupName": "expressions-monaco-editor",
-      "matchPackageNames": ["monaco-editor"],
-      "enabled": false
-    }
-  ]
+  "constraints": {
+    "pnpm": "8.6.11"
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,5 @@
   ],
   "ignorePaths": [
     "packages/core/cli/src/__template__/package.json"
-  ],
-  "constraints": {
-    "pnpm": "8.6.11"
-  }
+  ]
 }


### PR DESCRIPTION
# Summary

> Need thorough tests in host apps

This pull request reverts:

- https://github.com/Kong/public-ui-components/pull/1354

The reason why we decided to pin `monaco-editor` for `core/expressions` was because the latest version by that time was causing errors. However, it seems we cannot reproduce those errors anymore with the latest version as of today. This pull request is to revert the previous change that pinned `monaco-editor`.

KM-390