### PR TITLE
fx(analytics): timeserieschart uses terse date format on hover

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -216,7 +216,7 @@ const { options } = composables.useLinechartOptions({
 composables.useReportChartDataForSynthetics(toRef(props, 'chartData'), toRef(props, 'syntheticsDataKey'))
 
 const formatTimestamp = (ts: number): string | number => {
-  return formatByGranularity(new Date(ts), props.granularity, false)
+  return formatByGranularity(new Date(ts), props.granularity, true)
 }
 
 /**


### PR DESCRIPTION
When hovering, use terse display mode because space is less at a premium.