### PR TITLE
chore: ignore swagger package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,10 @@
   "extends": [
     "github>Kong/public-shared-renovate:kong-frontend-config"
   ],
+  "ignoreDeps": [
+    "swagger-client",
+    "swagger-ui"
+  ],
   "ignorePaths": [
     "packages/core/cli/src/__template__/package.json"
   ]


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
Renovatebot should ignore updates to `swagger` packages until `@kong/swagger-ui-kong-theme-universal` is able to handle the latest version of swagger-ui or the `swagger-ui-web-component` package is removed.
