### PR TITLE
feat(*): add support for masking credentials fields at L2 [KM-629]

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
@@ -144,6 +144,7 @@ import {
   SupportedEntityType,
 } from '@kong-ui-public/entities-shared'
 import composables from '../composables'
+import { useSchemaProvider } from '@kong-ui-public/entities-shared'
 import endpoints from '../plugins-endpoints'
 import PluginIcon from './PluginIcon.vue'
 import '@kong-ui-public/entities-shared/dist/style.css'
@@ -321,6 +322,7 @@ const schemaUrl = computed<string>(() => {
 })
 
 const schema = ref<Record<string, any>>({})
+useSchemaProvider(schema)
 const schemaLoading = ref(false)
 const fetchSchemaError = ref('')
 onBeforeMount(async () => {

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -162,8 +162,18 @@ const hasTooltip = computed((): boolean => !!(props.item.tooltip || slots['label
 const isJson = computed((): boolean => props.item.type === ConfigurationSchemaType.Json || props.item.type === ConfigurationSchemaType.JsonArray)
 const isJsonArray = computed((): boolean => props.item.type === ConfigurationSchemaType.JsonArray)
 
+const schema = composables.useSubSchema(props.item.key)
+
+const itemType = computed(() => {
+  return props.item.type
+    ? props.item.type
+    : schema?.value?.encrypted
+      ? ConfigurationSchemaType.Redacted
+      : undefined
+})
+
 const componentAttrsData = computed((): ComponentAttrsData => {
-  switch (props.item.type) {
+  switch (itemType.value) {
     case ConfigurationSchemaType.ID:
       return {
         tag: 'KCopy',

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -220,6 +220,8 @@ const { i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = composables.useErrors()
 const { convertKeyToTitle } = composables.useStringHelpers()
 
+composables.useSubSchema(props.pluginConfigKey) // reduce the schema to only the plugin config
+
 const { axiosInstance } = composables.useAxios(props.config?.axiosRequestConfig)
 
 const configFormatItems = [

--- a/packages/entities/entities-shared/src/composables/index.ts
+++ b/packages/entities/entities-shared/src/composables/index.ts
@@ -11,6 +11,7 @@ import useI18n from './useI18n'
 import useGatewayFeatureSupported from './useGatewayFeatureSupported'
 import useTruncationDetector from './useTruncationDetector'
 import useValidators from './useValidators'
+import { useSchemaProvider, useSubSchema } from './useSchema'
 
 // All composables must be exported as part of the default object for Cypress test stubs
 export default {
@@ -27,4 +28,6 @@ export default {
   useGatewayFeatureSupported,
   useTruncationDetector,
   useValidators,
+  useSchemaProvider,
+  useSubSchema,
 }

--- a/packages/entities/entities-shared/src/composables/useSchema.ts
+++ b/packages/entities/entities-shared/src/composables/useSchema.ts
@@ -1,0 +1,27 @@
+import { provide, inject, toRef } from 'vue'
+import type { Ref } from 'vue'
+
+type Schema = Record<string, any>
+
+const providerKey = Symbol('schema')
+
+export const useSchemaProvider = (schema: Ref<Schema>) => {
+  provide(providerKey, schema)
+}
+
+/**
+ * find the sub schema by key and provide it as the parent schema for the children
+ * @param subSchemaKey the key of the sub schema
+ * @returns the sub schema or undefined
+ */
+export const useSubSchema = (subSchemaKey: string): Readonly<Ref<Schema | undefined>> => {
+  const schema = inject<Ref<Schema> | undefined>(providerKey, undefined)
+
+  const field = schema?.value?.fields?.find((subSchema: Schema) => {
+    return Object.keys(subSchema)[0] === subSchemaKey
+  })
+  const subSchema = toRef(field?.[subSchemaKey])
+
+  provide(providerKey, subSchema)
+  return subSchema
+}

--- a/packages/entities/entities-shared/src/index.ts
+++ b/packages/entities/entities-shared/src/index.ts
@@ -16,13 +16,13 @@ import YamlCodeBlock from './components/common/YamlCodeBlock.vue'
 import composables from './composables'
 
 // Extract specific composables to export
-const { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators } = composables
+const { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchemaProvider } = composables
 
 // Components
 export { EntityBaseConfigCard, ConfigCardItem, ConfigCardDisplay, InternalLinkItem, EntityBaseForm, EntityBaseTable, EntityDeleteModal, EntityFilter, EntityToggleModal, PermissionsWrapper, EntityFormSection, EntityLink, JsonCodeBlock, TerraformCodeBlock, YamlCodeBlock }
 
 // Composables
-export { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators }
+export { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchemaProvider }
 
 // Types
 export * from './types'


### PR DESCRIPTION
# Summary
The schema information was lost in the nested rendering, this is a temporary solution for a quick fix to get the schema information in L2

**Before:**
<img width="615" alt="image" src="https://github.com/user-attachments/assets/807a651b-4671-4742-9e59-66a3678abbcb">

**After:**
<img width="568" alt="image" src="https://github.com/user-attachments/assets/64d44385-83e0-4232-bbc2-91f92a295d37">


[KM-629](https://konghq.atlassian.net/browse/KM-629)

[KM-629]: https://konghq.atlassian.net/browse/KM-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ