### PR TITLE
fix(rla-form): place enable switch in top of form

### DIFF
--- a/packages/core/forms/src/components/forms/RLAForm.vue
+++ b/packages/core/forms/src/components/forms/RLAForm.vue
@@ -3,7 +3,7 @@
     <VueFormGenerator
       :model="formModel"
       :options="formOptions"
-      :schema="scopingSchema"
+      :schema="globalFields"
       @model-updated="(value: any, model: string) => onModelUpdated(value, model)"
     />
 
@@ -331,15 +331,12 @@ const props = defineProps<{
   isEditing?: boolean
 }>()
 
-const scopingSchema = computed(() => {
+const globalFields = computed(() => {
   const selectionGroup = props.formSchema?.fields?.find((field: any) => field.type === 'selectionGroup' && field.model === 'selectionGroup')
-  if (!selectionGroup) {
-    return undefined
-  }
 
-  const enableSwitch = props.formSchema?.fields.find((field: any) => field.pinned && field.type === 'switch' && field.model === 'enabled')
+  const enableSwitch = props.formSchema?.fields.find((field: any) => field.model === 'enabled')
 
-  return { fields: [enableSwitch, selectionGroup] }
+  return { fields: [enableSwitch, selectionGroup].filter(Boolean) }
 })
 
 const advancedSchema = computed(() => {

--- a/packages/core/forms/src/components/forms/RLAForm.vue
+++ b/packages/core/forms/src/components/forms/RLAForm.vue
@@ -303,7 +303,7 @@ const USE_CASES: Record<string, UseCase[]> = {
  * These are fields that we will take care of out of the VFG
  */
 const OMITTED_MODEL_KEYS_FULL_MATCH = new Set([
-  'selectionGroup',
+  'selectionGroup', 'enabled',
   ...['identifier', 'limit', 'window_size', 'error_code', 'error_message']
     .map((field) => `config-${field}`),
 ])
@@ -337,7 +337,9 @@ const scopingSchema = computed(() => {
     return undefined
   }
 
-  return { fields: [selectionGroup] }
+  const enableSwitch = props.formSchema?.fields.find((field: any) => field.pinned && field.type === 'switch' && field.model === 'enabled')
+
+  return { fields: [enableSwitch, selectionGroup] }
 })
 
 const advancedSchema = computed(() => {


### PR DESCRIPTION
# Summary

KM-752

Place the enable switch from hidden advanced fields into top of form like other plugins for rate limiting advanced form.
Before:
<img width="807" alt="截屏2024-11-28 下午12 54 11" src="https://github.com/user-attachments/assets/d21254c4-8fe2-4a40-8791-7cf250f6f7f1">

After: 
<img width="716" alt="截屏2024-11-28 下午1 39 58" src="https://github.com/user-attachments/assets/85997d4f-45e7-40de-9b34-f896ff8bdc50">
