### PR TITLE
feat(dashboard-renderer): show badge for timeframe overrides [MA-3562]

### DIFF
--- a/packages/analytics/analytics-utilities/src/format.ts
+++ b/packages/analytics/analytics-utilities/src/format.ts
@@ -11,7 +11,7 @@ export function formatISOTimeWithTZ(ts: number | Date) {
   return format(ts, "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
 }
 
-export function formatTime(ts: number, options: TimeFormatOptions = {}) {
+export function formatTime(ts: number | string, options: TimeFormatOptions = {}) {
   if (!ts) {
     return ts
   }

--- a/packages/analytics/analytics-utilities/src/timeframes.ts
+++ b/packages/analytics/analytics-utilities/src/timeframes.ts
@@ -507,3 +507,23 @@ export function timeframeToDatepickerTimeperiod(timeframe: Timeframe): TimePerio
 export function dstOffsetHours(d1: Date, d2: Date): number {
   return minutesToHours(d1.getTimezoneOffset() - d2.getTimezoneOffset())
 }
+
+export const TIMEFRAME_LOOKUP: Record<string, TimeframeKeys> = {
+  '15M': TimeframeKeys.FIFTEEN_MIN,
+  '1H': TimeframeKeys.ONE_HOUR,
+  '6H': TimeframeKeys.SIX_HOUR,
+  '12H': TimeframeKeys.TWELVE_HOUR,
+  '24H': TimeframeKeys.ONE_DAY,
+  '7D': TimeframeKeys.SEVEN_DAY,
+  '15m': TimeframeKeys.FIFTEEN_MIN,
+  '1h': TimeframeKeys.ONE_HOUR,
+  '6h': TimeframeKeys.SIX_HOUR,
+  '12h': TimeframeKeys.TWELVE_HOUR,
+  '24h': TimeframeKeys.ONE_DAY,
+  '7d': TimeframeKeys.SEVEN_DAY,
+  '30d': TimeframeKeys.THIRTY_DAY,
+  current_week: TimeframeKeys.CURRENT_WEEK,
+  current_month: TimeframeKeys.CURRENT_MONTH,
+  previous_week: TimeframeKeys.PREVIOUS_WEEK,
+  previous_month: TimeframeKeys.PREVIOUS_MONTH,
+}

--- a/packages/analytics/dashboard-renderer/sandbox/pages/DynamicDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/DynamicDashboardDemo.vue
@@ -24,13 +24,14 @@
 </template>
 
 <script setup lang="ts">
-import type { DashboardConfig, DashboardRendererContext } from '../../src'
-import { dashboardConfigSchema, DashboardRenderer } from '../../src'
+import type { DashboardRendererContext } from '../../src'
+import { DashboardRenderer } from '../../src'
 import { computed, ref, inject } from 'vue'
 import Ajv from 'ajv'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
 import { SandboxLayout } from '@kong-ui-public/sandbox-layout'
 import '@kong-ui-public/sandbox-layout/dist/style.css'
+import { type DashboardConfig, dashboardConfigSchema } from '@kong-ui-public/analytics-utilities'
 
 const appLinks: SandboxNavigationItem[] = inject('app-links', [])
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -20,7 +20,7 @@
       <DashboardRenderer
         ref="dashboardRendererRef"
         :class="{ 'custom-styling': isToggled}"
-        :config="(dashboardConfig as DashboardConfig)"
+        :config="dashboardConfig"
         :context="context"
         @edit-tile="onEditTile"
       >
@@ -42,11 +42,15 @@
 </template>
 
 <script setup lang="ts">
-import type { DashboardConfig, DashboardRendererContext, TileConfig, TileDefinition, GridTile } from '../../src'
+import type { DashboardRendererContext, GridTile } from '../../src'
 import { DashboardRenderer } from '../../src'
 import { inject, ref } from 'vue'
-import { ChartMetricDisplay } from '@kong-ui-public/analytics-chart'
-import type { ExploreAggregations } from '@kong-ui-public/analytics-utilities'
+import type {
+  DashboardConfig,
+  ExploreAggregations,
+  TileConfig,
+  TileDefinition,
+} from '@kong-ui-public/analytics-utilities'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
 import { SandboxLayout } from '@kong-ui-public/sandbox-layout'
 import '@kong-ui-public/sandbox-layout/dist/style.css'
@@ -122,6 +126,10 @@ const dashboardConfig: DashboardConfig = {
         query: {
           datasource: 'basic',
           limit: 3,
+          time_range: {
+            type: 'relative',
+            time_range: 'current_month',
+          },
         },
       },
       layout: {
@@ -147,6 +155,10 @@ const dashboardConfig: DashboardConfig = {
           datasource: 'advanced',
           dimensions: ['route'],
           metrics: ['request_count'],
+          time_range: {
+            type: 'relative',
+            time_range: '1h',
+          },
         },
       },
       layout: {
@@ -172,6 +184,11 @@ const dashboardConfig: DashboardConfig = {
         query: {
           datasource: 'basic',
           dimensions: ['time'],
+          time_range: {
+            type: 'absolute',
+            start: '2024-01-01',
+            end: '2024-02-01',
+          },
         },
       },
       layout: {
@@ -189,7 +206,7 @@ const dashboardConfig: DashboardConfig = {
       definition: {
         chart: {
           type: 'gauge',
-          metricDisplay: ChartMetricDisplay.Full,
+          metricDisplay: 'full',
           reverseDataset: true,
           numerator: 0,
         },


### PR DESCRIPTION
- If a tile has a description and a badge, show the badge.
- Generate text of badge based on relative timeframe description or absolute time range.
- Add timeframe lookup to analytics-utilities.
- Fix dashboard renderer sandbox.
- Make tiles with overridden timeframes ignore the global time when issuing queries.

![image](https://github.com/user-attachments/assets/82a9471c-cf82-452d-b071-6b92990abe8d)

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
