### PR TITLE
feat(tracing): allow zooming in trace viewer

### DIFF
--- a/packages/core/tracing/src/components/trace-viewer/SpanAttribute.vue
+++ b/packages/core/tracing/src/components/trace-viewer/SpanAttribute.vue
@@ -181,6 +181,10 @@ watch([() => config.getEntityLinkData, entityRequest], async ([getEntityLinkData
     }
     // Do not update the link data when it is falsy
   } catch (e) {
+    if (e instanceof Error && e.name === 'CanceledError') {
+      // Ignore CanceledErrors
+      return
+    }
     console.warn('The host app MUST handle exceptions in `getEntityLinkData` instead of throwing them here:', e)
   }
 }, { immediate: true })

--- a/packages/core/tracing/src/components/waterfall/WaterfallScale.vue
+++ b/packages/core/tracing/src/components/waterfall/WaterfallScale.vue
@@ -32,8 +32,6 @@ if (!config) {
 }
 
 const durationPerTick = computed(() => config.totalDurationNano * (1 - config.viewport.left - config.viewport.right) / (config.ticks - 1))
-
-// RESERVED: Only used when zooming is enabled
 const durationShift = computed(() => config.totalDurationNano * config.viewport.left)
 </script>
 

--- a/packages/core/tracing/src/components/waterfall/WaterfallSpanBar.vue
+++ b/packages/core/tracing/src/components/waterfall/WaterfallSpanBar.vue
@@ -4,7 +4,7 @@
 
 <script setup lang="ts">
 import { computed, inject } from 'vue'
-import { WATERFALL_CONFIG, WATERFALL_LEGENDS, WaterfallLegendItemKind } from '../../constants'
+import { WATERFALL_CONFIG, WATERFALL_LEGENDS, WATERFALL_SPAN_BAR_FADING_WIDTH, WaterfallLegendItemKind } from '../../constants'
 import type { SpanNode, WaterfallConfig } from '../../types'
 
 const MIN_WIDTH = 1
@@ -39,17 +39,66 @@ const barColor = computed(() => {
   return WATERFALL_LEGENDS[WaterfallLegendItemKind.KONG].color
 })
 
-// RESERVED: Only used when zooming is enabled
-const relativeStartTimeNano = computed(() =>
-  Number(BigInt(props.spanNode.span.startTimeUnixNano) - (config.root?.subtreeValues.startTimeUnixNano ?? 0n)),
+/**
+ * Left position of the span bar in the whole trace, presented by a ratio where 0 marks the left-most
+ * position and 1 marks the right-most position. It is calculated by the following formula:
+ *
+ * ```
+ * (span_start_time - root_start_time) / (total_duration - minimal_duration)
+ *                                                         ^ reserve space for spans that are too short
+ * ```
+ *
+ * Note: The value is calculated without the zoom factor to reduce unnecessary recalculations.
+ */
+const barUnscaledLeftBaseRatio = computed(() => {
+  if (!config.root) {
+    return 0
+  }
+
+  const relativeStart = Number(BigInt(props.spanNode.span.startTimeUnixNano) - (config.root?.subtreeValues.startTimeUnixNano ?? 0n))
+
+  return (relativeStart / (config.totalDurationNano - config.root.subtreeValues.minDurationNano))
+})
+
+/**
+ * Scaled left position of the span bar with the zoom factor applied.
+ */
+const barLeftBaseRatio = computed(() => barUnscaledLeftBaseRatio.value * config.zoom)
+
+/**
+ * Scaled viewport left position with the zoom factor applied. It is calculated by the following formula:
+ */
+const viewportLeftRatio = computed(() => config.viewport.left * config.zoom)
+
+/**
+ * Left position of the span bar in the whole trace. This is the raw left position that may overflow
+ * the viewport a lot, which may bring performance issues.
+ */
+const barUnclampedLeft = computed(() => {
+  if (!config.root) {
+    return 0
+  }
+
+  return `calc((100% - ${MIN_WIDTH}px) * ${barLeftBaseRatio.value} - 100% * ${viewportLeftRatio.value})`
+})
+
+/**
+ * Clamped left position of the span bar within the viewport with fading edges on both ends, to ensure
+ * the performance. It is clamped in the following range:
+ *
+ * ```
+ * -fading_width <= position <= 100% + fading_width / 2
+ * ```
+ */
+const barLeft = computed(() =>
+  `min(calc(100% + ${WATERFALL_SPAN_BAR_FADING_WIDTH} / 2), max(-${WATERFALL_SPAN_BAR_FADING_WIDTH}, ${barUnclampedLeft.value}))`,
 )
-const barFixedLeft = computed(() => (relativeStartTimeNano.value / config.totalDurationNano) * config.zoom)
-const barShiftLeft = computed(() => -config.viewport.left * config.zoom)
-const barLeft = computed(() => `min(100% - ${MIN_WIDTH}px, calc((100% - ${MIN_WIDTH}px) * ${(barFixedLeft.value + barShiftLeft.value)})`)
+
 const barExtraWidthFactor = computed(() => {
   if (!config.root) {
     return 0
   }
+
   /**
    * We will make minDuration as `MIN_WIDTH`. Therefore, we will calculate the "extra" width besides the
    * `MIN_WIDTH`. We will present this extra width as a factor.
@@ -64,9 +113,27 @@ const barExtraWidthFactor = computed(() => {
   return (props.spanNode.durationNano - config.root.subtreeValues.minDurationNano)
     / (config.totalDurationNano - config.root.subtreeValues.minDurationNano)
 })
-const barWidth = computed(() =>
-  `calc((${MIN_WIDTH}px + (100% - ${MIN_WIDTH}px) * ${barExtraWidthFactor.value}) * ${config.zoom})`,
-)
+
+/**
+ * Clamped right position of the span bar within the viewport with fading edges on both ends, to ensure
+ * the performance. It is clamped in the following range:
+ *
+ * ```
+ * -fading_width <= position <= 100% + fading_width / 2
+ * ```
+ */
+const barRight = computed(() => {
+  // The unclamped but scaled width of the span bar with zoom factor applied
+  const unclampedWidth = `calc((${MIN_WIDTH}px + (100% - ${MIN_WIDTH}px) * ${barExtraWidthFactor.value}) * ${config.zoom})`
+
+  /**
+   * Right position of the span bar in the whole trace. This is the raw right position that may overflow
+   * the viewport a lot, which may bring performance issues.
+   */
+  const unclampedRight = `calc(100% - ${barUnclampedLeft.value} - ${unclampedWidth})`
+
+  return `min(calc(100% + ${WATERFALL_SPAN_BAR_FADING_WIDTH} / 2), max(-${WATERFALL_SPAN_BAR_FADING_WIDTH}, ${unclampedRight}))`
+})
 </script>
 
 <style lang="scss" scoped>
@@ -83,8 +150,8 @@ const barWidth = computed(() =>
     height: 100%;
     left: v-bind(barLeft);
     position: absolute;
+    right: v-bind(barRight);
     top: 0;
-    width: v-bind(barWidth);
   }
 
   .bar-label {

--- a/packages/core/tracing/src/types/waterfall.ts
+++ b/packages/core/tracing/src/types/waterfall.ts
@@ -10,11 +10,6 @@ export interface WaterfallConfig {
   totalDurationNano: number
   /** Zoom level */
   zoom: number
-  /**
-   * Horizontal shift of the viewport in pixels (used by zooming)
-   * Values & directions: <-- negative -- positive -->
-   */
-  viewportShift: number
   viewport: { left: number; right: number }
   selectedSpan?: SpanNode
 }


### PR DESCRIPTION
# Summary

This pull request adds support for zooming interaction to the trace viewer.

https://github.com/user-attachments/assets/7eab6362-4a44-40cf-b0be-aa6bfcc2c6b0


- The `left` and `right` attributes of span bars are clamped within the viewport to ensure performance under a high zoom level.
- We will show color at the edge when the view is zoomed in and the span is out of the viewport to indicate that the span is in that direction.
- Cleaned up unused config `viewportShift` in the waterfall view

KM-755