### PR TITLE
fix(expressions): router playground known issues [KM-391]

### DIFF
--- a/packages/core/expressions/src/components/RequestModal.vue
+++ b/packages/core/expressions/src/components/RequestModal.vue
@@ -23,7 +23,6 @@
       :model="model"
       :options="options"
       :schema="ADD_REQUEST_SCHEMA"
-      @model-updated="handleModelUpdated"
     />
 
     <KAlert
@@ -142,11 +141,6 @@ const model = reactive<Partial<Request>>({})
 
 const urlHasError = ref<boolean>(false)
 const urlErrorMessage = ref<string | undefined>(undefined)
-
-
-const handleModelUpdated = (value: any, key: string) => {
-  (model as any)[key] = value
-}
 
 const handleProceed = () => {
   try {

--- a/packages/core/expressions/src/components/RouterPlayground.cy.ts
+++ b/packages/core/expressions/src/components/RouterPlayground.cy.ts
@@ -70,7 +70,7 @@
 //   }: {
 //     url: string
 //     method: string
-//     headers?: Record<string, string>[]
+//     headers?: { key: string, value: string | string[] }[]
 //   }) {
 //     cy.getTestId('btn-add-request').click()
 //     cy.getTestId('url-input').should('be.visible')
@@ -82,7 +82,7 @@
 //       headers.forEach((header, index) => {
 //         cy.getTestId('keyname-input').type(header.key)
 //         cy.getTestId('add-key').click()
-//         cy.get(`:nth-child(${index + 3}) > .form-control`).type(header.value)
+//         cy.get(`:nth-child(${index + 3}) > .form-control`).type(Array.isArray(header.value) ? header.value.join(',') : header.value)
 //       })
 //     }
 
@@ -90,6 +90,7 @@
 //   }
 
 //   it('add/remove requests', () => {
+//     cy.clearAllLocalStorage()
 //     cy.mount(RouterPlayground)
 
 //     addRequest({
@@ -107,6 +108,7 @@
 //   })
 
 //   it('matching requests', () => {
+//     cy.clearAllLocalStorage()
 //     cy.mount(RouterPlayground)
 //     const requestIds: string[] = []
 
@@ -130,6 +132,45 @@
 //       cy.get('.view-lines').type('http.host == "localhost"')
 //       cy.getTestId(requestIds[0]).should('have.class', 'active')
 //       cy.getTestId(requestIds[1]).should('not.have.class', 'active')
+//     })
+//   })
+
+//   it('matching multiple values in header', () => {
+//     cy.clearAllLocalStorage()
+//     cy.mount(RouterPlayground)
+//     const requestIds: string[] = []
+//     addRequest({
+//       url: 'http://localhost:8000',
+//       method: 'GET',
+//       headers: [
+//         { key: 'Foo', value: ['a', 'b', 'c'] },
+//       ],
+//     })
+
+//     addRequest({
+//       url: 'http://localhost:8000',
+//       method: 'GET',
+//       headers: [
+//         { key: 'Foo', value: 'a' },
+//       ],
+//     })
+
+//     addRequest({
+//       url: 'http://localhost:8000',
+//       method: 'GET',
+//       headers: [
+//         { key: 'Foo', value: ['b'] },
+//       ],
+//     })
+
+//     // eslint-disable-next-line cypress/unsafe-to-chain-command
+//     cy.get('.request-card').each($card => {
+//       requestIds.push($card.data('testid'))
+//     }).then(() => {
+//       cy.get('.view-lines').type('any(http.headers.foo) == "a"')
+//       cy.getTestId(requestIds[0]).should('have.class', 'active')
+//       cy.getTestId(requestIds[1]).should('have.class', 'active')
+//       cy.getTestId(requestIds[2]).should('not.have.class', 'active')
 //     })
 //   })
 

--- a/packages/core/expressions/src/components/RouterPlayground.vue
+++ b/packages/core/expressions/src/components/RouterPlayground.vue
@@ -296,7 +296,11 @@ const routeMatches = computed<{ [id: string]: boolean }>(() => requests.value.re
 
   if (route.headers) {
     Object.entries(route.headers).forEach(([key, values]) => {
-      context.addValue(`http.headers.${key.toLowerCase().replace(/-/g, '_')}`, { String: values.toString() })
+      const headerKey = `http.headers.${key.toLowerCase().replace(/-/g, '_')}`
+      const valueSet: string[] = Array.isArray(values) ? values : [values]
+      valueSet.forEach((value) => {
+        context.addValue(headerKey, { String: `${value}` })
+      })
     })
   }
 

--- a/packages/core/expressions/src/utils.ts
+++ b/packages/core/expressions/src/utils.ts
@@ -59,4 +59,14 @@ export const transformCheckRequest = (request: Partial<Request>): string | undef
       return i18n.t('errors.methodShouldCapitalized')
     }
   }
+
+  if (request.headers) {
+    Object.keys(request.headers).forEach(key => {
+      const values = request.headers![key]
+      // transform header values to array
+      if (typeof values === 'string' && values.indexOf(',') !== -1) {
+        request.headers![key] = values.split(',').map(value => value.trim())
+      }
+    })
+  }
 }


### PR DESCRIPTION
# Summary
* HTTP headers in requests appeared as [object Object] in the exported JSON
* Support HTTP headers with multiple values (should add context value per header value)

[KM-391](https://konghq.atlassian.net/browse/KM-391?atlOrigin=eyJpIjoiMzc3NTQ1MDAzMWVhNDRjZDllZDFkNDA4OGM4Mjg0MDIiLCJwIjoiaiJ9)


[KM-391]: https://konghq.atlassian.net/browse/KM-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ