### PR TITLE
chore(codeowners): update codeowners for core/tracing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,6 +33,7 @@
 /packages/core/misc-widgets/ @Kong/team-core-ui
 /packages/core/forms/ @Kong/team-km @Kong/team-core-ui @LukeSwierlik @QueaT-kong
 /packages/core/documentation/ @Kong/team-core-ui @Kong/team-konnectx-platform-fe @Kong/team-devx
+/packages/core/tracing/ @Kong/team-km @Kong/team-core-ui
 
 # Portal packages
 /packages/portal/document-viewer/ @Kong/team-devx @Kong/team-core-ui


### PR DESCRIPTION
# Summary

This pull request adds Team KM as a code owner for the `core/tracing` package.

`core/tracing` is currently built for the Active Tracing feature on Konnect.