### PR TITLE
fix(forms): make textarea resizable

### DIFF
--- a/packages/core/forms/src/components/fields/FieldTextArea.vue
+++ b/packages/core/forms/src/components/fields/FieldTextArea.vue
@@ -13,7 +13,8 @@
       :placeholder="schema.placeholder"
       :readonly="schema.readonly"
       :required="schema.required"
-      :rows="schema.rows || 2"
+      resizable
+      :rows="schema.rows || 3"
     />
 
     <!-- autofill -->


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This PR makes the textarea resizable. It also changes the default `rows` to 3 because 2 seems too small.

KM-901
