### PR TITLE
fix(entities-routes): invisible expressions editor sometimes

### DIFF
--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -473,7 +473,7 @@ import type { SelectItem } from '@kong/kongponents'
 import type { AxiosError, AxiosResponse } from 'axios'
 import isEqual from 'lodash.isequal'
 import type { PropType } from 'vue'
-import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRef, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import composables from '../composables'
 import endpoints from '../routes-endpoints'
@@ -648,7 +648,7 @@ const getSelectedService = (item: any) => {
 
 /** Declare as BaseRouteStateFields but use type narrowing helper functions to allow accessing more fields */
 const state = reactive<RouteState<BaseRouteStateFields>>({
-  routeFlavors: props.routeFlavors,
+  routeFlavors: toRef(props, 'routeFlavors'),
   fields: {
     name: '',
     protocols: 'http,https',

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -473,7 +473,7 @@ import type { SelectItem } from '@kong/kongponents'
 import type { AxiosError, AxiosResponse } from 'axios'
 import isEqual from 'lodash.isequal'
 import type { PropType } from 'vue'
-import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRef, watch } from 'vue'
+import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import composables from '../composables'
 import endpoints from '../routes-endpoints'
@@ -648,7 +648,7 @@ const getSelectedService = (item: any) => {
 
 /** Declare as BaseRouteStateFields but use type narrowing helper functions to allow accessing more fields */
 const state = reactive<RouteState<BaseRouteStateFields>>({
-  routeFlavors: toRef(props, 'routeFlavors'),
+  routeFlavors: props.routeFlavors,
   fields: {
     name: '',
     protocols: 'http,https',
@@ -660,7 +660,7 @@ const state = reactive<RouteState<BaseRouteStateFields>>({
     tags: '',
     service_id: '',
     ...{
-      ...(!props.routeId && { paths: [''] }),
+      ...(!props.routeId && { paths: [''] }), // We don't expect this prop to be updated throughout the lifecycle of the component
       regex_priority: 0,
       path_handling: 'v0',
     } as TraditionalRouteStateFields,
@@ -671,6 +671,10 @@ const state = reactive<RouteState<BaseRouteStateFields>>({
   },
   isReadonly: false,
   errorMessage: '',
+})
+
+watch(() => props.routeFlavors, (routeFlavors) => {
+  state.routeFlavors = routeFlavors
 })
 
 const exprEditorProtocol = computed(() => state.fields.protocols.split(',')[0])

--- a/packages/entities/entities-routes/src/types/route-form.ts
+++ b/packages/entities/entities-routes/src/types/route-form.ts
@@ -1,7 +1,6 @@
 import type { BaseFormConfig, KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
 import type { RouteLocationRaw } from 'vue-router'
-import type { Methods, Method } from './method-badge'
-import { unref, type MaybeRef } from 'vue'
+import type { Method, Methods } from './method-badge'
 
 export enum RouteFlavor {
   TRADITIONAL = 'traditional', // includes traditional_compatible
@@ -98,7 +97,7 @@ export interface ExpressionsRouteStateFields {
 }
 
 export interface RouteState<Fields extends BaseRouteStateFields> {
-  routeFlavors: MaybeRef<RouteFlavors> // For better type narrowing
+  routeFlavors: RouteFlavors // For better type narrowing
   fields: Fields
   isReadonly: boolean
   errorMessage: string
@@ -106,11 +105,11 @@ export interface RouteState<Fields extends BaseRouteStateFields> {
 
 /** Type narrowing down helper function */
 export const stateHasTraditionalFlavor = (state: RouteState<BaseRouteStateFields>): state is RouteState<BaseRouteStateFields & TraditionalRouteStateFields> =>
-  unref(state.routeFlavors).traditional === true
+  state.routeFlavors.traditional === true
 
 /** Type narrowing down helper function */
 export const stateHasExpressionsFlavor = (state: RouteState<BaseRouteStateFields>): state is RouteState<BaseRouteStateFields & ExpressionsRouteStateFields> =>
-  unref(state.routeFlavors).expressions === true
+  state.routeFlavors.expressions === true
 
 export interface Headers {
   [key: string]: string[]

--- a/packages/entities/entities-routes/src/types/route-form.ts
+++ b/packages/entities/entities-routes/src/types/route-form.ts
@@ -1,6 +1,7 @@
 import type { BaseFormConfig, KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
 import type { RouteLocationRaw } from 'vue-router'
 import type { Methods, Method } from './method-badge'
+import { unref, type MaybeRef } from 'vue'
 
 export enum RouteFlavor {
   TRADITIONAL = 'traditional', // includes traditional_compatible
@@ -97,7 +98,7 @@ export interface ExpressionsRouteStateFields {
 }
 
 export interface RouteState<Fields extends BaseRouteStateFields> {
-  routeFlavors: RouteFlavors // For better type narrowing
+  routeFlavors: MaybeRef<RouteFlavors> // For better type narrowing
   fields: Fields
   isReadonly: boolean
   errorMessage: string
@@ -105,11 +106,11 @@ export interface RouteState<Fields extends BaseRouteStateFields> {
 
 /** Type narrowing down helper function */
 export const stateHasTraditionalFlavor = (state: RouteState<BaseRouteStateFields>): state is RouteState<BaseRouteStateFields & TraditionalRouteStateFields> =>
-  state.routeFlavors.traditional === true
+  unref(state.routeFlavors).traditional === true
 
 /** Type narrowing down helper function */
 export const stateHasExpressionsFlavor = (state: RouteState<BaseRouteStateFields>): state is RouteState<BaseRouteStateFields & ExpressionsRouteStateFields> =>
-  state.routeFlavors.expressions === true
+  unref(state.routeFlavors).expressions === true
 
 export interface Headers {
   [key: string]: string[]


### PR DESCRIPTION
# Summary

This pull request fixes an issue where the expressions editor became invisible sometimes

KM-737
