### PR TITLE
fix: kebab menu dropdown placement and alignment

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -15,6 +15,7 @@
         v-if="canShowKebabMenu"
         class="dropdown"
         data-testid="chart-action-menu"
+        :kpop-attributes="{ placement: 'bottom-end' }"
       >
         <button
           appearance="none"

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -15,5 +15,5 @@
     "defaultFilename": "Chart Export",
     "exportAsCsv": "Export as CSV"
   },
-  "jumpToExplore": "Open in Explorer"
+  "jumpToExplore": "Explore"
 }


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-3472
https://konghq.atlassian.net/browse/MA-3473

- align kebab menu dropdown `bottom-end`
- Rename "Open in Explorer" -> "Explore"

<img width="248" alt="image" src="https://github.com/user-attachments/assets/3fa855c1-a0a5-453d-b7bc-8752d200531a">


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
