### PR TITLE
fix(entities-plugins): custom plugins disappeared after page reload [KM-658]

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginIcon.vue
+++ b/packages/entities/entities-plugins/src/components/PluginIcon.vue
@@ -2,6 +2,7 @@
   <img
     ref="img"
     :alt="alt"
+    :height="size"
     :src="iconSrc"
     :width="size"
     @error="onError"

--- a/packages/entities/entities-plugins/src/components/custom-plugins/PluginCustomGrid.vue
+++ b/packages/entities/entities-plugins/src/components/custom-plugins/PluginCustomGrid.vue
@@ -185,7 +185,8 @@ const handleClose = (revalidate?: boolean): void => {
   selectedPlugin.value = null
 }
 
-const tallestPluginCardHeight = ref<number>(310) // begin with default height
+const minHeight = 310
+const tallestPluginCardHeight = ref<number>(minHeight) // begin with default height
 const pluginCardContainerRef = ref<HTMLElement | null>(null)
 const pluginCardRef = ref<Array<InstanceType<typeof PluginSelectCard>> | null>(null)
 
@@ -204,7 +205,7 @@ const collapsedGroupStyles = computed((): Record<string, string> => {
 const showCollapseTrigger = ref<boolean>(false) // don't display a trigger if all plugins will already be visible
 
 const handleResize = (): void => {
-  tallestPluginCardHeight.value = getTallestPluginCardHeight(pluginCardRef.value!)
+  tallestPluginCardHeight.value = Math.max(getTallestPluginCardHeight(pluginCardRef.value!), minHeight)
   setToggleVisibility()
 }
 
@@ -218,7 +219,7 @@ const setToggleVisibility = (): void => {
 onMounted(async () => {
   await nextTick()
 
-  tallestPluginCardHeight.value = getTallestPluginCardHeight(pluginCardRef.value!)
+  tallestPluginCardHeight.value = Math.max(getTallestPluginCardHeight(pluginCardRef.value!), minHeight)
   setToggleVisibility()
   window?.addEventListener('resize', handleResize)
 })

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectGroup.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectGroup.vue
@@ -84,7 +84,8 @@ const emit = defineEmits<{
 const { i18n: { t } } = composables.useI18n()
 const { getTallestPluginCardHeight, getToggleVisibility } = composables.usePluginHelpers()
 
-const tallestPluginCardHeight = ref<number>(310) // begin with default height
+const minHeight = 310
+const tallestPluginCardHeight = ref<number>(minHeight) // begin with default height
 const pluginCardContainerRef = ref<HTMLElement | null>(null)
 const pluginCardRef = ref<Array<InstanceType<typeof PluginSelectCard>> | null>(null)
 
@@ -103,7 +104,7 @@ const collapsedGroupStyles = computed((): Record<string, string> => {
 const showCollapseTrigger = ref<boolean>(false) // don't display a trigger if all plugins will already be visible
 
 const handleResize = (): void => {
-  tallestPluginCardHeight.value = getTallestPluginCardHeight(pluginCardRef.value!)
+  tallestPluginCardHeight.value = Math.max(getTallestPluginCardHeight(pluginCardRef.value!), minHeight)
   setToggleVisibility()
 }
 
@@ -117,7 +118,7 @@ const setToggleVisibility = (): void => {
 onMounted(async () => {
   await nextTick()
 
-  tallestPluginCardHeight.value = getTallestPluginCardHeight(pluginCardRef.value!)
+  tallestPluginCardHeight.value = Math.max(getTallestPluginCardHeight(pluginCardRef.value!), minHeight)
   setToggleVisibility()
   window?.addEventListener('resize', handleResize)
 })


### PR DESCRIPTION
# Summary

For the reproduction method, please refer to: [KM-658](https://konghq.atlassian.net/browse/KM-658)

in fact, this problem is caused by the konnect, which hides the app container during initialization ([see here](https://github.com/Kong/shared-ui-components/blob/defb8926e9a7ae6b2c29239fdd895d4d813dfe8d/packages/core/konnect-app-shell/src/components/KonnectAppShell.vue#L305)), during which the card height is always calculated to be 0px.

This is a quick and easy fix that provide a minimum height.

[preview link](https://pr-4755--gateway-manager.cloud-preview.konghq.tech/gateway-manager)


[KM-658]: https://konghq.atlassian.net/browse/KM-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ