### PR TITLE
fix(key): fix keySet query expected 404 [KM-545]

### DIFF
--- a/packages/entities/entities-keys/src/components/KeyConfigCard.vue
+++ b/packages/entities/entities-keys/src/components/KeyConfigCard.vue
@@ -212,7 +212,9 @@ watch(entityKeySetId, async () => {
   try {
     isKeySetNameLoading.value = true
     // make the call to get keySetName
-    const { data } = await axiosInstance.get(url)
+    const { data } = await axiosInstance.get(url, {
+      validateStatus: (status: number) => status === 404 || (status >= 200 && status < 300), // in case KeySet is deleted
+    })
     keySetName.value = data?.name || data?.id
   } catch (err: any) {
     // emit this error for the host app


### PR DESCRIPTION
# Summary

KM-545

In a key config card, if this key is included in a deleted key set, querying it triggers global 404 in Konnect, we need to avoid this.