### PR TITLE
fix: revert padding change for kebab menu ff

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -88,6 +88,6 @@ const onChartData = (data: ExploreResultV4) => {
 
 <style scoped lang="scss">
 .analytics-chart {
-  height: v-bind('`${height}px`');
+  height: 100%;
 }
 </style>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -48,7 +48,7 @@ import {
   TIMEFRAME_TOKEN,
 } from '../constants'
 import { useAnalyticsConfigStore } from '@kong-ui-public/analytics-config-store'
-import { KUI_SPACE_70, KUI_SPACE_30 } from '@kong/design-tokens'
+import { KUI_SPACE_70 } from '@kong/design-tokens'
 
 const props = defineProps<{
   context: DashboardRendererContext,
@@ -72,9 +72,6 @@ if (!queryBridge) {
   console.warn("Please ensure your application has a query bridge provided under the key 'analytics-query-provider', as described in")
   console.warn('https://github.com/Kong/public-ui-components/blob/main/packages/analytics/dashboard-renderer/README.md#requirements')
 }
-
-const { evaluateFeatureFlag } = composables.useEvaluateFeatureFlag()
-const hasKebabMenuAccess = evaluateFeatureFlag('ma-3043-analytics-chart-kebab-menu', false)
 
 const configStore = useAnalyticsConfigStore()
 
@@ -185,7 +182,7 @@ defineExpose({ refresh: refreshTiles })
     border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
     border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
     height: 100%;
-    padding: v-bind('!hasKebabMenuAccess ? KUI_SPACE_70 : KUI_SPACE_30');
+    padding: var(--kui-space-70, $kui-space-70);
   }
 }
 </style>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -69,12 +69,14 @@
         @toggle-modal="setExportModalVisibility"
       />
     </div>
-    <component
-      :is="componentData.component"
-      v-if="componentData"
-      v-bind="componentData.rendererProps"
-      @chart-data="onChartData"
-    />
+    <div class="tile-content">
+      <component
+        :is="componentData.component"
+        v-if="componentData"
+        v-bind="componentData.rendererProps"
+        @chart-data="onChartData"
+      />
+    </div>
   </div>
 </template>
 <script setup lang="ts">
@@ -189,6 +191,8 @@ const exportCsv = () => {
 
 <style lang="scss" scoped>
 .tile-boundary {
+  display: flex;
+  flex-direction: column;
   height: v-bind('`${height}px`');
 
   .tile-header {
@@ -245,6 +249,10 @@ const exportCsv = () => {
         cursor: pointer;
       }
     }
+  }
+
+  .tile-content {
+    flex-grow: 1;
   }
 }
 </style>


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-3465

- Make the `.tile-boundary` have `display: flex` then create a new tile-content div to wrap the component rendered in the tile.
- Use `flex-grow: 1` on the `.tile-content` so that it takes up available space (taking siblings into account) 
- The analytics chart renderer component can now use `height: 100%` and it will gracefully stay within the bounds of its container, vertically. 

There should be visible effect on users from this change. 

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
