### PR TITLE
feat(consumer-groups): new empty state [khcp-14827]

### DIFF
--- a/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
@@ -166,6 +166,13 @@ A synchronous or asynchronous function, that returns a boolean, that evaluates i
 
 A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
+#### `enableV2EmptyStates`
+
+- type: `boolean`
+- default: `false`
+
+Enables the new empty state design, this prop can be removed when the khcp-14756-empty-states-m2 FF is removed.
+
 ### Events
 
 #### error

--- a/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupListPage.vue
+++ b/packages/entities/entities-consumer-groups/sandbox/pages/ConsumerGroupListPage.vue
@@ -2,6 +2,9 @@
   <SandboxPermissionsControl
     @update="handlePermissionsUpdate"
   />
+  <h2>Konnect Actions Outside</h2>
+  <div id="kong-ui-app-page-header-action-button" />
+
   <h2>Konnect API</h2>
   <ConsumerGroupList
     v-if="permissions"
@@ -12,6 +15,7 @@
     :can-edit="permissions.canEdit"
     :can-retrieve="permissions.canRetrieve"
     :config="konnectConfig"
+    use-action-outside
     @add:success="onAddSuccess"
     @copy:error="onCopyIdError"
     @copy:success="onCopyIdSuccess"

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -398,27 +398,10 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
+      // click empty state cta
       cy.getTestId('empty-state-action').should('exist')
-      cy.getTestId('empty-state-action').should('contain.text', 'Add to Consumer Group')
-    })
-
-    it('should render AddToGroupModal onclick Add to Group button when consumerId is provided', () => {
-      interceptConsumerKM()
-
-      cy.mount(ConsumerGroupList, {
-        props: {
-          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
-          config: configConsumerKM,
-          canCreate: () => true,
-          canEdit: () => false,
-          canDelete: () => false,
-          canRetrieve: () => false,
-        },
-      })
-
-      cy.wait('@getGroups')
-
       cy.getTestId('empty-state-action').click()
+      // add to group modal
       cy.getTestId('add-to-group-modal').should('exist')
     })
 

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -999,27 +999,10 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
+      // click empty state cta
       cy.getTestId('empty-state-action').should('exist')
-      cy.getTestId('empty-state-action').should('contain.text', 'Add to Consumer Group')
-    })
-
-    it('should render AddToGroupModal onclick Add to Group button when consumerId is provided', () => {
-      interceptConsumerKonnect()
-
-      cy.mount(ConsumerGroupList, {
-        props: {
-          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
-          config: configConsumerKonnect,
-          canCreate: () => true,
-          canEdit: () => false,
-          canDelete: () => false,
-          canRetrieve: () => false,
-        },
-      })
-
-      cy.wait('@getGroups')
-
       cy.getTestId('empty-state-action').click()
+      // add to group modal
       cy.getTestId('add-to-group-modal').should('exist')
     })
 

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -36,7 +36,7 @@
         >
           <div class="button-row">
             <KButton
-              v-if="showEmptyState && config.app === 'konnect'"
+              v-if="!showEmptyState && config.app === 'konnect'"
               appearance="secondary"
               class="open-learning-hub"
               data-testid="consumer-groups-learn-more-button"

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -311,11 +311,11 @@ const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const { hideTableToolbar: showEmptyState, handleStateChange } = useTableState(() => filterQuery.value)
+const { hasRecords, handleStateChange } = useTableState(() => filterQuery.value)
 // Current empty state logic is only for Konnect, KM will pick up at GA.
 // If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
 // If new empty states are not enabled, show the learning hub button (for Konnect)
-const showLHButton = computed((): boolean => props.enableV2EmptyStates ? !showEmptyState.value && props.config.app === 'konnect' : props.config.app === 'konnect')
+const showLHButton = computed((): boolean => props.enableV2EmptyStates ? hasRecords.value && props.config.app === 'konnect' : props.config.app === 'konnect')
 
 /**
  * Table Headers

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -36,7 +36,7 @@
         >
           <div class="button-row">
             <KButton
-              v-if="showLHButton"
+              v-if="showHeaderLHButton"
               appearance="secondary"
               class="open-learning-hub"
               data-testid="consumer-groups-learn-more-button"
@@ -58,6 +58,27 @@
               </KButton>
             </PermissionsWrapper>
           </div>
+        </Teleport>
+      </template>
+
+      <!-- TODO: remove this slot when empty states M2 is cleaned up -->
+      <template
+        v-if="!hasRecords && isLegacyLHButton"
+        #outside-actions
+      >
+        <Teleport
+          :disabled="!useActionOutside"
+          to="#kong-ui-app-page-header-action-button"
+        >
+          <KButton
+            appearance="secondary"
+            class="open-learning-hub"
+            data-testid="consumer-groups-learn-more-button"
+            icon
+            @click="$emit('click:learn-more')"
+          >
+            <BookIcon decorative />
+          </KButton>
         </Teleport>
       </template>
 
@@ -388,8 +409,8 @@ const { hasRecords, handleStateChange } = useTableState(filterQuery)
 // Current empty state logic is only for Konnect, KM will pick up at GA.
 // If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
 // If new empty states are not enabled, show the learning hub button (for Konnect)
-const showLHButton = computed((): boolean => props.enableV2EmptyStates ? hasRecords.value && props.config.app === 'konnect' : props.config.app === 'konnect')
-
+const showHeaderLHButton = computed((): boolean => hasRecords.value && props.config.app === 'konnect')
+const isLegacyLHButton = computed((): boolean => !props.enableV2EmptyStates && props.config.app === 'konnect')
 
 const isConsumerPage = computed<boolean>(() => !!props.config.consumerId)
 const preferencesStorageKey = computed<string>(

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -36,7 +36,7 @@
         >
           <div class="button-row">
             <KButton
-              v-if="!showEmptyState && config.app === 'konnect'"
+              v-if="showLHButton"
               appearance="secondary"
               class="open-learning-hub"
               data-testid="consumer-groups-learn-more-button"
@@ -312,6 +312,10 @@ const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { hideTableToolbar: showEmptyState, handleStateChange } = useTableState(() => filterQuery.value)
+// Current empty state logic is only for Konnect, KM will pick up at GA.
+// If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
+// If new empty states are not enabled, show the learning hub button (for Konnect)
+const showLHButton = computed((): boolean => props.enableV2EmptyStates ? !showEmptyState.value && props.config.app === 'konnect' : props.config.app === 'konnect')
 
 /**
  * Table Headers

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -311,11 +311,6 @@ const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const { hasRecords, handleStateChange } = useTableState(() => filterQuery.value)
-// Current empty state logic is only for Konnect, KM will pick up at GA.
-// If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
-// If new empty states are not enabled, show the learning hub button (for Konnect)
-const showLHButton = computed((): boolean => props.enableV2EmptyStates ? hasRecords.value && props.config.app === 'konnect' : props.config.app === 'konnect')
 
 /**
  * Table Headers
@@ -388,6 +383,13 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     schema: props.config.filterSchema,
   } as FuzzyMatchFilterConfig
 })
+
+const { hasRecords, handleStateChange } = useTableState(filterQuery)
+// Current empty state logic is only for Konnect, KM will pick up at GA.
+// If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
+// If new empty states are not enabled, show the learning hub button (for Konnect)
+const showLHButton = computed((): boolean => props.enableV2EmptyStates ? hasRecords.value && props.config.app === 'konnect' : props.config.app === 'konnect')
+
 
 const isConsumerPage = computed<boolean>(() => !!props.config.consumerId)
 const preferencesStorageKey = computed<string>(

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -36,7 +36,7 @@
         >
           <div class="button-row">
             <KButton
-              v-if="!showEmptyState && config.app === 'konnect'"
+              v-if="showEmptyState && config.app === 'konnect'"
               appearance="secondary"
               class="open-learning-hub"
               data-testid="consumer-groups-learn-more-button"

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -51,8 +51,7 @@
                 appearance="primary"
                 data-testid="toolbar-add-consumer-group"
                 :size="useActionOutside ? 'medium' : 'large'"
-                :to="config.consumerId ? undefined : config.createRoute"
-                @click="() => config.consumerId ? handleAddToGroupClick() : undefined"
+                @click="handleCreateClick"
               >
                 <AddIcon />
                 {{ config.consumerId ? t('consumer_groups.actions.add_to_group') : t('consumer_groups.list.toolbar_actions.new_consumer_group') }}
@@ -73,7 +72,7 @@
           :description="t('consumer_groups.list.empty_state_v2.description')"
           :learn-more="config.app === 'konnect'"
           :title="t('consumer_groups.list.empty_state_v2.title')"
-          @click:create="() => config.consumerId ? handleAddToGroupClick() : undefined"
+          @click:create="handleCreateClick"
           @click:learn-more="$emit('click:learn-more')"
         >
           <template #image>
@@ -333,6 +332,15 @@ const tableHeaders: BaseTableHeaders = fields
 const rowAttributes = (row: Record<string, any>) => ({
   'data-testid': row.username ?? row.custom_id ?? row.id,
 })
+
+const handleCreateClick = (): void => {
+  // if consumer is in consumer group, open add consumer modal
+  if (props.config.consumerId) {
+    handleAddToGroupClick()
+  } else { // else go to create consumer group page
+    router.push(props.config.createRoute)
+  }
+}
 
 /**
  * Fetcher & Filtering

--- a/packages/entities/entities-consumer-groups/src/locales/en.json
+++ b/packages/entities/entities-consumer-groups/src/locales/en.json
@@ -10,10 +10,14 @@
       "empty_state": {
         "title": "Configure a New Consumer Group",
         "description": "Use consumer groups to manage custom rate limiting configuration for subsets of consumers.",
-        "title_for_consumer": "Add to a Consumer Group"
+        "title_for_consumer": "Add to a consumer group"
+      },
+      "empty_state_v2": {
+        "title": "Configure your first consumer group",
+        "description": "Consumer groups allow you to manage shared rate limiting and access control policies for multiple consumers."
       },
       "toolbar_actions": {
-        "new_consumer_group": "New Consumer Group"
+        "new_consumer_group": "New consumer group"
       }
     },
     "title": "Consumer Groups",
@@ -21,8 +25,8 @@
       "placeholder": "Filter by exact name or ID"
     },
     "actions": {
-      "add_to_group": "Add to Consumer Group",
-      "create": "New Consumer Group",
+      "add_to_group": "Add to consumer group",
+      "create": "New consumer group",
       "copy_id": "Copy ID",
       "copy_json": "Copy JSON",
       "edit": "Edit",

--- a/packages/entities/entities-consumers/docs/consumer-list.md
+++ b/packages/entities/entities-consumers/docs/consumer-list.md
@@ -166,6 +166,13 @@ A synchronous or asynchronous function, that returns a boolean, that evaluates i
 
 A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
+#### `enableV2EmptyStates`
+
+- type: `boolean`
+- default: `false`
+
+Enables the new empty state design, this prop can be removed when the khcp-14756-empty-states-m2 FF is removed.
+
 ### Events
 
 #### error

--- a/packages/entities/entities-consumers/sandbox/pages/ConsumerListPage.vue
+++ b/packages/entities/entities-consumers/sandbox/pages/ConsumerListPage.vue
@@ -2,6 +2,9 @@
   <SandboxPermissionsControl
     @update="handlePermissionsUpdate"
   />
+  <h2>Konnect Actions Outside</h2>
+  <div id="kong-ui-app-page-header-action-button" />
+
   <h2>Konnect API</h2>
   <ConsumerList
     v-if="permissions"
@@ -12,6 +15,7 @@
     :can-edit="permissions.canEdit"
     :can-retrieve="permissions.canRetrieve"
     :config="konnectConfig"
+    use-action-outside
     @add:success="onAddSuccess"
     @copy:error="onCopyIdError"
     @copy:success="onCopyIdSuccess"

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -36,7 +36,7 @@
         >
           <div class="button-row">
             <KButton
-              v-if="!showEmptyState && config.app === 'konnect'"
+              v-if="!showEmptyState && !isConsumerGroupPage && config.app === 'konnect'"
               appearance="secondary"
               class="open-learning-hub"
               data-testid="consumers-learn-more-button"

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -311,11 +311,6 @@ const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const { hasRecords, handleStateChange } = useTableState(() => filterQuery.value)
-// Current empty state logic is only for Konnect, KM will pick up at GA.
-// If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
-// If new empty states are not enabled, show the learning hub button (for Konnect)
-const showLHButton = computed((): boolean => props.enableV2EmptyStates ? hasRecords.value && props.config.app === 'konnect' : props.config.app === 'konnect')
 
 /**
  * Table Headers
@@ -381,6 +376,13 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     schema: props.config.filterSchema,
   } as FuzzyMatchFilterConfig
 })
+
+const { hasRecords, handleStateChange } = useTableState(filterQuery)
+// Current empty state logic is only for Konnect, KM will pick up at GA.
+// If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
+// If new empty states are not enabled, show the learning hub button (for Konnect)
+const showLHButton = computed((): boolean => props.enableV2EmptyStates ? hasRecords.value && props.config.app === 'konnect' : props.config.app === 'konnect')
+
 
 const isConsumerGroupPage = computed<boolean>(() => !!props.config.consumerGroupId)
 const preferencesStorageKey = computed<string>(

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -311,11 +311,11 @@ const { i18nT, i18n: { t } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
-const { hideTableToolbar: showEmptyState, handleStateChange } = useTableState(() => filterQuery.value)
+const { hasRecords, handleStateChange } = useTableState(() => filterQuery.value)
 // Current empty state logic is only for Konnect, KM will pick up at GA.
 // If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
 // If new empty states are not enabled, show the learning hub button (for Konnect)
-const showLHButton = computed((): boolean => props.enableV2EmptyStates ? !showEmptyState.value && props.config.app === 'konnect' : props.config.app === 'konnect')
+const showLHButton = computed((): boolean => props.enableV2EmptyStates ? hasRecords.value && props.config.app === 'konnect' : props.config.app === 'konnect')
 
 /**
  * Table Headers

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -36,7 +36,7 @@
         >
           <div class="button-row">
             <KButton
-              v-if="enableV2EmptyStates && !showEmptyState && config.app === 'konnect'"
+              v-if="!showEmptyState && config.app === 'konnect'"
               appearance="secondary"
               class="open-learning-hub"
               data-testid="consumers-learn-more-button"

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -36,7 +36,7 @@
         >
           <div class="button-row">
             <KButton
-              v-if="!showEmptyState && !isConsumerGroupPage && config.app === 'konnect'"
+              v-if="!isConsumerGroupPage && showLHButton"
               appearance="secondary"
               class="open-learning-hub"
               data-testid="consumers-learn-more-button"
@@ -312,6 +312,10 @@ const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const { hideTableToolbar: showEmptyState, handleStateChange } = useTableState(() => filterQuery.value)
+// Current empty state logic is only for Konnect, KM will pick up at GA.
+// If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
+// If new empty states are not enabled, show the learning hub button (for Konnect)
+const showLHButton = computed((): boolean => props.enableV2EmptyStates ? !showEmptyState.value && props.config.app === 'konnect' : props.config.app === 'konnect')
 
 /**
  * Table Headers

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -36,7 +36,7 @@
         >
           <div class="button-row">
             <KButton
-              v-if="!showEmptyState && config.app === 'konnect'"
+              v-if="showEmptyState && config.app === 'konnect'"
               appearance="secondary"
               class="open-learning-hub"
               data-testid="consumers-learn-more-button"

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -95,6 +95,15 @@
         <AddIcon />
       </template>
     </KTableData>
+
+    <!-- TODO: remove this slot when empty states M2 is cleaned up -->
+    <!-- This slot is for teleported actions that should be visible even if the toolbar is hidden -->
+    <div
+      v-if="$slots['outside-actions'] && hideTableToolbar"
+      class="hidden"
+    >
+      <slot name="outside-actions" />
+    </div>
   </KCard>
 </template>
 
@@ -401,6 +410,10 @@ const handleUpdateTablePreferences = (newTablePreferences: TablePreferences): vo
 
   .toolbar-button-container {
     margin-left: auto;
+  }
+
+  .hidden {
+    display: none;
   }
 
   // shared styles for entity empty state


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
New empty state usage in consumer groups.
Part of [KHCP-14827](https://konghq.atlassian.net/browse/KHCP-14827).

Preview: https://github.com/Kong/konnect-ui-apps/pull/5741

[KHCP-14827]: https://konghq.atlassian.net/browse/KHCP-14827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ