### PR TITLE
feat(dashboards and charts): editable tiles | slottable menu items

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -68,6 +68,7 @@
               {{ i18n.t('csvExport.exportButton') }}
             </span>
           </KDropdownItem>
+          <slot name="menu-items" />
         </template>
       </KDropdown>
       <!-- Keep outside of dropdown, so we can independently affect its visibility -->
@@ -230,6 +231,11 @@ const props = defineProps({
     required: false,
     default: false,
   },
+  showMenu: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 })
 
 const emit = defineEmits<{
@@ -361,7 +367,7 @@ const showChartHeader = computed(() => {
   return (hasValidChartData.value && resultSetTruncated.value && maxEntitiesShown.value) || props.chartTitle || (props.allowCsvExport && hasValidChartData.value)
 })
 
-const hasMenuOptions = computed(() => (props.allowCsvExport && hasValidChartData.value) || !!props.goToExplore)
+const hasMenuOptions = computed(() => (props.allowCsvExport && hasValidChartData.value) || !!props.goToExplore || props.showMenu)
 
 const timeSeriesGranularity = computed<GranularityValues>(() => {
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -46,6 +46,7 @@ const appLinks: SandboxNavigationItem[] = inject('app-links', [])
 const context: DashboardRendererContext = {
   filters: [],
   refreshInterval: 0,
+  editable: true,
 }
 
 const dashboardConfig: DashboardConfig = {
@@ -136,7 +137,6 @@ const dashboardConfig: DashboardConfig = {
           datasource: 'basic',
           dimensions: ['route'],
         },
-        editable: true,
       },
       layout: {
         position: {
@@ -159,7 +159,6 @@ const dashboardConfig: DashboardConfig = {
           datasource: 'basic',
           dimensions: ['time'],
         },
-        editable: true,
       },
       layout: {
         position: {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -13,6 +13,7 @@
         :class="{ 'custom-styling': isToggled}"
         :config="(dashboardConfig as DashboardConfig)"
         :context="context"
+        @edit-tile="onEditTile"
       >
         <template #slot-1>
           <div class="slot-container">
@@ -32,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import type { DashboardConfig, DashboardRendererContext, TileConfig } from '../../src'
+import type { DashboardConfig, DashboardRendererContext, TileConfig, TileDefinition, GridTile } from '../../src'
 import { DashboardRenderer } from '../../src'
 import { inject, ref } from 'vue'
 import { ChartMetricDisplay } from '@kong-ui-public/analytics-chart'
@@ -135,6 +136,7 @@ const dashboardConfig: DashboardConfig = {
           datasource: 'basic',
           dimensions: ['route'],
         },
+        editable: true,
       },
       layout: {
         position: {
@@ -157,6 +159,7 @@ const dashboardConfig: DashboardConfig = {
           datasource: 'basic',
           dimensions: ['time'],
         },
+        editable: true,
       },
       layout: {
         position: {
@@ -238,6 +241,10 @@ const dashboardConfig: DashboardConfig = {
 }
 
 const isToggled = ref(false)
+
+const onEditTile = (tile: GridTile<TileDefinition>) => {
+  console.log('@edit-tile', tile)
+}
 
 </script>
 

--- a/packages/analytics/dashboard-renderer/src/components/BarChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BarChartRenderer.vue
@@ -1,42 +1,19 @@
+<!-- BarChartRenderer.vue -->
 <template>
-  <QueryDataProvider
-    v-slot="{ data }"
+  <BaseAnalyticsChartRenderer
+    :chart-options="chartOptions"
     :context="context"
+    :editable="editable"
+    :extra-props="{ showAnnotations: false }"
+    :height="height"
     :query="query"
     :query-ready="queryReady"
-  >
-    <div class="analytics-chart">
-      <AnalyticsChart
-        :allow-csv-export="chartOptions.allowCsvExport"
-        :chart-data="data"
-        :chart-options="options"
-        :chart-title="chartOptions.chartTitle"
-        legend-position="bottom"
-        :show-annotations="false"
-        :synthetics-data-key="chartOptions.syntheticsDataKey"
-        tooltip-title=""
-      />
-    </div>
-  </QueryDataProvider>
+  />
 </template>
+
 <script setup lang="ts">
+import BaseAnalyticsChartRenderer from './BaseAnalyticsChartRenderer.vue'
 import type { BarChartOptions, RendererProps } from '../types'
-import QueryDataProvider from './QueryDataProvider.vue'
-import { computed } from 'vue'
-import type { AnalyticsChartOptions } from '@kong-ui-public/analytics-chart'
-import { AnalyticsChart } from '@kong-ui-public/analytics-chart'
 
-const props = defineProps<RendererProps<BarChartOptions>>()
-
-const options = computed((): AnalyticsChartOptions => ({
-  type: props.chartOptions.type,
-  stacked: props.chartOptions.stacked,
-  chartDatasetColors: props.chartOptions.chartDatasetColors,
-}))
+defineProps<RendererProps<BarChartOptions>>()
 </script>
-
-<style scoped lang="scss">
-.analytics-chart {
-  height: v-bind('`${height}px`');
-}
-</style>

--- a/packages/analytics/dashboard-renderer/src/components/BarChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BarChartRenderer.vue
@@ -3,7 +3,6 @@
   <BaseAnalyticsChartRenderer
     :chart-options="chartOptions"
     :context="context"
-    :editable="context.editable"
     :extra-props="{ showAnnotations: false }"
     :height="height"
     :query="query"

--- a/packages/analytics/dashboard-renderer/src/components/BarChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BarChartRenderer.vue
@@ -3,7 +3,7 @@
   <BaseAnalyticsChartRenderer
     :chart-options="chartOptions"
     :context="context"
-    :editable="editable"
+    :editable="context.editable"
     :extra-props="{ showAnnotations: false }"
     :height="height"
     :query="query"

--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -1,0 +1,62 @@
+<template>
+  <QueryDataProvider
+    v-slot="{ data }"
+    :context="context"
+    :query="query"
+    :query-ready="queryReady"
+  >
+    <div class="analytics-chart">
+      <AnalyticsChart
+        :allow-csv-export="chartOptions.allowCsvExport"
+        :chart-data="data"
+        :chart-options="options"
+        :chart-title="chartOptions.chartTitle"
+        legend-position="bottom"
+        :show-menu="editable"
+        :synthetics-data-key="chartOptions.syntheticsDataKey"
+        tooltip-title=""
+        v-bind="extraProps"
+      >
+        <template
+          v-if="editable"
+          #menu-items
+        >
+          <KDropdownItem @click="editTile">
+            {{ i18n.t('renderer.edit') }}
+          </KDropdownItem>
+        </template>
+      </AnalyticsChart>
+    </div>
+  </QueryDataProvider>
+</template>
+
+<script setup lang="ts">
+import type { RendererProps } from '../types'
+import QueryDataProvider from './QueryDataProvider.vue'
+import { computed, defineProps } from 'vue'
+import type { AnalyticsChartOptions } from '@kong-ui-public/analytics-chart'
+import { AnalyticsChart } from '@kong-ui-public/analytics-chart'
+import composables from '../composables'
+
+const props = defineProps<RendererProps<any> & { extraProps?: Record<string, any> }>()
+const emit = defineEmits<{
+  (e: 'edit-tile'): void
+}>()
+const { i18n } = composables.useI18n()
+
+const options = computed((): AnalyticsChartOptions => ({
+  type: props.chartOptions.type,
+  stacked: props.chartOptions.stacked ?? false,
+  chartDatasetColors: props.chartOptions.chartDatasetColors,
+}))
+
+const editTile = () => {
+  emit('edit-tile')
+}
+</script>
+
+<style scoped lang="scss">
+.analytics-chart {
+  height: v-bind('`${height}px`');
+}
+</style>

--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -12,13 +12,13 @@
         :chart-options="options"
         :chart-title="chartOptions.chartTitle"
         legend-position="bottom"
-        :show-menu="editable"
+        :show-menu="context.editable"
         :synthetics-data-key="chartOptions.syntheticsDataKey"
         tooltip-title=""
         v-bind="extraProps"
       >
         <template
-          v-if="editable"
+          v-if="context.editable"
           #menu-items
         >
           <KDropdownItem @click="editTile">

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -134,7 +134,7 @@ const gridTiles = computed(() => {
 })
 
 const mergedContext = computed<DashboardRendererContextInternal>(() => {
-  let { tz, refreshInterval } = props.context
+  let { tz, refreshInterval, editable } = props.context
 
   if (!tz) {
     tz = (new Intl.DateTimeFormat()).resolvedOptions().timeZone
@@ -145,11 +145,16 @@ const mergedContext = computed<DashboardRendererContextInternal>(() => {
     refreshInterval = DEFAULT_TILE_REFRESH_INTERVAL_MS
   }
 
+  if (editable === undefined) {
+    editable = false
+  }
+
   return {
     ...props.context,
     tz,
     timeSpec: timeSpec.value,
     refreshInterval,
+    editable,
   }
 })
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -26,6 +26,7 @@
           :definition="tile.meta"
           :height="tile.layout.size.rows * (config.tileHeight || DEFAULT_TILE_HEIGHT) + parseInt(KUI_SPACE_70, 10)"
           :query-ready="queryReady"
+          @edit-tile="onEditTile(tile)"
         />
       </template>
     </GridLayout>
@@ -51,6 +52,10 @@ import { KUI_SPACE_70 } from '@kong/design-tokens'
 const props = defineProps<{
   context: DashboardRendererContext,
   config: DashboardConfig,
+}>()
+
+const emit = defineEmits<{
+  (e: 'edit-tile', tile: GridTile<TileDefinition>): void
 }>()
 
 const { i18n } = composables.useI18n()
@@ -150,6 +155,10 @@ const mergedContext = computed<DashboardRendererContextInternal>(() => {
 
 // Right now, tiles don't have unique keys.  Perhaps in the future they will,
 // and we can use that instead of `index` as the fragment key.
+
+const onEditTile = (tile: GridTile<TileDefinition>) => {
+  emit('edit-tile', tile)
+}
 
 </script>
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -4,6 +4,7 @@
       :is="componentData.component"
       v-if="componentData"
       v-bind="componentData.rendererProps"
+      @edit-tile="onEditTile"
     />
   </div>
 </template>
@@ -34,6 +35,10 @@ const props = withDefaults(defineProps<{
   height: DEFAULT_TILE_HEIGHT,
 })
 
+const emit = defineEmits<{
+  (e: 'edit-tile', tile: TileDefinition): void
+}>()
+
 const rendererLookup: Record<DashboardTileType, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,
   'horizontal_bar': BarChartRenderer,
@@ -56,9 +61,14 @@ const componentData = computed(() => {
       queryReady: props.queryReady,
       chartOptions: props.definition.chart,
       height: props.height - PADDING_SIZE * 2,
+      editable: props.definition.editable,
     },
   }
 })
+
+const onEditTile = () => {
+  emit('edit-tile', props.definition)
+}
 </script>
 
 <style lang="scss" scoped>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -61,7 +61,7 @@ const componentData = computed(() => {
       queryReady: props.queryReady,
       chartOptions: props.definition.chart,
       height: props.height - PADDING_SIZE * 2,
-      editable: props.definition.editable,
+      editable: props.context.editable,
     },
   }
 })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -61,7 +61,6 @@ const componentData = computed(() => {
       queryReady: props.queryReady,
       chartOptions: props.definition.chart,
       height: props.height - PADDING_SIZE * 2,
-      editable: props.context.editable,
     },
   }
 })

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -46,18 +46,24 @@ const overrideTimeframe: Ref<Timeframe> = computed(() => {
   return relativePeriod
 })
 
-const options = computed<ProviderProps>(() => ({
-  datasource: props.query?.datasource,
-  overrideTimeframe: overrideTimeframe.value,
-  tz: props.context.tz,
-  additionalFilter: props.context.filters as ExploreFilter[], // TODO: Decide how to handle metric card filters.
-  longCardTitles: props.chartOptions.longCardTitles,
-  containerTitle: props.chartOptions.chartTitle,
-  description: props.chartOptions.description,
-  percentileLatency: props.chartOptions.percentileLatency,
-  refreshInterval: props.context.refreshInterval,
-  queryReady: props.queryReady,
-}))
+const options = computed<ProviderProps>(() => {
+  const datasource = props.query?.datasource
+  if (datasource && datasource !== 'advanced' && datasource !== 'basic') {
+    throw new Error(`Invalid datasource value: ${datasource}`)
+  }
+  return {
+    datasource: props.query?.datasource,
+    overrideTimeframe: overrideTimeframe.value,
+    tz: props.context.tz,
+    additionalFilter: props.context.filters as ExploreFilter[], // TODO: Decide how to handle metric card filters.
+    longCardTitles: props.chartOptions.longCardTitles,
+    containerTitle: props.chartOptions.chartTitle,
+    description: props.chartOptions.description,
+    percentileLatency: props.chartOptions.percentileLatency,
+    refreshInterval: props.context.refreshInterval,
+    queryReady: props.queryReady,
+  }
+})
 </script>
 
 <style scoped lang="scss">

--- a/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
@@ -1,48 +1,18 @@
+<!-- TimeseriesChartRenderer.vue -->
 <template>
-  <QueryDataProvider
-    v-slot="{ data }"
+  <BaseAnalyticsChartRenderer
+    :chart-options="chartOptions"
     :context="context"
+    :editable="editable"
+    :height="height"
     :query="query"
     :query-ready="queryReady"
-  >
-    <div class="analytics-chart">
-      <AnalyticsChart
-        :allow-csv-export="chartOptions.allowCsvExport"
-        :chart-data="data"
-        :chart-options="options"
-        :chart-title="chartOptions.chartTitle"
-        legend-position="bottom"
-        :synthetics-data-key="chartOptions.syntheticsDataKey"
-        tooltip-title=""
-      />
-    </div>
-  </QueryDataProvider>
+  />
 </template>
+
 <script setup lang="ts">
-import type { RendererProps, TimeseriesChartOptions } from '../types'
-import QueryDataProvider from './QueryDataProvider.vue'
-import { computed } from 'vue'
-import type { AnalyticsChartOptions } from '@kong-ui-public/analytics-chart'
-import { AnalyticsChart } from '@kong-ui-public/analytics-chart'
+import BaseAnalyticsChartRenderer from './BaseAnalyticsChartRenderer.vue'
+import type { TimeseriesChartOptions, RendererProps } from '../types'
 
-const props = defineProps<RendererProps<TimeseriesChartOptions>>()
-
-const options = computed((): AnalyticsChartOptions => {
-  // Default `stacked` to false.
-  const stacked = props.chartOptions.stacked ?? false
-
-  // Note that `fill` and `stacked` are linked; it's not possible to have a non-filled stacked chart.
-  // This matches our intuitions about how these charts work.
-  return {
-    type: props.chartOptions.type,
-    stacked,
-    chartDatasetColors: props.chartOptions.chartDatasetColors,
-  }
-})
+defineProps<RendererProps<TimeseriesChartOptions>>()
 </script>
-
-<style scoped lang="scss">
-.analytics-chart {
-  height: v-bind('`${height}px`');
-}
-</style>

--- a/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
@@ -3,7 +3,7 @@
   <BaseAnalyticsChartRenderer
     :chart-options="chartOptions"
     :context="context"
-    :editable="editable"
+    :editable="context.editable"
     :height="height"
     :query="query"
     :query-ready="queryReady"

--- a/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
@@ -3,7 +3,6 @@
   <BaseAnalyticsChartRenderer
     :chart-options="chartOptions"
     :context="context"
-    :editable="context.editable"
     :height="height"
     :query="query"
     :query-ready="queryReady"

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -5,7 +5,8 @@
       "24h": "Last 24-Hour Summary",
       "7d": "Last 7-Day Summary",
       "30d": "Last 30-Day Summary"
-    }
+    },
+    "edit": "Edit"
   },
   "queryDataProvider": {
     "timeRangeExceeded":  "The time range for this report is outside of your organization's data retention period"

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -22,6 +22,7 @@ export interface DashboardRendererContext {
   timeSpec?: TimeRangeV4
   tz?: string
   refreshInterval?: number
+  editable?: boolean
 }
 
 type FromSchemaWithOptions<T extends JSONSchema> = FromSchema<T, { keepDefaultedPropertiesOptional: true }>
@@ -57,10 +58,6 @@ const allowCsvExport = {
 
 const goToExplore = {
   type: 'string',
-} as const
-
-const editable = {
-  type: 'boolean',
 } as const
 
 const chartDatasetColorsSchema = {
@@ -408,7 +405,6 @@ export const tileDefinitionSchema = {
     chart: {
       anyOf: [barChartSchema, gaugeChartSchema, timeseriesChartSchema, metricCardSchema, topNTableSchema, slottableSchema],
     },
-    editable,
   },
   required: ['query', 'chart'],
   additionalProperties: false,
@@ -508,5 +504,4 @@ export interface RendererProps<T> {
   queryReady: boolean
   chartOptions: T
   height: number
-  editable?: boolean
 }

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -55,6 +55,14 @@ const allowCsvExport = {
   type: 'boolean',
 } as const
 
+const goToExplore = {
+  type: 'string',
+} as const
+
+const editable = {
+  type: 'boolean',
+} as const
+
 const chartDatasetColorsSchema = {
   type: ['object', 'array'],
   items: {
@@ -96,6 +104,7 @@ export const barChartSchema = {
     syntheticsDataKey,
     chartTitle,
     allowCsvExport,
+    goToExplore,
   },
   required: ['type'],
   additionalProperties: false,
@@ -117,6 +126,7 @@ export const timeseriesChartSchema = {
     syntheticsDataKey,
     chartTitle,
     allowCsvExport,
+    goToExplore,
   },
   required: ['type'],
   additionalProperties: false,
@@ -398,6 +408,7 @@ export const tileDefinitionSchema = {
     chart: {
       anyOf: [barChartSchema, gaugeChartSchema, timeseriesChartSchema, metricCardSchema, topNTableSchema, slottableSchema],
     },
+    editable,
   },
   required: ['query', 'chart'],
   additionalProperties: false,
@@ -497,4 +508,5 @@ export interface RendererProps<T> {
   queryReady: boolean
   chartOptions: T
   height: number
+  editable?: boolean
 }

--- a/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/dashboard-renderer-types.ts
@@ -56,10 +56,6 @@ const allowCsvExport = {
   type: 'boolean',
 } as const
 
-const goToExplore = {
-  type: 'string',
-} as const
-
 const chartDatasetColorsSchema = {
   type: ['object', 'array'],
   items: {
@@ -101,7 +97,6 @@ export const barChartSchema = {
     syntheticsDataKey,
     chartTitle,
     allowCsvExport,
-    goToExplore,
   },
   required: ['type'],
   additionalProperties: false,
@@ -123,7 +118,6 @@ export const timeseriesChartSchema = {
     syntheticsDataKey,
     chartTitle,
     allowCsvExport,
-    goToExplore,
   },
   required: ['type'],
   additionalProperties: false,


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-3367

- add new edit-tile event to dashboard renderer
- forward `go-to -explore` prop to analytics chart through tile definition
- add new editable property to tile definition that will add an "edit" item to the analytics chart kebab menu. Clicking on edit, will emit an @edit-tile event with the entire GridTile<T> object containing the tile layout, definition and index

## `@edit-tile` event
```
{
    "layout": {
        "position": {
            "col": 0,
            "row": 2
        },
        "size": {
            "cols": 3,
            "rows": 2
        }
    },
    "meta": {
        "chart": {
            "type": "horizontal_bar",
            "chartTitle": "Horizontal bar chart of mock data",
            "allowCsvExport": true
        },
        "query": {
            "datasource": "basic",
            "dimensions": [
                "route"
            ]
        },
        "editable": true
    },
    "id": 3
}
```

<img width="830" alt="image" src="https://github.com/user-attachments/assets/47a37de8-29cb-453e-9854-017efbb06005">


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
