### PR TITLE
fix(i18n): compatible with timestamp in milliseconds or null values

### DIFF
--- a/packages/core/i18n/src/i18n.spec.ts
+++ b/packages/core/i18n/src/i18n.spec.ts
@@ -131,6 +131,7 @@ describe('i18n', () => {
       const november = formatUnixTimeStamp(1573772400)
       const decimalTimestamp = formatUnixTimeStamp(1570111995.652561)
       const integerTimestamp = formatUnixTimeStamp(1570111995)
+      const timestampInMs = formatUnixTimeStamp(1570111995652)
 
       expect(formattedDateAM).toBe('May 16, 2019, 11:42 AM')
       expect(formattedDatePM).toBe('May 17, 2019, 1:39 AM')
@@ -138,6 +139,7 @@ describe('i18n', () => {
       expect(october.substring(0, 7)).toBe('Oct 3, ')
       expect(november.substring(0, 7)).toBe('Nov 14,')
       expect(decimalTimestamp).toEqual(integerTimestamp)
+      expect(timestampInMs).toBe('Nov 13, 2018, 0:08 AM')
     })
   })
 

--- a/packages/core/i18n/src/i18n.spec.ts
+++ b/packages/core/i18n/src/i18n.spec.ts
@@ -139,7 +139,7 @@ describe('i18n', () => {
       expect(october.substring(0, 7)).toBe('Oct 3, ')
       expect(november.substring(0, 7)).toBe('Nov 14,')
       expect(decimalTimestamp).toEqual(integerTimestamp)
-      expect(timestampInMs).toBe('Nov 13, 2018, 12:08 PM')
+      expect(timestampInMs).toBe('Nov 13, 2018, 12:18 AM')
     })
   })
 

--- a/packages/core/i18n/src/i18n.spec.ts
+++ b/packages/core/i18n/src/i18n.spec.ts
@@ -139,7 +139,7 @@ describe('i18n', () => {
       expect(october.substring(0, 7)).toBe('Oct 3, ')
       expect(november.substring(0, 7)).toBe('Nov 14,')
       expect(decimalTimestamp).toEqual(integerTimestamp)
-      expect(timestampInMs).toBe('Nov 13, 2018, 0:08 AM')
+      expect(timestampInMs).toBe('Nov 13, 2018, 2:13 PM')
     })
   })
 

--- a/packages/core/i18n/src/i18n.spec.ts
+++ b/packages/core/i18n/src/i18n.spec.ts
@@ -131,7 +131,7 @@ describe('i18n', () => {
       const november = formatUnixTimeStamp(1573772400)
       const decimalTimestamp = formatUnixTimeStamp(1570111995.652561)
       const integerTimestamp = formatUnixTimeStamp(1570111995)
-      const timestampInMs = formatUnixTimeStamp(1570111995652)
+      const timestampInMs = formatUnixTimeStamp(1542068280000)
 
       expect(formattedDateAM).toBe('May 16, 2019, 11:42 AM')
       expect(formattedDatePM).toBe('May 17, 2019, 1:39 AM')
@@ -139,7 +139,7 @@ describe('i18n', () => {
       expect(october.substring(0, 7)).toBe('Oct 3, ')
       expect(november.substring(0, 7)).toBe('Nov 14,')
       expect(decimalTimestamp).toEqual(integerTimestamp)
-      expect(timestampInMs).toBe('Nov 13, 2018, 2:13 PM')
+      expect(timestampInMs).toBe('Nov 13, 2018, 12:08 PM')
     })
   })
 

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -70,10 +70,10 @@ export const createI18n = <MessageSource extends Record<string, any>>
    * @param {Number} timestamp a unix timestamp in seconds
    * @returns a date string formatted like 'Apr 6, 2022 10:50'
    */
-  const formatUnixTimeStamp = (timestamp?: number | null): string => {
+  const formatUnixTimeStamp = (timestamp: number): string => {
     const invalidDate = 'Invalid Date'
     if (!timestamp) {
-      return '-'
+      return invalidDate
     }
 
     try {

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -53,18 +53,31 @@ export const createI18n = <MessageSource extends Record<string, any>>
   const intl = otherProps
 
   /**
+   * Shamefully normalize a timestamp to be in seconds as some APIs are returning timestamps in milliseconds
+   * TODO: Remove this function once all timestamps are normalized from the backend
+   * @param {number} timestamp a unix timestamp in seconds *or milliseconds*
+   * @returns {number} a unix timestamp in seconds
+   */
+  const shamefullyNormalizeTimeStamp = (timestamp: number): number => {
+    if (timestamp.toString().length === 13) {
+      return Math.floor(timestamp / 1000)
+    }
+    return timestamp
+  }
+
+  /**
    * Formats a unix timestamp into a formatted date string
    * @param {Number} timestamp a unix timestamp in seconds
    * @returns a date string formatted like 'Apr 6, 2022 10:50'
    */
-  const formatUnixTimeStamp = (timestamp: number): string => {
+  const formatUnixTimeStamp = (timestamp?: number | null): string => {
     const invalidDate = 'Invalid Date'
     if (!timestamp) {
-      return invalidDate
+      return '-'
     }
 
     try {
-      const date = new Date(timestamp * 1000)
+      const date = new Date(shamefullyNormalizeTimeStamp(timestamp) * 1000)
 
       return intl.formatDate(date, datetimeFormat)
     } catch (err) {
@@ -83,15 +96,27 @@ export const createI18n = <MessageSource extends Record<string, any>>
     return formatUnixTimeStamp(date)
   }
 
-  const t = (translationKey: PathToDotNotation<MessageSource, string>, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions): string => {
-    return intl.formatMessage(<MessageDescriptor>{ id: translationKey }, values, opts)
+  const t = (
+    translationKey: PathToDotNotation<MessageSource, string>,
+    values?: Record<string, MessageFormatPrimitiveValue> | undefined,
+    opts?: IntlMessageFormatOptions,
+  ): string => {
+    return intl.formatMessage(
+      <MessageDescriptor>{ id: translationKey },
+      values,
+      opts,
+    )
   }
 
-  const te = (translationKey: PathToDotNotation<MessageSource, string>): boolean => {
+  const te = (
+    translationKey: PathToDotNotation<MessageSource, string>,
+  ): boolean => {
     return !!intl.messages[translationKey]
   }
 
-  const tm = (translationKey: PathToDotNotation<MessageSource, string>): Array<string> => {
+  const tm = (
+    translationKey: PathToDotNotation<MessageSource, string>,
+  ): Array<string> => {
     // @ts-ignore: string is valid key
     return intl.messages[translationKey] || []
   }
@@ -106,7 +131,10 @@ export const createI18n = <MessageSource extends Record<string, any>>
     source: messages,
   }
 
-  if ((typeof (config) === 'boolean' && config === true) || (typeof (config) !== 'boolean' && config.isGlobal === true)) {
+  if (
+    (typeof config === 'boolean' && config === true) ||
+    (typeof config !== 'boolean' && config.isGlobal === true)
+  ) {
     globIntl = localIntl
   }
 

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -96,27 +96,15 @@ export const createI18n = <MessageSource extends Record<string, any>>
     return formatUnixTimeStamp(date)
   }
 
-  const t = (
-    translationKey: PathToDotNotation<MessageSource, string>,
-    values?: Record<string, MessageFormatPrimitiveValue> | undefined,
-    opts?: IntlMessageFormatOptions,
-  ): string => {
-    return intl.formatMessage(
-      <MessageDescriptor>{ id: translationKey },
-      values,
-      opts,
-    )
+  const t = (translationKey: PathToDotNotation<MessageSource, string>, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions): string => {
+    return intl.formatMessage(<MessageDescriptor>{ id: translationKey }, values, opts)
   }
 
-  const te = (
-    translationKey: PathToDotNotation<MessageSource, string>,
-  ): boolean => {
+  const te = (translationKey: PathToDotNotation<MessageSource, string>): boolean => {
     return !!intl.messages[translationKey]
   }
 
-  const tm = (
-    translationKey: PathToDotNotation<MessageSource, string>,
-  ): Array<string> => {
+  const tm = (translationKey: PathToDotNotation<MessageSource, string>): Array<string> => {
     // @ts-ignore: string is valid key
     return intl.messages[translationKey] || []
   }
@@ -131,10 +119,7 @@ export const createI18n = <MessageSource extends Record<string, any>>
     source: messages,
   }
 
-  if (
-    (typeof config === 'boolean' && config === true) ||
-    (typeof config !== 'boolean' && config.isGlobal === true)
-  ) {
+  if ((typeof (config) === 'boolean' && config === true) || (typeof (config) !== 'boolean' && config.isGlobal === true)) {
     globIntl = localIntl
   }
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -85,8 +85,8 @@
       <template #created_at="{ rowValue }">
         {{ formatUnixTimeStamp(rowValue) }}
       </template>
-      <template #updated_at="{ rowValue }">
-        {{ formatUnixTimeStamp(rowValue) }}
+      <template #updated_at="{ row, rowValue }">
+        {{ formatUnixTimeStamp(rowValue ?? row.created_at) }}
       </template>
 
       <!-- Row actions -->

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -120,8 +120,8 @@
       <template #created_at="{ rowValue }">
         {{ formatUnixTimeStamp(rowValue) }}
       </template>
-      <template #updated_at="{ rowValue }">
-        {{ formatUnixTimeStamp(rowValue) }}
+      <template #updated_at="{ row, rowValue }">
+        {{ formatUnixTimeStamp(rowValue ?? row.created_at) }}
       </template>
 
       <!-- Row actions -->

--- a/packages/entities/entities-vaults/src/components/SecretListInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretListInner.vue
@@ -44,8 +44,8 @@
         <b>{{ rowValue ?? '-' }}</b>
       </div>
     </template>
-    <template #updated_at="{ row, rowValue }">
-      {{ formatUnixTimeStamp(rowValue ?? row.created_at) }}
+    <template #updated_at="{ rowValue }">
+      <span>{{ rowValue ? formatUnixTimeStamp(new Date(rowValue).getTime() / 1000) : '-' }}</span>
     </template>
 
     <!-- Row actions -->

--- a/packages/entities/entities-vaults/src/components/SecretListInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretListInner.vue
@@ -44,8 +44,8 @@
         <b>{{ rowValue ?? '-' }}</b>
       </div>
     </template>
-    <template #updated_at="{ rowValue }">
-      <span>{{ rowValue ? formatUnixTimeStamp(new Date(rowValue).getTime() / 1000) : '-' }}</span>
+    <template #updated_at="{ row, rowValue }">
+      {{ formatUnixTimeStamp(rowValue ?? row.created_at) }}
     </template>
 
     <!-- Row actions -->


### PR DESCRIPTION
# Summary

The filter API is returning timestamps in milliseconds instead of seconds and `null` as `updated_at` values for those weren't modified since created. The issue affects both filtered services and routes.

Before:

<img width="458" alt="image" src="https://github.com/user-attachments/assets/7c447603-9cf4-4d6f-ac29-1b6c8ed961f2">

After:

<img width="437" alt="image" src="https://github.com/user-attachments/assets/02cee67a-a4bc-4dca-8772-9babac7143c4">
