### PR TITLE
fix(app-layout): slotted elements style fix

### DIFF
--- a/packages/core/app-layout/src/components/pageInfoSection/AppPageInfoSection.vue
+++ b/packages/core/app-layout/src/components/pageInfoSection/AppPageInfoSection.vue
@@ -120,7 +120,7 @@ defineProps({
     gap: $kui-space-40;
     padding: $kui-space-70;
 
-    :slotted(> .k-table-view) {
+    :slotted(.k-table-view) {
       background-color: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
 
       tr.is-scrolled {
@@ -131,7 +131,7 @@ defineProps({
       }
     }
 
-    :slotted(> .k-empty-state) {
+    :slotted(.k-empty-state) {
       background-color: $kui-color-background-neutral-weakest;
     }
   }

--- a/packages/core/app-layout/src/components/pageInfoSection/AppPageInfoSection.vue
+++ b/packages/core/app-layout/src/components/pageInfoSection/AppPageInfoSection.vue
@@ -120,7 +120,7 @@ defineProps({
     gap: $kui-space-40;
     padding: $kui-space-70;
 
-    :deep(.k-table-view) {
+    :slotted(> .k-table-view) {
       background-color: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
 
       tr.is-scrolled {
@@ -131,7 +131,7 @@ defineProps({
       }
     }
 
-    :deep(.k-empty-state) {
+    :slotted(> .k-empty-state) {
       background-color: $kui-color-background-neutral-weakest;
     }
   }


### PR DESCRIPTION
# Summary

Fixing AppPageInfoSection deeply slotted table and empty state background color

Before
![Screenshot 2025-01-15 at 4 11 06 PM](https://github.com/user-attachments/assets/8ac0a990-afe9-4604-9d80-bc65f6c5aed0)

After
![Screenshot 2025-01-15 at 4 11 49 PM](https://github.com/user-attachments/assets/d103d974-2e2a-4c85-8d4e-2804ceb94746)

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
