### PR TITLE
fix(tracing): fix height for skeleton container

### DIFF
--- a/packages/core/tracing/sandbox/pages/TraceViewerPage.vue
+++ b/packages/core/tracing/sandbox/pages/TraceViewerPage.vue
@@ -109,7 +109,8 @@ const url = `https://example.com${path}`
     .slideout-title {
       flex-shrink: 1;
       min-width: 0;
-      height: $kui-line-height-50;
+      height: 28px; // $kui-line-height-50
+      line-height: $kui-line-height-50;
     }
 
     .slideout-content {

--- a/packages/core/tracing/src/components/trace-viewer/TraceViewer.vue
+++ b/packages/core/tracing/src/components/trace-viewer/TraceViewer.vue
@@ -210,9 +210,11 @@ const spanNothingToDisplay = computed(() => {
       align-items: center;
       display: flex;
       flex-direction: row;
-      flex-shrink: 1;
+      flex-shrink: 0;
       gap: $kui-space-50;
+      height: 20px; // $kui-line-height-30
       justify-content: space-between;
+      line-height: $kui-line-height-30;
 
       .url {
         align-items: center;


### PR DESCRIPTION
# Summary

This pull request fixes the height for skeleton containers to avoid shaking while switching between the ON and OFF states of skeletons in `TraceViewer`.