### PR TITLE
fix(entities-plugins): wrong custom plugin tab active state [KM-647]

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -309,18 +309,27 @@ const noSearchResults = computed((): boolean => {
   return (Object.keys(pluginsList.value).length > 0 && !hasFilteredResults.value)
 })
 
-const tabs = props.config.app === 'konnect'
-  ? [{
-    hash: '#kong',
-    title: t('plugins.select.tabs.kong.title'),
-  },
-  {
-    hash: '#custom',
-    title: t('plugins.select.tabs.custom.title'),
-    disabled: props.disableCustomPlugins,
-  }]
-  : []
-const activeTab = ref(tabs.length ? route?.hash || tabs[0]?.hash || '' : '')
+const tabs = computed(() => {
+  return props.config.app === 'konnect'
+    ? [{
+      hash: '#kong',
+      title: t('plugins.select.tabs.kong.title'),
+    },
+    {
+      hash: '#custom',
+      title: t('plugins.select.tabs.custom.title'),
+      disabled: props.disableCustomPlugins,
+    }]
+    : []
+})
+const activeTab = computed(() => {
+  let hash = tabs.value.length ? route?.hash || tabs.value[0]?.hash || '' : ''
+  // If custom plugins are disabled, default to kong tab
+  if (hash === '#custom' && props.disableCustomPlugins) {
+    hash = '#kong'
+  }
+  return hash
+})
 
 const buildPluginList = (): PluginCardList => {
   // If availableOnServer is false, we included unavailable plugins from pluginMeta in addition to available plugins


### PR DESCRIPTION
# Summary
[KM-647](https://konghq.atlassian.net/browse/KM-647)

**Reproduction:**
1. accessing a serverless cp
2. go to the add plugin page
3. reload the page
4. the custom plugin tab can be clicked

**Expected:**
the custom plugin tab should always be disabled under the serverless CP

[preview link](https://pr-4751--gateway-manager.cloud-preview.konghq.tech/gateway-manager)

[KM-647]: https://konghq.atlassian.net/browse/KM-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ