### PR TITLE
feat(ai-rate-limiting-advanced): add new providers to plugin config m…

### DIFF
--- a/packages/entities/entities-plugins/src/definitions/schemas/AIRateLimitingAdvanced.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/AIRateLimitingAdvanced.ts
@@ -24,7 +24,9 @@ export const aiRateLimitingAdvancedSchema: AIRateLimitingAdvancedSchema = {
           values: [
             'anthropic',
             'azure',
+            'bedrock',
             'cohere',
+            'gemini',
             'llama2',
             'mistral',
             'openai',


### PR DESCRIPTION
…enu choice

# Summary

AG-110
AG-55

Adds 'gemini' and 'bedrock' to the supported providers list in the Kong Manager, for the `ai-rate-limiting-advanced` plugin.

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
