### PR TITLE
chore(expressions): remove @kong-ui-public/forms from peerDependencies

### DIFF
--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -64,7 +64,6 @@
     "errorLimit": "2048KB"
   },
   "peerDependencies": {
-    "@kong-ui-public/forms": "workspace:^",
     "@kong/kongponents": "^9.3.0",
     "vue": "^3.4.31"
   },


### PR DESCRIPTION
# Summary
Since `@kong-ui-public/forms` moved into `dependencies`, should not keep it in `peerDependencies`
