### PR TITLE
fix(tracing): check i18n key in a better way

### DIFF
--- a/packages/core/tracing/src/components/trace-viewer/SpanDescription.vue
+++ b/packages/core/tracing/src/components/trace-viewer/SpanDescription.vue
@@ -26,7 +26,7 @@ import composables from '../../composables'
 import type { SpanNode } from '../../types'
 import { computed } from 'vue'
 
-const { i18n: { t } } = composables.useI18n()
+const { i18n: { t, te } } = composables.useI18n()
 
 const props = defineProps<{ span: SpanNode['span'] }>()
 
@@ -35,8 +35,7 @@ const description = computed(() => {
   // We will use general description for plugin spans that exactly match `kong.(phase).plugin.(plugin)`.
   const subI18nKey = pluginSpan && !pluginSpan.suffix ? `kong.${pluginSpan.phase}.plugin` : props.span.name
   const i18nKey = `trace_viewer.span_descriptions.${subI18nKey}`
-  const localizedString = t(i18nKey as any)
-  return i18nKey !== localizedString && localizedString ? localizedString : undefined
+  return te(i18nKey as any) ? t(i18nKey as any) : undefined
 })
 </script>
 


### PR DESCRIPTION
# Summary

This pull request updates the logic to check the availability of an i18n key to avoid printing errors in the console:

<img width="600" alt="Screenshot 2024-12-20 at 14 44 20" src="https://github.com/user-attachments/assets/3ecee056-bbd2-47fc-9934-b1e5bc1d62d0" />
