### PR TITLE
feat: add explore base url to query bridge for analytics jump to explore

### DIFF
--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -5,7 +5,7 @@
   "entityNoName": "no-name",
   "debug": "debug",
   "total": "Total",
-  "jumpToExplore": "Jump to Explore",
+  "jumpToExplore": "Go to Explorer",
   "chartUnits": {
     "ms": "ms",
     "bytes": "Byte{plural}",

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -30,4 +30,5 @@ export interface AnalyticsBridge {
   //  https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#the-noinfer-utility-type
   //  See note in DashboardRenderer tests.
   evaluateFeatureFlagFn: <T = boolean>(key: string, defaultValue: T) => T,
+  exploreBaseUrl?: string,
 }

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -30,5 +30,5 @@ export interface AnalyticsBridge {
   //  https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#the-noinfer-utility-type
   //  See note in DashboardRenderer tests.
   evaluateFeatureFlagFn: <T = boolean>(key: string, defaultValue: T) => T,
-  exploreBaseUrl?: string,
+  exploreBaseUrl?: () => string,
 }

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -134,8 +134,9 @@ const dashboardConfig: DashboardConfig = {
           allowCsvExport: true,
         },
         query: {
-          datasource: 'basic',
+          datasource: 'advanced',
           dimensions: ['route'],
+          metrics: ['request_count'],
         },
       },
       layout: {

--- a/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
@@ -54,9 +54,11 @@ const configFn = (): Promise<AnalyticsConfigV2> => {
 
 const evaluateFeatureFlagFn = () => true
 
+const exploreBaseUrl = 'https://cloud.konghq.tech/us/analytics/explorer'
+
 const sandboxQueryProvider: Plugin = {
   install(app) {
-    app.provide(INJECT_QUERY_PROVIDER, { queryFn, configFn, evaluateFeatureFlagFn } as AnalyticsBridge)
+    app.provide(INJECT_QUERY_PROVIDER, { queryFn, configFn, evaluateFeatureFlagFn, exploreBaseUrl } as AnalyticsBridge)
   },
 }
 

--- a/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
@@ -54,7 +54,7 @@ const configFn = (): Promise<AnalyticsConfigV2> => {
 
 const evaluateFeatureFlagFn = () => true
 
-const exploreBaseUrl = 'https://cloud.konghq.tech/us/analytics/explorer'
+const exploreBaseUrl = () => 'https://cloud.konghq.tech/us/analytics/explorer'
 
 const sandboxQueryProvider: Plugin = {
   install(app) {

--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -39,7 +39,7 @@ import type { AnalyticsChartOptions } from '@kong-ui-public/analytics-chart'
 import { AnalyticsChart } from '@kong-ui-public/analytics-chart'
 import composables from '../composables'
 import { INJECT_QUERY_PROVIDER } from '../constants'
-import type { AiExploreAggregations, AiExploreQuery, AnalyticsBridge, ExploreAggregations, ExploreFilter, ExploreQuery, QueryableAiExploreDimensions, QueryableExploreDimensions, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
+import type { AiExploreAggregations, AiExploreQuery, AnalyticsBridge, ExploreAggregations, ExploreQuery, QueryableAiExploreDimensions, QueryableExploreDimensions, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
 
 const props = defineProps<RendererProps<any> & { extraProps?: Record<string, any> }>()
 const emit = defineEmits<{
@@ -63,7 +63,9 @@ const exploreLink = computed(() => {
       time_range: props.query.time_range as TimeRangeV4 || props.context.timeSpec,
 
     } as ExploreQuery | AiExploreQuery
-    return `${queryBridge.exploreBaseUrl()}?q=${JSON.stringify(exploreQuery)}&d=${props.query.datasource}&c=${props.chartOptions.type}`
+    // Explore only supports advanced or ai
+    const datasource = ['advanced', 'ai'].includes(props.query.datasource) ? props.query.datasource : 'advanced'
+    return `${queryBridge.exploreBaseUrl()}?q=${JSON.stringify(exploreQuery)}&d=${datasource}&c=${props.chartOptions.type}`
   }
 
   return ''

--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -68,7 +68,7 @@ const exploreLink = computed(() => {
       time_range: props.query.time_range as TimeRangeV4 || props.context.timeSpec,
 
     } as ExploreQuery | AiExploreQuery
-    return `${queryBridge.exploreBaseUrl}?q=${JSON.stringify(exploreQuery)}&d=${props.query.datasource}&c=${props.chartOptions.type}`
+    return `${queryBridge.exploreBaseUrl()}?q=${JSON.stringify(exploreQuery)}&d=${props.query.datasource}&c=${props.chartOptions.type}`
   }
 
   return ''

--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -57,12 +57,7 @@ const options = computed((): AnalyticsChartOptions => ({
 const exploreLink = computed(() => {
   if (queryBridge && queryBridge.exploreBaseUrl) {
     const exploreQuery: ExploreQuery | AiExploreQuery = {
-      filters: props.query.filters?.map((filter) => {
-        return {
-          ...filter,
-          type: filter.type,
-        } as ExploreFilter
-      }) ?? [],
+      filters: props.query.filters ?? [],
       metrics: props.query.metrics as ExploreAggregations[] | AiExploreAggregations[] ?? [],
       dimensions: props.query.dimensions as QueryableExploreDimensions[] | QueryableAiExploreDimensions[] ?? [],
       time_range: props.query.time_range as TimeRangeV4 || props.context.timeSpec,

--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -11,6 +11,7 @@
         :chart-data="data"
         :chart-options="options"
         :chart-title="chartOptions.chartTitle"
+        :go-to-explore="exploreLink"
         legend-position="bottom"
         :show-menu="context.editable"
         :synthetics-data-key="chartOptions.syntheticsDataKey"
@@ -33,15 +34,18 @@
 <script setup lang="ts">
 import type { RendererProps } from '../types'
 import QueryDataProvider from './QueryDataProvider.vue'
-import { computed, defineProps } from 'vue'
+import { computed, defineProps, inject } from 'vue'
 import type { AnalyticsChartOptions } from '@kong-ui-public/analytics-chart'
 import { AnalyticsChart } from '@kong-ui-public/analytics-chart'
 import composables from '../composables'
+import { INJECT_QUERY_PROVIDER } from '../constants'
+import type { AiExploreAggregations, AiExploreQuery, AnalyticsBridge, ExploreAggregations, ExploreFilter, ExploreQuery, QueryableAiExploreDimensions, QueryableExploreDimensions, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
 
 const props = defineProps<RendererProps<any> & { extraProps?: Record<string, any> }>()
 const emit = defineEmits<{
   (e: 'edit-tile'): void
 }>()
+const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
 const { i18n } = composables.useI18n()
 
 const options = computed((): AnalyticsChartOptions => ({
@@ -49,6 +53,26 @@ const options = computed((): AnalyticsChartOptions => ({
   stacked: props.chartOptions.stacked ?? false,
   chartDatasetColors: props.chartOptions.chartDatasetColors,
 }))
+
+const exploreLink = computed(() => {
+  if (queryBridge && queryBridge.exploreBaseUrl) {
+    const exploreQuery: ExploreQuery | AiExploreQuery = {
+      filters: props.query.filters?.map((filter) => {
+        return {
+          ...filter,
+          type: filter.type,
+        } as ExploreFilter
+      }) ?? [],
+      metrics: props.query.metrics as ExploreAggregations[] | AiExploreAggregations[] ?? [],
+      dimensions: props.query.dimensions as QueryableExploreDimensions[] | QueryableAiExploreDimensions[] ?? [],
+      time_range: props.query.time_range as TimeRangeV4 || props.context.timeSpec,
+
+    } as ExploreQuery | AiExploreQuery
+    return `${queryBridge.exploreBaseUrl}?q=${JSON.stringify(exploreQuery)}&d=${props.query.datasource}&c=${props.chartOptions.type}`
+  }
+
+  return ''
+})
 
 const editTile = () => {
   emit('edit-tile')


### PR DESCRIPTION
# Summary

- Add optional `exploreBaseUrl` property to AnalyticsQueryBridge interface
- If Query Bridge is provided with an `exploreBaseUrl` this will be forwarded to `analytics-chart` along with the explore query, datasource and chart type as the `go-to-explore` link, which will show the go to explore option in the analytics chart kebab menu
- Updated "go to explore" text to match figma

https://konghq.atlassian.net/browse/MA-3380

![image](https://github.com/user-attachments/assets/f1d5628b-97b8-48a4-aeba-365db950fdfe)


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
