### PR TITLE
fix(pluginform): remove reset type of cancel button

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -74,7 +74,6 @@
               class="form-action-button"
               :data-testid="`plugin-${isEditing ? 'edit' : 'create'}-form-cancel`"
               :disabled="form.isReadonly"
-              type="reset"
               @click="handleClickCancel"
             >
               {{ t('actions.cancel') }}


### PR DESCRIPTION
# Summary

KM-882

`EntityBaseForm` has a built-in method for reset events(https://github.com/Kong/public-ui-components/blob/fix/KM-882-duplicate-call-of-handle-click-cancel/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue#L30), so the `handleClickCancel` is triggered twice when cancel button is clicked(once by click event of button, once by cancel event triggered by form reset event). 

Normally this not a problem because when `handleClickCancel` executes for the first time, `router.push(props.config.cancelRoute)` goes to another page so that the current component no longer exists and the second execution of `handleClickCancel` won't happen. However, if no `props.config.cancelRoute` is passed, then duplicate calls of `handleClickCancel` surface.

So i removed `type="reset"` for cancel button since `handleClickCancel` already handles click event of cancel button.