### PR TITLE
refactor(analytics): move dashboard schema [MA-3389]

### DIFF
--- a/packages/analytics/analytics-chart/README.md
+++ b/packages/analytics/analytics-chart/README.md
@@ -230,9 +230,9 @@ export default defineComponent({
 
 Optional value which can be any one of the following:
 
-- `Hidden`: will only show the outer doughnut chart
-- `SingleMetric`: displays only the large metric value
-- `Full`: displays both the large metric and subtext
+- `hidden`: will only show the outer doughnut chart
+- `single`: displays only the large metric value
+- `full`: displays both the large metric and subtext
 
 #### `reverseDataset`
 
@@ -306,7 +306,7 @@ export default defineComponent({
 
     const chartOptions = ref<SimpleChartOptions>({
       type: 'gauge',
-      metricDisplay: ChartMetricDisplay.Full
+      metricDisplay: 'full'
     })
 
     return {

--- a/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
@@ -42,27 +42,27 @@
               <KRadio
                 v-model="metricDisplay"
                 name="metricDisplay"
-                :selected-value="ChartMetricDisplay.SingleMetric"
+                :selected-value="'single'"
               >
-                {{ ChartMetricDisplay.SingleMetric }}
+                single
               </KRadio>
             </div>
             <div>
               <KRadio
                 v-model="metricDisplay"
                 name="metricDisplay"
-                :selected-value="ChartMetricDisplay.Full"
+                :selected-value="'full'"
               >
-                {{ ChartMetricDisplay.Full }}
+                full
               </KRadio>
             </div>
             <div>
               <KRadio
                 v-model="metricDisplay"
                 name="metricDisplay"
-                :selected-value="ChartMetricDisplay.Hidden"
+                :selected-value="'hidden'"
               >
-                {{ ChartMetricDisplay.Hidden }}
+                hidden
               </KRadio>
             </div>
           </div>
@@ -224,7 +224,6 @@
 <script setup lang="ts">
 import { computed, ref, watch, inject } from 'vue'
 import {
-  ChartMetricDisplay,
   SimpleChart,
   type SimpleChartType,
   TopNTable,
@@ -236,6 +235,7 @@ import { rand } from '../utils/utils'
 import { lookupDatavisColor } from '../../src/utils'
 import { lookupStatusCodeColor } from '../../src/utils/customColors'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
+import type { SimpleChartMetricDisplay } from '../../src'
 
 enum Metrics {
   TotalRequests = 'TotalRequests',
@@ -259,7 +259,7 @@ const multiDimensionToggle = ref(false)
 const showLoadingState = ref(false)
 const emptyState = ref(false)
 const chartType = ref<SimpleChartType>('gauge')
-const metricDisplay = ref(ChartMetricDisplay.Full)
+const metricDisplay = ref<SimpleChartMetricDisplay>('full')
 const reverseDataset = ref(true)
 const gaugeNumerator = ref(0)
 const selectedMetric = ref<MetricSelection>({

--- a/packages/analytics/analytics-chart/src/components/SimpleChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/SimpleChart.cy.ts
@@ -1,5 +1,5 @@
 // Cypress component test spec file
-import { ChartMetricDisplay, ChartLegendPosition } from '../enums/'
+import { ChartLegendPosition } from '../enums/'
 import SimpleChart from './SimpleChart.vue'
 import { emptyExploreResult } from '../../fixtures/mockData'
 
@@ -59,7 +59,7 @@ describe('<SimpleChart />', () => {
         chartData: exploreResultTruncated,
         chartOptions: {
           type: 'gauge',
-          metricDisplay: ChartMetricDisplay.Full,
+          metricDisplay: 'full',
         },
         legendPosition: ChartLegendPosition.Hidden,
       },
@@ -75,7 +75,7 @@ describe('<SimpleChart />', () => {
         chartData: exploreResultTruncated,
         chartOptions: {
           type: 'gauge',
-          metricDisplay: ChartMetricDisplay.SingleMetric,
+          metricDisplay: 'single',
         },
         legendPosition: ChartLegendPosition.Hidden,
       },
@@ -91,7 +91,7 @@ describe('<SimpleChart />', () => {
         chartData: exploreResultTruncated,
         chartOptions: {
           type: 'gauge',
-          metricDisplay: ChartMetricDisplay.Hidden,
+          metricDisplay: 'hidden',
         },
         legendPosition: ChartLegendPosition.Hidden,
       },

--- a/packages/analytics/analytics-chart/src/components/chart-types/GaugeChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/GaugeChart.vue
@@ -45,9 +45,8 @@ import { datavisPalette } from '../../utils'
 import { v4 as uuidv4 } from 'uuid'
 import { Doughnut } from 'vue-chartjs'
 import composables from '../../composables'
-import type { AnalyticsChartColors, KChartData } from '../../types'
+import type { AnalyticsChartColors, KChartData, SimpleChartMetricDisplay } from '../../types'
 import type { Chart, ChartDataset } from 'chart.js'
-import { ChartMetricDisplay } from '../../enums'
 import type { DoughnutChartData } from '../../types/chart-data'
 
 const props = defineProps({
@@ -57,9 +56,9 @@ const props = defineProps({
     default: null,
   },
   metricDisplay: {
-    type: String as PropType<ChartMetricDisplay>,
+    type: String as PropType<SimpleChartMetricDisplay>,
     required: false,
-    default: ChartMetricDisplay.Hidden,
+    default: 'hidden',
   },
   numerator: {
     type: Number,
@@ -151,8 +150,8 @@ const metricTotal = computed(() => approxNum(formattedDataset?.value[0]?.data[0]
 const metricHighlightColor = computed(() => `color: ${formattedDataset?.value[0]?.backgroundColor[props.numerator]}`)
 
 // Conditionally show large or small metric value, or neither
-const showMetricLarge = computed(() => [ChartMetricDisplay.Full, ChartMetricDisplay.SingleMetric].includes(props.metricDisplay))
-const showMetricSmall = computed(() => props.metricDisplay === ChartMetricDisplay.Full)
+const showMetricLarge = computed(() => ['full', 'single'].includes(props.metricDisplay))
+const showMetricSmall = computed(() => props.metricDisplay === 'full')
 </script>
 
 <style lang="scss" scoped>

--- a/packages/analytics/analytics-chart/src/enums/chart-metric-display.enum.ts
+++ b/packages/analytics/analytics-chart/src/enums/chart-metric-display.enum.ts
@@ -1,6 +1,0 @@
-
-export enum ChartMetricDisplay {
-  Hidden = 'hidden',
-  SingleMetric = 'single',
-  Full = 'full',
-}

--- a/packages/analytics/analytics-chart/src/enums/index.ts
+++ b/packages/analytics/analytics-chart/src/enums/index.ts
@@ -1,2 +1,1 @@
 export * from './chart-legend-position.enum'
-export * from './chart-metric-display.enum'

--- a/packages/analytics/analytics-chart/src/types/chart-data.ts
+++ b/packages/analytics/analytics-chart/src/types/chart-data.ts
@@ -1,5 +1,4 @@
 import type { ChartData, ChartDataset, LegendItem } from 'chart.js'
-import type { ChartMetricDisplay } from '../enums'
 import type { ChartTooltipSortFn } from './chartjs-options'
 import type { ChartType, SimpleChartType } from './chart-types'
 import type { ExploreAggregations } from '@kong-ui-public/analytics-utilities'
@@ -100,6 +99,13 @@ export interface AnalyticsChartOptions {
 }
 
 /**
+ * Metric display for simple charts
+ */
+export const simpleChartMetricDisplay = ['hidden', 'single', 'full'] as const
+
+export type SimpleChartMetricDisplay = typeof simpleChartMetricDisplay[number]
+
+/**
  * Simple Chart options
  */
 export interface SimpleChartOptions {
@@ -114,7 +120,7 @@ export interface SimpleChartOptions {
   /**
    * Determines how much detail about the metric (eg: value, info text, etc) is to be shown in the center
    */
-  metricDisplay?: ChartMetricDisplay,
+  metricDisplay?: SimpleChartMetricDisplay,
   /**
    * Determines whether the dataset order will be reversed
    */

--- a/packages/analytics/analytics-utilities/package.json
+++ b/packages/analytics/analytics-utilities/package.json
@@ -54,13 +54,14 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "500KB"
+    "errorLimit": "600KB"
   },
   "dependencies": {
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0"
   },
   "devDependencies": {
-    "@kong/design-tokens": "1.17.2"
+    "@kong/design-tokens": "1.17.2",
+    "json-schema-to-ts": "^3.1.1"
   }
 }

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.ts
@@ -1,7 +1,4 @@
 import type { FromSchema, JSONSchema } from 'json-schema-to-ts'
-import { ChartMetricDisplay } from '@kong-ui-public/analytics-chart'
-import { DEFAULT_TILE_HEIGHT } from '../constants'
-import type { AllFilters, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
 import {
   aiExploreAggregations,
   basicExploreAggregations,
@@ -16,20 +13,9 @@ import {
   queryableExploreDimensions,
   relativeTimeRangeValuesV4,
   requestFilterTypeEmptyV2,
-} from '@kong-ui-public/analytics-utilities'
-
-export interface DashboardRendererContext {
-  filters: AllFilters[]
-  timeSpec?: TimeRangeV4
-  tz?: string
-  refreshInterval?: number
-  editable?: boolean
-}
+} from './types'
 
 type FromSchemaWithOptions<T extends JSONSchema> = FromSchema<T, { keepDefaultedPropertiesOptional: true }>
-
-// The DashboardRenderer component fills in optional values before passing them down to the tile renderers.
-export type DashboardRendererContextInternal = Required<DashboardRendererContext>
 
 // TODO: Once we support all chart types, this could potentially be replaced with a direct reference to `chartTypes`.
 // This is partially overlapping with analytics chart types, but not strictly so.
@@ -142,7 +128,7 @@ export const gaugeChartSchema = {
     },
     metricDisplay: {
       type: 'string',
-      enum: Object.values(ChartMetricDisplay),
+      enum: ['hidden', 'single', 'full'], // This matches the SimpleChartMetricDisplay type.
     },
     reverseDataset: {
       type: 'boolean',
@@ -526,7 +512,7 @@ export const dashboardConfigSchema = {
     },
     tileHeight: {
       type: 'number',
-      description: `Height of each tile in pixels. Default: ${DEFAULT_TILE_HEIGHT}`,
+      description: 'Height of each tile in pixels.',
     },
     gridSize: {
       type: 'object',
@@ -548,12 +534,3 @@ export const dashboardConfigSchema = {
 } as const satisfies JSONSchema
 
 export type DashboardConfig = FromSchemaWithOptions<typeof dashboardConfigSchema>
-
-export interface RendererProps<T> {
-  query: ValidDashboardQuery
-  context: DashboardRendererContextInternal
-  queryReady: boolean
-  chartOptions: T
-  height: number
-  refreshCounter: number
-}

--- a/packages/analytics/analytics-utilities/src/index.ts
+++ b/packages/analytics/analytics-utilities/src/index.ts
@@ -1,4 +1,5 @@
 export * from './constants'
+export * from './dashboardSchema'
 export * from './types'
 export * from './format'
 export * from './granularity'

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -47,7 +47,6 @@
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.17.2",
     "@kong/kongponents": "9.14.16",
-    "json-schema-to-ts": "^3.1.1",
     "pinia": ">= 2.1.7 < 3",
     "swrv": "^1.0.4",
     "vue": "^3.5.12"

--- a/packages/analytics/dashboard-renderer/src/components/BarChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BarChartRenderer.vue
@@ -13,7 +13,8 @@
 
 <script setup lang="ts">
 import BaseAnalyticsChartRenderer from './BaseAnalyticsChartRenderer.vue'
-import type { BarChartOptions, RendererProps } from '../types'
+import type { RendererProps } from '../types'
+import type { BarChartOptions } from '@kong-ui-public/analytics-utilities'
 
 defineProps<RendererProps<BarChartOptions>>()
 </script>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -1,4 +1,3 @@
-import { ChartMetricDisplay } from '@kong-ui-public/analytics-chart'
 import { INJECT_QUERY_PROVIDER, CP_ID_TOKEN, ENTITY_ID_TOKEN } from '../constants'
 import type {
   AdvancedDatasourceQuery,
@@ -153,7 +152,7 @@ describe('<DashboardRenderer />', () => {
             definition: {
               chart: {
                 type: 'gauge',
-                metricDisplay: ChartMetricDisplay.Full,
+                metricDisplay: 'full',
                 reverseDataset: true,
                 numerator: 0,
               },

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import Ajv from 'ajv'
-import { dashboardConfigSchema } from '../types'
+import { dashboardConfigSchema } from '@kong-ui-public/analytics-utilities'
 
 const ajv = new Ajv()
 const validate = ajv.compile(dashboardConfigSchema)

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -35,7 +35,8 @@
 </template>
 
 <script setup lang="ts">
-import type { DashboardConfig, DashboardRendererContext, GridTile, TileConfig, TileDefinition, DashboardRendererContextInternal } from '../types'
+import type { DashboardRendererContext, DashboardRendererContextInternal, GridTile } from '../types'
+import type { DashboardConfig, TileConfig, TileDefinition } from '@kong-ui-public/analytics-utilities'
 import DashboardTile from './DashboardTile.vue'
 import { computed, inject, ref } from 'vue'
 import composables from '../composables'

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -77,11 +77,9 @@
   </div>
 </template>
 <script setup lang="ts">
-import type { DashboardRendererContextInternal, DashboardTileType, TileDefinition } from '../types'
-import type {
-  Component,
-} from 'vue'
-import { computed, inject, ref } from 'vue'
+import type { DashboardRendererContextInternal } from '../types'
+import type { DashboardTileType, TileDefinition } from '@kong-ui-public/analytics-utilities'
+import { type Component, computed, inject, ref } from 'vue'
 import '@kong-ui-public/analytics-chart/dist/style.css'
 import '@kong-ui-public/analytics-metric-provider/dist/style.css'
 import SimpleChartRenderer from './SimpleChartRenderer.vue'

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -6,7 +6,8 @@
   </div>
 </template>
 <script setup lang="ts">
-import type { MetricCardOptions, RendererProps } from '../types'
+import type { RendererProps } from '../types'
+import type { MetricCardOptions } from '@kong-ui-public/analytics-utilities'
 import { MetricsProvider, MetricsConsumer } from '@kong-ui-public/analytics-metric-provider'
 import { computed, type Ref } from 'vue'
 import { type ExploreFilter, Timeframe, TimePeriods } from '@kong-ui-public/analytics-utilities'

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
@@ -34,14 +34,20 @@ import { computed, inject, onUnmounted, ref, watch } from 'vue'
 import useSWRV from 'swrv'
 import { useSwrvState } from '@kong-ui-public/core'
 import composables from '../composables'
-import {
-  type AllFilters,
-  type AnalyticsBridge,
-  type DatasourceAwareQuery, type ExploreFilter,
-  type ExploreQuery, type ExploreResultV4, type FilterTypeMap, type QueryDatasource, stripUnknownFilters,
+import type {
+  AllFilters,
+  AnalyticsBridge,
+  DatasourceAwareQuery,
+  ExploreFilter,
+  ExploreQuery,
+  ExploreResultV4,
+  FilterTypeMap,
+  QueryDatasource,
+  ValidDashboardQuery,
 } from '@kong-ui-public/analytics-utilities'
+import { stripUnknownFilters } from '@kong-ui-public/analytics-utilities'
 import { INJECT_QUERY_PROVIDER } from '../constants'
-import type { DashboardRendererContextInternal, ValidDashboardQuery } from '../types'
+import type { DashboardRendererContextInternal } from '../types'
 
 const props = defineProps<{
   context: DashboardRendererContextInternal

--- a/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.vue
@@ -17,7 +17,8 @@
 </template>
 
 <script setup lang="ts">
-import type { GaugeChartOptions, RendererProps } from '../types'
+import type { RendererProps } from '../types'
+import type { GaugeChartOptions } from '@kong-ui-public/analytics-utilities'
 import { SimpleChart } from '@kong-ui-public/analytics-chart'
 import QueryDataProvider from './QueryDataProvider.vue'
 

--- a/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TimeseriesChartRenderer.vue
@@ -12,7 +12,8 @@
 
 <script setup lang="ts">
 import BaseAnalyticsChartRenderer from './BaseAnalyticsChartRenderer.vue'
-import type { TimeseriesChartOptions, RendererProps } from '../types'
+import type { RendererProps } from '../types'
+import type { TimeseriesChartOptions } from '@kong-ui-public/analytics-utilities'
 
 defineProps<RendererProps<TimeseriesChartOptions>>()
 </script>

--- a/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
@@ -30,7 +30,8 @@
 </template>
 
 <script setup lang="ts">
-import type { RendererProps, TopNTableOptions } from '../types'
+import type { RendererProps } from '../types'
+import type { TopNTableOptions } from '@kong-ui-public/analytics-utilities'
 import { CP_ID_TOKEN, ENTITY_ID_TOKEN } from '../constants'
 import { TopNTable } from '@kong-ui-public/analytics-chart'
 import type { TopNTableRecord } from '@kong-ui-public/analytics-chart'

--- a/packages/analytics/dashboard-renderer/src/types/grid-layout-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/grid-layout-types.ts
@@ -1,4 +1,4 @@
-import type { TileLayout } from './dashboard-renderer-types'
+import type { TileLayout } from '@kong-ui-public/analytics-utilities'
 
 export interface TilePosition {
   col: number,

--- a/packages/analytics/dashboard-renderer/src/types/index.ts
+++ b/packages/analytics/dashboard-renderer/src/types/index.ts
@@ -1,5 +1,5 @@
 // Export all types and interfaces from this index.ts
 // The actual types and interfaces should be contained in separate files within this folder.
 
-export * from './dashboard-renderer-types'
 export * from './grid-layout-types'
+export * from './renderer-types'

--- a/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
@@ -1,0 +1,25 @@
+import type {
+  AllFilters,
+  TimeRangeV4,
+  ValidDashboardQuery,
+} from '@kong-ui-public/analytics-utilities'
+
+export interface DashboardRendererContext {
+  filters: AllFilters[]
+  timeSpec?: TimeRangeV4
+  tz?: string
+  refreshInterval?: number
+  editable?: boolean
+}
+
+// The DashboardRenderer component fills in optional values before passing them down to the tile renderers.
+export type DashboardRendererContextInternal = Required<DashboardRendererContext>
+
+export interface RendererProps<T> {
+  query: ValidDashboardQuery
+  context: DashboardRendererContextInternal
+  queryReady: boolean
+  chartOptions: T
+  height: number
+  refreshCounter: number
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       '@kong/design-tokens':
         specifier: 1.17.2
         version: 1.17.2
+      json-schema-to-ts:
+        specifier: ^3.1.1
+        version: 3.1.1
 
   packages/analytics/dashboard-renderer:
     dependencies:
@@ -385,9 +388,6 @@ importers:
       '@kong/kongponents':
         specifier: 9.14.16
         version: 9.14.16(axios@1.7.7)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.3)))(vue@3.5.12(typescript@5.6.3))
-      json-schema-to-ts:
-        specifier: ^3.1.1
-        version: 3.1.1
       pinia:
         specifier: '>= 2.1.7 < 3'
         version: 2.1.7(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))
@@ -1391,10 +1391,6 @@ packages:
     resolution: {integrity: sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.25.6':
-    resolution: {integrity: sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.26.0':
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
@@ -1803,7 +1799,6 @@ packages:
 
   '@evilmartians/lefthook@1.8.2':
     resolution: {integrity: sha512-SZdQk3W9q7tcJwnSwEMUubQqVIK7SHxv52hEAnV7o3nPI+xKcmd+rN0hZIJg07wjBaJRAjzdvoQySKQQYPW5Qw==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -10153,10 +10148,6 @@ snapshots:
       core-js-pure: 3.38.1
       regenerator-runtime: 0.14.1
 
-  '@babel/runtime@7.25.6':
-    dependencies:
-      regenerator-runtime: 0.14.1
-
   '@babel/runtime@7.26.0':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -16166,7 +16157,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.26.0
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}


### PR DESCRIPTION
Move dashboard schema definitions to analytics-utilities.

- Update simple chart metric prop to align better with dashboard renderer.
- Move schema definitions from renderer to analytics-utilities.

BREAKING CHANGE: Dashboard schema definitions are in a different package.
BREAKING CHANGE: Simple chart no longer uses an enum for metric display prop.

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
