### PR TITLE
chore(entity-base-table): fix missing prop warning

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -200,7 +200,6 @@ const props = defineProps({
   preferencesStorageKey: {
     type: String,
     default: '',
-    required: true,
   },
   /** default table preferences to use if no user preferences are found */
   defaultTablePreferences: {


### PR DESCRIPTION
# Summary

Defining `preferencesStorageKey` cause missing prop warning in console. Since `preferencesStorageKey` has a default value, it can be removed.
