### PR TITLE
fix(forms): number values in map fields

### DIFF
--- a/packages/core/forms/src/components/fields/FieldObjectAdvanced.vue
+++ b/packages/core/forms/src/components/fields/FieldObjectAdvanced.vue
@@ -220,7 +220,9 @@ export default {
         this.subSchema.fields.length === 1 &&
         this.subSchema.fields[0].type === 'array'
       const defaultValue = this.schema.values?.default ?? (this.valueInputType === 'number' ? 0 : '')
-      const initialValue = this.subSchema ? valueIsArray ? [''] : {} : defaultValue
+      const initialValue = this.subSchema
+        ? (valueIsArray ? [''] : {})
+        : defaultValue
 
       this.value[this.newKeyName] = initialValue
       this.newKeyName = ''

--- a/packages/core/forms/src/components/fields/FieldObjectAdvanced.vue
+++ b/packages/core/forms/src/components/fields/FieldObjectAdvanced.vue
@@ -39,7 +39,7 @@
               v-model="value[index]"
               class="form-control"
               :placeholder="schema.fields && schema.fields[0].schema.placeholder"
-              type="text"
+              :type="valueInputType"
               @input="updateModel(value[index], model[schema.model])"
             >
             <p
@@ -134,6 +134,9 @@ export default {
 
       return this.model[this.schema.model]
     },
+    valueInputType() {
+      return ['number', 'integer'].includes(this.schema.values?.type) ? 'number' : 'text'
+    },
   },
   mounted() {
     if (!this.value) this.value = {}
@@ -216,9 +219,10 @@ export default {
         Array.isArray(this.subSchema.fields) &&
         this.subSchema.fields.length === 1 &&
         this.subSchema.fields[0].type === 'array'
-      const type = this.subSchema ? valueIsArray ? [''] : {} : ''
+      const defaultValue = this.schema.values?.default ?? ''
+      const initialValue = this.subSchema ? valueIsArray ? [''] : {} : defaultValue
 
-      this.value[this.newKeyName] = type
+      this.value[this.newKeyName] = initialValue
       this.newKeyName = ''
     },
 

--- a/packages/core/forms/src/components/fields/FieldObjectAdvanced.vue
+++ b/packages/core/forms/src/components/fields/FieldObjectAdvanced.vue
@@ -219,7 +219,7 @@ export default {
         Array.isArray(this.subSchema.fields) &&
         this.subSchema.fields.length === 1 &&
         this.subSchema.fields[0].type === 'array'
-      const defaultValue = this.schema.values?.default ?? ''
+      const defaultValue = this.schema.values?.default ?? (this.valueInputType === 'number' ? 0 : '')
       const initialValue = this.subSchema ? valueIsArray ? [''] : {} : defaultValue
 
       this.value[this.newKeyName] = initialValue


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Problematic field example:
```json
 {
    "trace_services": {
      "description": "Map of routes matchers with sampling rates, use when plugin mode is global",
      "keys": {
        "type": "string"
      },
      "type": "map",
      "values": {
        "between": [
          0,
          1
        ],
        "default": 0,
        "required": true,
        "type": "number"
      }
    }
  }
```

This PR ensures the form respects `"type": "number"` and `"default": 0`.

FTI-6360