### PR TITLE
fix(entities-gateway-services): switch enable status fix

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -416,12 +416,11 @@ const confirmSwitchEnablement = async () => {
       : await axiosInstance.patch(url, { ...switchEnablementTarget.value, enabled })
     // Emit the success event for the host app
     emit('toggle:success', data)
+    // Update switchEnablementTarget
+    switchEnablementTarget.value.enabled = enabled
   } catch (e: any) {
     emit('error', e)
   }
-
-  // Update switchEnablementTarget
-  switchEnablementTarget.value.enabled = enabled
 }
 
 /**


### PR DESCRIPTION
# Summary

Only updates the switch cell status when update request succeeds in `GatewayServiceList`
