### PR TITLE
feat(field-multiselect): setup syntax [khcp-11341]

### DIFF
--- a/packages/core/forms/sandbox/App.vue
+++ b/packages/core/forms/sandbox/App.vue
@@ -67,6 +67,31 @@ const fieldSchema = {
         { name: 'Female', value: 'female' },
       ],
     },
+    // FieldSelect
+    {
+      type: 'select',
+      model: 'https_redirect_status_code',
+      label: 'HTTPS Redirect Status Code',
+      values: [426, 301, 302, 307, 308],
+    },
+    // FieldMultiselect
+    {
+      type: 'multiselect',
+      model: 'protocols',
+      label:'Protocols',
+      values: [
+        { label: 'GRPC', value: 'grpc' },
+        { label: 'GRPCS', value: 'grpcs' },
+        { label: 'HTTP', value: 'http' },
+        { label: 'HTTPS', value: 'https' },
+        { label: 'TCP', value: 'tcp' },
+        { label: 'TLS', value: 'tls' },
+        { label: 'TLS_PASSTHROUGH', value: 'tls_passthrough' },
+        { label: 'UDP', value: 'udp' },
+        { label: 'WS', value: 'ws' },
+        { label: 'WSS', value: 'wss' },
+      ],
+    },
     // FieldSwitch
     {
       type: 'switch',
@@ -92,6 +117,8 @@ const fieldModelDefault = ref({
   is_friendly: true,
   is_cute: true,
   gender: 'male',
+  https_redirect_status_code: '',
+  protocols: ['http', 'https'],
 })
 
 const fieldModelModified = ref({
@@ -100,6 +127,8 @@ const fieldModelModified = ref({
   is_cute: false,
   gender: null,
   personality: 'A little bit of a brat',
+  https_redirect_status_code: 307,
+  protocols: ['https', 'wss'],
 })
 </script>
 

--- a/packages/core/forms/src/components/fields/FieldMultiselect.vue
+++ b/packages/core/forms/src/components/fields/FieldMultiselect.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, toRefs, type PropType } from 'vue'
+import { computed, toRef, type PropType } from 'vue'
 import type { MultiselectItem } from '@kong/kongponents'
 import composables from '../../composables'
 
@@ -60,10 +60,10 @@ const emit = defineEmits<{
   (event: 'modelUpdated', value: any, model: Record<string, any>): void
 }>()
 
-const propsRefs = toRefs(props)
+const modelRef = toRef(props)
 
 const { getLabelId, getFieldID, clearValidationErrors, value: inputValue } = composables.useAbstractFields({
-  model: propsRefs.model,
+  model: modelRef,
   schema: props.schema,
   formOptions: props.formOptions,
   emitModelUpdated: (data: { value: any, model: Record<string, any> }): void => {

--- a/packages/core/forms/src/components/fields/FieldMultiselect.vue
+++ b/packages/core/forms/src/components/fields/FieldMultiselect.vue
@@ -1,41 +1,89 @@
 <template>
   <KMultiselect
+    :id="getFieldID(schema)"
+    v-model="inputValue"
     :aria-labelledby="getLabelId(schema)"
+    :class="schema.fieldClasses"
     data-testid="field-multiselect"
+    :disabled="disabled || undefined"
     :items="items"
+    :kpop-attributes="{ 'data-testid': `${getFieldID(schema)}-items` }"
     :label-attributes="{ info: schema.help }"
-    :model-value="value"
+    :name="schema.inputName"
     :placeholder="schema.placeholder"
     :required="schema.required || undefined"
     width="100%"
-    @update:model-value="onUpdate"
   />
 </template>
 
-<script>
-import abstractField from './abstractField'
+<script lang="ts" setup>
+import { computed, toRefs, type PropType } from 'vue'
+import type { MultiselectItem } from '@kong/kongponents'
+import composables from '../../composables'
 
-export default {
-  mixins: [abstractField],
-
-  emits: ['model-updated'],
-
-  computed: {
-    items() {
-      if (this.schema.values) {
-        return this.schema.values
-      }
-      if (this.schema.elements?.one_of?.length) {
-        return this.schema.elements.one_of.map(value => ({ label: value, value }))
-      }
-      return []
-    },
+const props = defineProps({
+  disabled: {
+    type: Boolean,
+    default: false,
   },
-
-  methods: {
-    onUpdate(value) {
-      this.$emit('model-updated', value, this.schema.model)
-    },
+  formOptions: {
+    type: Object as PropType<Record<string, any>>,
+    default: () => undefined,
   },
-}
+  model: {
+    type: Object as PropType<Record<string, any>>,
+    default: () => undefined,
+  },
+  schema: {
+    type: Object as PropType<Record<string, any>>,
+    required: true,
+  },
+  vfg: {
+    type: Object,
+    required: true,
+  },
+  /**
+   * TODO: stronger type
+   * TODO: pass this down to KInput error and errorMessage
+   */
+  errors: {
+    type: Array,
+    default: () => [],
+  },
+  hint: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits<{
+  (event: 'modelUpdated', value: any, model: Record<string, any>): void
+}>()
+
+const propsRefs = toRefs(props)
+
+const { getLabelId, getFieldID, clearValidationErrors, value: inputValue } = composables.useAbstractFields({
+  model: propsRefs.model,
+  schema: props.schema,
+  formOptions: props.formOptions,
+  emitModelUpdated: (data: { value: any, model: Record<string, any> }): void => {
+    emit('modelUpdated', data.value, data.model)
+  },
+})
+
+defineExpose({
+  clearValidationErrors,
+})
+
+const items = computed((): MultiselectItem[] => {
+  if (props.schema.values) {
+    return props.schema.values
+  }
+
+  if (props.schema.elements?.one_of?.length) {
+    return props.schema.elements.one_of.map((value: string | number | boolean) => ({ label: String(value), value: String(value) } as MultiselectItem))
+  }
+
+  return []
+})
 </script>

--- a/packages/core/forms/src/components/fields/FieldMultiselect.vue
+++ b/packages/core/forms/src/components/fields/FieldMultiselect.vue
@@ -5,7 +5,7 @@
     :aria-labelledby="getLabelId(schema)"
     :class="schema.fieldClasses"
     data-testid="field-multiselect"
-    :disabled="disabled"
+    :disabled="disabled || undefined"
     :items="items"
     :kpop-attributes="{ 'data-testid': `${getFieldID(schema)}-items` }"
     :label-attributes="{ info: schema.help }"
@@ -60,7 +60,7 @@ const emit = defineEmits<{
   (event: 'modelUpdated', value: any, model: Record<string, any>): void
 }>()
 
-const modelRef = toRef(props)
+const modelRef = toRef(props, 'model')
 
 const { getLabelId, getFieldID, clearValidationErrors, value: inputValue } = composables.useAbstractFields({
   model: modelRef,

--- a/packages/core/forms/src/components/fields/FieldMultiselect.vue
+++ b/packages/core/forms/src/components/fields/FieldMultiselect.vue
@@ -5,7 +5,7 @@
     :aria-labelledby="getLabelId(schema)"
     :class="schema.fieldClasses"
     data-testid="field-multiselect"
-    :disabled="disabled || undefined"
+    :disabled="disabled"
     :items="items"
     :kpop-attributes="{ 'data-testid': `${getFieldID(schema)}-items` }"
     :label-attributes="{ info: schema.help }"
@@ -81,7 +81,7 @@ const items = computed((): MultiselectItem[] => {
   }
 
   if (props.schema.elements?.one_of?.length) {
-    return props.schema.elements.one_of.map((value: string | number | boolean) => ({ label: String(value), value: String(value) } as MultiselectItem))
+    return props.schema.elements.one_of.map((value: string | number | boolean) => ({ label: String(value), value: String(value) } satisfies MultiselectItem))
   }
 
   return []

--- a/packages/core/forms/src/components/fields/FieldRadio.vue
+++ b/packages/core/forms/src/components/fields/FieldRadio.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts" setup>
-import { toRefs, type PropType } from 'vue'
+import { toRef, type PropType } from 'vue'
 import composables from '../../composables'
 
 const props = defineProps({
@@ -58,10 +58,10 @@ const emit = defineEmits<{
   (event: 'modelUpdated', value: any, model: Record<string, any>): void
 }>()
 
-const propsRefs = toRefs(props)
+const modelRef = toRef(props, 'model')
 
 const { updateModelValue, value: inputValue, clearValidationErrors } = composables.useAbstractFields({
-  model: propsRefs.model,
+  model: modelRef,
   schema: props.schema,
   formOptions: props.formOptions,
   emitModelUpdated: (data: { value: any, model: Record<string, any> }): void => {

--- a/packages/core/forms/src/components/fields/FieldRadio.vue
+++ b/packages/core/forms/src/components/fields/FieldRadio.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts" setup>
-import { toRef, type PropType } from 'vue'
+import { toRefs, type PropType } from 'vue'
 import composables from '../../composables'
 
 const props = defineProps({
@@ -58,10 +58,10 @@ const emit = defineEmits<{
   (event: 'modelUpdated', value: any, model: Record<string, any>): void
 }>()
 
-const modelRef = toRef(props, 'model')
+const propsRefs = toRefs(props)
 
 const { updateModelValue, value: inputValue, clearValidationErrors } = composables.useAbstractFields({
-  model: modelRef,
+  model: propsRefs.model,
   schema: props.schema,
   formOptions: props.formOptions,
   emitModelUpdated: (data: { value: any, model: Record<string, any> }): void => {

--- a/packages/core/forms/src/components/fields/__tests__/FieldCheckbox.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldCheckbox.cy.ts
@@ -13,6 +13,7 @@ describe('<FieldTester /> - FieldCheckbox', () => {
       label: fieldLabel,
       help: 'Check if the cat is cool.',
       required: true,
+      styleClasses: 'cool-cats',
     }],
   }
 
@@ -41,6 +42,11 @@ describe('<FieldTester /> - FieldCheckbox', () => {
       cy.get('.required').find(`.form-group-label[for="${fieldKey}"]`).should('exist')
     } else {
       cy.get('.required').find(`.form-group-label[for="${fieldKey}"]`).should('not.exist')
+    }
+
+    // check style classes
+    if (schema.fields[0].styleClasses) {
+      cy.get('.form-group.field-checkbox').should('have.class', schema.fields[0].styleClasses)
     }
 
     // check help text

--- a/packages/core/forms/src/components/fields/__tests__/FieldInput.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldInput.cy.ts
@@ -12,6 +12,7 @@ describe('<FieldTester /> - FieldInput', () => {
       id: fieldKey,
       inputType: 'text',
       label: fieldLabel,
+      styleClasses: 'awesome-cats',
       help: 'The name of the cat.',
       required: true,
     }],
@@ -59,6 +60,11 @@ describe('<FieldTester /> - FieldInput', () => {
     if (schema.fields[0].help) {
       cy.get(`label[for="${fieldKey}"] .info-icon`).should('be.visible')
       cy.get(`label[for="${fieldKey}"]`).should('contain.text', schema.fields[0].help)
+    }
+
+    // check style classes
+    if (schema.fields[0].styleClasses) {
+      cy.get('.form-group.field-input').should('have.class', schema.fields[0].styleClasses)
     }
   })
 

--- a/packages/core/forms/src/components/fields/__tests__/FieldMultiselect.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldMultiselect.cy.ts
@@ -1,0 +1,198 @@
+import type { FormSchema } from '../../../types'
+import FieldTester from '../../../../sandbox/FieldTester.vue'
+
+describe('<FieldTester /> - FieldMultiselect', () => {
+  const fieldKeys = ['https_redirect_status_code', 'protocols']
+  const fieldLabels = ['HTTPS Redirect Status Code', 'Protocols']
+  const fieldValues = [['400'], ['https']]
+  const updatedValues = [['426'], ['tls', 'ws']]
+  const styleClasses = ['', 'plugin-protocols-select']
+
+  const schema: FormSchema = {
+    fields: [
+      // with elements.one_of
+      {
+        type: 'multiselect',
+        label: fieldLabels[0],
+        id: fieldKeys[0],
+        model: fieldKeys[0],
+        name: fieldKeys[0],
+        elements: {
+          one_of: [
+            301,
+            302,
+            307,
+            308,
+            400,
+            426,
+          ],
+        },
+        help: 'The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308. ',
+      },
+      // with values
+      {
+        type: 'multiselect',
+        label: fieldLabels[1],
+        id: fieldKeys[1],
+        model: fieldKeys[1],
+        name: fieldKeys[1],
+        required: true,
+        styleClasses: styleClasses[1],
+        values: [
+          { label: 'GRPC', value: 'grpc' },
+          { label: 'GRPCS', value: 'grpcs' },
+          { label: 'HTTP', value: 'http' },
+          { label: 'HTTPS', value: 'https' },
+          { label: 'TCP', value: 'tcp' },
+          { label: 'TLS', value: 'tls' },
+          { label: 'TLS_PASSTHROUGH', value: 'tls_passthrough' },
+          { label: 'UDP', value: 'udp' },
+          { label: 'WS', value: 'ws' },
+          { label: 'WSS', value: 'wss' },
+        ],
+        help: 'An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols. When set to only `"https"`, HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error. ',
+      }],
+  }
+
+  for (let i = 0; i < fieldKeys.length; i++) {
+    const fieldKey = fieldKeys[i]
+    const fieldLabel = fieldLabels[i]
+    const fieldValue = fieldValues[i]
+    const updatedValue = updatedValues[i]
+
+    it('renders default state correctly - without model', () => {
+      cy.mount(FieldTester, {
+        props: {
+          schema,
+        },
+      })
+
+      cy.get('.field-tester-container').should('exist')
+
+      // check VFG input value
+      cy.get(`#${fieldKey}`).should('exist')
+      cy.get(`#${fieldKey}`).should('have.value', '')
+
+      // initial model is empty after load
+      cy.getTestId(`field-tester-form-model-${fieldKey}-value`).should('not.exist')
+
+      // check VFG label is set correctly
+      cy.get(`.form-group-label[for="${fieldKey}"]`).should('be.visible')
+      cy.get(`.form-group-label[for="${fieldKey}"]`).should('contain.text', fieldLabel)
+
+      // check help text
+      if (schema.fields[i].help) {
+        cy.get(`label[for="${fieldKey}"] .info-icon`).should('be.visible')
+        cy.get(`label[for="${fieldKey}"]`).should('contain.text', schema.fields[i].help)
+      }
+
+      // check required state
+      if (schema.fields[i].required) {
+        cy.get(`.field-multiselect.required label[for="${fieldKey}"]`).should('exist')
+      } else {
+        cy.get(`.field-multiselect.required label[for="${fieldKey}"]`).should('not.exist')
+      }
+
+      // check style classes
+      if (schema.fields[i].styleClasses) {
+        cy.get('.form-group.field-multiselect').should('have.class', styleClasses[i])
+      }
+
+      // check all options render
+      cy.get(`#${fieldKey}`).click()
+
+      const items = schema.fields[i].elements?.one_of || schema.fields[i].values
+      items.forEach((item: Record<string, any> | string) => {
+        if (typeof item === 'object') {
+          cy.getTestId(`multiselect-item-${item.value}`).should('exist')
+        } else {
+          cy.getTestId(`multiselect-item-${item}`).should('exist')
+        }
+      })
+    })
+
+    it('renders default state correctly - with model', () => {
+      cy.mount(FieldTester, {
+        props: {
+          schema,
+          model: {
+            [fieldKey]: fieldValue,
+          },
+        },
+      })
+
+      cy.get('.field-tester-container').should('exist')
+
+      cy.get(`#${fieldKey}`).should('exist')
+      cy.getTestId(`field-tester-form-model-${fieldKey}-value`).should('be.visible')
+
+      // check VFG input value
+      // check field test form model matches
+      for (let j = 0; j < fieldValue.length; j++) {
+        // label is to uppercase of value
+        cy.get(`[data-testid="${fieldKey}-items"] [data-testid="selection-badges-container"] .badge-content-wrapper`).should('contain.text', fieldValue[j].toUpperCase())
+        cy.getTestId(`field-tester-form-model-${fieldKey}-value`).should('contain.text', fieldValue[j])
+      }
+    })
+
+    it('handles input changes', () => {
+      cy.mount(FieldTester, {
+        props: {
+          schema,
+        },
+      })
+
+      cy.get('.field-tester-container').should('exist')
+
+      // edit the input value
+      cy.get(`#${fieldKey}`).should('exist')
+      cy.get(`#${fieldKey}`).click()
+      for (let j = 0; j < updatedValue.length; j++) {
+        cy.getTestId(`multiselect-item-${updatedValue[j]}`).find('button').should('exist')
+        cy.getTestId(`multiselect-item-${updatedValue[j]}`).find('button').scrollIntoView()
+        cy.getTestId(`multiselect-item-${updatedValue[j]}`).find('button').should('be.visible')
+        cy.getTestId(`multiselect-item-${updatedValue[j]}`).find('button').click()
+      }
+
+      for (let j = 0; j < updatedValue.length; j++) {
+        // check VFG input value - label is to uppercase of value
+        cy.get(`[data-testid="${fieldKey}-items"] [data-testid="selection-badges-container"] .badge-content-wrapper`).should('contain.text', updatedValue[j].toUpperCase())
+        // check field test form model
+        cy.getTestId(`field-tester-form-model-${fieldKey}-value`).should('contain.text', updatedValue[j])
+      }
+    })
+
+    it('handles programmatic input changes', () => {
+      cy.mount(FieldTester, {
+        props: {
+          schema,
+          model: {
+            [fieldKey]: fieldValue,
+          },
+          modifiedModel: {
+            [fieldKey]: updatedValue,
+          },
+        },
+      })
+
+      cy.get('.field-tester-container').should('exist')
+
+      // initial value loaded
+      cy.getTestId(`field-tester-form-model-${fieldKey}-value`).should('be.visible')
+      for (let j = 0; j < fieldValue.length; j++) {
+        cy.getTestId(`field-tester-form-model-${fieldKey}-value`).should('contain.text', fieldValue[j])
+      }
+
+      // programmatic update
+      cy.getTestId('tester-update-button').should('be.visible')
+      cy.getTestId('tester-update-button').click()
+
+      for (let j = 0; j < updatedValue.length; j++) {
+        // check VFG input value - label is to uppercase of value
+        cy.get(`[data-testid="${fieldKey}-items"] [data-testid="selection-badges-container"] .badge-content-wrapper`).should('contain.text', updatedValue[j].toUpperCase())
+        // check field test form model also matches
+        cy.getTestId(`field-tester-form-model-${fieldKey}-value`).should('contain.text', updatedValue[j])
+      }
+    })
+  }
+})

--- a/packages/core/forms/src/components/fields/__tests__/FieldRadio.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldRadio.cy.ts
@@ -15,6 +15,7 @@ describe('<FieldTester /> - FieldRadio', () => {
       label: fieldLabel,
       required: true,
       help: 'Specify a gender if it is known',
+      styleClasses: 'cool-cats',
       values: [
         { name: 'Male', value: fieldValue },
         { name: 'Female', value: 'female' },
@@ -50,6 +51,11 @@ describe('<FieldTester /> - FieldRadio', () => {
       cy.get('.required').find(`.form-group-label[for="${fieldKey}"]`).should('exist')
     } else {
       cy.get('.required').find(`.form-group-label[for="${fieldKey}"]`).should('not.exist')
+    }
+
+    // check style classes
+    if (schema.fields[0].styleClasses) {
+      cy.get('.form-group.field-radio').should('have.class', schema.fields[0].styleClasses)
     }
 
     // check help text

--- a/packages/core/forms/src/components/fields/__tests__/FieldSelect.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldSelect.cy.ts
@@ -6,6 +6,8 @@ describe('<FieldTester /> - FieldSelect', () => {
   const fieldLabels = ['HTTPS Redirect Status Code', 'Protocols']
   const fieldValues = [307, 'http, https']
   const updatedValues = [426, 'https']
+  const styleClasses = ['', 'plugin-protocols-select']
+
   const schema: FormSchema = {
     fields: [
       // with number[] and no groups
@@ -38,6 +40,7 @@ describe('<FieldTester /> - FieldSelect', () => {
           hideNoneSelectedText: true,
         },
         required: true,
+        styleClasses: styleClasses[1],
         values: [
           {
             name: 'grpc',
@@ -178,6 +181,11 @@ describe('<FieldTester /> - FieldSelect', () => {
         cy.get(`.field-select.required label[for="${fieldKey}"]`).should('exist')
       } else {
         cy.get(`.field-select.required label[for="${fieldKey}"]`).should('not.exist')
+      }
+
+      // check style classes
+      if (schema.fields[i].styleClasses) {
+        cy.get('.form-group.field-select').should('have.class', styleClasses[i])
       }
 
       // check all groups / options render

--- a/packages/core/forms/src/components/fields/__tests__/FieldSwitch.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldSwitch.cy.ts
@@ -12,6 +12,7 @@ describe('<FieldTester /> - FieldSwitch', () => {
       id: fieldKey,
       inputType: 'text',
       label: fieldLabel,
+      styleClasses: 'cool-cats',
       required: true,
     }],
   }
@@ -41,6 +42,11 @@ describe('<FieldTester /> - FieldSwitch', () => {
       cy.get('.required').find(`.form-group-label[for="${fieldKey}"]`).should('exist')
     } else {
       cy.get('.required').find(`.form-group-label[for="${fieldKey}"]`).should('not.exist')
+    }
+
+    // check style classes
+    if (schema.fields[0].styleClasses) {
+      cy.get('.form-group.field-switch').should('have.class', schema.fields[0].styleClasses)
     }
 
     // check help text

--- a/packages/core/forms/src/components/fields/__tests__/FieldTextArea.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldTextArea.cy.ts
@@ -12,6 +12,7 @@ describe('<FieldTester /> - FieldTextArea', () => {
       id: fieldKey,
       label: fieldLabel,
       help: 'Describe the personality of the cat.',
+      styleClasses: 'cool-cats',
       required: true,
     }],
   }
@@ -41,6 +42,11 @@ describe('<FieldTester /> - FieldTextArea', () => {
       cy.get('.required').find(`.form-group-label[for="${fieldKey}"]`).should('exist')
     } else {
       cy.get('.required').find(`.form-group-label[for="${fieldKey}"]`).should('not.exist')
+    }
+
+    // check style classes
+    if (schema.fields[0].styleClasses) {
+      cy.get('.form-group.field-text-area').should('have.class', schema.fields[0].styleClasses)
     }
 
     // check help text


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
Convert KMultiselect to setup syntax for [KHCP-11341](https://konghq.atlassian.net/browse/KHCP-11341).

Other fixes:
- Add testing of style classes to other entities
- add support for missing props to FieldMultiselect:
  - `id`
  - `classNames`
  - `disabled`
  - `name`
  - add `data-testid` to KPop

[KHCP-11341]: https://konghq.atlassian.net/browse/KHCP-11341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ