### PR TITLE
fix: draggable dashboard ui tweaks

### DIFF
--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -291,6 +291,66 @@ const dashboardConfig: DashboardConfig = {
         },
       },
     } satisfies TileConfig,
+    {
+      definition: {
+        chart: {
+          type: 'timeseries_line',
+          chartTitle: 'Timeseries line chart of mock data',
+          threshold: {
+            'request_count': 3200,
+          } as Record<ExploreAggregations, number>,
+        },
+        query: {
+          datasource: 'basic',
+          dimensions: ['time'],
+          time_range: {
+            type: 'absolute',
+            start: '2024-01-01',
+            end: '2024-02-01',
+          },
+        },
+      },
+      layout: {
+        position: {
+          col: 0,
+          row: 7,
+        },
+        size: {
+          cols: 3,
+          rows: 2,
+        },
+      },
+    } satisfies TileConfig,
+    {
+      definition: {
+        chart: {
+          type: 'timeseries_line',
+          chartTitle: 'Timeseries line chart of mock data',
+          threshold: {
+            'request_count': 3200,
+          } as Record<ExploreAggregations, number>,
+        },
+        query: {
+          datasource: 'basic',
+          dimensions: ['time'],
+          time_range: {
+            type: 'absolute',
+            start: '2024-01-01',
+            end: '2024-02-01',
+          },
+        },
+      },
+      layout: {
+        position: {
+          col: 0,
+          row: 9,
+        },
+        size: {
+          cols: 3,
+          rows: 2,
+        },
+      },
+    } satisfies TileConfig,
   ],
 }
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -201,7 +201,7 @@ defineExpose({ refresh: refreshTiles })
     border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
     border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
     height: 100%;
-    padding: var(--kui-space-70, $kui-space-70);
+    padding: 0 var(--kui-space-70, $kui-space-70) var(--kui-space-70, $kui-space-70) var(--kui-space-70, $kui-space-70);
   }
 }
 </style>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -256,6 +256,8 @@ const exportCsv = () => {
     display: flex;
     justify-content: space-between;
     margin-bottom: var(--kui-space-30, $kui-space-30);
+    // So any "handlers" for the tile header includes the padding
+    padding-top: var(--kui-space-70, $kui-space-70);
     right: 0;
     width: 100%;
 

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -49,7 +49,9 @@ onMounted(() => {
     grid = GridStack.init({
       column: props.gridSize.cols,
       cellHeight: props.tileHeight,
-      resizable: { handles: 'all' },
+      resizable: { handles: 'se' },
+      lazyLoad: true,
+      handle: '.tile-header',
     }, gridContainer.value)
     grid.on('change', (_, items) => {
       const updatedTiles: GridTile<any>[] = props.tiles.map((tile, i) => {
@@ -92,3 +94,9 @@ watch(() => props.tiles, newTiles => {
   }
 }, { deep: true })
 </script>
+
+<style lang="scss" scoped>
+:deep(.tile-header) {
+  cursor: move;
+}
+</style>


### PR DESCRIPTION
# Summary

- tiles only resizable from "southeast" corner
- make the tile header apply the top padding so that any handlers we want to add to the header, stretch to the tile boundary
- Add lazyLoad flag to gridStack... at worst it does nothing, at best we get some lazy loading? I'd like to experiment in the host app as well

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
