### PR TITLE
fix(entities-plugins): prevent infinite updates for dev

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginIcon.vue
+++ b/packages/entities/entities-plugins/src/components/PluginIcon.vue
@@ -34,7 +34,7 @@ const iconSrc = computed(() => getPluginIconURL(props.name))
 
 const onError = () => {
   const defaultIcon = new URL('../assets/images/plugin-icons/missing.png', import.meta.url).href // only need to compute it when icon URL is invalid
-  if (img.value) {
+  if (img.value && img.value.src !== defaultIcon) {
     img.value.src = defaultIcon
   }
 }


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

KM-532

This PR introduces a check for changes to the `src` attribute, which should prevent the infinite update issue.

Currently, we are directly updating the `src` attribute of the `<img>` element within the `@error` handler. If the `defaultIcon` is invalid, this can result in an infinite update loop.

Additionally, due to a bug in Vite, even though the `new URL(...)` part is correctly transformed into base64 data URIs, when developing a project that depends on `public-ui-components`, Vite reprocesses the asset URL, leading to an invalid URL in the development environment. Combined with the original implementation of `<PluginIcon>`, this causes an infinite update loop during host app development (e.g., `konnect-ui-apps`).

![](https://github.com/user-attachments/assets/348de448-883c-411d-84fa-3e1aa6555978)

I’ve also [submitted a PR](https://github.com/vitejs/vite/pull/18163) to address the issue in Vite itself, but since we are still using `vite@4.5.3` in `konnect-ui-apps`, we may need this temporary fix in the meantime.
