### PR TITLE
feat(entities-*): externalize deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
+shamefully-hoist=true
 strict-peer-dependencies=false
-auto-install-peers=false
+auto-install-peers=true
+side-effects-cache=false # Ensure the postinstall script of the lefthook package is executed and hooks are installed
+manage-package-manager-versions=true

--- a/packages/analytics/analytics-chart/vite.config.ts
+++ b/packages/analytics/analytics-chart/vite.config.ts
@@ -16,16 +16,6 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       entry: resolve(__dirname, './src/index.ts'),
       fileName: (format) => `${sanitizedPackageName}.${format}.js`,
     },
-    rollupOptions: {
-      // Make sure to externalize deps that shouldn't be bundled into your library
-      external: ['@kong-ui-public/i18n'],
-      output: {
-        // Provide global variables to use in the UMD build for externalized deps
-        globals: {
-          '@kong-ui-public/i18n': 'kong-ui-public-i18n',
-        },
-      },
-    },
   },
   server: {
     open: true,

--- a/packages/analytics/analytics-geo-map/vite.config.ts
+++ b/packages/analytics/analytics-geo-map/vite.config.ts
@@ -18,11 +18,11 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
     },
     rollupOptions: {
       // Make sure to externalize deps that shouldn't be bundled into your library
-      external: ['maplibre-gl', '@kong-ui-public/i18n'],
+      external: ['maplibre-gl'],
       output: {
         // Provide global variables to use in the UMD build for externalized deps
         globals: {
-          '@kong-ui-public/i18n': 'kong-ui-public-i18n',
+          'maplibre-gl': 'maplibregl',
         },
       },
     },

--- a/packages/analytics/analytics-metric-provider/vite.config.ts
+++ b/packages/analytics/analytics-metric-provider/vite.config.ts
@@ -19,7 +19,6 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
     rollupOptions: {
       // Make sure to externalize deps that shouldn't be bundled into your library
       external: [
-        '@kong-ui-public/i18n',
         '@kong-ui-public/analytics-config-store',
         '@kong-ui-public/analytics-utilities',
         '@kong-ui-public/metric-cards',
@@ -28,9 +27,9 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       output: {
         // Provide global variables to use in the UMD build for externalized deps
         globals: {
-          '@kong-ui-public/i18n': 'kong-ui-public-i18n',
           '@kong-ui-public/analytics-config-store': 'kong-ui-public-analytics-config-store',
           '@kong-ui-public/analytics-utilities': 'kong-ui-public-analytics-utilities',
+          '@kong-ui-public/metric-cards': 'kong-ui-public-metric-cards',
           pinia: 'pinia',
         },
       },

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "^3.7.4",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "^3.7.4",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -65,8 +69,6 @@
     "extends": "../../../package.json"
   },
   "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1",
     "@peculiar/x509": "^1.9.7"
   },
   "distSizeChecker": {

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@kong-ui-public/entities-shared": "^3.7.4",
+    "@kong-ui-public/entities-shared": "^3.7.5",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
@@ -30,7 +30,7 @@
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
-    "@kong-ui-public/entities-shared": "^3.7.4",
+    "@kong-ui-public/entities-shared": "^3.7.5",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
     "@kong/icons": "^1.15.1",

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@kong-ui-public/entities-shared": "^3.7.5",
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
@@ -30,7 +30,7 @@
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
-    "@kong-ui-public/entities-shared": "^3.7.5",
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
     "@kong/icons": "^1.15.1",

--- a/packages/entities/entities-certificates/vite.config.ts
+++ b/packages/entities/entities-certificates/vite.config.ts
@@ -16,6 +16,18 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       entry: resolve(__dirname, './src/index.ts'),
       fileName: (format) => `${sanitizedPackageName}.${format}.js`,
     },
+    rollupOptions: {
+      external: [
+        '@kong/icons',
+        '@kong-ui-public/entities-shared',
+      ],
+      output: {
+        globals: {
+          '@kong/icons': 'KongIcons',
+          '@kong-ui-public/entities-shared': 'kong-ui-public-entities-shared',
+        },
+      },
+    },
   },
   server: {
     proxy: {

--- a/packages/entities/entities-certificates/vite.config.ts
+++ b/packages/entities/entities-certificates/vite.config.ts
@@ -19,7 +19,7 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
     rollupOptions: {
       external: [
         '@kong/icons',
-        '@kong-ui-public/entities-shared',
+        /^@kong-ui-public\/entities-shared(.*)?$/,
       ],
       output: {
         globals: {

--- a/packages/entities/entities-certificates/vite.config.ts
+++ b/packages/entities/entities-certificates/vite.config.ts
@@ -16,18 +16,6 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       entry: resolve(__dirname, './src/index.ts'),
       fileName: (format) => `${sanitizedPackageName}.${format}.js`,
     },
-    rollupOptions: {
-      external: [
-        '@kong/icons',
-        /^@kong-ui-public\/entities-shared(.*)?$/,
-      ],
-      output: {
-        globals: {
-          '@kong/icons': 'KongIcons',
-          '@kong-ui-public/entities-shared': 'kong-ui-public-entities-shared',
-        },
-      },
-    },
   },
   server: {
     proxy: {

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -66,9 +70,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "300KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -66,9 +70,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "500KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -66,9 +70,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "500KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/packages/entities/entities-data-plane-nodes/package.json
+++ b/packages/entities/entities-data-plane-nodes/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -66,9 +70,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "500KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -66,9 +70,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "600KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -21,14 +21,18 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -65,9 +69,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "500KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -66,9 +70,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "486KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -25,16 +25,20 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/entities-vaults": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -78,9 +82,7 @@
     "@kong-ui-public/entities-consumers": "workspace:^",
     "@kong-ui-public/entities-gateway-services": "workspace:^",
     "@kong-ui-public/entities-routes": "workspace:^",
-    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/forms": "workspace:^",
-    "@kong/icons": "^1.15.1",
     "marked": "^12.0.2"
   }
 }

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "@types/lodash.isequal": "^4.5.8",
     "axios": "^1.6.8",
@@ -70,9 +74,7 @@
     "errorLimit": "800KB"
   },
   "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/expressions": "workspace:^",
-    "@kong/icons": "^1.15.1",
     "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/entities/entities-routes/vite.config.ts
+++ b/packages/entities/entities-routes/vite.config.ts
@@ -19,11 +19,8 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
     },
     rollupOptions: {
       external: [
-        '@kong-ui-public/entities-shared',
-        '@kong-ui-public/entities-shared/dist/style.css',
         '@kong-ui-public/expressions',
         '@kong-ui-public/expressions/dist/style.css',
-        '@kong/icons',
         'lodash.isequal',
       ],
     },

--- a/packages/entities/entities-routes/vite.config.ts
+++ b/packages/entities/entities-routes/vite.config.ts
@@ -20,7 +20,6 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
     rollupOptions: {
       external: [
         '@kong-ui-public/expressions',
-        '@kong-ui-public/expressions/dist/style.css',
         'lodash.isequal',
       ],
     },

--- a/packages/entities/entities-routes/vite.config.ts
+++ b/packages/entities/entities-routes/vite.config.ts
@@ -22,6 +22,12 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
         '@kong-ui-public/expressions',
         'lodash.isequal',
       ],
+      output: {
+        // Provide global variables to use in the UMD build for externalized deps
+        globals: {
+          '@kong-ui-public/expressions': 'kong-ui-public-expressions',
+        },
+      },
     },
   },
   ...(process.env.USE_SANDBOX

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -22,6 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -69,7 +71,6 @@
   },
   "dependencies": {
     "@kong-ui-public/core": "workspace:^",
-    "@kong/icons": "^1.15.1",
     "compare-versions": "^6.1.0"
   }
 }

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -66,9 +70,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "400KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -66,9 +70,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "900KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -21,15 +21,19 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "^9.3.0",
     "axios": "^1.6.8",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.3.3"
   },
   "devDependencies": {
+    "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.2",
+    "@kong/icons": "^1.15.1",
     "@kong/kongponents": "9.3.0",
     "axios": "^1.6.8",
     "vue": "^3.4.31",
@@ -66,9 +70,5 @@
   },
   "distSizeChecker": {
     "errorLimit": "900KB"
-  },
-  "dependencies": {
-    "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong/icons": "^1.15.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,8 +673,8 @@ importers:
         version: 1.9.7
     devDependencies:
       '@kong-ui-public/entities-shared':
-        specifier: ^3.7.4
-        version: 3.7.4(@kong-ui-public/i18n@packages+core+i18n)(@kong/kongponents@9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3)))(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
+        specifier: ^3.7.5
+        version: 3.7.5(@kong-ui-public/i18n@packages+core+i18n)(@kong/kongponents@9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3)))(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
@@ -1862,8 +1862,8 @@ packages:
       swrv: ^1.0.4
       vue: ^3.4.31
 
-  '@kong-ui-public/entities-shared@3.7.4':
-    resolution: {integrity: sha512-Ezxo5P7VAFXMux0aLamSxuhs2nMqBpT765dxr5dxAxzhclfFkrUjHLX9znjFZDukqJHkF9phSWYjqA+1wlA0sg==}
+  '@kong-ui-public/entities-shared@3.7.5':
+    resolution: {integrity: sha512-0uekW6pt0J69yo4uUUZvDuAeZOv/XPjeK7JjeI9jecovJwu2yTYFFALFJzLIbH1KSy5Cmp81CVns9t80hH2/qA==}
     peerDependencies:
       '@kong-ui-public/i18n': ^2.2.2
       '@kong/kongponents': ^9.3.0
@@ -9833,7 +9833,7 @@ snapshots:
       swrv: 1.0.4(vue@3.4.31(typescript@5.3.3))
       vue: 3.4.31(typescript@5.3.3)
 
-  '@kong-ui-public/entities-shared@3.7.4(@kong-ui-public/i18n@packages+core+i18n)(@kong/kongponents@9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3)))(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))':
+  '@kong-ui-public/entities-shared@3.7.5(@kong-ui-public/i18n@packages+core+i18n)(@kong/kongponents@9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3)))(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))':
     dependencies:
       '@kong-ui-public/core': 1.7.8(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
       '@kong-ui-public/i18n': link:packages/core/i18n

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,8 +673,8 @@ importers:
         version: 1.9.7
     devDependencies:
       '@kong-ui-public/entities-shared':
-        specifier: ^3.7.5
-        version: 3.7.5(@kong-ui-public/i18n@packages+core+i18n)(@kong/kongponents@9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3)))(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
+        specifier: workspace:^
+        version: link:../entities-shared
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
@@ -1854,22 +1854,6 @@ packages:
       axios: ^1.4.0
       swrv: ^1.0.4
       vue: ^3.2.47
-
-  '@kong-ui-public/core@1.7.8':
-    resolution: {integrity: sha512-YLxJSDD8rVCNQnOj4FSqL/Tu3MvHTLZfGUeM1WJtl5/YbVBvm2XtRoGeUXvJQFI1tiEpdb2yCWY55pkxDwN6Wg==}
-    peerDependencies:
-      axios: ^1.6.8
-      swrv: ^1.0.4
-      vue: ^3.4.31
-
-  '@kong-ui-public/entities-shared@3.7.5':
-    resolution: {integrity: sha512-0uekW6pt0J69yo4uUUZvDuAeZOv/XPjeK7JjeI9jecovJwu2yTYFFALFJzLIbH1KSy5Cmp81CVns9t80hH2/qA==}
-    peerDependencies:
-      '@kong-ui-public/i18n': ^2.2.2
-      '@kong/kongponents': ^9.3.0
-      axios: ^1.6.8
-      vue: '>= 3.3.13 < 4'
-      vue-router: ^4.3.3
 
   '@kong/atc-router@1.6.0-rc.1':
     resolution: {integrity: sha512-nFR01kKK4vAsXGZ0g8YPzJSOrTEPzgtVm3iWv4JPNx1kFFRKDTJrmDFSWZmEPC2VtsSdglewGB3Sqzpi/DfiIg==}
@@ -9825,26 +9809,6 @@ snapshots:
       date-fns: 2.30.0
       swrv: 1.0.4(vue@3.4.31(typescript@5.3.3))
       vue: 3.4.31(typescript@5.3.3)
-
-  '@kong-ui-public/core@1.7.8(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))':
-    dependencies:
-      axios: 1.6.8
-      date-fns: 2.30.0
-      swrv: 1.0.4(vue@3.4.31(typescript@5.3.3))
-      vue: 3.4.31(typescript@5.3.3)
-
-  '@kong-ui-public/entities-shared@3.7.5(@kong-ui-public/i18n@packages+core+i18n)(@kong/kongponents@9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3)))(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))':
-    dependencies:
-      '@kong-ui-public/core': 1.7.8(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
-      '@kong-ui-public/i18n': link:packages/core/i18n
-      '@kong/icons': 1.15.1(vue@3.4.31(typescript@5.3.3))
-      '@kong/kongponents': 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
-      axios: 1.6.8
-      compare-versions: 6.1.0
-      vue: 3.4.31(typescript@5.3.3)
-      vue-router: 4.4.0(vue@3.4.31(typescript@5.3.3))
-    transitivePeerDependencies:
-      - swrv
 
   '@kong/atc-router@1.6.0-rc.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,20 +698,19 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-consumer-credentials:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -726,20 +725,19 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-consumer-groups:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -754,20 +752,19 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-consumers:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -782,20 +779,19 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-data-plane-nodes:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -810,20 +806,19 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-gateway-services:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -838,17 +833,16 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-key-sets:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -863,20 +857,19 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-keys:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -904,19 +897,16 @@ importers:
       '@kong-ui-public/entities-routes':
         specifier: workspace:^
         version: link:../entities-routes
-      '@kong-ui-public/entities-shared':
-        specifier: workspace:^
-        version: link:../entities-shared
       '@kong-ui-public/forms':
         specifier: workspace:^
         version: link:../../core/forms
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       marked:
         specifier: ^12.0.2
         version: 12.0.2
     devDependencies:
+      '@kong-ui-public/entities-shared':
+        specifier: workspace:^
+        version: link:../entities-shared
       '@kong-ui-public/entities-vaults':
         specifier: workspace:^
         version: link:../entities-vaults
@@ -926,6 +916,9 @@ importers:
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -941,25 +934,25 @@ importers:
 
   packages/entities/entities-routes:
     dependencies:
-      '@kong-ui-public/entities-shared':
-        specifier: workspace:^
-        version: link:../entities-shared
       '@kong-ui-public/expressions':
         specifier: workspace:^
         version: link:../../core/expressions
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0
     devDependencies:
+      '@kong-ui-public/entities-shared':
+        specifier: workspace:^
+        version: link:../entities-shared
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -984,9 +977,6 @@ importers:
       '@kong-ui-public/core':
         specifier: workspace:^
         version: link:../../core/core
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       compare-versions:
         specifier: ^6.1.0
         version: 6.1.0
@@ -997,6 +987,9 @@ importers:
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -1011,20 +1004,19 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-snis:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -1039,20 +1031,19 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-upstreams-targets:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -1067,20 +1058,19 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-vaults:
-    dependencies:
+    devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
-    devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 overrides:
@@ -489,6 +489,9 @@ importers:
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
+      vue:
+        specifier: ^3.4.31
+        version: 3.4.31(typescript@5.3.3)
     devDependencies:
       '@kong/design-tokens':
         specifier: 1.17.2
@@ -597,6 +600,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      vue:
+        specifier: ^3.4.31
+        version: 3.4.31(typescript@5.3.3)
     devDependencies:
       '@kong-ui-public/i18n':
         specifier: workspace:^
@@ -625,6 +631,9 @@ importers:
       intl-messageformat:
         specifier: ^10.5.14
         version: 10.5.14
+      vue:
+        specifier: '>= 3.3.13 < 4'
+        version: 3.4.31(typescript@5.3.3)
 
   packages/core/misc-widgets:
     devDependencies:
@@ -659,22 +668,22 @@ importers:
 
   packages/entities/entities-certificates:
     dependencies:
-      '@kong-ui-public/entities-shared':
-        specifier: workspace:^
-        version: link:../entities-shared
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@peculiar/x509':
         specifier: ^1.9.7
         version: 1.9.7
     devDependencies:
+      '@kong-ui-public/entities-shared':
+        specifier: ^3.7.4
+        version: 3.7.4(@kong-ui-public/i18n@packages+core+i18n)(@kong/kongponents@9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3)))(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.3.0
         version: 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
@@ -1750,7 +1759,6 @@ packages:
 
   '@evilmartians/lefthook@1.7.1':
     resolution: {integrity: sha512-Wp8DaTMHZM1tUV4Mow6nG+6zq+giruD5054zHmFIDLXlPQxqYxnZMqJg0aYxe16vYwqFmH6NIClEMRdtGucO0Q==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -1856,6 +1864,22 @@ packages:
       axios: ^1.4.0
       swrv: ^1.0.4
       vue: ^3.2.47
+
+  '@kong-ui-public/core@1.7.8':
+    resolution: {integrity: sha512-YLxJSDD8rVCNQnOj4FSqL/Tu3MvHTLZfGUeM1WJtl5/YbVBvm2XtRoGeUXvJQFI1tiEpdb2yCWY55pkxDwN6Wg==}
+    peerDependencies:
+      axios: ^1.6.8
+      swrv: ^1.0.4
+      vue: ^3.4.31
+
+  '@kong-ui-public/entities-shared@3.7.4':
+    resolution: {integrity: sha512-Ezxo5P7VAFXMux0aLamSxuhs2nMqBpT765dxr5dxAxzhclfFkrUjHLX9znjFZDukqJHkF9phSWYjqA+1wlA0sg==}
+    peerDependencies:
+      '@kong-ui-public/i18n': ^2.2.2
+      '@kong/kongponents': ^9.3.0
+      axios: ^1.6.8
+      vue: '>= 3.3.13 < 4'
+      vue-router: ^4.3.3
 
   '@kong/atc-router@1.6.0-rc.1':
     resolution: {integrity: sha512-nFR01kKK4vAsXGZ0g8YPzJSOrTEPzgtVm3iWv4JPNx1kFFRKDTJrmDFSWZmEPC2VtsSdglewGB3Sqzpi/DfiIg==}
@@ -3210,6 +3234,11 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -9807,6 +9836,26 @@ snapshots:
       swrv: 1.0.4(vue@3.4.31(typescript@5.3.3))
       vue: 3.4.31(typescript@5.3.3)
 
+  '@kong-ui-public/core@1.7.8(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))':
+    dependencies:
+      axios: 1.6.8
+      date-fns: 2.30.0
+      swrv: 1.0.4(vue@3.4.31(typescript@5.3.3))
+      vue: 3.4.31(typescript@5.3.3)
+
+  '@kong-ui-public/entities-shared@3.7.4(@kong-ui-public/i18n@packages+core+i18n)(@kong/kongponents@9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3)))(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))':
+    dependencies:
+      '@kong-ui-public/core': 1.7.8(axios@1.6.8)(swrv@1.0.4(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
+      '@kong-ui-public/i18n': link:packages/core/i18n
+      '@kong/icons': 1.15.1(vue@3.4.31(typescript@5.3.3))
+      '@kong/kongponents': 9.3.0(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))
+      axios: 1.6.8
+      compare-versions: 6.1.0
+      vue: 3.4.31(typescript@5.3.3)
+      vue-router: 4.4.0(vue@3.4.31(typescript@5.3.3))
+    transitivePeerDependencies:
+      - swrv
+
   '@kong/atc-router@1.6.0-rc.1': {}
 
   '@kong/design-tokens@1.17.2': {}
@@ -11940,8 +11989,8 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1:
-    dependencies:
+  ajv-formats@2.1.1(ajv@8.12.0):
+    optionalDependencies:
       ajv: 8.12.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -16913,7 +16962,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.12
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-keywords: 5.1.0(ajv@8.12.0)
 
   scule@1.3.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,6 +1058,10 @@ importers:
         version: 4.4.0(vue@3.4.31(typescript@5.3.3))
 
   packages/entities/entities-vaults:
+    dependencies:
+      '@kong/icons':
+        specifier: ^1.15.1
+        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
     devDependencies:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
@@ -1068,9 +1072,6 @@ importers:
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
-      '@kong/icons':
-        specifier: ^1.15.1
-        version: 1.15.1(vue@3.4.31(typescript@5.3.3))
       '@kong/kongponents':
         specifier: 9.4.1
         version: 9.4.1(axios@1.6.8)(vue-router@4.4.0(vue@3.4.31(typescript@5.3.3)))(vue@3.4.31(typescript@5.3.3))

--- a/vite.config.shared.ts
+++ b/vite.config.shared.ts
@@ -73,10 +73,10 @@ export default defineConfig({
       external: [
         'vue',
         'vue-router',
-        /^@kong\/kongponents(.*)?$/,
+        /^@kong\/kongponents(\/.*)?$/,
         '@kong/icons',
         '@kong-ui-public/i18n',
-        /^@kong-ui-public\/entities-shared(.*)?$/,
+        /^@kong-ui-public\/entities-shared(\/.*)?$/,
         'axios',
       ],
       output: {

--- a/vite.config.shared.ts
+++ b/vite.config.shared.ts
@@ -74,9 +74,11 @@ export default defineConfig({
         'vue',
         'vue-router',
         '@kong/kongponents',
+        '@kong/kongponents/dist/style.css',
         '@kong/icons',
         '@kong-ui-public/i18n',
         '@kong-ui-public/entities-shared',
+        '@kong-ui-public/entities-shared/dist/style.css',
         'axios',
       ],
       output: {

--- a/vite.config.shared.ts
+++ b/vite.config.shared.ts
@@ -70,7 +70,13 @@ export default defineConfig({
     rollupOptions: {
       // Make sure to externalize deps that shouldn't be bundled into your library
       // If config.build.rollupOptions.external is also set at the package level, the arrays will be merged
-      external: ['vue', 'vue-router', '@kong/kongponents', '@kong-ui-public/i18n', 'axios'],
+      external: [
+        'vue',
+        'vue-router',
+        /^@kong\/kongponents(.*)?$/,
+        '@kong-ui-public/i18n',
+        'axios',
+      ],
       output: {
         // Provide global variables to use in the UMD build for externalized deps
         globals: {

--- a/vite.config.shared.ts
+++ b/vite.config.shared.ts
@@ -74,11 +74,9 @@ export default defineConfig({
         'vue',
         'vue-router',
         '@kong/kongponents',
-        '@kong/kongponents/dist/style.css',
         '@kong/icons',
         '@kong-ui-public/i18n',
         '@kong-ui-public/entities-shared',
-        '@kong-ui-public/entities-shared/dist/style.css',
         'axios',
       ],
       output: {

--- a/vite.config.shared.ts
+++ b/vite.config.shared.ts
@@ -74,7 +74,9 @@ export default defineConfig({
         'vue',
         'vue-router',
         /^@kong\/kongponents(.*)?$/,
+        '@kong/icons',
         '@kong-ui-public/i18n',
+        /^@kong-ui-public\/entities-shared(.*)?$/,
         'axios',
       ],
       output: {
@@ -84,6 +86,8 @@ export default defineConfig({
           'vue-router': 'VueRouter',
           '@kong-ui-public/i18n': 'kong-ui-public-i18n',
           '@kong/kongponents': 'Kongponents',
+          '@kong/icons': 'KongIcons',
+          '@kong-ui-public/entities-shared': 'kong-ui-public-entities-shared',
           axios: 'axios',
         },
         exports: 'named',

--- a/vite.config.shared.ts
+++ b/vite.config.shared.ts
@@ -73,10 +73,10 @@ export default defineConfig({
       external: [
         'vue',
         'vue-router',
-        /^@kong\/kongponents(\/.*)?$/,
+        '@kong/kongponents',
         '@kong/icons',
         '@kong-ui-public/i18n',
-        /^@kong-ui-public\/entities-shared(\/.*)?$/,
+        '@kong-ui-public/entities-shared',
         'axios',
       ],
       output: {


### PR DESCRIPTION
# Summary

Update the build configuration of `entities-*` packages to externalize common dependencies.

Externalizes:

- `@kong-ui-public/entities-shared`
- `@kong/icons`

Switches the Kongponents external to utilize a Regular Expression

The `.npmrc` changes need to be replicated in `konnect-ui-apps`

## Before

```md
dist/style.css                      11.06 kB │ gzip:   2.37 kB
dist/entities-certificates.es.js   504.87 kB │ gzip: 111.05 kB
dist/style.css                      11.06 kB │ gzip:  2.37 kB
dist/entities-certificates.umd.js  363.66 kB │ gzip: 94.92 kB
```

## After

```md
dist/style.css                      11.06 kB │ gzip:  2.37 kB
dist/entities-certificates.es.js   336.60 kB │ gzip: 69.73 kB
dist/style.css                      11.06 kB │ gzip:  2.37 kB
dist/entities-certificates.umd.js  246.57 kB │ gzip: 60.10 kB
```

---

## Before

![before](https://github.com/user-attachments/assets/dc550d0e-a8c6-4010-a8c8-59cac5a42f4b)

## After

![after](https://github.com/user-attachments/assets/10a6d1a3-1913-4561-be94-ee3a76e85b2e)


Consuming [PR in konnect-ui-apps](https://github.com/Kong/konnect-ui-apps/pull/4043)