### PR TITLE
fix(entities-routes): placeholder should reflect actual behavior

### DIFF
--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -353,7 +353,8 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   if (isExactMatch) {
     return {
       isExactMatch,
-      placeholder: t(`search.placeholder.${props.config.app}`),
+      // force exact placeholder if `props.config.isExactMatch` is true
+      placeholder: t(`search.placeholder.${props.config.isExactMatch ? 'exact' : props.config.app}`),
     } as ExactMatchFilterConfig
   }
 

--- a/packages/entities/entities-routes/src/locales/en.json
+++ b/packages/entities/entities-routes/src/locales/en.json
@@ -12,6 +12,7 @@
   "search": {
     "placeholder": {
       "konnect": "Filter by name",
+      "exact": "Filter by exact name or ID",
       "kongManager": "Filter by exact name or ID"
     },
     "no_results": "No results found"


### PR DESCRIPTION
# Summary

[KM-673](https://konghq.atlassian.net/browse/KM-673)

If `<RouteList>` receives `config.isExactMatch: true`, the placeholder should reflect that.

[KM-673]: https://konghq.atlassian.net/browse/KM-673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ