### PR TITLE
fix(entities): plugin icon size and tag warning

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
@@ -39,7 +39,7 @@
           <PluginIcon
             class="plugin-icon"
             :name="getPropValue('rowValue', slotProps)"
-            :width="24"
+            :size="24"
           />
           <span class="info-name">
             {{ pluginMetaData.getDisplayName(getPropValue('rowValue', slotProps)) }}

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -54,7 +54,7 @@
           <PluginIcon
             class="plugin-icon"
             :name="row.name"
-            :width="24"
+            :size="24"
           />
           <div class="info-wrapper">
             <span

--- a/packages/entities/entities-shared/src/components/common/TableTags.vue
+++ b/packages/entities/entities-shared/src/components/common/TableTags.vue
@@ -20,7 +20,6 @@ const props = defineProps({
   /** The tags to display in the table */
   tags: {
     type: [Array, String],
-    required: true,
   },
   tagMaxWidth: {
     type: String,


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This PR fixes the plugin icon size:

<img width="746" alt="image" src="https://github.com/user-attachments/assets/ffb7554c-2a97-4a38-8309-e1a36c9c343b">

<img width="778" alt="image" src="https://github.com/user-attachments/assets/616c064e-470d-431d-851a-dbc44c087618">


It also fixes a console warning:

<img width="732" alt="image" src="https://github.com/user-attachments/assets/304f73e5-99a2-40c2-8376-d034c8845441">
