### PR TITLE
fix(analytics-chart): render timeseries charts with a single point [MA-2682]

### DIFF
--- a/packages/analytics/analytics-chart/README.md
+++ b/packages/analytics/analytics-chart/README.md
@@ -510,3 +510,11 @@ const fileName = ref('exportFilename')
 </script>
 
 ```
+
+## Development
+
+Follow the setup instructions for the [top level README](../../../README.md). Then run the sandbox with:
+
+```
+pnpm run dev
+```

--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -203,6 +203,8 @@ const plugins = computed(() => [
 const remountLineKey = computed(() => `line-${plugins.value.map(p => p.id).join('-')}`)
 const remountBarKey = computed(() => `bar-${plugins.value.map(p => p.id).join('-')}`)
 
+const pointsWithoutHover = computed(() => props.chartData?.length == 1)
+
 const { options } = composables.useLinechartOptions({
   tooltipState: tooltipData,
   timeRangeMs: toRef(props, 'timeRangeMs'),
@@ -211,6 +213,7 @@ const { options } = composables.useLinechartOptions({
   stacked: toRef(props, 'stacked'),
   metricAxesTitle: toRef(props, 'metricAxesTitle'),
   dimensionAxesTitle: toRef(props, 'dimensionAxesTitle'),
+  pointsWithoutHover: pointsWithoutHover,
 })
 
 composables.useReportChartDataForSynthetics(toRef(props, 'chartData'), toRef(props, 'syntheticsDataKey'))

--- a/packages/analytics/analytics-chart/src/composables/useLineChartOptions.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useLineChartOptions.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import useLinechartOptions from './useLineChartOptions'
+import { ref } from 'vue'
+
+const mockTooltipState = {
+  showTooltip: false,
+  tooltipContext: 0,
+  tooltipSeries: [],
+  left: 'foo',
+  top: 'bar',
+  units: 'count',
+  translateUnit: (unit: string, value: number) => '',
+  offsetX: 0,
+  offsetY: 0,
+  width: 0,
+  height:0,
+  chartType: 'timeseries_line' as const,
+}
+
+describe('useLineChartOptions', () => {
+
+  it('has no radius without hover when pointsWithoutHover is false', () => {
+    const { options } = useLinechartOptions({
+      tooltipState: mockTooltipState,
+      legendID: 'foo',
+      stacked: ref(false),
+      timeRangeMs: ref(1000),
+      granularity: ref('secondly'),
+      pointsWithoutHover: false,
+    })
+
+    expect(options.value.elements.point.radius).toBe(0)
+  })
+
+  it('has a radius without hover when pointsWithoutHover is true', () => {
+    const { options } = useLinechartOptions({
+      tooltipState: mockTooltipState,
+      legendID: 'foo',
+      stacked: ref(false),
+      timeRangeMs: ref(1000),
+      granularity: ref('secondly'),
+      pointsWithoutHover: true,
+    })
+
+    expect(options.value.elements.point.radius).toBe(2)
+  })
+})

--- a/packages/analytics/analytics-chart/src/composables/useLineChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useLineChartOptions.ts
@@ -124,7 +124,7 @@ export default function useLinechartOptions(chartOptions: LineChartOptions) {
       },
       elements: {
         point: {
-          radius: 0,
+          radius: chartOptions.pointsWithoutHover ? 2 : 0,
           hitRadius: 4,
           hoverRadius: 4,
         },

--- a/packages/analytics/analytics-chart/src/types/chartjs-options.ts
+++ b/packages/analytics/analytics-chart/src/types/chartjs-options.ts
@@ -46,6 +46,7 @@ export interface BarChartOptions extends BaseChartOptions {
 export interface LineChartOptions extends BaseChartOptions {
   timeRangeMs: Ref<number | undefined>, // time range in seconds
   granularity: Ref<GranularityValues>,
+  pointsWithoutHover?: boolean,
 }
 
 export interface DoughnutChartOptions {

--- a/packages/analytics/analytics-chart/src/utils/commonOptions.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/commonOptions.spec.ts
@@ -1,0 +1,124 @@
+import type { KChartData } from '../types'
+import { computed } from 'vue'
+import commonOptions, { hasTimeseriesData } from './commonOptions'
+
+const lineChartData = computed<KChartData>(() => {
+  return {
+    datasets: [
+      {
+        rawMetric: 'test1',
+        rawDimension: 'test1',
+        label: 'test1',
+        data: [
+          {
+            x: 1678262400000,
+            y: 10,
+          },
+        ],
+      },
+      {
+        rawMetric: 'test2',
+        rawDimension: 'test2',
+        label: 'test2',
+        data: [
+          {
+            x: 1677744000000,
+            y: 10,
+          },
+        ],
+      },
+    ],
+  }
+})
+
+describe('commonOptions.hasTimeseriesData', () => {
+
+  it('is valid for timeseries data with only 1 datapoint', () => {
+    const lineChartData = {
+      datasets: [
+        {
+          rawMetric: 'test1',
+          rawDimension: 'test1',
+          label: 'test1',
+          data: [
+            {
+              x: 1678262400000,
+              y: 10,
+            },
+          ],
+        },
+        {
+          rawMetric: 'test2',
+          rawDimension: 'test2',
+          label: 'test2',
+          data: [
+            {
+              x: 1677744000000,
+              y: 10,
+            },
+          ],
+        },
+      ],
+    }
+
+    const valid = hasTimeseriesData(lineChartData)
+    expect(valid).true
+  })
+
+  it('is not valid for empty series', () => {
+    const lineChartData = {
+      datasets: [
+        {
+          rawMetric: 'test1',
+          rawDimension: 'test1',
+          label: 'test1',
+          data: [
+          ],
+        },
+        {
+          rawMetric: 'test2',
+          rawDimension: 'test2',
+          label: 'test2',
+          data: [
+          ],
+        },
+      ],
+    }
+
+    const valid = hasTimeseriesData(lineChartData)
+    expect(valid).false
+  })
+
+  it('is not valid for non-point-like series', () => {
+    const testChartData = {
+      labels: [
+        'test1',
+        'test2',
+      ],
+      datasets: [
+        {
+          rawDimension: 'test1',
+          rawMetric: 'test1',
+          label: 'test1',
+          data: [
+            10,
+            0,
+          ],
+        },
+        {
+          rawDimension: 'test2',
+          rawMetric: 'test2',
+          label: 'test2',
+          data: [
+            0,
+            20,
+          ],
+        },
+      ],
+    }
+
+    const valid = hasTimeseriesData(testChartData)
+
+    expect(valid).false
+  })
+})

--- a/packages/analytics/analytics-chart/src/utils/commonOptions.ts
+++ b/packages/analytics/analytics-chart/src/utils/commonOptions.ts
@@ -68,12 +68,9 @@ export const hasDatasets = (chartData: KChartData) =>
 export const hasDataInDatasets = (chartData: KChartData) =>
   hasDatasets(chartData) && chartData.datasets.some((ds) => ds.data.length)
 
-export const hasTwoOrMoreDataPoints = (chartData: KChartData) =>
-  hasDataInDatasets(chartData) &&
-  chartData.datasets.some((ds) => ds.data.length > 1)
-
-export const hasTimeseriesData = (chartData: KChartData) =>
-  hasTwoOrMoreDataPoints(chartData) && chartData.datasets.some((ds) => ds.data[0] && isValid((ds.data[0] as ScatterDataPoint).x))
+export const hasTimeseriesData = (chartData: KChartData) => {
+  return chartData.datasets.some((ds) => ds.data[0] && isValid((ds.data[0] as ScatterDataPoint).x))
+}
 
 export const hasMillisecondTimestamps = (chartData: KChartData) =>
   hasTimeseriesData(chartData) &&


### PR DESCRIPTION
# Summary

When a line chart is asked to display a single data point, display that datapoint with a radius smaller than the hover radius instead of displaying a deceptive "No data" error.

Test dataset:
```
{
  "data": [
    {
      "event": {
        "request_count": 100000
      },
      "timestamp": "2024-12-23T07:00:00.000Z"
    }
  ],
  "meta": {
    "start_ms": 1734937200000,
    "end_ms": 1735023600000,
    "limit": 50,
    "granularity_ms": 86400000,
    "metric_names": [
      "request_count"
    ],
    "truncated": false,
    "display": {},
    "metric_units": {
      "request_count": "count"
    }
  }
}
```

Before:
![image](https://github.com/user-attachments/assets/03c7f69f-2ebd-4502-9819-95e1c3fb8198)


After:

![image](https://github.com/user-attachments/assets/f223672c-de53-459a-b4b7-38babac441aa)

