### PR TITLE
chore: adjusting dependencies of expressions and routers

### DIFF
--- a/packages/core/expressions/README.md
+++ b/packages/core/expressions/README.md
@@ -24,13 +24,6 @@ Reusable components to support [Kong's expressions language](https://docs.konghq
 
 ### Install
 
-Install required `dependencies` in your host application:
-
-```sh
-yarn add monaco-editor
-yarn add @kong-ui-public/forms # optional: required for `RouterPlaygroundModal` component
-```
-
 Install required `devDependencies` in your host application:
 
 ```sh
@@ -60,9 +53,6 @@ Import the component(s) in your host application as well as the package styles:
 ```ts
 import { asyncInit, ExpressionsEditor } from '@kong-ui-public/expressions'
 import '@kong-ui-public/expressions/dist/style.css'
-import '@kong-ui-public/forms/dist/style.css' // optional: required for `RouterPlaygroundModal` component
-
-app.component('VueFormGenerator', VueFormGenerator) // optional: required for `RouterPlaygroundModal` component
 ```
 
 This package utilizes [vite-plugin-top-level-await](https://github.com/Menci/vite-plugin-top-level-await) to transform code in order to use top-level await on older browsers. To load the WASM correctly, you must use `await` or `Promise.then` to wait the imported `asyncInit` before using any other imported values.

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -37,12 +37,10 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
   },
   "devDependencies": {
-    "@kong-ui-public/forms": "workspace:^",
     "@kong/atc-router": "1.6.0-rc.1",
     "@kong/design-tokens": "1.16.0",
     "@kong/kongponents": "9.1.7",
     "@types/uuid": "^9.0.8",
-    "monaco-editor": "0.21.3",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vite-plugin-top-level-await": "^1.4.1",
     "vite-plugin-wasm": "^3.3.0",
@@ -67,15 +65,15 @@
   },
   "peerDependencies": {
     "@kong-ui-public/forms": "workspace:^",
-    "@kong/atc-router": "^1.6.0-rc.1",
     "@kong/kongponents": "^9.1.7",
-    "monaco-editor": "0.21.3",
     "vue": "^3.4.31"
   },
   "dependencies": {
     "@kong-ui-public/core": "workspace:^",
+    "@kong-ui-public/forms": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.14.2",
+    "monaco-editor": "0.21.3",
     "uuid": "^9.0.1"
   }
 }

--- a/packages/core/expressions/vite.config.ts
+++ b/packages/core/expressions/vite.config.ts
@@ -21,7 +21,14 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       fileName: (format) => `${sanitizedPackageName}.${format}.js`,
     },
     rollupOptions: {
-      external: ['monaco-editor', '@kong-ui-public/forms', '@kong-ui-public/forms/dist/style.css'],
+      external: [
+        '@kong-ui-public/core',
+        '@kong-ui-public/forms',
+        '@kong-ui-public/forms/dist/style.css',
+        '@kong/icons',
+        'monaco-editor',
+        'uuid',
+      ],
     },
   },
   plugins: [

--- a/packages/entities/entities-routes/README.md
+++ b/packages/entities/entities-routes/README.md
@@ -36,6 +36,26 @@ Install the component in your host application
 yarn add @kong-ui-public/entities-routes
 ```
 
+If you want to enable [expressions feature](#expressions-features), you also need to install `devDependencies` in your host application:
+
+```sh
+yarn add -D vite-plugin-monaco-editor
+```
+
+Enable the `vite-plugin-monaco-editor` plugin. Your Vite config should look like this:
+
+```ts
+import monacoEditorPlugin from 'vite-plugin-monaco-editor'
+
+export default defineConfig({
+  // ...
+  plugins: [
+    monacoEditorPlugin({}),
+  ],
+  // ...
+}
+```
+
 ### Registration
 
 Import the component(s) in your host application as well as the package styles

--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -17,7 +17,6 @@ A form component for Routes.
 - `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
 - `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
 - `axios` must be installed as a dependency in the host application.
-- If you want to use Expressions features, `@kong-ui-public/expressions` and `monaco-editor` must be installed as dependencies in the host application.
 
 ## Usage
 

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -71,11 +71,8 @@
   },
   "dependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
+    "@kong-ui-public/expressions": "workspace:^",
     "@kong/icons": "^1.15.1",
     "lodash.isequal": "^4.5.0"
-  },
-  "optionalDependencies": {
-    "@kong-ui-public/expressions": "workspace:^",
-    "monaco-editor": "0.21.3"
   }
 }

--- a/packages/entities/entities-routes/vite.config.ts
+++ b/packages/entities/entities-routes/vite.config.ts
@@ -19,9 +19,12 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
     },
     rollupOptions: {
       external: [
-        '@kong-ui-public/expressions', // This is optional if we do not use Expressions features
-        '@kong-ui-public/expressions/dist/style.css', // This is optional if we do not use Expressions features
-        'monaco-editor', // This is optional if we do not use Expressions features
+        '@kong-ui-public/entities-shared',
+        '@kong-ui-public/entities-shared/dist/style.css',
+        '@kong-ui-public/expressions',
+        '@kong-ui-public/expressions/dist/style.css',
+        '@kong/icons',
+        'lodash.isequal',
       ],
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,19 +545,22 @@ importers:
       '@kong-ui-public/core':
         specifier: workspace:^
         version: link:../core
+      '@kong-ui-public/forms':
+        specifier: workspace:^
+        version: link:../forms
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../i18n
       '@kong/icons':
         specifier: ^1.14.2
         version: 1.15.1(vue@3.4.31(typescript@5.3.3))
+      monaco-editor:
+        specifier: 0.21.3
+        version: 0.21.3
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
     devDependencies:
-      '@kong-ui-public/forms':
-        specifier: workspace:^
-        version: link:../forms
       '@kong/atc-router':
         specifier: 1.6.0-rc.1
         version: 1.6.0-rc.1
@@ -570,9 +573,6 @@ importers:
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
-      monaco-editor:
-        specifier: 0.21.3
-        version: 0.21.3
       vite-plugin-monaco-editor:
         specifier: ^1.1.0
         version: 1.1.0(monaco-editor@0.21.3)
@@ -935,19 +935,15 @@ importers:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
+      '@kong-ui-public/expressions':
+        specifier: workspace:^
+        version: link:../../core/expressions
       '@kong/icons':
         specifier: ^1.15.1
         version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0
-    optionalDependencies:
-      '@kong-ui-public/expressions':
-        specifier: workspace:^
-        version: link:../../core/expressions
-      monaco-editor:
-        specifier: 0.21.3
-        version: 0.21.3
     devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^


### PR DESCRIPTION
## Simplified Usage and Installation of entities-routes
To streamline the installation process, `optionalDependencies` and `peerDependencies` have been moved to dependencies. Now, the host app only needs to install entities-routes itself.

before:
```json5
// package.json
"@kong-ui-public/entities-routes": "x.x.x"
"@kong-ui-public/forms": "x.x.x"
"@kong-ui-public/expressions": "x.x.x"
```
```js
// vue
import { RouteForm } from '@kong-ui-public/entities-routes'
import '@kong-ui-public/expressions/dist/style.css'
```
after:
```json5
// package.json
"@kong-ui-public/entities-routes": "x.x.x"
```
```js
// vue
import { RouteForm } from '@kong-ui-public/entities-routes'
```
All other dependencies are automatically installed.

## Bundle Size Optimization
By externalizing most of the module from `node_modules`, the bundle size has been reduced from [633KB](https://www.npmjs.com/package/@kong-ui-public/entities-routes/v/3.5.4) to [308KB](https://www.npmjs.com/package/@kong-ui-public/entities-routes/v/3.5.5-pr.1550.a8a375a9.0) (-51.34%)

The `@kong/atc-router` was kept in the expressions bundle because there are no scenarios where it would be used directly in the host app, and its use requires the `wasm` Vite plugin, which would complicate the installation process in the host app.
