### PR TITLE
fix(entities-plugins): fields set to null

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -1201,6 +1201,7 @@ const saveFormData = async (): Promise<void> => {
         originalModel: formFieldsOriginal,
         model: form.fields,
         payload,
+        schema: schema.value,
       })
     }
 

--- a/packages/entities/entities-plugins/src/definitions/schemas/AIProxyAdvanced.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/AIProxyAdvanced.ts
@@ -4,8 +4,14 @@ export const aiProxyAdvancedSchema: CommonSchemaFields = {
   // For the ai-proxy-advanced plugin, 'config-embeddings' and 'config-vectordb' fields are non-required
   // but they have nested fields that are required. If the nested fields are not provided, 'config-embeddings'
   // and 'config-vectordb' should be set to null in the payload.
-  shamefullyTransformPayload: ({ originalModel, model, payload }) => {
+  shamefullyTransformPayload: ({ originalModel, model, payload, schema }) => {
     const isDirty = (key: string) => {
+      // if the field is required and the model value is not empty
+      // the field is dirty
+      if (schema[key]?.required && model[key]) {
+        return true
+      }
+
       // if the model value is the same as the original value
       // the field is not dirty
       if (originalModel[key] === model[key]) {


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Fixing a bug where `vectordb` or `embeddings` will be set to `null` when editing an `ai-proxy-advanced` plugin.

KM-945
