### PR TITLE
fix(entities-shared): exact match should strip trailing slash

### DIFF
--- a/packages/entities/entities-shared/src/composables/tests/useFetchUrlBuilder.spec.ts
+++ b/packages/entities/entities-shared/src/composables/tests/useFetchUrlBuilder.spec.ts
@@ -46,7 +46,7 @@ describe('useFetchUrlBuilder()', () => {
       query: 'testQuery',
     }
 
-    expect(builder(query)).toBe('http://foo.bar/entity/testQuery/')
+    expect(builder(query)).toBe('http://foo.bar/entity/testQuery')
   })
 
   it('should apply correct query schema for konnect when isExactMatch is not activated', () => {
@@ -89,6 +89,6 @@ describe('useFetchUrlBuilder()', () => {
       query: 'testQuery',
     }
 
-    expect(builder(query)).toBe('http://foo.bar/entity/testQuery/')
+    expect(builder(query)).toBe('http://foo.bar/entity/testQuery')
   })
 })

--- a/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
+++ b/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
@@ -36,7 +36,7 @@ export default function useFetchUrlBuilder(
         // 2) kongManager usage with _config.value.isExactMatch === true
         urlWithParams.search = '' // trim any query params
         urlWithParams = _config.value.isExactMatch
-          ? new URL(`${urlWithParams.href}/${query}/`)
+          ? new URL(`${urlWithParams.href}/${query}`)
           : new URL(`${urlWithParams.href}?filter[name][contains]=${query}`)
       } else {
         // handle kongManager usage with _config.value.isExactMatch === false

--- a/packages/entities/entities-shared/src/types/entity-filter.ts
+++ b/packages/entities/entities-shared/src/types/entity-filter.ts
@@ -6,19 +6,23 @@ interface BaseFilterConfig {
   isExactMatch: boolean
 }
 
-/** Exact match filter configuration */
+/**
+ * Exact match filter configuration
+ * FIXME: "Exact match" here is no longer accurate, in reality it works as an indicator
+ * to use a single input field for filtering.
+ */
 export interface ExactMatchFilterConfig extends BaseFilterConfig {
   isExactMatch: true
   /** Placeholder for the exact match filter input */
   placeholder: string
 }
 
-/** Exact match filter fields */
+/** Fuzzy match filter fields */
 export interface FilterFields {
   [key: string]: Field
 }
 
-/** Exact match filter schema */
+/** Fuzzy match filter schema */
 export interface FilterSchema {
   [key: string]: {
     /** Used in the filter dropdown to determine the type of input */
@@ -28,7 +32,11 @@ export interface FilterSchema {
   }
 }
 
-/** Fuzzy match filter configuration */
+/**
+ * Fuzzy match filter configuration
+ * FIXME: "Fuzzy match" here is no longer accurate, in reality it works as an indicator
+ * to use a relatively complex form for filtering.
+ */
 export interface FuzzyMatchFilterConfig extends BaseFilterConfig {
   isExactMatch: false
   /** Fuzzy match filter fields */


### PR DESCRIPTION
# Summary

[KM-639](https://konghq.atlassian.net/browse/KM-639)

The following request URLs do not work unless we strip the trailing slash.

- `/v2/control-planes/{control-plane-id}/core-entities/key-sets/{query}/`
- `/v2/control-planes/{control-plane-id}/core-entities/key/{query}/`
- `/v2/control-planes/{control-plane-id}/core-entities/key-sets/{key-set-id}/keys/{query}/`

So we remove them to at least make them work.

Also added some comments for filter types.

[KM-639]: https://konghq.atlassian.net/browse/KM-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ