### PR TITLE
fix(entities): toolbar create button size

### DIFF
--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -13,7 +13,6 @@
       preferences-storage-key="kong-ui-entities-ca-certificates-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @sort="resetPagination"
@@ -37,7 +36,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-ca-certificate"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -13,7 +13,6 @@
       preferences-storage-key="kong-ui-entities-certificates-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @sort="resetPagination"
@@ -37,7 +36,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-certificate"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -13,7 +13,6 @@
       pagination-type="offset"
       preferences-storage-key="kong-ui-entities-consumer-credentials-list"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @sort="resetPagination"
     >
       <!-- Create action -->
@@ -28,7 +27,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-credential"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -15,7 +15,6 @@
       :query="filterQuery"
       :row-attributes="rowAttributes"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @empty-state-cta-clicked="handleEmptyStateCtaClicked"
@@ -41,7 +40,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-consumer-group"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.consumerId ? undefined : config.createRoute"
               @click="() => config.consumerId ? handleAddToGroupClick() : undefined"
             >

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -15,7 +15,6 @@
       :query="filterQuery"
       :row-attributes="rowAttributes"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @empty-state-cta-clicked="handleEmptyStateCtaClicked"
@@ -41,7 +40,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-consumer"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.consumerGroupId ? undefined : config.createRoute"
               @click="() => config.consumerGroupId ? handleAddConsumerClick() : undefined"
             >

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -13,7 +13,6 @@
       preferences-storage-key="kong-ui-entities-gateway-services-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @sort="resetPagination"
@@ -37,7 +36,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-gateway-service"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -13,7 +13,6 @@
       preferences-storage-key="kong-ui-entities-key-sets-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @sort="resetPagination"
@@ -37,7 +36,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-key-set"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -13,7 +13,6 @@
       preferences-storage-key="kong-ui-entities-keys-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @sort="resetPagination"
@@ -37,7 +36,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-key"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -16,7 +16,6 @@
       :table-headers="tableHeaders"
       :title="title"
       :title-tag="titleTag"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @sort="resetPagination"
@@ -40,7 +39,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-plugin"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -16,7 +16,6 @@
       :table-headers="tableHeaders"
       :title="title"
       :title-tag="titleTag"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @sort="resetPagination"
@@ -40,7 +39,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-route"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -15,7 +15,6 @@
       preferences-storage-key="kong-ui-entities-snis-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @sort="resetPagination"
     >
@@ -38,7 +37,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-sni"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -12,7 +12,6 @@
       pagination-type="offset"
       preferences-storage-key="kong-ui-entities-targets-list"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @empty-state-cta-clicked="() => !props.config.createRoute ? handleCreateTarget() : undefined"
       @sort="resetPagination"
     >
@@ -28,6 +27,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-new-target"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="props.config.createRoute ? props.config.createRoute : undefined"
               @click="() => !props.config.createRoute ? handleCreateTarget() : undefined"
             >

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -13,7 +13,6 @@
       preferences-storage-key="kong-ui-entities-upstreams-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @sort="resetPagination"
@@ -38,7 +37,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-upstream"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -13,7 +13,6 @@
       preferences-storage-key="kong-ui-entities-vaults-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
-      :use-action-outside="useActionOutside"
       @clear-search-input="clearFilter"
       @click:row="(row: any) => rowClick(row as EntityRow)"
       @sort="resetPagination"
@@ -37,7 +36,7 @@
               v-show="hasData"
               appearance="primary"
               data-testid="toolbar-add-vault"
-              size="large"
+              :size="useActionOutside ? 'medium' : 'large'"
               :to="config.createRoute"
             >
               <AddIcon />


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This PR uses `useActionOutside` to decide the size of the create entity button in the toolbar, so that:
1. the create entity button size aligns with the learning hub icon *in Gateway Manager*
2. the create entity button size aligns with the column toggle icon *in Kong Manager*

This PR also removes `use-action-outside` on `EntityBaseTable` because `EntityBaseTable` does not have this prop.

| Gateway Manager | Kong Manager |
| - | - |
| <img width="1727" alt="image" src="https://github.com/user-attachments/assets/c26c7611-6959-4040-852c-aa297fd71c7e"> | <img width="1723" alt="image" src="https://github.com/user-attachments/assets/ad730388-59eb-41a6-a779-a0c9e93bcb3f"> |

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
