### PR TITLE
fix(entities-shared): truncate labels in config card items

### DIFF
--- a/packages/entities/entities-shared/sandbox/pages/ConfigCardItemPage.vue
+++ b/packages/entities/entities-shared/sandbox/pages/ConfigCardItemPage.vue
@@ -191,6 +191,40 @@
       </template>
     </ConfigCardItem>
 
+    <h2>Truncated Labels</h2>
+    <ConfigCardItem
+      :item="{
+        key: 'truncated-label-1',
+        label: 'Super Long Label Will Also Be Truncated With A Tooltip',
+        value: 'I am a really long string but I am not truncated.',
+      }"
+    />
+    <ConfigCardItem
+      :item="{
+        key: 'truncated-label-2',
+        label: 'Double Tooltips! Super Long Label Will Also Be Truncated With A Tooltip',
+        value: 'I am a really long string but I am not truncated.',
+        tooltip: 'I am the tooltip for the supaa long label',
+      }"
+    />
+    <ConfigCardItem
+      :item="{
+        key: 'truncated-label-3',
+        label: 'Super Long Label Will Also Be Truncated With A Tooltip',
+        value: 'I am a really long string and I am truncated.',
+      }"
+      truncated
+    />
+    <ConfigCardItem
+      :item="{
+        key: 'truncated-label-4',
+        label: 'Double Tooltips! Super Long Label Will Also Be Truncated With A Tooltip',
+        value: 'I am a really long string and I am truncated.',
+        tooltip: 'I am the tooltip for the supaa long label',
+      }"
+      truncated
+    />
+
     <h2>Slim card</h2>
     <div style="width: 400px;">
       <ConfigCardItem
@@ -234,6 +268,42 @@
           value: 'I am a really long string but I am not truncated.',
         }"
         slim
+      />
+      <ConfigCardItem
+        :item="{
+          key: 'slim6',
+          label: 'Super Long Label Will Also Be Truncated With A Tooltip',
+          value: 'I am a really long string but I am not truncated.',
+        }"
+        slim
+      />
+      <ConfigCardItem
+        :item="{
+          key: 'slim7',
+          label: 'Double Tooltips! Super Long Label Will Also Be Truncated With A Tooltip',
+          value: 'I am a really long string but I am not truncated.',
+          tooltip: 'I am the tooltip for the supaa long label',
+        }"
+        slim
+      />
+      <ConfigCardItem
+        :item="{
+          key: 'slim8',
+          label: 'Super Long Label Will Also Be Truncated With A Tooltip',
+          value: 'I am a really long string and I am truncated.',
+        }"
+        slim
+        truncated
+      />
+      <ConfigCardItem
+        :item="{
+          key: 'slim9',
+          label: 'Double Tooltips! Super Long Label Will Also Be Truncated With A Tooltip',
+          value: 'I am a really long string and I am truncated.',
+          tooltip: 'I am the tooltip for the supaa long label',
+        }"
+        slim
+        truncated
       />
     </div>
   </div>

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
@@ -54,11 +54,11 @@ describe('<ConfigCardItem />', () => {
       cy.getTestId(`${item.key}-label-tooltip`).should('not.exist')
 
       cy.get('.config-card-details-row').invoke('width').then((rowWidth) => {
-        cy.getTestId(`${item.key}-label`).invoke('width').then((labelWidth) => {
+        cy.getTestId(`${item.key}-label`).invoke('outerWidth').then((labelWidth) => {
           expect(labelWidth).to.be.closeTo(Number(rowWidth) / 2, 1)
         })
-        cy.getTestId(`${item.key}-plain-text`).invoke('width').then((labelWidth) => {
-          expect(labelWidth).to.be.closeTo(Number(rowWidth) / 2, 1)
+        cy.getTestId(`${item.key}-property-value`).invoke('outerWidth').then((valueWidth) => {
+          expect(valueWidth).to.be.closeTo(Number(rowWidth) / 2, 1)
         })
       })
     })

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -9,7 +9,15 @@
         name="label"
       >
         <KLabel :tooltip-attributes="{ maxWidth: '500px' }">
-          {{ item.label }}
+          <KTooltip :text="isLabelTruncated ? item.label : ''">
+            <span
+              ref="labelContent"
+              class="label-content"
+            >
+              {{ item.label }}
+            </span>
+          </KTooltip>
+
           <template
             v-if="hasTooltip"
             #tooltip
@@ -308,10 +316,11 @@ const componentAttrsData = computed((): ComponentAttrsData => {
   }
 })
 
+const labelContent = ref<HTMLElement>()
 const textContent = ref<HTMLElement>()
 
+const { isTruncated: isLabelTruncated } = composables.useTruncationDetector(labelContent as Ref<HTMLElement>)
 const { isTruncated } = composables.useTruncationDetector(textContent as Ref<HTMLElement>)
-
 </script>
 
 <script lang="ts">
@@ -327,20 +336,38 @@ export default {
 .config-card-details-row {
   align-items: center;
   border-bottom: v-bind('isJsonArray ? "none" : `solid ${KUI_BORDER_WIDTH_10} ${KUI_COLOR_BORDER}`');
+  box-sizing: border-box;
   display: v-bind('isJson && itemHasValue ? "block" : "flex"');
   padding: $kui-space-60;
   padding-left: 0;
   width: 100%;
 
   .config-card-details-label {
+    box-sizing: border-box;
+    padding-right: $kui-space-60;
     width: v-bind('isJson && itemHasValue ? "100%" : props.slim ? "50%" : "25%"');
 
     label {
       color: $kui-color-text-neutral-stronger;
+      display: inline-flex;
+      max-width: 100%;
+
+      .label-content {
+        line-height: initial;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .k-popover {
+        min-width: 0;
+      }
     }
   }
 
   .config-card-details-value {
+    box-sizing: border-box;
     width: v-bind('isJson && itemHasValue ? "100%" : props.slim ? "50%" : "75%"');
 
     .truncated {


### PR DESCRIPTION
# Summary

This pull request fixes the several issues with `<ConfigCardItem />`:

1. Incorrect `box-sizing`
2. Label text overflows when too long

|Before|After|
|:-|:-|
|![Screenshot 2024-11-19 at 12 32 45 2](https://github.com/user-attachments/assets/f1ebcd6c-cf0a-4918-b10c-9753b2487f7a)|<video src="https://github.com/user-attachments/assets/baad9400-e7ce-4b28-9489-1d5dc37358af">|

KM-719

