### PR TITLE
fix: clean up request filter types

### DIFF
--- a/packages/analytics/analytics-utilities/src/types/explore/requests.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/requests.ts
@@ -13,6 +13,7 @@ export const queryableRequestDimensions = [
   'consumer_group',
   'control_plane',
   'control_plane_group',
+  'country_code',
   'data_plane_node',
   'gateway_service',
   'header_host',
@@ -58,9 +59,7 @@ export const queryableRequestMetrics = [
   'response_body_size',
   'request_body_size',
   'status_code',
-  'status_code_grouped',
   'upstream_status_code',
-  'upstream_status_code_grouped',
 ] as const
 
 export type QueryableRequestMetrics = typeof queryableRequestMetrics[number]


### PR DESCRIPTION
# Summary
- Missed removing status code groups from metric fields
- Adding back `country_code`. It's baked into a few of our tests and I figure it's easier to not rip out the functionality that's already there


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
