### PR TITLE
feat(entities-plugin): add streaming custom plugin support

### DIFF
--- a/packages/entities/entities-plugins/docs/plugin-select.md
+++ b/packages/entities/entities-plugins/docs/plugin-select.md
@@ -61,7 +61,7 @@ A grid component for selecting Plugins.
     - The route for creating a custom plugin.
 
   - `getCustomEditRoute`:
-    - type: `(plugin: string) => RouteLocationRaw`
+    - type: `(plugin: string, type: 'schema' | 'streaming') => RouteLocationRaw`
     - required: `false`
     - default: `undefined`
     - A function that returns the route for editing a custom plugin.
@@ -92,21 +92,17 @@ A grid component for selecting Plugins.
 
 The base konnect or kongManger config.
 
-#### `disableCustomPlugins`
+#### `customPluginSupport`
 
-- type: `boolean`
+- type: `'none' | 'disabled' | 'schema' | 'streaming'`
 - required: `false`
-- default: `false`
+- default: `'none'`
 
-Show the custom plugins tab, but disable it.
-
-#### `hideCustomPlugins`
-
-- type: `boolean`
-- required: `false`
-- default: `false`
-
-Hide UIs for custom plugin create/selelect/delete.
+Control plane custom plugins support level.
+- When `'none'`, custom plugins tab is hidden from the UI.
+- When `'disabled'`, custom plugins tab is shown but grayed out and disabled.
+- When `'schema'`, custom plugins tab is enabled for creating schema-only custom plugins, only the schema-only custom plugins can be rendered, edited, and deleted due to API limitations.
+- When `'streaming'`, custom plugins tab is enabled for creating streaming custom plugins, both schema-only and streaming custom plugins can be rendered, edited, and deleted.
 
 #### `canCreateCustomPlugin`
 

--- a/packages/entities/entities-plugins/fixtures/mockData.ts
+++ b/packages/entities/entities-plugins/fixtures/mockData.ts
@@ -536,6 +536,13 @@ export const konnectAvailablePlugins = {
   ],
 }
 
+export const konnectStreamingCustomPlugins = {
+  data: [
+    { id: '3e26ba5a-9c6b-4e79-9501-0e0bd9ade0ad', name: 'plugin-1', schema: 'schema text', handler: 'handler text' },
+    { id: '3e26ba5a-9c6b-4e79-9501-0e0bd9ade0ae', name: 'plugin-2', schema: 'schema text', handler: 'handler text' },
+  ],
+}
+
 /**
  * Form page data
  */

--- a/packages/entities/entities-plugins/sandbox/pages/PluginSelectPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginSelectPage.vue
@@ -3,6 +3,7 @@
     <h2>Konnect API</h2>
     <PluginSelect
       :config="konnectConfig"
+      custom-plugins="disabled"
       :disabled-plugins="{ 'acl': 'ACL is not supported for this entity type'}"
       :highlighted-plugin-ids="highlightedPluginIds"
       @delete-custom:success="handleDeleteSuccess"
@@ -18,7 +19,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import type { KonnectPluginSelectConfig, KongManagerPluginSelectConfig } from '../../src'
+import type { KonnectPluginSelectConfig, KongManagerPluginSelectConfig, CustomPluginType } from '../../src'
 import { PluginSelect } from '../../src'
 
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
@@ -40,11 +41,12 @@ const konnectConfig = ref<KonnectPluginSelectConfig>({
   }),
   // custom plugins
   createCustomRoute: { name: 'create-custom-plugin' },
-  getCustomEditRoute: (plugin: string) => ({
+  getCustomEditRoute: (plugin: string, type: CustomPluginType) => ({
     name: 'edit-custom-plugin',
     params: {
       control_plane_id: controlPlaneId.value,
       plugin,
+      customPluginType: type,
     },
   }),
 })

--- a/packages/entities/entities-plugins/src/components/custom-plugins/PluginCustomGrid.vue
+++ b/packages/entities/entities-plugins/src/components/custom-plugins/PluginCustomGrid.vue
@@ -72,6 +72,7 @@ import { computed, nextTick, onMounted, ref, onUnmounted } from 'vue'
 import type { PropType } from 'vue'
 import {
   PluginGroup,
+  type CustomPluginType,
   type KongManagerPluginSelectConfig,
   type KonnectPluginSelectConfig,
   type PluginType,
@@ -165,13 +166,14 @@ const modifiedCustomPlugins = computed((): PluginType[] => {
 })
 
 const openDeleteModal = ref(false)
-const selectedPlugin = ref<{ name: string, id: string } | null>(null)
+const selectedPlugin = ref<{ name: string, id: string, customPluginType?: CustomPluginType } | null>(null)
 
 const handleCustomPluginDelete = (plugin: PluginType): void => {
   openDeleteModal.value = true
   selectedPlugin.value = {
     id: plugin.id,
     name: plugin.name,
+    customPluginType: plugin.customPluginType,
   }
 }
 

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectCard.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectCard.vue
@@ -40,7 +40,7 @@
                 <KDropdownItem
                   v-if="canDeleteCustomPlugin"
                   data-testid="edit-plugin-schema"
-                  @click.stop="handleCustomEdit(plugin.name)"
+                  @click.stop="handleCustomEdit(plugin.name, plugin.customPluginType!)"
                 >
                   {{ t('actions.edit') }}
                 </KDropdownItem>
@@ -104,6 +104,7 @@ import { computed, type PropType } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   PluginGroup,
+  type CustomPluginType,
   type KongManagerPluginSelectConfig,
   type KonnectPluginSelectConfig,
   type PluginType,
@@ -187,10 +188,10 @@ const handleCustomDelete = (): void => {
   }
 }
 
-const handleCustomEdit = (pluginName: string): void => {
+const handleCustomEdit = (pluginName: string, type: CustomPluginType): void => {
   const konnectConfig = props.config as KonnectPluginSelectConfig
   if (props.config.app === 'konnect' && typeof konnectConfig.getCustomEditRoute === 'function' && konnectConfig.getCustomEditRoute) {
-    router.push(konnectConfig.getCustomEditRoute(pluginName))
+    router.push(konnectConfig.getCustomEditRoute(pluginName, type))
   }
 }
 

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -518,7 +518,7 @@
         "custom": {
           "title": "Custom Plugins",
           "description": "Custom plugins will be available in this control plane only.",
-          "disabled_tooltip": "Custom Plugins are not available with this Gateway. Create a Hybrid Gateway to leverage Custom Plugins.",
+          "disabled_tooltip": "Custom Plugins are not available with this Gateway. Create a Hybrid or Dedicated Cloud Gateway to leverage Custom Plugins.",
           "empty_title": "No Custom Plugins",
           "empty_description": "No custom plugins have been added to this Control Plane.",
           "create": {

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -15,6 +15,9 @@ export default {
   select: {
     konnect: {
       availablePlugins: `${konnectBaseApiUrl}/v1/available-plugins`,
+      streamingCustomPlugins: `${konnectBaseApiUrl}/custom-plugins`,
+      schemaCustomPluginItem: `${konnectBaseApiUrl}/plugin-schemas/{pluginId}`,
+      streamingCustomPluginItem: `${konnectBaseApiUrl}/custom-plugins/{pluginId}`,
     },
     kongManager: {
       availablePlugins: `${KMBaseApiUrl}/kong`,

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -1,6 +1,6 @@
 import type { RouteLocationRaw } from 'vue-router'
 import type { KonnectBaseFormConfig, KongManagerBaseFormConfig } from '@kong-ui-public/entities-shared'
-import type { EntityType } from './plugin'
+import type { CustomPluginType, EntityType } from './plugin'
 import type { CommonSchemaFields } from './plugins/shared'
 import type { ApplicationRegistrationSchema } from './plugins/application-registration-schema'
 import type { StatsDSchema } from './plugins/stats-d'
@@ -45,7 +45,7 @@ export interface KonnectPluginSelectConfig extends BasePluginSelectConfig, Konne
   /** Route for creating a custom plugin */
   createCustomRoute?: RouteLocationRaw
   /** A function that returns the route for editing a custom plugin */
-  getCustomEditRoute?: (id: string) => RouteLocationRaw
+  getCustomEditRoute?: (id: string, type: CustomPluginType) => RouteLocationRaw
 }
 
 export interface KonnectPluginFormConfig extends BasePluginFormConfig, KonnectBaseFormConfig {}

--- a/packages/entities/entities-plugins/src/types/plugin.ts
+++ b/packages/entities/entities-plugins/src/types/plugin.ts
@@ -127,6 +127,9 @@ export interface FieldRules {
   onlyOneOfMutuallyRequired?: string[][][]
 }
 
+export type CustomPluginType = 'schema' | 'streaming'
+export type CustomPluginSupportLevel = 'none' | 'disabled' | CustomPluginType
+
 export type PluginMetaData<I18nMessageSource = void> = {
   nameKey: I18nMessageSource extends void ? string : PathToDotNotation<I18nMessageSource, string>
   name: string // A display name of the Plugin.
@@ -145,6 +148,7 @@ export interface PluginType extends PluginMetaData {
   available?: boolean // whether the plugin is available or not
   exists?: boolean // whether the plugin exists already for the current entity
   disabledMessage?: string // An optional field for plugin's disabled message.
+  customPluginType?: CustomPluginType // custom plugin type
 }
 
 export type DisabledPlugin = {
@@ -166,4 +170,20 @@ export type PluginOrdering = {
   after: {
     access: string[]
   }
+}
+
+export interface CreateOrEditStreamingCustomPluginRequest {
+  name: string
+  schema: string
+  handler: string
+}
+
+export interface StreamingCustomPluginSchema {
+  id: string
+  name: string
+  schema: string
+  handler: string
+  created_at?: number
+  updated_at?: number
+  tags?: string[]
 }


### PR DESCRIPTION
Changes include:
1. Remove `disableCustomPlugins` 
2. A new prop `customPluginSupport` is added to indicate the which type of custom plugin should be created for the CP
3. The plugin grid now renders schema-only and streaming custom plugins correctly.
4. `getCustomEditRoute` now provides `type: 'schema' | 'streaming'` for custom plugin type indication
5. Text and sandbox change

JIRA: KM-895