### PR TITLE
fix(entities-*): persist fetcher cache key within session

### DIFF
--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-ca-certificates-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-ca-certificates-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -225,7 +225,6 @@ const { i18n: { t, formatUnixTimeStamp }, i18nT } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -273,7 +272,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const preferencesStorageKey = 'kong-ui-entities-ca-certificates-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-ca-certificates-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-ca-certificates-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -272,14 +272,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-ca-certificates-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-certificates-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-certificates-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -255,7 +255,6 @@ const { i18n: { t, formatUnixTimeStamp }, i18nT } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -305,7 +304,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const preferencesStorageKey = 'kong-ui-entities-certificates-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-certificates-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-certificates-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -304,14 +304,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-certificates-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-consumer-credentials-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       disable-row-click
       disable-sorting
       :empty-state-options="emptyStateOptions"
@@ -10,7 +10,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-consumer-credentials-list"
       :table-headers="tableHeaders"
       @sort="resetPagination"
     >
@@ -327,14 +327,11 @@ const fetcherBaseUrl = computed((): string => {
   return url
 })
 
-const preferencesStorageKey = 'kong-ui-entities-consumer-credentials-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const resetPagination = (): void => {
   // Increment the cache key on sort

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-consumer-credentials-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       disable-row-click
       disable-sorting
       :empty-state-options="emptyStateOptions"
@@ -10,7 +10,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-consumer-credentials-list"
+      :preferences-storage-key="preferencesStorageKey"
       :table-headers="tableHeaders"
       @sort="resetPagination"
     >
@@ -259,7 +259,6 @@ const props = defineProps({
 const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -328,7 +327,14 @@ const fetcherBaseUrl = computed((): string => {
   return url
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl)
+const preferencesStorageKey = 'kong-ui-entities-consumer-credentials-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const resetPagination = (): void => {
   // Increment the cache key on sort

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-consumer-groups-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-pagination="isConsumerPage && !config.paginatedEndpoint"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
@@ -330,7 +330,6 @@ const isConsumerPage = computed<boolean>(() => !!props.config.consumerId)
 const preferencesStorageKey = computed<string>(
   () => isConsumerPage.value ? 'kong-ui-entities-consumer-groups-list-in-consumer-page' : 'kong-ui-entities-consumer-groups-list',
 )
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey.value)
 const dataKeyName = computed((): string | undefined => {
   if (props.config.app === 'konnect' && filterQuery.value) {
     return 'consumer_group'
@@ -342,7 +341,7 @@ const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value, dataKeyName)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value, dataKeyName)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-consumer-groups-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-pagination="isConsumerPage && !config.paginatedEndpoint"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
@@ -262,11 +262,6 @@ const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
-const isConsumerPage = computed<boolean>(() => !!props.config.consumerId)
-const preferencesStorageKey = computed<string>(
-  () => isConsumerPage.value ? 'kong-ui-entities-consumer-groups-list-in-consumer-page' : 'kong-ui-entities-consumer-groups-list',
-)
 
 /**
  * Table Headers
@@ -331,6 +326,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
+const isConsumerPage = computed<boolean>(() => !!props.config.consumerId)
+const preferencesStorageKey = computed<string>(
+  () => isConsumerPage.value ? 'kong-ui-entities-consumer-groups-list-in-consumer-page' : 'kong-ui-entities-consumer-groups-list',
+)
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey.value)
 const dataKeyName = computed((): string | undefined => {
   if (props.config.app === 'konnect' && filterQuery.value) {
     return 'consumer_group'
@@ -338,7 +338,11 @@ const dataKeyName = computed((): string | undefined => {
   return isConsumerPage.value && !props.config.paginatedEndpoint ? 'consumer_groups' : undefined
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value, dataKeyName)
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value, dataKeyName)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-consumers-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -262,11 +262,6 @@ const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
-const isConsumerGroupPage = computed<boolean>(() => !!props.config.consumerGroupId)
-const preferencesStorageKey = computed<string>(
-  () => isConsumerGroupPage.value ? 'kong-ui-entities-consumers-list-in-group-page' : 'kong-ui-entities-consumers-list',
-)
 
 /**
  * Table Headers
@@ -323,8 +318,18 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     schema: props.config.filterSchema,
   } as FuzzyMatchFilterConfig
 })
+
+const isConsumerGroupPage = computed<boolean>(() => !!props.config.consumerGroupId)
+const preferencesStorageKey = computed<string>(
+  () => isConsumerGroupPage.value ? 'kong-ui-entities-consumers-list-in-group-page' : 'kong-ui-entities-consumers-list',
+)
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey.value)
 const dataKeyName = computed((): string | undefined => isConsumerGroupPage.value && !props.config.paginatedEndpoint ? 'consumers' : undefined)
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value, dataKeyName.value)
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value, dataKeyName.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-consumers-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -323,13 +323,12 @@ const isConsumerGroupPage = computed<boolean>(() => !!props.config.consumerGroup
 const preferencesStorageKey = computed<string>(
   () => isConsumerGroupPage.value ? 'kong-ui-entities-consumers-list-in-group-page' : 'kong-ui-entities-consumers-list',
 )
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey.value)
 const dataKeyName = computed((): string | undefined => isConsumerGroupPage.value && !props.config.paginatedEndpoint ? 'consumers' : undefined)
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value, dataKeyName.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value, dataKeyName.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-gateway-services-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :default-table-preferences="defaultTablePreferences"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
@@ -10,7 +10,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-gateway-services-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -328,14 +328,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-gateway-services-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="kong-ui-entities-gateway-services-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :default-table-preferences="defaultTablePreferences"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
       :error-message="errorMessage"
       :fetcher="fetcher"
-      :fetcher-cache-key="fetchCacheKey"
+      :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-gateway-services-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -259,7 +259,6 @@ const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetchCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -329,7 +328,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const preferencesStorageKey = 'kong-ui-entities-gateway-services-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''
@@ -337,7 +343,7 @@ const clearFilter = (): void => {
 
 const resetPagination = (): void => {
   // Increment the cache key on sort
-  fetchCacheKey.value++
+  fetcherCacheKey.value++
 }
 
 /**
@@ -536,7 +542,7 @@ const deleteRow = async (): Promise<void> => {
     emit('delete:success', gatewayServiceToBeDeleted.value)
 
     hideDeleteModal()
-    fetchCacheKey.value++
+    fetcherCacheKey.value++
   } catch (error: any) {
     deleteModalError.value = error.response?.data?.message ||
       error.message ||

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-key-sets-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-key-sets-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -262,14 +262,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-key-sets-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-key-sets-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-key-sets-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -212,7 +212,6 @@ const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -263,7 +262,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const preferencesStorageKey = 'kong-ui-entities-key-sets-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-keys-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-keys-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -216,7 +216,6 @@ const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -270,7 +269,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const preferencesStorageKey = 'kong-ui-entities-keys-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-keys-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-keys-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -269,14 +269,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-keys-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-plugins-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-plugins-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       :title="title"
@@ -425,14 +425,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-plugins-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-plugins-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-plugins-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       :title="title"
@@ -425,9 +425,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const fetcherCacheKey = ref<number>(1)
+const preferencesStorageKey = 'kong-ui-entities-plugins-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-routes/sandbox/pages/RouteListPage.vue
+++ b/packages/entities/entities-routes/sandbox/pages/RouteListPage.vue
@@ -151,8 +151,8 @@ watch([routeListHideTraditionalColumns, routeListHasExpressionColumn], () => {
   :deep(.k-collapse) {
     &.is-collapsed {
       .k-collapse-heading {
-        margin-bottom: $kui-space-0 !important;
         align-items: center;
+        margin-bottom: $kui-space-0 !important;
       }
 
       .k-collapse-title {

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-routes-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :cell-attributes="getCellAttrs"
       :default-table-preferences="defaultTablePreferences"
       :disable-sorting="disableSorting"
@@ -11,7 +11,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-routes-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       :title="title"
@@ -367,14 +367,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-routes-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const getCellAttrs = (params: Record<string, any>): Record<string, any> => {
   if (params.headerKey === 'expression') {

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-routes-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :cell-attributes="getCellAttrs"
       :default-table-preferences="defaultTablePreferences"
       :disable-sorting="disableSorting"
@@ -11,7 +11,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-routes-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       :title="title"
@@ -296,7 +296,6 @@ const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -368,7 +367,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const preferencesStorageKey = 'kong-ui-entities-routes-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const getCellAttrs = (params: Record<string, any>): Record<string, any> => {
   if (params.headerKey === 'expression') {

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -28,6 +28,7 @@
       :pagination-attributes="{ disablePageJump: disablePaginationPageJump, offset: paginationType === 'offset' }"
       resize-columns
       :row-attrs="rowAttrs"
+      :row-key="rowKey"
       :search-input="query"
       :sort-handler-function="enableClientSort ? sortHandlerFunction : undefined"
       :sortable="!disableSorting"
@@ -95,7 +96,7 @@ import type { PropType } from 'vue'
 import { computed, ref } from 'vue'
 import composables from '../../composables'
 import { useTablePreferences } from '@kong-ui-public/core'
-import type { HeaderTag, TablePreferences, SortHandlerFunctionParam, TableDataFetcherParams } from '@kong/kongponents'
+import type { HeaderTag, TablePreferences, SortHandlerFunctionParam, TableDataFetcherParams, TableDataProps } from '@kong/kongponents'
 import EntityBaseTableCell from './EntityBaseTableCell.vue'
 
 import type {
@@ -128,6 +129,10 @@ const props = defineProps({
   initialFetcherParams: {
     type: Object as PropType<Partial<Omit<TableDataFetcherParams, 'query'>>>,
     default: null,
+  },
+  rowKey: {
+    type: [String, Function] as PropType<TableDataProps['rowKey']>,
+    default: 'id',
   },
   // used to identify the cache entry
   cacheIdentifier: {

--- a/packages/entities/entities-shared/src/composables/useFetcher.ts
+++ b/packages/entities/entities-shared/src/composables/useFetcher.ts
@@ -134,9 +134,9 @@ export default function useFetcher(
     }
   }
 
-  watch(fetcherCacheKey, () => {
+  watch(fetcherCacheKey, (key) => {
     if (cacheId) {
-      cacheKeys.set(cacheId, fetcherCacheKey.value)
+      cacheKeys.set(cacheId, key)
     }
   })
 

--- a/packages/entities/entities-shared/src/types/entity-base-table.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-table.ts
@@ -5,11 +5,15 @@ import type { TableState } from '@kong/kongponents/dist/types'
 export interface KonnectBaseTableConfig extends KonnectConfig {
   /** Additional message to show when there are no records */
   additionMessageForEmptyState?: string
+  /** The cache identifier of current table */
+  cacheIdentifier?: string
 }
 
 export interface KongManagerBaseTableConfig extends KongManagerConfig {
   /** Additional message to show when there are no records */
   additionMessageForEmptyState?: string
+  /** The cache identifier of current table */
+  cacheIdentifier?: string
   /** Whether to use exact match or not */
   isExactMatch?: boolean
   /** Whether to disable table sorting */

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-snis-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :cell-attributes="cellAttrsFn"
       :disable-row-click="true"
       :disable-sorting="disableSorting"
@@ -11,7 +11,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-snis-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -273,14 +273,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-snis-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-snis-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :cell-attributes="cellAttrsFn"
       :disable-row-click="true"
       :disable-sorting="disableSorting"
@@ -9,9 +9,9 @@
       enable-entity-actions
       :error-message="errorMessage"
       :fetcher="fetcher"
-      :fetcher-cache-key="fetchCacheKey"
+      :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-snis-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -209,7 +209,6 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetchCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -274,7 +273,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const preferencesStorageKey = 'kong-ui-entities-snis-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''
@@ -282,7 +288,7 @@ const clearFilter = (): void => {
 
 const resetPagination = (): void => {
   // Increment the cache key on sort
-  fetchCacheKey.value++
+  fetcherCacheKey.value++
 }
 
 /**
@@ -394,7 +400,7 @@ const confirmDelete = async (): Promise<void> => {
 
     isDeletePending.value = false
     hideDeleteModal()
-    fetchCacheKey.value++
+    fetcherCacheKey.value++
   } catch (error: any) {
     deleteModalError.value = error.response?.data?.message ||
       error.message ||

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-targets-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-targets-list"
+      :preferences-storage-key="preferencesStorageKey"
       :table-headers="tableHeaders"
       @empty-state-cta-clicked="() => !props.config.createRoute ? handleCreateTarget() : undefined"
       @sort="resetPagination"
@@ -223,7 +223,6 @@ const props = defineProps({
 const { i18n: { t } } = composables.useI18n()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -256,7 +255,14 @@ const fetcherBaseUrl = computed((): string => {
   return url
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const preferencesStorageKey = 'kong-ui-entities-targets-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const resetPagination = (): void => {
   // Increment the cache key on sort

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-targets-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-targets-list"
       :table-headers="tableHeaders"
       @empty-state-cta-clicked="() => !props.config.createRoute ? handleCreateTarget() : undefined"
       @sort="resetPagination"
@@ -255,14 +255,11 @@ const fetcherBaseUrl = computed((): string => {
   return url
 })
 
-const preferencesStorageKey = 'kong-ui-entities-targets-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const resetPagination = (): void => {
   // Increment the cache key on sort

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-upstreams-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-upstreams-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -261,14 +261,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-upstreams-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-upstreams-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-upstreams-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -210,7 +210,6 @@ const { i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const fetcherCacheKey = ref<number>(1)
 
 /**
  * Table Headers
@@ -262,7 +261,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const preferencesStorageKey = 'kong-ui-entities-upstreams-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
+
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-vaults/src/components/SecretListInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretListInner.vue
@@ -1,6 +1,6 @@
 <template>
   <EntityBaseTable
-    :cache-identifier="cacheIdentifier"
+    :cache-identifier="cacheId"
     disable-sorting
     :empty-state-options="emptyStateOptions"
     enable-entity-actions
@@ -8,7 +8,7 @@
     :fetcher="fetcher"
     :fetcher-cache-key="fetcherCacheKey"
     pagination-type="offset"
-    preferences-storage-key="kong-ui-entities-secrets-list"
+    :preferences-storage-key="preferencesStorageKey"
     :query="filterQuery"
     :row-attributes="rowAttrs"
     :table-headers="tableHeaders"
@@ -200,9 +200,14 @@ const filterConfig: ExactMatchFilterConfig = {
   placeholder: t('search.placeholder_for_secrets.konnect'),
 }
 
-const fetcherCacheKey = ref<number>(1)
+const preferencesStorageKey = 'kong-ui-entities-secrets-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-vaults/src/components/SecretListInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretListInner.vue
@@ -1,6 +1,6 @@
 <template>
   <EntityBaseTable
-    :cache-identifier="cacheId"
+    :cache-identifier="cacheIdentifier"
     disable-sorting
     :empty-state-options="emptyStateOptions"
     enable-entity-actions
@@ -8,7 +8,7 @@
     :fetcher="fetcher"
     :fetcher-cache-key="fetcherCacheKey"
     pagination-type="offset"
-    :preferences-storage-key="preferencesStorageKey"
+    preferences-storage-key="kong-ui-entities-secrets-list"
     :query="filterQuery"
     :row-attributes="rowAttrs"
     :table-headers="tableHeaders"
@@ -200,14 +200,11 @@ const filterConfig: ExactMatchFilterConfig = {
   placeholder: t('search.placeholder_for_secrets.konnect'),
 }
 
-const preferencesStorageKey = 'kong-ui-entities-secrets-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-vaults-list">
     <EntityBaseTable
-      :cache-identifier="cacheId"
+      :cache-identifier="cacheIdentifier"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      :preferences-storage-key="preferencesStorageKey"
+      preferences-storage-key="kong-ui-entities-vaults-list"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -274,14 +274,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const preferencesStorageKey = 'kong-ui-entities-vaults-list'
-const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
-
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
+} = useFetcher({ ...props.config, cacheIdentifier: props.cacheIdentifier }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="kong-ui-entities-vaults-list">
     <EntityBaseTable
-      :cache-identifier="cacheIdentifier"
+      :cache-identifier="cacheId"
       :disable-sorting="disableSorting"
       :empty-state-options="emptyStateOptions"
       enable-entity-actions
@@ -9,7 +9,7 @@
       :fetcher="fetcher"
       :fetcher-cache-key="fetcherCacheKey"
       pagination-type="offset"
-      preferences-storage-key="kong-ui-entities-vaults-list"
+      :preferences-storage-key="preferencesStorageKey"
       :query="filterQuery"
       :table-headers="tableHeaders"
       @clear-search-input="clearFilter"
@@ -274,9 +274,14 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-const fetcherCacheKey = ref<number>(1)
+const preferencesStorageKey = 'kong-ui-entities-vaults-list'
+const cacheId = computed(() => props.cacheIdentifier || preferencesStorageKey)
 
-const { fetcher, fetcherState } = useFetcher(props.config, fetcherBaseUrl.value)
+const {
+  fetcher,
+  fetcherState,
+  fetcherCacheKey,
+} = useFetcher({ ...props.config, cacheIdentifier: cacheId.value }, fetcherBaseUrl.value)
 
 const clearFilter = (): void => {
   filterQuery.value = ''


### PR DESCRIPTION
# Summary

[KM-747](https://konghq.atlassian.net/browse/KM-747)

Before:

https://github.com/user-attachments/assets/f267a6f1-9d23-486f-a82d-141f44d546ec

After:

https://github.com/user-attachments/assets/d4a6cce2-8440-4157-a794-eb3f8c49d3c9

Issue:

This PR addresses an issue where a flash of outdated list data appears when navigating away from and back to a list page after changes are made to the entity list. This happens because the `fetcher-cache-key` is reset every time the list page reloads.

To fix this, the PR introduces a global map to track fetcher cache keys by `cacheIdentifier` within the same session. This ensures the fetcher cache remains consistent, reducing flickers of stale data while still allowing revalidation to update the list seamlessly.

I also added a default `row-key` to `<EntityBaseTable>` to minimize subtle flickering during revalidation.

Before:

https://github.com/user-attachments/assets/d508e325-dd76-4859-9d4b-4172f3490521

After:

https://github.com/user-attachments/assets/e0c99e21-96e3-48e2-ab69-7ae0e20b6e03

[KM-747]: https://konghq.atlassian.net/browse/KM-747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ