### PR TITLE
feat(expressions): add func to check if rhs autocompletion is necessary; dispose after use

### DIFF
--- a/packages/core/expressions/docs/expressions-editor.md
+++ b/packages/core/expressions/docs/expressions-editor.md
@@ -76,13 +76,29 @@ To control whether the editor should show the details of the autocompletion item
 
 Options to pass when creating the Monaco editor.
 
-#### `provideRhsValueCompletion`
+#### `rhsValueCompletion`
 
-- type: `ProvideRhsValueCompletion`
+- type: `RhsValueCompletion`
 - required: `false`
 - default: `undefined`
+- properties:
+  - `provide`:
+    - type: `ProvideRhsValueCompletion`
+    - required: `true`
+
+  - `shouldProvide`:
+    - type: `(lhsIdentValue: string) => boolean`
+    - required: `true`
+
+##### `provide`
 
 A function to provide completion items for the value of the right-hand side (RHS) of the expression. The function should return a `Promise` that resolves to a `CompletionList` or `undefined`.
+
+##### `shouldProvide`
+
+A function to determine whether the completion items should be provided for the value of the left-hand side (LHS) of the expression. The function accepts the string value of an identifier token and returns a `boolean`.
+
+##### Example
 
 For example, in the following case:
 
@@ -96,7 +112,7 @@ http.path == "foo"
                  ^cursor
 ```
 
-… the `provideRhsValueCompletion` function will be called with the following arguments:
+… the `provide` function will be called with the following arguments:
 
 | Argument        | Value                                                                      |
 | :-------------- | :------------------------------------------------------------------------- |
@@ -107,8 +123,8 @@ http.path == "foo"
 
 This function will only be triggered in either of the following cases:
 
-- The completion is manually triggered by the user (e.g., with `Ctrl` `I`)
-- A character is typed while the cursor is inside the range of the string value
+1. The completion is manually triggered by the user (e.g., with `Ctrl` `I`). If the cursor is inside the range of a string value, please refer to the 2nd case.
+2. A character is typed while the cursor is inside the range of a string value, AND `shouldProvide` function returns `true` for the value of the identifier token on the LHS.
 
 ### Events
 

--- a/packages/core/expressions/sandbox/App.vue
+++ b/packages/core/expressions/sandbox/App.vue
@@ -25,7 +25,7 @@
 
       <ExpressionsEditor
         v-model="expression"
-        :provide-rhs-value-completion="provideRhsCompletion"
+        :rhs-value-completion="rhsValueCompletion"
         :schema="schemaDefinition"
         @parse-result-update="onParseResultUpdate"
       />
@@ -34,7 +34,9 @@
         href="#"
         style="color: #0030cc; font-weight: bold;"
         @click.prevent="isVisible = true"
-      >Test with Router Playground</a>
+      >
+        Test with Router Playground
+      </a>
 
       <RouterPlaygroundModal
         :hide-editor-actions="false"
@@ -60,9 +62,8 @@
 <script setup lang="ts">
 import * as monaco from 'monaco-editor'
 import { ref, watch } from 'vue'
-import type { SchemaDefinition } from '../src'
+import type { RhsValueCompletion, SchemaDefinition } from '../src'
 import { ExpressionsEditor, HTTP_SCHEMA_DEFINITION, RouterPlaygroundModal, STREAM_SCHEMA_DEFINITION } from '../src'
-import type { ProvideRhsValueCompletion } from '../src/components/ExpressionsEditor.vue'
 
 type NamedSchemaDefinition = { name: string; definition: SchemaDefinition }
 
@@ -101,19 +102,24 @@ const handleCommit = (exp: string) => {
   isVisible.value = false
 }
 
-const provideRhsCompletion: ProvideRhsValueCompletion = async (lhsValue, rhsValueValue, lhsRange, rhsValueRange) => {
-  return {
-    suggestions: new Array(10).fill(0).map(() => {
-      const text = `${rhsValueValue}+${Math.random().toString(36).slice(2, 6)}`
-      return {
-        label: text,
-        kind: monaco.languages.CompletionItemKind.Value,
-        detail: `lhs = ${lhsValue}`,
-        insertText:text,
-        range: rhsValueRange,
-      }
-    }),
-  }
+const rhsValueCompletion: RhsValueCompletion = {
+  provide: async (lhsValue, rhsValueValue, lhsRange, rhsValueRange) => {
+    return {
+      suggestions: new Array(10).fill(0).map(() => {
+        const text = `${rhsValueValue}+${Math.random().toString(36).slice(2, 6)}`
+        return {
+          label: text,
+          kind: monaco.languages.CompletionItemKind.Value,
+          detail: `lhs = ${lhsValue}`,
+          insertText:text,
+          range: rhsValueRange,
+        }
+      }),
+    }
+  },
+  shouldProvide: (lhsIdentValue) => {
+    return lhsIdentValue === 'http.path'
+  },
 }
 
 watch(schemaDefinition, (newSchemaDefinition) => {

--- a/packages/core/expressions/src/index.ts
+++ b/packages/core/expressions/src/index.ts
@@ -4,6 +4,7 @@ import RouterPlaygroundModal from './components/RouterPlaygroundModal.vue'
 export * as Atc from '@kong/atc-router'
 export * from './schema'
 export * from './types'
+export * from './monaco'
 export { ExpressionsEditor, RouterPlaygroundModal }
 
 declare const asyncInit: Promise<any>

--- a/packages/core/expressions/src/types.ts
+++ b/packages/core/expressions/src/types.ts
@@ -1,4 +1,10 @@
 import type * as monaco from 'monaco-editor'
 
 export type ProvideCompletionItems = monaco.languages.CompletionItemProvider['provideCompletionItems']
+
 export type ProvideRhsValueCompletion = (lhsValue: string, rhsValueValue: string, lhsRange: monaco.Range, rhsValueRange: monaco.Range) => Promise<monaco.languages.CompletionList | undefined>
+
+export interface RhsValueCompletion {
+  provide: ProvideRhsValueCompletion
+  shouldProvide: (lhsIdentValue: string) => boolean
+}


### PR DESCRIPTION
# Summary

* `<ExpressionsEditor />` now accepts `rhsValueCompletion` which is made up of `provide` and `shouldProvide`, where the 2nd function accepts an LHS identifier value and returns a `boolean` to indicate whether the RHS value autocompletion is necessary.
* Disposables associated with a `languageId` will now be disposed upon the next registration with the same `languageId`