### PR TITLE
fix(entities-plugins): placeholder should reflect actual behavior

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -113,9 +113,7 @@
       </template>
 
       <template #ordering="{ rowValue }">
-        <KBadge
-          :appearance="isEmpty(rowValue) ? 'info' : 'warning'"
-        >
+        <KBadge :appearance="isEmpty(rowValue) ? 'info' : 'warning'">
           {{
             isEmpty(rowValue)
               ? t('plugins.list.table_headers.ordering_badge.static')
@@ -411,7 +409,8 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
         name: fields.name,
         id: { label: t('plugins.list.table_headers.id'), sortable: true },
       },
-      placeholder: t(`search.placeholder.${props.config.app}`),
+      // force exact placeholder if `props.config.isExactMatch` is true
+      placeholder: t(`search.placeholder.${props.config.isExactMatch ? 'exact' : props.config.app}`),
     } as ExactMatchFilterConfig
   }
 
@@ -545,10 +544,9 @@ const confirmSwitchEnablement = async () => {
     return
   }
 
-  let url = `${props.config.apiBaseUrl}${
-    endpoints.item[props.config.app]?.[props.config?.entityType ? 'forEntity' : 'all']
-      .replace(/{entityType}/gi, props.config?.entityType || '')
-      .replace(/{entityId}/gi, props.config?.entityId || '')
+  let url = `${props.config.apiBaseUrl}${endpoints.item[props.config.app]?.[props.config?.entityType ? 'forEntity' : 'all']
+    .replace(/{entityType}/gi, props.config?.entityType || '')
+    .replace(/{entityId}/gi, props.config?.entityId || '')
   }`
     .replace(/{id}/gi, switchEnablementTarget.value.id || '')
 

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -53,6 +53,7 @@
   "search": {
     "placeholder": {
       "konnect": "Filter by name",
+      "exact": "Filter by exact instance name or ID",
       "kongManager": "Filter by exact instance name or ID",
       "select": "Filter plugins"
     },


### PR DESCRIPTION
# Summary

[KM-667](https://konghq.atlassian.net/browse/KM-667)

If `<PluginList>` receives `config.isExactMatch: true`, the placeholder should reflect that.

[KM-659]: https://konghq.atlassian.net/browse/KM-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KM-660]: https://konghq.atlassian.net/browse/KM-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KM-667]: https://konghq.atlassian.net/browse/KM-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ