### PR TITLE
fix(entities-plugins): ai-proxy-advanced form

### DIFF
--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -4,6 +4,7 @@ import { customFields, getSharedFormName } from '@kong-ui-public/forms'
 import { PLUGIN_METADATA } from '../definitions/metadata'
 import { aiPromptDecoratorSchema } from '../definitions/schemas/AIPromptDecorator'
 import { aiPromptTemplateSchema } from '../definitions/schemas/AIPromptTemplate'
+import { aiProxyAdvancedSchema } from '../definitions/schemas/AIProxyAdvanced'
 import { aiRateLimitingAdvancedSchema } from '../definitions/schemas/AIRateLimitingAdvanced'
 import { applicationRegistrationSchema } from '../definitions/schemas/ApplicationRegistration'
 import { ArrayInputFieldSchema } from '../definitions/schemas/ArrayInputFieldSchema'
@@ -125,6 +126,10 @@ export const useSchemas = (options?: UseSchemasOptions) => {
 
     'ai-prompt-template': {
       ...aiPromptTemplateSchema,
+    },
+
+    'ai-proxy-advanced': {
+      ...aiProxyAdvancedSchema,
     },
 
     'ai-rate-limiting-advanced': {

--- a/packages/entities/entities-plugins/src/definitions/schemas/AIProxyAdvanced.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/AIProxyAdvanced.ts
@@ -1,0 +1,38 @@
+import type { CommonSchemaFields } from '../../types/plugins/shared'
+
+export const aiProxyAdvancedSchema: CommonSchemaFields = {
+  // For the ai-proxy-advanced plugin, 'config-embeddings' and 'config-vectordb' fields are non-required
+  // but they have nested fields that are required. If the nested fields are not provided, 'config-embeddings'
+  // and 'config-vectordb' should be set to null in the payload.
+  shamefullyTransformPayload: ({ originalModel, model, payload }) => {
+    const isDirty = (key: string) => {
+      // if the model value is the same as the original value
+      // the field is not dirty
+      if (originalModel[key] === model[key]) {
+        return false
+      }
+
+      // if the original value is null, and the model value is not empty or NaN
+      // the field is dirty
+      if (originalModel[key] === null) {
+        return model[key] !== '' && !Number.isNaN(model[key])
+      }
+
+      // if the original value is not null, and the model value is not the same as the original value
+      // the field is dirty
+      return true
+    }
+
+    const hasDirtyFields = (prefix: string) => Object.keys(originalModel)
+      .some(key => key.startsWith(prefix) && isDirty(key))
+
+    // If 'config-embeddings-*' fields are not dirty, set 'config-embeddings' to null in the payload
+    if (!hasDirtyFields('config-embeddings')) {
+      payload.config.embeddings = null
+    }
+    // If 'config-vectordb-*' fields are not dirty, set 'config-vectordb' to null in the payload
+    if (!hasDirtyFields('config-vectordb')) {
+      payload.config.vectordb = null
+    }
+  },
+}

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -200,6 +200,7 @@ export interface CustomSchemas {
   'route-by-header': RouteByHeaderSchema
   'ai-prompt-decorator': AIPromptDecoratorSchema
   'ai-prompt-template': AIPromptTemplateSchema
+  'ai-proxy-advanced': CommonSchemaFields
   'ai-rate-limiting-advanced': AIRateLimitingAdvancedSchema
   'vault-auth': VaultAuthSchema
   'graphql-rate-limiting-advanced': GraphQLRateLimitingAdvancedSchema

--- a/packages/entities/entities-plugins/src/types/plugins/shared.d.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/shared.d.ts
@@ -44,4 +44,5 @@ export interface CommonSchemaFields {
   id?: string
   overwriteDefault?: boolean
   formSchema?: Record<string, any>
+  shamefullyTransformPayload?: (params: { payload: Record<string, any> } & Record<string, any>) => void
 }


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This is a temporary workaround for the issue that the `ai-proxy-advanced` plugin cannot be created if users don't provide `config.embeddings` or `config.vectordb`.

KM-675
