### PR TITLE
feat(tracing): update span name mappings

### DIFF
--- a/packages/core/tracing/src/constants/spans.ts
+++ b/packages/core/tracing/src/constants/spans.ts
@@ -21,8 +21,36 @@ export const SPAN_NAMES = {
   CLIENT_HEADERS: 'kong.read_client_http_headers',
   FIND_UPSTREAM: 'kong.find_upstream',
   FLUSH_TO_DOWNSTREAM: 'kong.wait_for_client_read',
+
+  /**
+   * Previously known as:
+   * - `kong.upstream.read_response`
+   * - {@link SPAN_NAMES.KONG_READ_RESPONSE_FROM_UPSTREAM}
+   */
+  KONG_READ_BODY_FROM_UPSTREAM: 'kong.read_body_from_upstream',
+
+  /**
+   * Previously known as:
+   * - `kong.upstream.ttfb`
+   * - {@link SPAN_NAMES.KONG_WAITING_FOR_UPSTREAM}
+   */
+  KONG_READ_HEADERS_FROM_UPSTREAM: 'kong.read_headers_from_upstream',
+
+  /**
+   * @deprecated Use {@link SPAN_NAMES.KONG_READ_BODY_FROM_UPSTREAM} instead
+   *
+   * Previously known as:
+   * - `kong.upstream.read_response`
+   */
   KONG_READ_RESPONSE_FROM_UPSTREAM: 'kong.read_response_from_upstream',
   KONG_UPSTREAM_SELECTION: 'kong.upstream.selection',
+
+  /**
+   * @deprecated Use {@link SPAN_NAMES.KONG_READ_HEADERS_FROM_UPSTREAM} instead
+   *
+   * Previously known as:
+   * - `kong.upstream.ttfb`
+   */
   KONG_WAITING_FOR_UPSTREAM: 'kong.waiting_for_upstream',
   READ_BODY: 'kong.read_client_http_body',
 }

--- a/packages/core/tracing/src/utils/spans.ts
+++ b/packages/core/tracing/src/utils/spans.ts
@@ -8,8 +8,10 @@ import { type IAnyValue, type IKeyValue, type Span, type SpanLatency, type SpanN
  */
 const MAPPED_SPAN_NAMES: Record<string, string> = {
   'kong.upstream.try_select': SPAN_NAMES.FIND_UPSTREAM,
-  'kong.upstream.ttfb': SPAN_NAMES.KONG_WAITING_FOR_UPSTREAM,
-  'kong.upstream.read_response': SPAN_NAMES.KONG_READ_RESPONSE_FROM_UPSTREAM,
+  'kong.upstream.ttfb': SPAN_NAMES.KONG_READ_HEADERS_FROM_UPSTREAM,
+  [SPAN_NAMES.KONG_WAITING_FOR_UPSTREAM]: SPAN_NAMES.KONG_READ_HEADERS_FROM_UPSTREAM,
+  'kong.upstream.read_response': SPAN_NAMES.KONG_READ_BODY_FROM_UPSTREAM,
+  [SPAN_NAMES.KONG_READ_RESPONSE_FROM_UPSTREAM]: SPAN_NAMES.KONG_READ_BODY_FROM_UPSTREAM,
 }
 
 const compareSpanNode = (a: SpanNode, b: SpanNode) => {


### PR DESCRIPTION
# Summary

This pull request adds two new pairs of span name mappings for reading on upstream headers and body while adding two pairs of mapping to cover the name mapping that happened last time.

|Old name|New name|
|:-|:-|
|kong.upstream.ttfb (original)|kong.read_headers_from_upstream|
|kong.waiting_for_upstream (to cover the previous change)|kong.read_headers_from_upstream|
|kong.upstream.read_response (original)|kong.read_body_from_upstream|
|kong.read_response_from_upstream (to cover the previous change)|kong.read_body_from_upstream|

KM-921