### PR TITLE
ci: rename workflow jobs [KHCP-14529]

### DIFF
--- a/.github/workflows/pr-on-close.yaml
+++ b/.github/workflows/pr-on-close.yaml
@@ -1,4 +1,4 @@
-name: On PR close
+name: PR on close
 on:
   pull_request:
     types: ['closed']

--- a/.github/workflows/renovate-auto-approve.yaml
+++ b/.github/workflows/renovate-auto-approve.yaml
@@ -1,5 +1,4 @@
----
-name: Renovate Bot dependency updates auto-approve
+name: Renovate Bot dependency updates PR auto-approval
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
# Summary

Renaming workflow jobs in order to manually disable old workflows that used `pull_request_trigger`
