### PR TITLE
fix(tracing): url truncation and tooltip work-break

### DIFF
--- a/packages/core/tracing/src/components/trace-viewer/TraceViewer.vue
+++ b/packages/core/tracing/src/components/trace-viewer/TraceViewer.vue
@@ -33,7 +33,7 @@
                 copy-tooltip="Copy"
                 :text="url"
                 truncate
-                :truncation-limit="48"
+                truncation-limit="auto"
               />
             </div>
           </div>
@@ -227,6 +227,15 @@ const spanNothingToDisplay = computed(() => {
         .label {
           font-size: $kui-font-size-30;
           font-weight: $kui-font-weight-semibold;
+        }
+
+        .content {
+          flex-shrink: 1;
+          min-width: 0;
+
+          :deep(.popover-content) {
+            word-break: break-all;
+          }
         }
       }
     }


### PR DESCRIPTION
# Summary

This pull request fixes the URL truncation and `word-break` in its tooltip:

<img width="1067" alt="Screenshot 2024-12-04 at 16 46 54" src="https://github.com/user-attachments/assets/334c704a-dd44-4b08-8e25-fb7895c8e3a5">
