### PR TITLE
fix(pluginlist): adapt empty ordering object for filtered plugin

### DIFF
--- a/packages/entities/entities-plugins/fixtures/mockData.ts
+++ b/packages/entities/entities-plugins/fixtures/mockData.ts
@@ -17,7 +17,7 @@ export const plugins: FetcherRawResponse = {
       name: 'basic-auth',
       protocols: ['http', 'https'],
       tags: ['tag1'],
-      ordering: {},
+      ordering: { 'before': { 'access': ['acl'] } },
       instance_name: 'instance-1',
       created_at: 1610617600,
       consumer_group: { id: 'consumer-group-1' },

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -113,11 +113,13 @@
       </template>
 
       <template #ordering="{ rowValue }">
-        <KBadge :appearance="rowValue ? 'warning' : 'info'">
+        <KBadge
+          :appearance="isEmpty(rowValue) ? 'info' : 'warning'"
+        >
           {{
-            rowValue
-              ? t('plugins.list.table_headers.ordering_badge.dynamic')
-              : t('plugins.list.table_headers.ordering_badge.static')
+            isEmpty(rowValue)
+              ? t('plugins.list.table_headers.ordering_badge.static')
+              : t('plugins.list.table_headers.ordering_badge.dynamic')
           }}
         </KBadge>
       </template>
@@ -260,6 +262,8 @@ import type {
 import PluginIcon from './PluginIcon.vue'
 
 import type { HeaderTag } from '@kong/kongponents'
+
+import isEmpty from 'lodash-es/isEmpty'
 
 const pluginMetaData = composables.usePluginMetaData()
 


### PR DESCRIPTION
# Summary

KM-662

Filtered plugin item in Konnect contains `ordering:{}` in response, this results in current UI showing dynamic badge for static ordering. This pr allows passing empty ordering object too.