### PR TITLE
fix(i18n): formatIsoDate handles trailing 0s

### DIFF
--- a/packages/core/i18n/src/i18n.spec.ts
+++ b/packages/core/i18n/src/i18n.spec.ts
@@ -158,6 +158,13 @@ describe('i18n', () => {
       const decimalTimestamp = formatIsoDate('2019-10-03T14:13:15.000Z')
       const integerTimestamp = formatIsoDate('2019-10-03T14:13:15.000Z')
 
+      expect(formatIsoDate('2019-10-03T14:13:15.123Z')).toBe('Oct 3, 2019, 2:13 PM')
+      expect(formatIsoDate('2019-10-03T14:13:15.000Z')).toBe('Oct 3, 2019, 2:13 PM')
+      expect(formatIsoDate('2019-10-03T14:13:15Z')).toBe('Oct 3, 2019, 2:13 PM')
+      expect(formatIsoDate('2019-05-16T11:42:59+00:00')).toBe('May 16, 2019, 11:42 AM')
+      expect(formatIsoDate('2019-05-16T11:42:59-04:00')).toBe('May 16, 2019, 3:42 PM')
+      expect(formatIsoDate('2019-05-16T11:42:59+08:00')).toBe('May 16, 2019, 3:42 AM')
+
       expect(formattedDateAM).toBe('May 16, 2019, 11:42 AM')
       expect(formattedDatePM).toBe('May 17, 2019, 1:39 AM')
       expect(january.substring(0, 7)).toBe('Jan 14,')

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -93,7 +93,9 @@ export const createI18n = <MessageSource extends Record<string, any>>
   const formatIsoDate = (isoDate: string): string => {
     const date = Date.parse(isoDate) / 1000
 
-    return formatUnixTimeStamp(date)
+    // excludes milliseconds with trailing 0s
+    const flooredDate = Math.floor(date)
+    return formatUnixTimeStamp(flooredDate)
   }
 
   const t = (translationKey: PathToDotNotation<MessageSource, string>, values?: Record<string, MessageFormatPrimitiveValue> | undefined, opts?: IntlMessageFormatOptions): string => {


### PR DESCRIPTION
This pull request includes changes to improve the date formatting in the i18n module. The most important changes include adding new test cases for various ISO date formats and modifying the `formatIsoDate` function to exclude milliseconds.

This resolves a bug where a timestamp with trailing 0s will result in dividing the number by 1000 twice, resulting in an incorrect date.


---
Improvements to date formatting:

* [`packages/core/i18n/src/i18n.spec.ts`](diffhunk://#diff-39efa8e72b2e74acd22901626beabcd9d5521455aaa59f62b17b491f0e39858bR161-R167): Added test cases to ensure `formatIsoDate` correctly formats ISO dates with and without milliseconds, and with different time zone offsets.

Codebase simplification:

* [`packages/core/i18n/src/i18n.ts`](diffhunk://#diff-e7652b19e52ba221117c0d8d125453eae4868c2e8daa82bab1fc6a16dbc01b65L96-R98): Modified the `formatIsoDate` function to exclude milliseconds by flooring the date value before formatting it.