### PR TITLE
fix(forms): hide edge built-in password handler [KM-502]

### DIFF
--- a/packages/core/forms/sandbox/schema.json
+++ b/packages/core/forms/sandbox/schema.json
@@ -177,6 +177,20 @@
       "disabled": false
     },
     {
+      "label": "Secrets",
+      "type": "input",
+      "submitWhenNull": true,
+      "inputType": "password",
+      "valueType": "array",
+      "valueArrayType": "string",
+      "placeholder": "Enter a secret",
+      "help": "Secrets saved in this route",
+      "id": "secrets",
+      "model": "secrets",
+      "order": 0,
+      "disabled": false
+    },
+    {
       "type": "array",
       "showRemoveButton": false,
       "newElementButtonLabelClasses": "k-button tertiary mt-2 p-2",

--- a/packages/core/forms/src/components/fields/FieldInput.vue
+++ b/packages/core/forms/src/components/fields/FieldInput.vue
@@ -267,5 +267,9 @@ onBeforeMount((): void => {
   :deep(input[type="range"]) {
     padding: $kui-space-0;
   }
+
+  :deep(input[type="password"]::-ms-reveal) {
+    display: none;
+  }
 }
 </style>


### PR DESCRIPTION
# Summary

If not specified in css, edge will have built-in password toggling mechanism that interferes with ours.

<img width="1516" alt="截屏2024-09-27 下午1 52 39" src="https://github.com/user-attachments/assets/aa112aa6-bf96-4320-a47e-df4da993e35c">


KM-502

