### PR TITLE
fix(analytics): backwards-compatible granularities [MA-2149]

### DIFF
--- a/packages/analytics/analytics-utilities/src/timeframes.ts
+++ b/packages/analytics/analytics-utilities/src/timeframes.ts
@@ -301,7 +301,7 @@ export const TimePeriods = new Map<string, Timeframe>([
       dataGranularity: 'hourly',
       isRelative: true,
       allowedTiers: ['free', 'trial', 'plus', 'enterprise'],
-      allowedGranularitiesOverride: ['thirtySecondly', 'minutely', 'fiveMinutely', 'tenMinutely', 'thirtyMinutely'],
+      allowedGranularitiesOverride: ['thirtySecondly', 'minutely', 'fiveMinutely', 'tenMinutely', 'thirtyMinutely', 'hourly'],
     }),
   ],
   [


### PR DESCRIPTION
Last 6 hours needs to support 1 hour granularity in order to remain compatible with its old set of allowed granularities.

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
