### PR TITLE
feat(app-layout): expose top offset

### DIFF
--- a/packages/core/app-layout/src/components/AppLayout.vue
+++ b/packages/core/app-layout/src/components/AppLayout.vue
@@ -243,6 +243,11 @@ const debouncedSetNotificationHeight = debounce((force = false): void => {
 // Add a ResizeObserver to determine when the navbar element content changes
 const resizeObserver = ref<ResizeObserver>()
 
+defineExpose({
+  /** Expose the computed top offset */
+  topOffset: notificationHeight,
+})
+
 onMounted(() => {
   // Add classes to the `html` and `body` elements to scope styles
   document?.body?.classList.add('kong-ui-app-layout-body')


### PR DESCRIPTION
# Summary

Expose the `topOffset` from the `AppLayout` - can be used to determine the top offset for downstream apps

## Example Usage

```vue
<template>
  <AppLayout ref="appLayout" />
</template>

<script setup lang="ts">
const appLayout = useTemplateRef('appLayout')

// Calculate the top offset for the Learning Hub slideout, always adding 60 to account for the height of the navbar
const learningHubSlideoutTopOffset = computed((): number => (appLayout.value?.topOffset || 0) + 60)
</script>
```