### PR TITLE
fix(analytics): trend range text in multi-entity queries [MA-3250]

### DIFF
--- a/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
+++ b/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
@@ -9,7 +9,6 @@ import type { MetricFetcherOptions } from '../types'
 import { MAX_ANALYTICS_REQUEST_RETRIES } from '../constants'
 import composables from '.'
 import { useSwrvState } from '@kong-ui-public/core'
-import { TimeframeKeys, TimePeriods } from '@kong-ui-public/analytics-utilities'
 
 export const DEFAULT_KEY = Symbol('default')
 export type MappedMetrics = Record<string | typeof DEFAULT_KEY, Record<string | typeof DEFAULT_KEY, number>>
@@ -168,8 +167,8 @@ export default function useMetricFetcher(opts: MetricFetcherOptions): FetcherRes
       return opts.withTrend.value
         // @ts-ignore - dynamic i18n key
         ? i18n.t(`trendRange.${opts.timeframe.value.key}`)
-        // @ts-ignore - dynamic i18n key
-        : i18n.t(`trendRange.${TimePeriods.get(TimeframeKeys.ONE_DAY)?.key}`)
+        // If we're unable to query with a trend, we can't render a meaningful trend range description.
+        : ''
     }
   })
 

--- a/packages/analytics/analytics-metric-provider/src/mockExploreResponse.ts
+++ b/packages/analytics/analytics-metric-provider/src/mockExploreResponse.ts
@@ -15,6 +15,7 @@ const fromUnixTimeMs = (t: number) => new Date(t)
 export interface MockOptions {
   dimensionNames?: string[]
   injectErrors?: 'latency' | 'traffic' | 'all'
+  deterministic?: boolean
 }
 
 export const mockExploreResponseFromCypress = (
@@ -67,7 +68,11 @@ export const mockExploreResponse = (
       if (body.dimensions?.includes('status_code_grouped')) {
         ALL_STATUS_CODE_GROUPS.forEach(code => {
           const event = metrics.reduce((accum, agg) => {
-            accum[agg] = (numRecords - i) * 1000 + 100 * j + 1
+            if (opts?.deterministic ?? true) {
+              accum[agg] = (numRecords - i) * 1000 + 100 * j + 1
+            } else {
+              accum[agg] = Math.round(Math.random() * 1000)
+            }
             return accum
           }, { ...eventValue, status_code_grouped: code })
 
@@ -88,7 +93,11 @@ export const mockExploreResponse = (
               ? fromUnixTimeMs(start).toISOString()
               : fromUnixTimeMs(start + granularity).toISOString(),
           event: metrics.reduce((accum, agg) => {
-            accum[agg] = (numRecords - i) * 1000 + (100 * j) + 1
+            if (opts?.deterministic ?? true) {
+              accum[agg] = (numRecords - i) * 1000 + (100 * j) + 1
+            } else {
+              accum[agg] = Math.round(Math.random() * 1000)
+            }
             return accum
           }, { ...eventValue }),
         })


### PR DESCRIPTION
In the case where we can't query a trend (either because the props said not to or because we're doing a multi-entity query), it doesn't make sense to render any trend text.

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
