### PR TITLE
fix(forms): adopt native mask support

### DIFF
--- a/packages/core/forms/src/components/fields/FieldInput.vue
+++ b/packages/core/forms/src/components/fields/FieldInput.vue
@@ -17,27 +17,12 @@
       :placeholder="schema.placeholder"
       :readonly="schema.readonly"
       :required="schema.required"
+      :show-password-mask-toggle="inputType === 'password'"
       :type="inputType"
       :width="schema.width"
       @blur="onBlur"
       @update:model-value="onInput"
-    >
-      <template
-        v-if="schema.inputType === 'password'"
-        #after
-      >
-        <VisibilityIcon
-          v-if="masked"
-          role="button"
-          @click="toggleMasked"
-        />
-        <VisibilityOffIcon
-          v-else
-          role="button"
-          @click="toggleMasked"
-        />
-      </template>
-    </KInput>
+    />
 
     <!-- autofill -->
     <component
@@ -60,7 +45,6 @@ import objGet from 'lodash-es/get'
 import isFunction from 'lodash-es/isFunction'
 import isNumber from 'lodash-es/isNumber'
 import composables from '../../composables'
-import { VisibilityIcon, VisibilityOffIcon } from '@kong/icons'
 
 const props = defineProps({
   disabled: {
@@ -102,7 +86,6 @@ const emit = defineEmits<{
 }>()
 
 const propsRefs = toRefs(props)
-const masked = ref(true)
 
 const autofillSlot = inject<AutofillSlot | undefined>(AUTOFILL_SLOT, undefined)
 
@@ -130,10 +113,6 @@ const inputType = computed((): string => {
     // 'datetime' maps to 'datetime-local'
     case 'datetime':
       return 'datetime-local'
-
-    // 'password' fields are masked by default, but can be toggled by the user
-    case 'password':
-      return masked.value ? 'password' : 'text'
 
     default:
       return iType || 'text'
@@ -200,10 +179,6 @@ const onBlur = (): void => {
   if (isFunction(debouncedFormatFunc.value)) {
     debouncedFormatFunc.value?.flush()
   }
-}
-
-const toggleMasked = () => {
-  masked.value = !masked.value
 }
 
 onMounted((): void => {


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Now `KInput` supports toggling password input mask natively through https://github.com/Kong/kongponents/issues/2448. This PR adopts this feature.

KM-586
