### PR TITLE
fix(entities-shared): persistent cache key should share the same refs

### DIFF
--- a/packages/entities/entities-shared/src/composables/index.ts
+++ b/packages/entities/entities-shared/src/composables/index.ts
@@ -3,7 +3,7 @@ import useDebouncedFilter from './useDebouncedFilter'
 import useDeleteUrlBuilder from './useDeleteUrlBuilder'
 import useErrors from './useErrors'
 import useExternalLinkCreator from './useExternalLinkCreator'
-import useFetcher from './useFetcher'
+import useFetcher, { useFetcherCacheKey } from './useFetcher'
 import useFetchUrlBuilder from './useFetchUrlBuilder'
 import useHelpers from './useHelpers'
 import useStringHelpers from './useStringHelpers'
@@ -21,6 +21,7 @@ export default {
   useErrors,
   useExternalLinkCreator,
   useFetcher,
+  useFetcherCacheKey,
   useFetchUrlBuilder,
   useHelpers,
   useStringHelpers,


### PR DESCRIPTION
# Summary

[KM-805](https://konghq.atlassian.net/browse/KM-805)

- `useFetcher` should return shared refs for `fetcherCacheKey`
- added a new `useFetcherCacheKey` composable that can be used alone


[KM-805]: https://konghq.atlassian.net/browse/KM-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ