### PR TITLE
feat(forms): visibility toggle for password inputs [KM-502]

### DIFF
--- a/packages/core/forms/src/components/fields/FieldInput.vue
+++ b/packages/core/forms/src/components/fields/FieldInput.vue
@@ -17,11 +17,27 @@
       :placeholder="schema.placeholder"
       :readonly="schema.readonly"
       :required="schema.required"
-      :type="inputType"
+      :type="displayInputType"
       :width="schema.width"
       @blur="onBlur"
       @update:model-value="onInput"
-    />
+    >
+      <template
+        v-if="schema.inputType === 'password'"
+        #after
+      >
+        <VisibilityOffIcon
+          v-if="eyeOpen"
+          role="button"
+          @click="() => { eyeOpen = !eyeOpen }"
+        />
+        <VisibilityIcon
+          v-else
+          role="button"
+          @click="() => { eyeOpen = !eyeOpen }"
+        />
+      </template>
+    </KInput>
 
     <!-- autofill -->
     <component
@@ -44,6 +60,7 @@ import objGet from 'lodash-es/get'
 import isFunction from 'lodash-es/isFunction'
 import isNumber from 'lodash-es/isNumber'
 import composables from '../../composables'
+import { VisibilityIcon, VisibilityOffIcon } from '@kong/icons'
 
 const props = defineProps({
   disabled: {
@@ -85,6 +102,14 @@ const emit = defineEmits<{
 }>()
 
 const propsRefs = toRefs(props)
+const eyeOpen = ref(false)
+
+const displayInputType = computed(() => {
+  if (inputType.value === 'password') {
+    return eyeOpen.value ? 'text' : 'password'
+  }
+  return inputType.value
+})
 
 const autofillSlot = inject<AutofillSlot | undefined>(AUTOFILL_SLOT, undefined)
 

--- a/packages/core/forms/src/components/fields/__tests__/FieldInput.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldInput.cy.ts
@@ -16,6 +16,17 @@ describe('<FieldTester /> - FieldInput', () => {
       required: true,
     }],
   }
+  const passwordSchema: FormSchema = {
+    fields: [{
+      type: 'input',
+      model: fieldKey,
+      id: fieldKey,
+      inputType: 'password',
+      label: fieldLabel,
+      help: 'The name of the cat.',
+      required: true,
+    }],
+  }
 
   it('renders default state correctly - without model', () => {
     cy.mount(FieldTester, {
@@ -124,5 +135,37 @@ describe('<FieldTester /> - FieldInput', () => {
     cy.get(`#${fieldKey}`).should('have.value', updatedFieldValue)
     // check field test form model also matches
     cy.getTestId(`field-tester-form-model-${fieldKey}-value`).should('contain.text', updatedFieldValue)
+  })
+
+  it('handles password field visibility toggle', () => {
+    const editText = ' the Second'
+    cy.mount(FieldTester, {
+      props: {
+        schema: passwordSchema,
+        model: {
+          [fieldKey]: fieldValue,
+        },
+      },
+    })
+
+    cy.get('.field-tester-container').should('exist')
+
+    // check VFG input value and type
+    cy.get(`#${fieldKey}`).should('be.visible')
+    cy.get(`#${fieldKey}`).should('have.value', fieldValue).and('have.attr', 'type', 'password')
+    cy.getTestId('kui-icon-wrapper-visibility-icon').should('be.visible')
+
+    // toggle visibility
+    cy.getTestId('kui-icon-wrapper-visibility-icon').click()
+    cy.get(`#${fieldKey}`).should('have.value', fieldValue).and('have.attr', 'type', 'text')
+    cy.getTestId('kui-icon-wrapper-visibility-off-icon').should('be.visible')
+
+    cy.get(`#${fieldKey}`).type(editText)
+    cy.get(`#${fieldKey}`).should('have.value', fieldValue + editText)
+
+    // check VFG input value and type after toggling back
+    cy.getTestId('kui-icon-wrapper-visibility-off-icon').click()
+    cy.get(`#${fieldKey}`).should('have.value', fieldValue + editText).and('have.attr', 'type', 'password')
+    cy.getTestId('kui-icon-wrapper-visibility-icon').should('be.visible')
   })
 })

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -870,7 +870,7 @@ const buildFormSchema = (parentKey: string, response: Record<string, any>, initi
       }
 
       initialFormSchema[field].inputType = scheme.type === 'array' || scheme.type === 'string'
-        ? 'text'
+        ? (scheme.encrypted ? 'password' : 'text')
         : scheme.type
     }
 


### PR DESCRIPTION
# Summary

KM-502

Some encrypted fields are required to be able to toggle visibility when edited in forms

