### PR TITLE
fix(core): fix form sandbox

### DIFF
--- a/packages/core/forms/sandbox/App.vue
+++ b/packages/core/forms/sandbox/App.vue
@@ -23,11 +23,18 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, provide } from 'vue'
 import FieldTester from './FieldTester.vue'
+import { FORMS_API_KEY, VueFormGenerator } from '../src'
+
 // dummy data
 import schema from './schema.json'
 import model from './model.json'
+
+provide(FORMS_API_KEY, {
+  getOne: async () => ({}),
+  getAll: async () => [{}],
+})
 
 const mutableModel = ref(model)
 

--- a/packages/core/forms/sandbox/index.ts
+++ b/packages/core/forms/sandbox/index.ts
@@ -1,8 +1,8 @@
-import { createApp, provide } from 'vue'
+import { createApp } from 'vue'
 import App from './App.vue'
 import Kongponents from '@kong/kongponents'
 import '@kong/kongponents/dist/style.css'
-import { FORMS_API_KEY, VueFormGenerator } from '../src'
+import { VueFormGenerator } from '../src'
 
 const app = createApp(App)
 
@@ -11,9 +11,5 @@ app.use(Kongponents)
 // For correct rendering, host app should make the component available
 // globally and provide the API endpoints for autosuggest
 app.component('VueFormGenerator', VueFormGenerator)
-provide(FORMS_API_KEY, {
-  getOne: async () => ({}),
-  getAll: async () => [{}],
-})
 
 app.mount('#app')


### PR DESCRIPTION
# Summary

![image](https://github.com/user-attachments/assets/4f3d624d-90a7-4989-b77f-b399d1ca8ece)

`provide` call should be moved into the `setup` block.