### PR TITLE
fix(expressions): autocompletion in parentheses

### DIFF
--- a/packages/core/expressions/src/monaco.ts
+++ b/packages/core/expressions/src/monaco.ts
@@ -77,12 +77,13 @@ export const registerLanguage = (schema: Schema) => {
             '@default': 'variable',
           },
         }],
+        [/[()]/, 'delimiter.parenthesis'],
         [/==|!=|~|\^=|=\^|>=?|<=?|&&|\|\|/, 'operators'],
-        [/[()]/, 'brackets'],
         [/".*?"/, 'string'],
         [/\d+/, 'number'],
       ],
     },
+    brackets: [{ open: '(', close: ')', token: 'delimiter.parenthesis' }],
   } as MonarchLanguage)
 
   monaco.languages.registerCompletionItemProvider(languageId, {
@@ -130,7 +131,9 @@ export const registerLanguage = (schema: Schema) => {
       })
 
       const words = lastChars.replace('\t', '').split(' ')
-      const activeTyping = words[words.length - 1] // what the user is currently typing (everything after the last space)
+      let activeTyping = words[words.length - 1] // what the user is currently typing (everything after the last space)
+      // Here, we will start counting the characters after the last open parenthesis
+      activeTyping = activeTyping.slice(activeTyping.lastIndexOf('(') + 1)
 
       const inputTokens = activeTyping.split('.').slice(0, -1)
       let token: Token = tokenTree


### PR DESCRIPTION
# Summary

This pull request fixes the issue where the autocompletion was not working while typing inside the parentheses.

|Before|After|
|:-|:-|
|![](https://github.com/user-attachments/assets/fd910b62-fa16-40f2-a077-24f4d7fe102d)|![Screen Recording 2024-12-20 at 11 34 37](https://github.com/user-attachments/assets/b262221d-fe72-4694-b8fa-c242b4484b2a)|

KM-839