### PR TITLE
fix: set custom max-widths for path names

### DIFF
--- a/packages/portal/spec-renderer/sandbox/test.yaml
+++ b/packages/portal/spec-renderer/sandbox/test.yaml
@@ -37,6 +37,32 @@ tags:
   - name: user
     description: Operations about user
 paths:
+  /super-long-omg-omg-omg-omg-omg-omg-omg-omg-omg-omg:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - api_key: []
+        - petstore_auth:
+            - write:pets
+            - read:pets
   /pet:
     put:
       tags:

--- a/packages/portal/spec-renderer/src/components/SpecDetails.vue
+++ b/packages/portal/spec-renderer/src/components/SpecDetails.vue
@@ -123,3 +123,22 @@ watch(() => props.activeOperation, () => {
   font-size: var(--kong-ui-portal-spec-details-font-size, $kui-font-size-40);
 }
 </style>
+
+<style lang="scss">
+main {
+  --kui-operation-summary-path-display: block;
+  --kui-operation-summary-path-overflow: hidden;
+  --kui-operation-summary-path-text-overflow: ellipsis;
+  --kui-operation-summary-path-white-space: nowrap;
+  --kui-operation-summary-path-word-wrap: normal;
+  --kui-operation-summary-path-max-width: 30ch;
+
+  @media screen and (min-width: $kui-breakpoint-phablet) {
+    --kui-operation-summary-path-max-width: 40ch;
+  }
+
+  @media screen and (min-width: $kui-breakpoint-desktop) {
+    --kui-operation-summary-path-max-width: 100ch;
+  }
+}
+</style>

--- a/packages/portal/swagger-ui-web-component/public/index.html
+++ b/packages/portal/swagger-ui-web-component/public/index.html
@@ -14,6 +14,17 @@
 <body>
   <kong-swagger-ui url="http://localhost:5173/test.yaml"></kong-swagger-ui>
   <script src="/main.js"></script>
+  <style>
+    body {
+      --kui-operation-summary-path-overflow: hidden;
+      --kui-operation-summary-path-display: block;
+      --kui-operation-summary-path-max-width: 34ch;
+      --kui-operation-summary-path-overflow: hidden;
+      --kui-operation-summary-path-text-overflow: ellipsis;
+      --kui-operation-summary-path-white-space: nowrap;
+      --kui-operation-summary-path-word-wrap: normal;
+    }
+  </style>
 </body>
 
 </html>

--- a/packages/portal/swagger-ui-web-component/public/petstore_v3.json
+++ b/packages/portal/swagger-ui-web-component/public/petstore_v3.json
@@ -45,6 +45,31 @@
     }
   ],
   "paths": {
+    "/super-long-omg-omg-omg-omg-omg-omg-omg-omg-omg-omg-omg-omg-omg": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Super long path",
+        "description": "Super long path",
+        "operationId": "superLongPath",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/pet": {
       "put": {
         "tags": [

--- a/packages/portal/swagger-ui-web-component/public/test.yaml
+++ b/packages/portal/swagger-ui-web-component/public/test.yaml
@@ -37,6 +37,23 @@ tags:
   - name: user
     description: Operations about user
 paths:
+  /super-long-omg-omg-omg-omg-omg-omg-omg-omg-omg-omg:
+    get:
+      tags: 
+        - pet
+      summary: Get super long path
+      description: Get super long path
+      operationId: getSuperLongPath
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
   /pet:
     put:
       tags:

--- a/packages/portal/swagger-ui-web-component/src/styles/overrides.css
+++ b/packages/portal/swagger-ui-web-component/src/styles/overrides.css
@@ -11,6 +11,16 @@
   background: none !important;
 }
 
+.swagger-ui .opblock-summary-path {
+  display: var(--kui-operation-summary-path-display, grid) !important;
+  /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+  max-width: var(--kui-operation-summary-path-max-width, 100%) !important;
+  overflow: var(--kui-operation-summary-path-overflow, visible) !important;
+  text-overflow: var(--kui-operation-summary-path-text-overflow, visible) !important;
+  white-space: var(--kui-operation-summary-path-white-space, wrap) !important;
+  word-wrap: var(--kui-operation-summary-path-word-wrap, break-all) !important;
+}
+
 .swagger-ui .opblock-control-arrow {
   grid-column-start: 4;
   grid-row-start: 1;


### PR DESCRIPTION
# Summary

Context: Swagger UI Web Component uses shadow root, which makes overriding styles difficult from consuming applications.

Goal: Stop the operation path name from overflowing its container.

Solution: Add CSS Variables with sane defaults, and make changes to the renderer in order to prevent drastic overflow.

Before:
<img width="884" alt="image" src="https://github.com/user-attachments/assets/e13b9409-52aa-4a54-b68c-7aee5caf12f2">

After:
<img width="866" alt="image" src="https://github.com/user-attachments/assets/f375829e-16ea-4004-9f6c-10608b9fc057">


NB: There is a [sister PR](https://github.com/Kong/swagger-ui-kong-theme/pull/183) to add the `title` property in order to get the full string to render on hover.
