### PR TITLE
fix: chart dataset sorting issue

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
@@ -175,8 +175,8 @@ describe('<AnalyticsChart />', () => {
     cy.get('[data-testid="doughnut-chart-parent"]').should('be.visible')
     cy.get('.chart-header').should('contain.text', 'Doughnut chart')
     cy.get('[data-testid="legend"]').children().should('have.length', 6)
-    cy.get('.label').eq(0).should('include.text', 'dp-mock-us-dev')
-    cy.get('.label').eq(1).should('include.text', 'GetMeAKongDefault')
+    cy.get('.label').eq(0).should('include.text', 'GetMeAKongDefault')
+    cy.get('.label').eq(1).should('include.text', 'GetMeASongRoute')
   })
 
   it('renders a doughnut chart with sigle dimension data', () => {

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
@@ -178,214 +178,300 @@ describe('useVitalsExploreDatasets', () => {
     )
   })
 
-})
-
-it('handles no dimension', () => {
-  const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
-    data: [
-      {
-        timestamp: '2022-01-01T01:01:02Z',
-        event: {
-          request_count: 1,
+  it('handles no dimension', () => {
+    const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
+      data: [
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            request_count: 1,
+          },
         },
-      },
-    ],
-    meta: {
-      start_ms: 1640998862000,
-      end_ms: 1640998870000,
-      granularity_ms: 8000,
-      metric_names: ['request_count'],
-      query_id: '',
-      metric_units: { request_count: 'units' },
-      truncated: false,
-      limit: 15,
-      display: {},
-    },
-  }))
-  const result = useExploreResultToDatasets({ fill: true }, exploreResult)
-
-  expect(result.value).toEqual(
-    {
-      labels: ['Request Count'],
-      datasets: [
-        { label: 'Request Count', backgroundColor: '#a86cd5', data: [1] },
       ],
-    },
-  )
-})
+      meta: {
+        start_ms: 1640998862000,
+        end_ms: 1640998870000,
+        granularity_ms: 8000,
+        metric_names: ['request_count'],
+        query_id: '',
+        metric_units: { request_count: 'units' },
+        truncated: false,
+        limit: 15,
+        display: {},
+      },
+    }))
+    const result = useExploreResultToDatasets({ fill: true }, exploreResult)
 
-it('handles multiple metrics with no dimension', () => {
-  const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
-    data: [
+    expect(result.value).toEqual(
       {
-        timestamp: '2022-01-01T01:01:02Z',
-        event: {
-          metric1: 1,
-          metric2: 2,
-        },
-      } as GroupByResult,
-    ],
-    meta: {
-      start_ms: 1640998862000,
-      end_ms: 1640998870000,
-      granularity_ms: 8000,
-      metric_names: [
-        'metric1',
-        'metric2',
-      ] as any as ExploreAggregations[],
-      query_id: '',
-      metric_units: { metric1: 'units', metric2: 'units' },
-      truncated: false,
-      limit: 15,
-      display: {},
-    } as QueryResponseMeta,
-  }))
-  const result = useExploreResultToDatasets({ fill: true }, exploreResult)
+        labels: ['Request Count'],
+        datasets: [
+          { label: 'Request Count', backgroundColor: '#a86cd5', data: [1] },
+        ],
+      },
+    )
+  })
 
-  expect(result.value).toEqual(
-    {
-      labels: ['metric1', 'metric2'],
-      datasets: [
-        { label: 'metric1', backgroundColor: '#a86cd5', data: [1, null] },
-        { label: 'metric2', backgroundColor: '#6a86d2', data: [null, 2] },
+  it('handles multiple metrics with no dimension', () => {
+    const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
+      data: [
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            metric1: 1,
+            metric2: 2,
+          },
+        } as GroupByResult,
       ],
-    },
-  )
-})
+      meta: {
+        start_ms: 1640998862000,
+        end_ms: 1640998870000,
+        granularity_ms: 8000,
+        metric_names: [
+          'metric1',
+          'metric2',
+        ] as any as ExploreAggregations[],
+        query_id: '',
+        metric_units: { metric1: 'units', metric2: 'units' },
+        truncated: false,
+        limit: 15,
+        display: {},
+      } as QueryResponseMeta,
+    }))
+    const result = useExploreResultToDatasets({ fill: true }, exploreResult)
 
-it('handles multiple metrics with dimension', () => {
-  const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
-    data: [
+    expect(result.value).toEqual(
       {
-        timestamp: '2022-01-01T01:01:02Z',
-        event: {
-          metric1: 1,
-          metric2: 2,
-          gateway_service: 'service1',
-        },
+        labels: ['metric1', 'metric2'],
+        datasets: [
+          { label: 'metric1', backgroundColor: '#a86cd5', data: [1, null] },
+          { label: 'metric2', backgroundColor: '#6a86d2', data: [null, 2] },
+        ],
       },
-      {
-        timestamp: '2022-01-01T01:01:02Z',
-        event: {
-          metric1: 3,
-          metric2: 4,
-          gateway_service: 'service2',
-        },
-      },
-    ],
-    meta: {
-      start_ms: 1640998862000,
-      end_ms: 1640998870000,
-      granularity_ms: 8000,
-      metric_names: [
-        'metric1',
-        'metric2',
-      ] as any as ExploreAggregations[],
-      query_id: '',
-      metric_units: { metric1: 'units', metric2: 'units' },
-      truncated: false,
-      limit: 15,
-      display: {
-        gateway_service: {
-          service1: { name: 'service1' },
-          service2: { name: 'service2' },
-        },
-      },
-    } as QueryResponseMeta,
-  }))
-  const result = useExploreResultToDatasets({ fill: true }, exploreResult)
+    )
+  })
 
-  expect(result.value).toEqual(
-    {
-      labels: ['service2', 'service1'],
-      datasets: [
-        { label: 'metric1', backgroundColor: '#a86cd5', data: [3, 1] },
-        { label: 'metric2', backgroundColor: '#6a86d2', data: [4, 2] },
+  it('handles multiple metrics with dimension', () => {
+    const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
+      data: [
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            metric1: 1,
+            metric2: 2,
+            gateway_service: 'service1',
+          },
+        },
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            metric1: 3,
+            metric2: 4,
+            gateway_service: 'service2',
+          },
+        },
       ],
-    },
-  )
-})
+      meta: {
+        start_ms: 1640998862000,
+        end_ms: 1640998870000,
+        granularity_ms: 8000,
+        metric_names: [
+          'metric1',
+          'metric2',
+        ] as any as ExploreAggregations[],
+        query_id: '',
+        metric_units: { metric1: 'units', metric2: 'units' },
+        truncated: false,
+        limit: 15,
+        display: {
+          gateway_service: {
+            service1: { name: 'service1' },
+            service2: { name: 'service2' },
+          },
+        },
+      } as QueryResponseMeta,
+    }))
+    const result = useExploreResultToDatasets({ fill: true }, exploreResult)
 
-it('Correct status code colors', () => {
-  const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
-    data: [
+    expect(result.value).toEqual(
       {
-        timestamp: '2022-01-01T01:01:02Z',
-        event: {
-          status_code: 100,
-          metric1: 2,
-        },
-      } as GroupByResult,
-      {
-        timestamp: '2022-01-01T01:01:02Z',
-        event: {
-          status_code: 200,
-          metric1: 2,
-        },
-      } as GroupByResult,
-      {
-        timestamp: '2022-01-01T01:01:02Z',
-        event: {
-          status_code: 300,
-          metric1: 2,
-        },
-      } as GroupByResult,
-      {
-        timestamp: '2022-01-01T01:01:02Z',
-        event: {
-          status_code: 400,
-          metric1: 2,
-        },
-      } as GroupByResult,
-      {
-        timestamp: '2022-01-01T01:01:02Z',
-        event: {
-          status_code: 500,
-          metric1: 2,
-        },
-      } as GroupByResult,
-    ],
-    meta: {
-      start_ms: 1640998862000,
-      end_ms: 1640998870000,
-      granularity_ms: 86400000,
-      metric_names: ['metric1'] as any as ExploreAggregations[],
-      display: {
-        status_code: {
-          100: {
-            name: '100',
-            deleted: false,
-          },
-          200: {
-            name: '200',
-            deleted: false,
-          },
-          300: {
-            name: '300',
-            deleted: false,
-          },
-          400: {
-            name: '400',
-            deleted: false,
-          },
-          500: {
-            name: '500',
-            deleted: false,
-          },
-        },
+        labels: ['service2', 'service1'],
+        datasets: [
+          { label: 'metric1', backgroundColor: '#a86cd5', data: [3, 1] },
+          { label: 'metric2', backgroundColor: '#6a86d2', data: [4, 2] },
+        ],
       },
-      query_id: '',
-      metric_units: { metric: 'units' } as MetricUnit,
-    },
-  }))
-  const result = useExploreResultToDatasets(
-    { fill: false, colorPalette: defaultStatusCodeColors },
-    exploreResult,
-  )
+    )
+  })
 
-  expect(result.value.datasets[0].backgroundColor).toEqual('#80bfff')
-  expect(result.value.datasets[1].backgroundColor).toEqual('#9edca6')
-  expect(result.value.datasets[2].backgroundColor).toEqual('#ffe9b8')
-  expect(result.value.datasets[3].backgroundColor).toEqual('#ffd5b1')
-  expect(result.value.datasets[4].backgroundColor).toEqual('#ffb6b6')
+  it('Correct status code colors', () => {
+    const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
+      data: [
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            status_code: 100,
+            metric1: 2,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            status_code: 200,
+            metric1: 2,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            status_code: 300,
+            metric1: 2,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            status_code: 400,
+            metric1: 2,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            status_code: 500,
+            metric1: 2,
+          },
+        } as GroupByResult,
+      ],
+      meta: {
+        start_ms: 1640998862000,
+        end_ms: 1640998870000,
+        granularity_ms: 86400000,
+        metric_names: ['metric1'] as any as ExploreAggregations[],
+        display: {
+          status_code: {
+            100: {
+              name: '100',
+              deleted: false,
+            },
+            200: {
+              name: '200',
+              deleted: false,
+            },
+            300: {
+              name: '300',
+              deleted: false,
+            },
+            400: {
+              name: '400',
+              deleted: false,
+            },
+            500: {
+              name: '500',
+              deleted: false,
+            },
+          },
+        },
+        query_id: '',
+        metric_units: { metric: 'units' } as MetricUnit,
+      },
+    }))
+    const result = useExploreResultToDatasets(
+      { fill: false, colorPalette: defaultStatusCodeColors },
+      exploreResult,
+    )
+
+    expect(result.value.datasets[0].backgroundColor).toEqual('#80bfff')
+    expect(result.value.datasets[1].backgroundColor).toEqual('#9edca6')
+    expect(result.value.datasets[2].backgroundColor).toEqual('#ffe9b8')
+    expect(result.value.datasets[3].backgroundColor).toEqual('#ffd5b1')
+    expect(result.value.datasets[4].backgroundColor).toEqual('#ffb6b6')
+  })
+
+
+  it('sorts datasets accordingly', () => {
+    const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
+      data: [
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            route: 'route1',
+            status_code: 100,
+            metric1: 1,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            route: 'route1',
+            status_code: 200,
+            metric1: 2,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            route: 'route2',
+            status_code: 100,
+            metric1: 3,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            route: 'route2',
+            status_code: 200,
+            metric1: 4,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            route: 'route3',
+            status_code: 100,
+            metric1: 5,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            route: 'route3',
+            status_code: 200,
+            metric1: 6,
+          },
+        } as GroupByResult,
+      ],
+      meta: {
+        start_ms: 1640998862000,
+        end_ms: 1640998870000,
+        granularity_ms: 86400000,
+        metric_names: ['metric1'] as any as ExploreAggregations[],
+        display: {
+          route: {
+            route1: { name: 'route1' },
+            route2: { name: 'route2' },
+            route3: { name: 'route3' },
+          },
+          status_code: {
+            100: {
+              name: '100',
+              deleted: false,
+            },
+            200: {
+              name: '200',
+              deleted: false,
+            },
+          },
+        },
+        query_id: '',
+        metric_units: { metric: 'units' } as MetricUnit,
+      },
+    }))
+    const result = useExploreResultToDatasets(
+      { fill: false, colorPalette: defaultStatusCodeColors },
+      exploreResult,
+    )
+
+    expect(result.value.labels).toEqual(['route3', 'route2', 'route1'])
+  })
 })

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
@@ -413,7 +413,7 @@ describe('useVitalsExploreDatasets', () => {
           event: {
             route: 'route2',
             status_code: 100,
-            metric1: 3,
+            metric1: 7,
           },
         } as GroupByResult,
         {
@@ -421,7 +421,7 @@ describe('useVitalsExploreDatasets', () => {
           event: {
             route: 'route2',
             status_code: 200,
-            metric1: 4,
+            metric1: 1,
           },
         } as GroupByResult,
         {
@@ -437,23 +437,7 @@ describe('useVitalsExploreDatasets', () => {
           event: {
             route: 'route3',
             status_code: 200,
-            metric1: 6,
-          },
-        } as GroupByResult,
-        {
-          timestamp: '2022-01-01T01:01:02Z',
-          event: {
-            route: 'route111',
-            status_code: 100,
-            metric1: 1,
-          },
-        } as GroupByResult,
-        {
-          timestamp: '2022-01-01T01:01:02Z',
-          event: {
-            route: 'route111',
-            status_code: 200,
-            metric1: 20,
+            metric1: 5,
           },
         } as GroupByResult,
       ],
@@ -467,7 +451,6 @@ describe('useVitalsExploreDatasets', () => {
             route1: { name: 'route1' },
             route2: { name: 'route2' },
             route3: { name: 'route3' },
-            route111: { name: 'route111' },
           },
           status_code: {
             100: {
@@ -489,6 +472,6 @@ describe('useVitalsExploreDatasets', () => {
       exploreResult,
     )
 
-    expect(result.value.labels).toEqual(['route111', 'route3', 'route2', 'route1'])
+    expect(result.value.labels).toEqual(['route3', 'route2', 'route1'])
   })
 })

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
@@ -440,6 +440,22 @@ describe('useVitalsExploreDatasets', () => {
             metric1: 6,
           },
         } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            route: 'route111',
+            status_code: 100,
+            metric1: 1,
+          },
+        } as GroupByResult,
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            route: 'route111',
+            status_code: 200,
+            metric1: 20,
+          },
+        } as GroupByResult,
       ],
       meta: {
         start_ms: 1640998862000,
@@ -451,6 +467,7 @@ describe('useVitalsExploreDatasets', () => {
             route1: { name: 'route1' },
             route2: { name: 'route2' },
             route3: { name: 'route3' },
+            route111: { name: 'route111' },
           },
           status_code: {
             100: {
@@ -472,6 +489,6 @@ describe('useVitalsExploreDatasets', () => {
       exploreResult,
     )
 
-    expect(result.value.labels).toEqual(['route3', 'route2', 'route1'])
+    expect(result.value.labels).toEqual(['route111', 'route3', 'route2', 'route1'])
   })
 })

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.ts
@@ -99,7 +99,18 @@ export default function useExploreResultToDatasets(
             return [label, value]
           }))
 
-        const sortedDatasetIds = Object.entries(pivotRecords).sort(([, a], [, b]) => Number(b) - Number(a)).map(([key]) => (key.split(',')[0]))
+        const aggregatedPivotRecords = Object.keys(pivotRecords).reduce((acc, key) => {
+          const [row] = key.split(',')
+          const pivotEntry = pivotRecords[key] as number
+
+          if (acc[row]) {
+            acc[row] += pivotEntry
+          } else {
+            acc[row] = pivotEntry
+          }
+          return acc
+        }, {} as Record<string, number>)
+        const sortedDatasetIds = Object.entries(aggregatedPivotRecords).sort(([, a], [, b]) => Number(b) - Number(a)).map(([key]) => key)
         const primaryDimensionDisplay = display[primaryDimension]
         const secondaryDimensionDisplay = display[secondaryDimension]
         const rowLabels: DatasetLabel[] = (hasDimensions && primaryDimensionDisplay && Object.entries(primaryDimensionDisplay).map(([id, val]) => ({ id, name: val.name }))) || metricNames.map(name => ({ id: name, name }))


### PR DESCRIPTION
# Summary

Sorting logic was only looking at one segment within the bar rather than taking all segments into account.

https://konghq.atlassian.net/browse/MA-3157

## After
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/625d95f4-c969-4fd3-a659-9ac2a66da058">

## Before
<img width="881" alt="image" src="https://github.com/user-attachments/assets/09ff3da8-3e09-4798-9c8d-677720285423">

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
