### PR TITLE
fix(forms): add index to deeply nested input id

### DIFF
--- a/packages/core/forms/src/components/FormGroup.vue
+++ b/packages/core/forms/src/components/FormGroup.vue
@@ -45,7 +45,7 @@
         :form-options="options"
         :hint="field.hint && getFieldType(field) === 'field-input' ? fieldHint(field) : undefined"
         :model="model"
-        :schema="field"
+        :schema="schema"
         :vfg="vfg"
         @model-updated="onModelUpdated"
         @validated="onFieldValidated"
@@ -97,6 +97,11 @@ export default {
   name: 'FormGroup',
   components: fieldComponents,
   mixins: [formMixin],
+  inject: {
+    'vfg-array-item-index': {
+      default: undefined,
+    },
+  },
   props: {
     vfg: {
       type: Object,
@@ -126,6 +131,30 @@ export default {
     return {
       child: ref(),
     }
+  },
+  computed: {
+    schema() {
+      if (!this.field?.schema || !Array.isArray(this.field.schema.fields)) {
+        return this.field
+      }
+
+      const index = this['vfg-array-item-index']
+
+      if (typeof index !== 'number' || Number.isNaN(index)) {
+        return this.field
+      }
+
+      return {
+        ...this.field,
+        schema: {
+          ...this.field.schema,
+          fields: this.field.schema.fields.map(field => ({
+            ...field,
+            ...(field.id ? { id: `${field.id}-${index}` } : undefined),
+          })),
+        },
+      }
+    },
   },
   methods: {
     // Should field type have a label?

--- a/packages/core/forms/src/components/fields/FieldArray.vue
+++ b/packages/core/forms/src/components/fields/FieldArray.vue
@@ -12,6 +12,7 @@
       <component
         :is="schema.itemContainerComponent"
         v-if="schema.items && schema.itemContainerComponent"
+        :index="index"
         :model="item"
         :schema="generateSchema(value, schema.items, index)"
         @remove-item="removeElement(index)"

--- a/packages/core/forms/src/components/fields/FieldArrayCardContainer.vue
+++ b/packages/core/forms/src/components/fields/FieldArrayCardContainer.vue
@@ -15,9 +15,10 @@
 </template>
 
 <script lang="ts" setup>
+import { provide } from 'vue'
 import { TrashIcon } from '@kong/icons'
 
-defineProps({
+const props = defineProps({
   model: {
     type: Object,
     default: () => null,
@@ -26,11 +27,17 @@ defineProps({
     type: Object,
     default: () => null,
   },
+  index: {
+    type: Number,
+    default: undefined,
+  },
 })
 
 defineEmits<{
   (e: 'remove-item'): void,
 }>()
+
+provide('vfg-array-item-index', props.index)
 </script>
 
 <style lang='scss'>


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Add missing index info to deeply nested input ID, e.g. `targets` in the `ai-proxy-advanced` plugin:

| Before | After |
| - | - |
| <img width="940" alt="image" src="https://github.com/user-attachments/assets/12956ad3-a1d0-4e67-95e7-e506fcd51b11"> | <img width="953" alt="image" src="https://github.com/user-attachments/assets/3806a76a-7fce-4d95-818e-ae9c2460d83d"> |

KM-521

#### Resources

- [Creating a package docs](https://github.com/Kong/public-ui-components/blob/main/docs/creating-a-package.md)
