### PR TITLE
fix(entitites-consumer-groups): filter response transform [KM-410]

### DIFF
--- a/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupListPage.vue
+++ b/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupListPage.vue
@@ -61,6 +61,7 @@ const konnectConfig = ref<KonnectConsumerGroupListConfig>({
   createRoute: { name: 'create-consumer-group' },
   getViewRoute: (id: string) => ({ name: 'view-consumer-group', params: { id } }),
   getEditRoute: (id: string) => ({ name: 'edit-consumer-group', params: { id } }),
+  isExactMatch: true,
 })
 
 const kongManagerConfig = ref<KongManagerConsumerGroupListConfig>({

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -342,8 +342,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const dataKeyName = computed((): string | undefined => isConsumerPage.value && !props.config.paginatedEndpoint ? 'consumer_groups' : undefined)
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value, dataKeyName.value)
+const dataKeyName = computed((): string | undefined => {
+  if (props.config.app === 'konnect' && filterQuery.value) {
+    return 'consumer_group'
+  }
+  return isConsumerPage.value && !props.config.paginatedEndpoint ? 'consumer_groups' : undefined
+})
+
+const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value, dataKeyName)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-shared/src/composables/useFetcher.ts
+++ b/packages/entities/entities-shared/src/composables/useFetcher.ts
@@ -58,11 +58,7 @@ export default function useFetcher(
 
 
       if (data[dataKey]) {
-        if (Array.isArray(data[dataKey])) {
-          tableData = data[dataKey]
-        } else {
-          tableData = [data[dataKey]]
-        }
+        tableData = Array.isArray(data[dataKey]) ? data[dataKey] : [data[dataKey]]
       } else if (Array.isArray(data)) {
         // An array of object is returned
         tableData = data

--- a/packages/entities/entities-shared/src/composables/useFetcher.ts
+++ b/packages/entities/entities-shared/src/composables/useFetcher.ts
@@ -1,4 +1,5 @@
-import { ref, unref } from 'vue'
+import { ref, toValue, unref } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import type {
   FetcherParams,
   FetcherResponse,
@@ -20,7 +21,7 @@ export default function useFetcher(
    * instead of the standard the majority of the endpoints have
    * { data: [{ ... }] }
    */
-  dataKeyName = 'data',
+  dataKeyNameRef: MaybeRefOrGetter<string | undefined>,
 ) {
   const _baseUrl = unref(baseUrl)
 
@@ -32,6 +33,7 @@ export default function useFetcher(
   })
 
   const fetcher = async (fetcherParams: FetcherParams): Promise<FetcherResponse> => {
+    const dataKeyName = toValue(dataKeyNameRef) || 'data'
     try {
       state.value = { status: FetcherStatus.Loading }
 
@@ -54,8 +56,13 @@ export default function useFetcher(
       const dataKey = (dataKeyName && dataKeyName.replace(/[^\w-_]/gi, ''))
       let tableData
 
-      if (data[dataKey] && Array.isArray(data[dataKey])) {
-        tableData = data[dataKey]
+
+      if (data[dataKey]) {
+        if (Array.isArray(data[dataKey])) {
+          tableData = data[dataKey]
+        } else {
+          tableData = [data[dataKey]]
+        }
       } else if (Array.isArray(data)) {
         // An array of object is returned
         tableData = data

--- a/packages/entities/entities-shared/src/composables/useFetcher.ts
+++ b/packages/entities/entities-shared/src/composables/useFetcher.ts
@@ -21,7 +21,7 @@ export default function useFetcher(
    * instead of the standard the majority of the endpoints have
    * { data: [{ ... }] }
    */
-  dataKeyNameRef: MaybeRefOrGetter<string | undefined>,
+  dataKeyNameRef?: MaybeRefOrGetter<string | undefined>,
 ) {
   const _baseUrl = unref(baseUrl)
 


### PR DESCRIPTION
# Summary

When apply filter in consumer group list in Konnect, response from backend is not tailored for the table, so this change is made to adapt that format.

KM-410
