### PR TITLE
feat: add eq match and filter after select behavior

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginListPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginListPage.vue
@@ -57,6 +57,7 @@ const konnectConfig = ref<KonnectPluginListConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   createRoute: { name: 'select-plugin' },
+  isEqMatch: true,
   getViewRoute: (plugin: EntityRow) => ({ name: 'view-plugin', params: { id: plugin.id, plugin: plugin.name } }),
   getEditRoute: (plugin: EntityRow) => ({ name: 'edit-plugin', params: { id: plugin.id, plugin: plugin.name } }),
   getScopedEntityViewRoute: (type: ViewRouteType, id: string) => ({ name: `view-${type}`, params: { id } }),

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -426,6 +426,7 @@ const { flattenPluginMap, filterPlugin } = composables.usePluginSelect({
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
+  const isEqMatch = (props.config.app === 'kongManager' || props.config.isEqMatch)
 
   if (isExactMatch) {
     return {
@@ -434,13 +435,15 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
         name: fields.name,
         id: { label: t('plugins.list.table_headers.id'), sortable: true },
       },
-      selectItems: Object.entries(flattenPluginMap.value).map(([name, plugin]) => {
-        return { value: name, label: plugin.name, plugin }
-      }),
-      selectFilterFunction: ({ query, items }) => {
-        return items.filter(({ plugin }) => filterPlugin(query, plugin))
-      },
       placeholder: t(`search.placeholder.${props.config.app}`),
+      ...isEqMatch ? {
+        selectItems: Object.entries(flattenPluginMap.value).map(([name, plugin]) => {
+          return { value: name, label: plugin.name, plugin }
+        }),
+        selectFilterFunction: ({ query, items }) => {
+          return items.filter(({ plugin }) => filterPlugin(query, plugin))
+        },
+      } : {},
     } as ExactMatchFilterConfig
   }
 

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -404,6 +404,15 @@ const fetcherBaseUrl = computed<string>(() => {
     .replace(/{entityId}/gi, props.config?.entityId || '')
 })
 
+// pluginMeta.pluginMeta is like:
+// { '<pluginSlug>': { id: '<pluginId>', name: '<pluginName>', ... } }
+// convert it to
+// [{ label: '<pluginName>', value: '<pluginId>' }]
+const plugins = Object.entries(pluginMetaData.pluginMetaData).map(([name, plugin]) => ({
+  label: plugin.name,
+  value: name,
+}))
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -415,6 +424,7 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
         name: fields.name,
         id: { label: t('plugins.list.table_headers.id'), sortable: true },
       },
+      queryItems: plugins,
       placeholder: t(`search.placeholder.${props.config.app}`),
     } as ExactMatchFilterConfig
   }

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -786,7 +786,7 @@ onBeforeMount(async () => {
 .kong-ui-entities-plugins-list {
   width: 100%;
 
-  .kong-ui-entity-filter-input {
+  :deep(.kong-ui-entity-filter-input) {
     margin-right: $kui-space-50;
   }
 

--- a/packages/entities/entities-plugins/src/composables/index.ts
+++ b/packages/entities/entities-plugins/src/composables/index.ts
@@ -1,12 +1,14 @@
 import useI18n from './useI18n'
 import usePluginHelpers from './usePluginHelpers'
 import { usePluginMetaData } from './usePluginMeta'
+import { usePluginSelect } from './usePluginSelect'
 import { useSchemas } from './useSchemas'
 
 // All composables must be exported as part of the default object for Cypress test stubs
 export default {
   useI18n,
   usePluginMetaData,
+  usePluginSelect,
   usePluginHelpers,
   useSchemas,
 }

--- a/packages/entities/entities-plugins/src/composables/usePluginSelect.ts
+++ b/packages/entities/entities-plugins/src/composables/usePluginSelect.ts
@@ -1,0 +1,281 @@
+import { onMounted, ref, computed, toValue } from 'vue'
+import { useAxios, useHelpers, useErrors } from '@kong-ui-public/entities-shared'
+import composables from '../composables'
+import endpoints from '../plugins-endpoints'
+import { PluginGroup, PluginScope } from '../types'
+
+import type { MaybeRef } from 'vue'
+import type { PluginType, PluginCardList, EntityType } from '../types'
+import type { KongManagerConfig, KonnectConfig } from '@kong-ui-public/entities-shared'
+
+export interface BasePluginSelectConfig {
+  entityType?: EntityType
+  entityId?: string
+}
+
+export interface KonnectPluginSelectConfig extends KonnectConfig, BasePluginSelectConfig { }
+export interface KongManagerPluginSelectConfig extends KongManagerConfig, BasePluginSelectConfig { }
+
+export type PluginSelectConfig = KonnectPluginSelectConfig | KongManagerPluginSelectConfig
+
+export interface UsePluginSelectOptions {
+  availableOnServer: MaybeRef<boolean>
+  ignoredPlugins: MaybeRef<string[]>
+  disabledPlugins: MaybeRef<Record<string, string>>
+  config: PluginSelectConfig
+  filter?: MaybeRef<string>
+}
+
+const getAvailablePluginsUrl = (config: PluginSelectConfig): string => {
+  let url = `${config.apiBaseUrl}${endpoints.select[config.app].availablePlugins}`
+
+  if (config.app === 'konnect') {
+    url = url.replace(/{controlPlaneId}/gi, config.controlPlaneId || '')
+  } else if (config.app === 'kongManager') {
+    url = config.gatewayInfo?.edition === 'community'
+      ? `${config.apiBaseUrl}${endpoints.select[config.app].availablePluginsForOss}`
+      : url.replace(/\/{workspace}/gi, config.workspace ? `/${config.workspace}` : '')
+  }
+
+  return url
+}
+
+const getFetchEntityPluginsUrl = (config: PluginSelectConfig): string => {
+  if (config.entityType && config.entityId) {
+    let url = `${config.apiBaseUrl}${endpoints.list[config.app].forEntity}`
+
+    if (config.app === 'konnect') {
+      url = url.replace(/{controlPlaneId}/gi, config.controlPlaneId || '')
+    } else if (config.app === 'kongManager') {
+      url = url.replace(/\/{workspace}/gi, config.workspace ? `/${config.workspace}` : '')
+    }
+
+    return url
+      .replace(/{entityType}/gi, config.entityType || '')
+      .replace(/{entityId}/gi, config.entityId || '')
+  }
+
+  return ''
+}
+
+const normalizeName = (name: string): string => {
+  return name.toLowerCase().replace(/[\s-_.]/g, '')
+}
+
+const filterPlugin = (query: string, plugin: PluginType): boolean => {
+  const q = normalizeName(query)
+  return (['name', 'id', 'group'] as const).some((key) => normalizeName(plugin[key]).includes(q))
+}
+
+export const usePluginSelect = ({ config, availableOnServer, ignoredPlugins, disabledPlugins, filter }: UsePluginSelectOptions) => {
+  const { pluginMetaData } = composables.usePluginMetaData()
+  const { i18n: { t } } = composables.useI18n()
+  const { getMessageFromError } = useErrors()
+  const { sortAlpha } = useHelpers()
+
+  const isLoading = ref(true)
+  const hasError = ref(false)
+  const fetchErrorMessage = ref('')
+  const availablePlugins = ref<string[]>([])
+  const existingEntityPlugins = ref<string[]>([])
+
+  const { axiosInstance } = useAxios(config?.axiosRequestConfig)
+
+  const availablePluginsUrl = getAvailablePluginsUrl(config)
+  const fetchEntityPluginsUrl = getFetchEntityPluginsUrl(config)
+
+  const pluginsList = computed((): PluginCardList => {
+    if (hasError.value) {
+      return {}
+    }
+
+    // If availableOnServer is false, we included unavailable plugins from pluginMeta in addition to available plugins
+    // returning an array of unique plugin ids
+    // either grab all plugins from metadata file or use list of available plugins provided by API
+    return [...new Set(
+      [
+        ...Object.keys({ ...(!toValue(availableOnServer) ? pluginMetaData : {}) }),
+        ...availablePlugins.value,
+      ],
+    )]
+      // Filter out ignored plugins
+      .filter((plugin: string) => !toValue(ignoredPlugins).includes(plugin))
+      // Filter plugins by entity type if adding scoped plugin
+      .filter((plugin: string) => {
+        // For Global Plugins
+        if (!config.entityType) {
+          return plugin
+        }
+
+        if (config.entityType === 'services') {
+          const isNotServicePlugin = (pluginMetaData[plugin] && !pluginMetaData[plugin].scope.includes(PluginScope.SERVICE))
+          if (isNotServicePlugin) {
+            return false
+          }
+        }
+
+        if (config.entityType === 'routes') {
+          const isNotRoutePlugin = (pluginMetaData[plugin] && !pluginMetaData[plugin].scope.includes(PluginScope.ROUTE))
+          if (isNotRoutePlugin) {
+            return false
+          }
+        }
+
+        if (config.entityType === 'consumer_groups') {
+          const isNotConsumerGroupPlugin = (pluginMetaData[plugin] && !pluginMetaData[plugin].scope.includes(PluginScope.CONSUMER_GROUP))
+          if (isNotConsumerGroupPlugin) {
+            return false
+          }
+        }
+
+        if (config.entityType === 'consumers') {
+          const isNotConsumerPlugin = (pluginMetaData[plugin] && !pluginMetaData[plugin].scope.includes(PluginScope.CONSUMER))
+          if (isNotConsumerPlugin) {
+            return false
+          }
+        }
+
+        return plugin
+      })
+      // build the actual card list
+      .reduce((list: PluginCardList, pluginId: string) => {
+        const pluginName = (pluginMetaData[pluginId] && pluginMetaData[pluginId].name) || pluginId
+        const plugin = {
+          ...pluginMetaData[pluginId],
+          id: pluginId,
+          name: pluginName,
+          available: availablePlugins.value.includes(pluginId),
+          disabledMessage: '',
+          group: pluginMetaData[pluginId]?.group || PluginGroup.CUSTOM_PLUGINS,
+        } as PluginType
+
+        const disabled = toValue(disabledPlugins)
+        if (disabled) {
+          plugin.disabledMessage = disabled[pluginId]
+        }
+
+        const groupName = plugin.group || t('plugins.select.misc_plugins')
+        let plugins = list[groupName]
+
+        if (!plugins) {
+          plugins = []
+        }
+
+        plugins.push(plugin)
+        plugins.sort(sortAlpha('name'))
+
+        list[groupName] = plugins
+
+        return list
+      }, {})
+  })
+  const createFlattenPluginMap = (plugins: PluginCardList): Record<string, PluginType> => {
+    return Object.entries(plugins)
+      .reduce((m, [, plugins]) => {
+        for (const plugin of plugins) {
+          m[plugin.id] = plugin
+        }
+        return m
+      }, {} as Record<string, PluginType>)
+  }
+
+  const filteredPlugins = computed((): PluginCardList => {
+    if (!pluginsList.value) {
+      return {}
+    }
+
+    const query = toValue(filter || '').toLowerCase()
+    const results = JSON.parse(JSON.stringify(pluginsList.value))
+
+    for (const type in pluginsList.value) {
+      const matches = pluginsList.value[type as keyof PluginCardList]?.filter((plugin: PluginType) => filterPlugin(query, plugin)) || []
+
+      if (!matches.length) {
+        delete results[type]
+      } else {
+        results[type] = matches
+      }
+    }
+
+    return results
+  })
+
+  const flattenPluginMap = computed(() => {
+    if (!pluginsList.value) {
+      return {}
+    }
+    return createFlattenPluginMap(pluginsList.value)
+  })
+
+  const filteredFlattenPluginMap = computed(() => {
+    if (!filteredPlugins.value) {
+      return {}
+    }
+    return createFlattenPluginMap(filteredPlugins.value)
+  })
+
+  const hasFilteredResults = computed((): boolean => {
+    return Object.keys(filteredPlugins.value).length > 0
+  })
+
+  const noSearchResults = computed((): boolean => {
+    return (Object.keys(pluginsList.value).length > 0 && !hasFilteredResults.value)
+  })
+
+  onMounted(async () => {
+    try {
+      const { data } = await axiosInstance.get(availablePluginsUrl)
+
+      // TODO: endpoints temporarily return different formats
+      if (config.app === 'konnect') {
+        const { names: available } = data
+        availablePlugins.value = available || []
+      } else if (config.app === 'kongManager') {
+        const { plugins: { available_on_server: aPlugins } } = data
+        availablePlugins.value = aPlugins ? Object.keys(aPlugins) : []
+      }
+    } catch (error: any) {
+      hasError.value = true
+      fetchErrorMessage.value = getMessageFromError(error)
+    }
+
+    // fetch scoped entity to check for pre-existing plugins
+    if (fetchEntityPluginsUrl) {
+      try {
+        const { data: { data } } = await axiosInstance.get(fetchEntityPluginsUrl)
+
+        if (data?.length) {
+          const eplugins = data.reduce((plugins: string[], plugin: Record<string, any>) => {
+            if (plugin.name) {
+              plugins.push(plugin.name)
+            }
+
+            return plugins
+          }, [])
+
+          existingEntityPlugins.value = existingEntityPlugins.value.concat(eplugins)
+        }
+      } catch (error: any) {
+        // no op if it fails, backend will catch if they try to create
+        // duplicate plugins
+      }
+    }
+
+    isLoading.value = false
+  })
+
+  return {
+    isLoading,
+    hasError,
+    fetchErrorMessage,
+    availablePlugins,
+    existingEntityPlugins,
+    pluginsList,
+    filteredPlugins,
+    flattenPluginMap,
+    filteredFlattenPluginMap,
+    hasFilteredResults,
+    noSearchResults,
+    filterPlugin,
+  }
+}

--- a/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
+++ b/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
@@ -1,6 +1,7 @@
 <template>
   <template v-if="config.isExactMatch">
     <KInput
+      v-if="!config.queryItems"
       autocomplete="off"
       class="kong-ui-entity-filter-input"
       data-testid="search-input"
@@ -21,6 +22,17 @@
         />
       </template>
     </KInput>
+    <KSelect
+      v-else
+      class="kong-ui-entity-filter-input"
+      clearable
+      data-testid="search-input"
+      enable-filtering
+      :items="config.queryItems"
+      :model-value="modelValue"
+      :placeholder="config.placeholder"
+      @update:model-value="handleQueryUpdate"
+    />
   </template>
   <template v-else>
     <div class="kong-ui-entity-filter">
@@ -201,8 +213,8 @@ const toggleExpanded = (field: string) => {
   expandedFields.value.has(field) ? expandedFields.value.delete(field) : expandedFields.value.add(field)
 }
 
-const handleQueryUpdate = (query: string) => {
-  emit('update:modelValue', query)
+const handleQueryUpdate = (query: string | number | null) => {
+  emit('update:modelValue', String(query ?? ''))
 }
 
 const handleQueryClear = () => {

--- a/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
+++ b/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
@@ -1,7 +1,7 @@
 <template>
   <template v-if="config.isExactMatch">
     <KInput
-      v-if="!config.queryItems"
+      v-if="!config.selectItems"
       autocomplete="off"
       class="kong-ui-entity-filter-input"
       data-testid="search-input"
@@ -28,11 +28,16 @@
       clearable
       data-testid="search-input"
       enable-filtering
-      :items="config.queryItems"
+      :filter-function="config.selectFilterFunction"
+      :items="config.selectItems"
       :model-value="modelValue"
       :placeholder="config.placeholder"
       @update:model-value="handleQueryUpdate"
-    />
+    >
+      <template #before>
+        <IconFilter />
+      </template>
+    </KSelect>
   </template>
   <template v-else>
     <div class="kong-ui-entity-filter">

--- a/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
+++ b/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
@@ -35,9 +35,11 @@ export default function useFetchUrlBuilder(
         // 1) all konnect usage or
         // 2) kongManager usage with _config.value.isExactMatch === true
         urlWithParams.search = '' // trim any query params
-        urlWithParams = _config.value.isExactMatch
-          ? new URL(`${urlWithParams.href}/${query}`)
-          : new URL(`${urlWithParams.href}?filter[name][contains]=${query}`)
+        urlWithParams = _config.value.app === 'konnect' && _config.value.isEqMatch
+          ? new URL(`${urlWithParams.href}?filter[name][eq]=${query}`)
+          : _config.value.isExactMatch
+            ? new URL(`${urlWithParams.href}/${query}`)
+            : new URL(`${urlWithParams.href}?filter[name][contains]=${query}`)
       } else {
         // handle kongManager usage with _config.value.isExactMatch === false
         if (!isExactMatch.value) {

--- a/packages/entities/entities-shared/src/types/app-config.ts
+++ b/packages/entities/entities-shared/src/types/app-config.ts
@@ -18,6 +18,8 @@ export interface KonnectConfig extends BaseAppConfig {
   controlPlaneId: string
   /** Should use exact match */
   isExactMatch?: boolean
+  /** Should use ?filter[name][eq]={query} when exact match */
+  isEqMatch?: boolean
 }
 
 /** Base config properties for Kong Manager. All entity configs should extend this interface for the app. */

--- a/packages/entities/entities-shared/src/types/entity-filter.ts
+++ b/packages/entities/entities-shared/src/types/entity-filter.ts
@@ -1,14 +1,10 @@
-import type { SelectItem } from '@kong/kongponents/dist/types'
+import type { SelectItem, SelectFilterFunctionParams } from '@kong/kongponents/dist/types'
 import type { Field } from './index'
 
 /** Base filter configuration */
 interface BaseFilterConfig {
   /** If true, the filter will be an exact match filter, otherwise it will be a fuzzy match filter */
   isExactMatch: boolean
-}
-
-interface QueryItem extends SelectItem {
-  value: string
 }
 
 /**
@@ -18,7 +14,10 @@ interface QueryItem extends SelectItem {
  */
 export interface ExactMatchFilterConfig extends BaseFilterConfig {
   isExactMatch: true
-  queryItems?: QueryItem[]
+  /** If provided, the filter will be a select input and the query will be the value of the selected item */
+  selectItems?: SelectItem[]
+  /** If selectItems is provided, we can customize the filter function */
+  selectFilterFunction?: (params: SelectFilterFunctionParams) => SelectItem[] | boolean
   /** Placeholder for the exact match filter input */
   placeholder: string
 }

--- a/packages/entities/entities-shared/src/types/entity-filter.ts
+++ b/packages/entities/entities-shared/src/types/entity-filter.ts
@@ -1,9 +1,14 @@
+import type { SelectItem } from '@kong/kongponents/dist/types'
 import type { Field } from './index'
 
 /** Base filter configuration */
 interface BaseFilterConfig {
   /** If true, the filter will be an exact match filter, otherwise it will be a fuzzy match filter */
   isExactMatch: boolean
+}
+
+interface QueryItem extends SelectItem {
+  value: string
 }
 
 /**
@@ -13,6 +18,7 @@ interface BaseFilterConfig {
  */
 export interface ExactMatchFilterConfig extends BaseFilterConfig {
   isExactMatch: true
+  queryItems?: QueryItem[]
   /** Placeholder for the exact match filter input */
   placeholder: string
 }


### PR DESCRIPTION
# Summary

[KM-591](https://konghq.atlassian.net/browse/KM-591)

[Preview link](https://pr-4750--gateway-manager.cloud-preview.konghq.tech/gateway-manager)

This pull request provides a PoC for a new filter interaction in the plugins list, aimed at improving usability by addressing the mismatch between visible display names and filterable names.

## Context

A plugin instance may have three different "names":

- **name**: the backend-stored plugin name (key), e.g., `mtls-auth`
- **display name**: the UI-visible name, e.g., `Key Authentication`
- **instance name**: a user-defined name for a plugin instance, e.g., `MyAwesomePlugin`

Currently, because display names are not stored on the backend, the filter API (`/plugins?filter[name][contains]={query}`) only matches against the plugin's backend name or user-defined instance name. This gap can cause confusion when users try to filter by the display names they see in the UI.

To address this, @erichsend proposed an approach with these steps:

1. Replace the standard input filter with a **Select component**.
2. Allow users to type a query into the Select component.
3. Fuzzy match plugin (not plugin instances) against multiple fields—names, display names, and groups—aligning with filter logic on the plugin creation page.
4. When a user selects a plugin, use an exact match query (e.g., `/plugins?filter[name][eq]=mtls-auth`) to display all instances of the selected plugin.

### Trade-Offs

This approach presents some benefits and limitations:

```diff
+ Enables filtering by display names and group names apart from names.
+ Aligns filter behavior with the plugin creation page.
- Limits filtering to instances of a single plugin at a time.
- Disables filtering by instance names.
```

## Code Changes

- Added `usePluginSelect` composable (extracted from `PluginsSelectPage.vue` with modifications)
  - `pluginList` is now a computed reference instead of a simple ref - **need confirmation**.
  - Removed the watch logic for `pluginList` updates, as it should update automatically as a computed reference.
  - Removed `@revalidate="() => pluginsList = buildPluginList()"` from `PluginSelect.vue` - **need confirmation**.

- Added `selectItems` and `selectFilterFunction` to `ExactMatchFilterConfig`
  - Introduced  to enable the new select-then-filter behavior and customize the Select component’s filter logic.

- Added `isEqMatch` in `KonnectConfig`
  - This option supports the newly implemented exact match filtering, differentiating it from other filtering methods.
  - When a user selects an exact plugin name, the `/plugins?filter[name][eq]={query}` endpoint is called to ensure precise results (e.g., preventing `Rate Limiting` from returning instances of `Rate Limiting Advanced`).


[KM-591]: https://konghq.atlassian.net/browse/KM-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ