### PR TITLE
fix: handle adding/removing tiles (widgets)

### DIFF
--- a/packages/analytics/analytics-utilities/src/dashboardSchema.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.ts
@@ -496,6 +496,10 @@ export const tileConfigSchema = {
   properties: {
     definition: tileDefinitionSchema,
     layout: tileLayoutSchema,
+    id: {
+      type: 'string',
+      description: 'Unique identifier for the tile.  If not provided, one will be generated.',
+    },
   },
   required: ['definition', 'layout'],
   additionalProperties: false,

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -66,7 +66,7 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "512KB"
+    "errorLimit": "600KB"
   },
   "peerDependencies": {
     "@kong-ui-public/analytics-chart": "workspace:^",

--- a/packages/analytics/dashboard-renderer/sandbox/index.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/index.ts
@@ -21,6 +21,11 @@ const router = createRouter({
       component: () => import('./pages/RendererDemo.vue'),
     },
     {
+      path: '/editable',
+      name: 'editable',
+      component: () => import('./pages/EditableDashboardDemo.vue'),
+    },
+    {
       path: '/',
       name: 'dynamic',
       component: () => import('./pages/DynamicDashboardDemo.vue'),
@@ -38,6 +43,10 @@ const appLinks: SandboxNavigationItem[] = ([
   {
     name: 'Static Dashboard',
     to: { name: 'home' },
+  },
+  {
+    name: 'Editable Dashboard',
+    to: { name: 'editable' },
   },
   {
     name: 'Dynamic Dashboard',

--- a/packages/analytics/dashboard-renderer/sandbox/pages/DynamicDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/DynamicDashboardDemo.vue
@@ -16,6 +16,7 @@
     <div class="sandbox-container">
       <DashboardRenderer
         v-if="definition.type === ValidationResultType.Success"
+        can-edit
         :config="definition.data"
         :context="context"
         draggable

--- a/packages/analytics/dashboard-renderer/sandbox/pages/DynamicDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/DynamicDashboardDemo.vue
@@ -16,7 +16,6 @@
     <div class="sandbox-container">
       <DashboardRenderer
         v-if="definition.type === ValidationResultType.Success"
-        can-edit
         :config="definition.data"
         :context="context"
         draggable
@@ -172,6 +171,7 @@ const context: DashboardRendererContext = {
     type: 'relative',
     time_range: '24h',
   },
+  editable: true,
 }
 
 const handleUpdateTiles = (tiles: any) => {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -1,0 +1,242 @@
+<template>
+  <SandboxLayout
+    :links="appLinks"
+    title="Editable Dashboard"
+  >
+    <div class="sandbox-container">
+      <br>
+      <div style="display: flex; gap: 5px; margin: 5px;">
+        <KButton
+          appearance="primary"
+          size="small"
+          @click="refresh"
+        >
+          refresh
+        </KButton>
+        <KButton
+          size="small"
+          @click="addTile"
+        >
+          Add tile
+        </KButton>
+      </div>
+      <DashboardRenderer
+        ref="dashboardRendererRef"
+        can-edit
+        :config="dashboardConfig"
+        :context="context"
+        @edit-tile="onEditTile"
+        @update-tiles="onUpdateTiles"
+      >
+        <template #slot-1>
+          <div class="slot-container">
+            <h3>Custom Slot</h3>
+            <p>This is a slotted tile</p>
+          </div>
+        </template>
+        <template #slot-2>
+          <div class="slot-container">
+            <h3>Custom Slot 2</h3>
+            <p>This is another slotted tile</p>
+          </div>
+        </template>
+      </DashboardRenderer>
+    </div>
+  </SandboxLayout>
+</template>
+
+<script setup lang="ts">
+import type { DashboardRendererContext, GridTile } from '../../src'
+import { DashboardRenderer } from '../../src'
+import { inject, ref } from 'vue'
+import type {
+  DashboardConfig,
+  DashboardTileType,
+  ExploreAggregations,
+  TileConfig,
+  TileDefinition,
+} from '@kong-ui-public/analytics-utilities'
+import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
+import { SandboxLayout } from '@kong-ui-public/sandbox-layout'
+import '@kong-ui-public/sandbox-layout/dist/style.css'
+
+const appLinks: SandboxNavigationItem[] = inject('app-links', [])
+
+const context: DashboardRendererContext = {
+  filters: [],
+  refreshInterval: 0,
+  editable: true,
+}
+
+const dashboardConfig = ref <DashboardConfig>({
+  gridSize: {
+    cols: 6,
+    rows: 7,
+  },
+  tileHeight: 167,
+  tiles: [
+    {
+      definition: {
+        chart: {
+          type: 'horizontal_bar',
+          chartTitle: 'This is a really long title lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet consectetur adipisicing elit.',
+          allowCsvExport: true,
+        },
+        query: {
+          datasource: 'advanced',
+          dimensions: ['route'],
+          metrics: ['request_count'],
+          time_range: {
+            type: 'relative',
+            time_range: '1h',
+          },
+        },
+      },
+      layout: {
+        position: {
+          col: 0,
+          row: 0,
+        },
+        size: {
+          cols: 3,
+          rows: 2,
+        },
+      },
+    } satisfies TileConfig,
+    {
+      definition: {
+        chart: {
+          type: 'timeseries_line',
+          chartTitle: 'Timeseries line chart of mock data',
+          threshold: {
+            'request_count': 3200,
+          } as Record<ExploreAggregations, number>,
+        },
+        query: {
+          datasource: 'basic',
+          dimensions: ['time'],
+          time_range: {
+            type: 'absolute',
+            start: '2024-01-01',
+            end: '2024-02-01',
+          },
+        },
+      },
+      layout: {
+        position: {
+          col: 3,
+          row: 0,
+        },
+        size: {
+          cols: 3,
+          rows: 2,
+        },
+      },
+    } satisfies TileConfig,
+    {
+      definition: {
+        chart: {
+          type: 'timeseries_bar',
+          chartTitle: 'Timeseries bar chart of mock data',
+          stacked: true,
+        },
+        query: {
+          datasource: 'basic',
+          dimensions: ['time'],
+        },
+      },
+      layout: {
+        position: {
+          col: 0,
+          row: 3,
+        },
+        size: {
+          cols: 3,
+          rows: 2,
+        },
+      },
+    } satisfies TileConfig,
+  ],
+})
+
+const onEditTile = (tile: GridTile<TileDefinition>) => {
+  console.log('@edit-tile', tile)
+
+  const chartTypeToggleMap = {
+    timeseries_line: 'timeseries_bar',
+    timeseries_bar: 'timeseries_line',
+    horizontal_bar: 'vertical_bar',
+    vertical_bar: 'horizontal_bar',
+    gauge: 'gauge',
+    golden_signals: 'golden_signals',
+    slottable: 'slottable',
+    top_n: 'top_n',
+  }
+
+  dashboardConfig.value.tiles = dashboardConfig.value.tiles.map((t, i) => {
+
+    const newType = chartTypeToggleMap[t.definition.chart.type] || t.definition.chart.type
+
+    if (i === tile.id) {
+      return {
+        ...t,
+        definition: {
+          ...t.definition,
+          chart: {
+            ...t.definition.chart,
+            type: newType as DashboardTileType,
+            chartTitle: `This is a ${newType} chart`,
+          } as any,
+        },
+      }
+    }
+    return t
+  })
+}
+
+const dashboardRendererRef = ref<InstanceType<typeof DashboardRenderer> | null>(null)
+
+
+const refresh = () => {
+  dashboardRendererRef.value?.refresh()
+}
+
+const addTile = () => {
+  dashboardConfig.value.tiles.push({
+    definition: {
+      chart: {
+        type: 'timeseries_line',
+        chartTitle: 'Timeseries line chart of mock data',
+        threshold: {
+          'request_count': 3200,
+        } as Record<ExploreAggregations, number>,
+      },
+      query: {
+        datasource: 'basic',
+        dimensions: ['time'],
+        time_range: {
+          type: 'absolute',
+          start: '2024-01-01',
+          end: '2024-02-01',
+        },
+      },
+    },
+    layout: {
+      position: {
+        col: -1,
+        row: -1,
+      },
+      size: {
+        cols: 3,
+        rows: 2,
+        fitToContent: true,
+      },
+    },
+  })
+}
+
+const onUpdateTiles = (tiles: TileConfig[]) => {
+  console.log('@update-tiles', tiles)
+  dashboardConfig.value.tiles = tiles
+}
+</script>

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -22,7 +22,6 @@
       </div>
       <DashboardRenderer
         ref="dashboardRendererRef"
-        can-edit
         :config="dashboardConfig"
         :context="context"
         @edit-tile="onEditTile"

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -76,6 +76,7 @@ const dashboardConfig = ref <DashboardConfig>({
   tileHeight: 167,
   tiles: [
     {
+      id: crypto.randomUUID(),
       definition: {
         chart: {
           type: 'horizontal_bar',
@@ -104,6 +105,7 @@ const dashboardConfig = ref <DashboardConfig>({
       },
     } satisfies TileConfig,
     {
+      id: crypto.randomUUID(),
       definition: {
         chart: {
           type: 'timeseries_line',
@@ -134,6 +136,7 @@ const dashboardConfig = ref <DashboardConfig>({
       },
     } satisfies TileConfig,
     {
+      id: crypto.randomUUID(),
       definition: {
         chart: {
           type: 'timeseries_bar',
@@ -173,11 +176,11 @@ const onEditTile = (tile: GridTile<TileDefinition>) => {
     top_n: 'top_n',
   }
 
-  dashboardConfig.value.tiles = dashboardConfig.value.tiles.map((t, i) => {
+  dashboardConfig.value.tiles = dashboardConfig.value.tiles.map(t => {
 
     const newType = chartTypeToggleMap[t.definition.chart.type] || t.definition.chart.type
 
-    if (i === tile.id) {
+    if (t.id === tile.id) {
       return {
         ...t,
         definition: {
@@ -200,12 +203,14 @@ const dashboardRendererRef = ref<InstanceType<typeof DashboardRenderer> | null>(
 const refresh = () => {
   dashboardRendererRef.value?.refresh()
 }
-
+let last = 0
 const addTile = () => {
+  last = (last + 1) % 2
   dashboardConfig.value.tiles.push({
+    id: crypto.randomUUID(),
     definition: {
       chart: {
-        type: 'timeseries_line',
+        type: ['timeseries_line', 'timeseries_bar'][last] as any,
         chartTitle: 'Timeseries line chart of mock data',
         threshold: {
           'request_count': 3200,
@@ -223,13 +228,12 @@ const addTile = () => {
     },
     layout: {
       position: {
-        col: -1,
-        row: -1,
+        col: 0,
+        row: 0,
       },
       size: {
         cols: 3,
         rows: 2,
-        fitToContent: true,
       },
     },
   })

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -30,6 +30,7 @@
         :context="context"
         draggable
         @edit-tile="onEditTile"
+        @remove-tile="onRemoveTile"
       >
         <template #slot-1>
           <div class="slot-container">
@@ -402,6 +403,10 @@ const addTile = () => {
       },
     },
   })
+}
+
+const onRemoveTile = (tile: GridTile<TileDefinition>) => {
+  console.log('@remove-tile', tile)
 }
 </script>
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -10,27 +10,20 @@
         :label="isToggled ? 'Custom styling' : 'Normal styling'"
       />
       <br>
-      <KButton
-        appearance="primary"
-        size="small"
-        @click="refresh"
-      >
-        refresh
-      </KButton>
-      <KButton
-        size="small"
-        @click="addTile"
-      >
-        Add tile
-      </KButton>
+      <div style="display: flex; gap: 5px; margin: 5px;">
+        <KButton
+          appearance="primary"
+          size="small"
+          @click="refresh"
+        >
+          refresh
+        </KButton>
+      </div>
       <DashboardRenderer
         ref="dashboardRendererRef"
-        can-edit
         :class="{ 'custom-styling': isToggled}"
         :config="dashboardConfig"
         :context="context"
-        @edit-tile="onEditTile"
-        @update-tiles="onUpdateTiles"
       >
         <template #slot-1>
           <div class="slot-container">
@@ -50,14 +43,13 @@
 </template>
 
 <script setup lang="ts">
-import type { DashboardRendererContext, GridTile } from '../../src'
+import type { DashboardRendererContext } from '../../src'
 import { DashboardRenderer } from '../../src'
 import { inject, ref } from 'vue'
 import type {
   DashboardConfig,
   ExploreAggregations,
   TileConfig,
-  TileDefinition,
 } from '@kong-ui-public/analytics-utilities'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
 import { SandboxLayout } from '@kong-ui-public/sandbox-layout'
@@ -298,119 +290,16 @@ const dashboardConfig = ref <DashboardConfig>({
         },
       },
     } satisfies TileConfig,
-    {
-      definition: {
-        chart: {
-          type: 'timeseries_line',
-          chartTitle: 'Timeseries line chart of mock data',
-          threshold: {
-            'request_count': 3200,
-          } as Record<ExploreAggregations, number>,
-        },
-        query: {
-          datasource: 'basic',
-          dimensions: ['time'],
-          time_range: {
-            type: 'absolute',
-            start: '2024-01-01',
-            end: '2024-02-01',
-          },
-        },
-      },
-      layout: {
-        position: {
-          col: 0,
-          row: 7,
-        },
-        size: {
-          cols: 3,
-          rows: 2,
-        },
-      },
-    } satisfies TileConfig,
-    {
-      definition: {
-        chart: {
-          type: 'timeseries_line',
-          chartTitle: 'Timeseries line chart of mock data',
-          threshold: {
-            'request_count': 3200,
-          } as Record<ExploreAggregations, number>,
-        },
-        query: {
-          datasource: 'basic',
-          dimensions: ['time'],
-          time_range: {
-            type: 'absolute',
-            start: '2024-01-01',
-            end: '2024-02-01',
-          },
-        },
-      },
-      layout: {
-        position: {
-          col: 0,
-          row: 9,
-        },
-        size: {
-          cols: 3,
-          rows: 2,
-        },
-      },
-    } satisfies TileConfig,
   ],
 })
 
 const isToggled = ref(false)
-
-const onEditTile = (tile: GridTile<TileDefinition>) => {
-  console.log('@edit-tile', tile)
-}
 
 const dashboardRendererRef = ref<InstanceType<typeof DashboardRenderer> | null>(null)
 
 
 const refresh = () => {
   dashboardRendererRef.value?.refresh()
-}
-
-const addTile = () => {
-  dashboardConfig.value.tiles.push({
-    definition: {
-      chart: {
-        type: 'timeseries_line',
-        chartTitle: 'Timeseries line chart of mock data',
-        threshold: {
-          'request_count': 3200,
-        } as Record<ExploreAggregations, number>,
-      },
-      query: {
-        datasource: 'basic',
-        dimensions: ['time'],
-        time_range: {
-          type: 'absolute',
-          start: '2024-01-01',
-          end: '2024-02-01',
-        },
-      },
-    },
-    layout: {
-      position: {
-        col: -1,
-        row: -1,
-      },
-      size: {
-        cols: 3,
-        rows: 2,
-        fitToContent: true,
-      },
-    },
-  })
-}
-
-const onUpdateTiles = (tiles: TileConfig[]) => {
-  console.log('@update-tiles', tiles)
-  dashboardConfig.value.tiles = tiles
 }
 </script>
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -101,58 +101,58 @@ const dashboardConfig = ref <DashboardConfig>({
         },
       },
     } satisfies TileConfig,
-    // {
-    //   definition: {
-    //     chart: {
-    //       type: 'top_n',
-    //       chartTitle: 'Top N chart of mock data',
-    //       description: '{timeframe}',
-    //     },
-    //     query: {
-    //       datasource: 'basic',
-    //       limit: 1,
-    //     },
-    //   },
-    //   layout: {
-    //     position: {
-    //       col: 0,
-    //       row: 1,
-    //     },
-    //     size: {
-    //       cols: 3,
-    //       rows: 1,
-    //       fitToContent: true,
-    //     },
-    //   },
-    // } satisfies TileConfig,
-    // {
-    //   definition: {
-    //     chart: {
-    //       type: 'top_n',
-    //       chartTitle: 'Top N chart of mock data',
-    //       description: 'Description',
-    //     },
-    //     query: {
-    //       datasource: 'basic',
-    //       limit: 3,
-    //       time_range: {
-    //         type: 'relative',
-    //         time_range: 'current_month',
-    //       },
-    //     },
-    //   },
-    //   layout: {
-    //     position: {
-    //       col: 3,
-    //       row: 1,
-    //     },
-    //     size: {
-    //       cols: 3,
-    //       rows: 1,
-    //       fitToContent: true,
-    //     },
-    //   },
-    // } satisfies TileConfig,
+    {
+      definition: {
+        chart: {
+          type: 'top_n',
+          chartTitle: 'Top N chart of mock data',
+          description: '{timeframe}',
+        },
+        query: {
+          datasource: 'basic',
+          limit: 1,
+        },
+      },
+      layout: {
+        position: {
+          col: 0,
+          row: 1,
+        },
+        size: {
+          cols: 3,
+          rows: 1,
+          fitToContent: true,
+        },
+      },
+    } satisfies TileConfig,
+    {
+      definition: {
+        chart: {
+          type: 'top_n',
+          chartTitle: 'Top N chart of mock data',
+          description: 'Description',
+        },
+        query: {
+          datasource: 'basic',
+          limit: 3,
+          time_range: {
+            type: 'relative',
+            time_range: 'current_month',
+          },
+        },
+      },
+      layout: {
+        position: {
+          col: 3,
+          row: 1,
+        },
+        size: {
+          cols: 3,
+          rows: 1,
+          fitToContent: true,
+        },
+      },
+    } satisfies TileConfig,
     {
       definition: {
         chart: {
@@ -211,71 +211,71 @@ const dashboardConfig = ref <DashboardConfig>({
         },
       },
     } satisfies TileConfig,
-    // {
-    //   definition: {
-    //     chart: {
-    //       type: 'gauge',
-    //       metricDisplay: 'full',
-    //       reverseDataset: true,
-    //       numerator: 0,
-    //     },
-    //     query: {
-    //       datasource: 'basic',
-    //     },
-    //   },
-    //   layout: {
-    //     position: {
-    //       col: 0,
-    //       row: 4,
-    //     },
-    //     size: {
-    //       cols: 1,
-    //       rows: 1,
-    //     },
-    //   },
-    // } satisfies TileConfig,
-    // {
-    //   definition: {
-    //     chart: {
-    //       type: 'slottable',
-    //       id: 'slot-1',
-    //     },
-    //     query: {
-    //       datasource: 'basic',
-    //     },
-    //   },
-    //   layout: {
-    //     position: {
-    //       col: 1,
-    //       row: 4,
-    //     },
-    //     size: {
-    //       cols: 1,
-    //       rows: 1,
-    //     },
-    //   },
-    // } satisfies TileConfig,
-    // {
-    //   definition: {
-    //     chart: {
-    //       type: 'slottable',
-    //       id: 'slot-2',
-    //     },
-    //     query: {
-    //       datasource: 'basic',
-    //     },
-    //   },
-    //   layout: {
-    //     position: {
-    //       col: 2,
-    //       row: 4,
-    //     },
-    //     size: {
-    //       cols: 3,
-    //       rows: 1,
-    //     },
-    //   },
-    // } satisfies TileConfig,
+    {
+      definition: {
+        chart: {
+          type: 'gauge',
+          metricDisplay: 'full',
+          reverseDataset: true,
+          numerator: 0,
+        },
+        query: {
+          datasource: 'basic',
+        },
+      },
+      layout: {
+        position: {
+          col: 0,
+          row: 4,
+        },
+        size: {
+          cols: 1,
+          rows: 1,
+        },
+      },
+    } satisfies TileConfig,
+    {
+      definition: {
+        chart: {
+          type: 'slottable',
+          id: 'slot-1',
+        },
+        query: {
+          datasource: 'basic',
+        },
+      },
+      layout: {
+        position: {
+          col: 1,
+          row: 4,
+        },
+        size: {
+          cols: 1,
+          rows: 1,
+        },
+      },
+    } satisfies TileConfig,
+    {
+      definition: {
+        chart: {
+          type: 'slottable',
+          id: 'slot-2',
+        },
+        query: {
+          datasource: 'basic',
+        },
+      },
+      layout: {
+        position: {
+          col: 2,
+          row: 4,
+        },
+        size: {
+          cols: 3,
+          rows: 1,
+        },
+      },
+    } satisfies TileConfig,
     {
       definition: {
         chart: {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -407,6 +407,9 @@ const addTile = () => {
 
 const onRemoveTile = (tile: GridTile<TileDefinition>) => {
   console.log('@remove-tile', tile)
+  console.log('before:', dashboardConfig.value.tiles.length)
+  dashboardConfig.value.tiles = dashboardConfig.value.tiles.filter((_, i) => i !== tile.id)
+  console.log('after:', dashboardConfig.value.tiles.length)
 }
 </script>
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -101,58 +101,58 @@ const dashboardConfig = ref <DashboardConfig>({
         },
       },
     } satisfies TileConfig,
-    {
-      definition: {
-        chart: {
-          type: 'top_n',
-          chartTitle: 'Top N chart of mock data',
-          description: '{timeframe}',
-        },
-        query: {
-          datasource: 'basic',
-          limit: 1,
-        },
-      },
-      layout: {
-        position: {
-          col: 0,
-          row: 1,
-        },
-        size: {
-          cols: 3,
-          rows: 1,
-          fitToContent: true,
-        },
-      },
-    } satisfies TileConfig,
-    {
-      definition: {
-        chart: {
-          type: 'top_n',
-          chartTitle: 'Top N chart of mock data',
-          description: 'Description',
-        },
-        query: {
-          datasource: 'basic',
-          limit: 3,
-          time_range: {
-            type: 'relative',
-            time_range: 'current_month',
-          },
-        },
-      },
-      layout: {
-        position: {
-          col: 3,
-          row: 1,
-        },
-        size: {
-          cols: 3,
-          rows: 1,
-          fitToContent: true,
-        },
-      },
-    } satisfies TileConfig,
+    // {
+    //   definition: {
+    //     chart: {
+    //       type: 'top_n',
+    //       chartTitle: 'Top N chart of mock data',
+    //       description: '{timeframe}',
+    //     },
+    //     query: {
+    //       datasource: 'basic',
+    //       limit: 1,
+    //     },
+    //   },
+    //   layout: {
+    //     position: {
+    //       col: 0,
+    //       row: 1,
+    //     },
+    //     size: {
+    //       cols: 3,
+    //       rows: 1,
+    //       fitToContent: true,
+    //     },
+    //   },
+    // } satisfies TileConfig,
+    // {
+    //   definition: {
+    //     chart: {
+    //       type: 'top_n',
+    //       chartTitle: 'Top N chart of mock data',
+    //       description: 'Description',
+    //     },
+    //     query: {
+    //       datasource: 'basic',
+    //       limit: 3,
+    //       time_range: {
+    //         type: 'relative',
+    //         time_range: 'current_month',
+    //       },
+    //     },
+    //   },
+    //   layout: {
+    //     position: {
+    //       col: 3,
+    //       row: 1,
+    //     },
+    //     size: {
+    //       cols: 3,
+    //       rows: 1,
+    //       fitToContent: true,
+    //     },
+    //   },
+    // } satisfies TileConfig,
     {
       definition: {
         chart: {
@@ -211,71 +211,71 @@ const dashboardConfig = ref <DashboardConfig>({
         },
       },
     } satisfies TileConfig,
-    {
-      definition: {
-        chart: {
-          type: 'gauge',
-          metricDisplay: 'full',
-          reverseDataset: true,
-          numerator: 0,
-        },
-        query: {
-          datasource: 'basic',
-        },
-      },
-      layout: {
-        position: {
-          col: 0,
-          row: 4,
-        },
-        size: {
-          cols: 1,
-          rows: 1,
-        },
-      },
-    } satisfies TileConfig,
-    {
-      definition: {
-        chart: {
-          type: 'slottable',
-          id: 'slot-1',
-        },
-        query: {
-          datasource: 'basic',
-        },
-      },
-      layout: {
-        position: {
-          col: 1,
-          row: 4,
-        },
-        size: {
-          cols: 1,
-          rows: 1,
-        },
-      },
-    } satisfies TileConfig,
-    {
-      definition: {
-        chart: {
-          type: 'slottable',
-          id: 'slot-2',
-        },
-        query: {
-          datasource: 'basic',
-        },
-      },
-      layout: {
-        position: {
-          col: 2,
-          row: 4,
-        },
-        size: {
-          cols: 3,
-          rows: 1,
-        },
-      },
-    } satisfies TileConfig,
+    // {
+    //   definition: {
+    //     chart: {
+    //       type: 'gauge',
+    //       metricDisplay: 'full',
+    //       reverseDataset: true,
+    //       numerator: 0,
+    //     },
+    //     query: {
+    //       datasource: 'basic',
+    //     },
+    //   },
+    //   layout: {
+    //     position: {
+    //       col: 0,
+    //       row: 4,
+    //     },
+    //     size: {
+    //       cols: 1,
+    //       rows: 1,
+    //     },
+    //   },
+    // } satisfies TileConfig,
+    // {
+    //   definition: {
+    //     chart: {
+    //       type: 'slottable',
+    //       id: 'slot-1',
+    //     },
+    //     query: {
+    //       datasource: 'basic',
+    //     },
+    //   },
+    //   layout: {
+    //     position: {
+    //       col: 1,
+    //       row: 4,
+    //     },
+    //     size: {
+    //       cols: 1,
+    //       rows: 1,
+    //     },
+    //   },
+    // } satisfies TileConfig,
+    // {
+    //   definition: {
+    //     chart: {
+    //       type: 'slottable',
+    //       id: 'slot-2',
+    //     },
+    //     query: {
+    //       datasource: 'basic',
+    //     },
+    //   },
+    //   layout: {
+    //     position: {
+    //       col: 2,
+    //       row: 4,
+    //     },
+    //     size: {
+    //       cols: 3,
+    //       rows: 1,
+    //     },
+    //   },
+    // } satisfies TileConfig,
     {
       definition: {
         chart: {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -25,6 +25,7 @@
       </KButton>
       <DashboardRenderer
         ref="dashboardRendererRef"
+        can-remove-tiles
         :class="{ 'custom-styling': isToggled}"
         :config="dashboardConfig"
         :context="context"

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -60,7 +60,6 @@ const appLinks: SandboxNavigationItem[] = inject('app-links', [])
 const context: DashboardRendererContext = {
   filters: [],
   refreshInterval: 0,
-  editable: true,
 }
 
 const dashboardConfig = ref <DashboardConfig>({

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -25,13 +25,13 @@
       </KButton>
       <DashboardRenderer
         ref="dashboardRendererRef"
-        can-remove-tiles
+        can-edit
         :class="{ 'custom-styling': isToggled}"
         :config="dashboardConfig"
         :context="context"
-        draggable
         @edit-tile="onEditTile"
         @remove-tile="onRemoveTile"
+        @update-tiles="onUpdateTiles"
       >
         <template #slot-1>
           <div class="slot-container">
@@ -379,16 +379,19 @@ const addTile = () => {
   dashboardConfig.value.tiles.push({
     definition: {
       chart: {
-        type: 'top_n',
-        chartTitle: 'Top N chart of mock data',
-        description: 'Description',
+        type: 'timeseries_line',
+        chartTitle: 'Timeseries line chart of mock data',
+        threshold: {
+          'request_count': 3200,
+        } as Record<ExploreAggregations, number>,
       },
       query: {
         datasource: 'basic',
-        limit: 3,
+        dimensions: ['time'],
         time_range: {
-          type: 'relative',
-          time_range: 'current_month',
+          type: 'absolute',
+          start: '2024-01-01',
+          end: '2024-02-01',
         },
       },
     },
@@ -408,9 +411,12 @@ const addTile = () => {
 
 const onRemoveTile = (tile: GridTile<TileDefinition>) => {
   console.log('@remove-tile', tile)
-  console.log('before:', dashboardConfig.value.tiles.length)
   dashboardConfig.value.tiles = dashboardConfig.value.tiles.filter((_, i) => i !== tile.id)
-  console.log('after:', dashboardConfig.value.tiles.length)
+}
+
+const onUpdateTiles = (tiles: TileConfig[]) => {
+  console.log('@update-tiles', tiles)
+  dashboardConfig.value.tiles = tiles
 }
 </script>
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -30,7 +30,6 @@
         :config="dashboardConfig"
         :context="context"
         @edit-tile="onEditTile"
-        @remove-tile="onRemoveTile"
         @update-tiles="onUpdateTiles"
       >
         <template #slot-1>
@@ -407,11 +406,6 @@ const addTile = () => {
       },
     },
   })
-}
-
-const onRemoveTile = (tile: GridTile<TileDefinition>) => {
-  console.log('@remove-tile', tile)
-  dashboardConfig.value.tiles = dashboardConfig.value.tiles.filter((_, i) => i !== tile.id)
 }
 
 const onUpdateTiles = (tiles: TileConfig[]) => {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -17,6 +17,12 @@
       >
         refresh
       </KButton>
+      <KButton
+        size="small"
+        @click="addTile"
+      >
+        Add tile
+      </KButton>
       <DashboardRenderer
         ref="dashboardRendererRef"
         :class="{ 'custom-styling': isToggled}"
@@ -64,7 +70,7 @@ const context: DashboardRendererContext = {
   editable: true,
 }
 
-const dashboardConfig: DashboardConfig = {
+const dashboardConfig = ref <DashboardConfig>({
   gridSize: {
     cols: 6,
     rows: 7,
@@ -352,7 +358,7 @@ const dashboardConfig: DashboardConfig = {
       },
     } satisfies TileConfig,
   ],
-}
+})
 
 const isToggled = ref(false)
 
@@ -365,6 +371,37 @@ const dashboardRendererRef = ref<InstanceType<typeof DashboardRenderer> | null>(
 
 const refresh = () => {
   dashboardRendererRef.value?.refresh()
+}
+
+const addTile = () => {
+  dashboardConfig.value.tiles.push({
+    definition: {
+      chart: {
+        type: 'top_n',
+        chartTitle: 'Top N chart of mock data',
+        description: 'Description',
+      },
+      query: {
+        datasource: 'basic',
+        limit: 3,
+        time_range: {
+          type: 'relative',
+          time_range: 'current_month',
+        },
+      },
+    },
+    layout: {
+      position: {
+        col: -1,
+        row: -1,
+      },
+      size: {
+        cols: 3,
+        rows: 2,
+        fitToContent: true,
+      },
+    },
+  })
 }
 </script>
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -603,6 +603,7 @@ describe('<DashboardRenderer />', () => {
         tileHeight: 167,
         tiles: [
           {
+            id: 0,
             definition: {
               chart: {
                 type: 'timeseries_line',
@@ -639,6 +640,7 @@ describe('<DashboardRenderer />', () => {
             },
           } as unknown as TileConfig, // TODO: MA-2987: Remove default datasource concept and associated tests.
           {
+            id: 1,
             definition: {
               chart: {
                 type: 'timeseries_line',
@@ -672,6 +674,7 @@ describe('<DashboardRenderer />', () => {
             },
           } as unknown as TileConfig, // TODO: MA-2987: Remove default datasource concept and associated tests.
           {
+            id: 2,
             definition: {
               chart: {
                 type: 'timeseries_line',
@@ -699,6 +702,7 @@ describe('<DashboardRenderer />', () => {
             },
           } as unknown as TileConfig, // TODO: MA-2987: Remove default datasource concept and associated tests.
           {
+            id: 3,
             definition: {
               chart: {
                 type: 'top_n',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -7,7 +7,7 @@
       {{ i18n.t('renderer.noQueryBridge') }}
     </KAlert>
     <component
-      :is="canEdit ? DraggableGridLayout : GridLayout"
+      :is="context.editable ? DraggableGridLayout : GridLayout"
       v-else
       ref="gridLayoutRef"
       :grid-size="config.gridSize"
@@ -27,7 +27,6 @@
           class="tile-container"
           :context="mergedContext"
           :definition="tile.meta"
-          :editable="canEdit"
           :height="tile.layout.size.rows * (config.tileHeight || DEFAULT_TILE_HEIGHT) + parseInt(KUI_SPACE_70, 10)"
           :query-ready="queryReady"
           :refresh-counter="refreshCounter"
@@ -60,13 +59,10 @@ import {
 import { useAnalyticsConfigStore } from '@kong-ui-public/analytics-config-store'
 import { KUI_SPACE_70 } from '@kong/design-tokens'
 
-const props = withDefaults(defineProps<{
+const props = defineProps<{
   context: DashboardRendererContext,
   config: DashboardConfig,
-  canEdit?: boolean,
-}>(), {
-  canEdit: false,
-})
+}>()
 
 const emit = defineEmits<{
   (e: 'edit-tile', tile: GridTile<TileDefinition>): void
@@ -141,7 +137,7 @@ const gridTiles = computed(() => {
       }
     }
 
-    if (props.canEdit && !tile.id) {
+    if (props.context.editable && !tile.id) {
       console.warn(
         'No id provided for tile. One will be generated automatically,',
         'however tracking changes to this tile may not work as expected.',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -23,10 +23,10 @@
         </div>
         <DashboardTile
           v-else
-          :can-remove-tile="canEdit"
           class="tile-container"
           :context="mergedContext"
           :definition="tile.meta"
+          :editable="canEdit"
           :height="tile.layout.size.rows * (config.tileHeight || DEFAULT_TILE_HEIGHT) + parseInt(KUI_SPACE_70, 10)"
           :query-ready="queryReady"
           :refresh-counter="refreshCounter"
@@ -208,7 +208,6 @@ defineExpose({ refresh: refreshTiles })
     border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
     border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
     height: 100%;
-    padding: 0 var(--kui-space-70, $kui-space-70) var(--kui-space-70, $kui-space-70) var(--kui-space-70, $kui-space-70);
   }
 }
 </style>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -9,6 +9,7 @@
     <component
       :is="canEdit ? DraggableGridLayout : GridLayout"
       v-else
+      ref="gridLayoutRef"
       :grid-size="config.gridSize"
       :tile-height="config.tileHeight"
       :tiles="gridTiles"
@@ -44,9 +45,11 @@ import type { DashboardRendererContext, DashboardRendererContextInternal, GridTi
 import type { DashboardConfig, TileConfig, TileDefinition } from '@kong-ui-public/analytics-utilities'
 import DashboardTile from './DashboardTile.vue'
 import { computed, inject, ref } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 import composables from '../composables'
 import GridLayout from './layout/GridLayout.vue'
 import DraggableGridLayout from './layout/DraggableGridLayout.vue'
+import type { DraggableGridLayoutExpose } from './layout/DraggableGridLayout.vue'
 import type { AnalyticsBridge, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
 import {
   DEFAULT_TILE_HEIGHT,
@@ -67,12 +70,12 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
   (e: 'edit-tile', tile: GridTile<TileDefinition>): void
-  (e: 'remove-tile', tile: GridTile<TileDefinition>): void
   (e: 'update-tiles', tiles: TileConfig[]): void
 }>()
 
 const { i18n } = composables.useI18n()
 const refreshCounter = ref(0)
+const gridLayoutRef = ref<ComponentPublicInstance<DraggableGridLayoutExpose> | null>(null)
 
 // Note: queryBridge is not directly used by the DashboardRenderer component.  It is required by many of the
 // subcomponents that get rendered in the dashboard, however.  Check for its existence here in order to catch
@@ -180,7 +183,9 @@ const onEditTile = (tile: GridTile<TileDefinition>) => {
 }
 
 const onRemoveTile = (tile: GridTile<TileDefinition>) => {
-  emit('remove-tile', tile)
+  if (gridLayoutRef.value) {
+    gridLayoutRef.value.removeWidget(tile.id)
+  }
 }
 
 const refreshTiles = () => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -60,8 +60,10 @@ const props = withDefaults(defineProps<{
   context: DashboardRendererContext,
   config: DashboardConfig,
   draggable?: boolean,
+  canRemoveTiles?: boolean,
 }>(), {
   draggable: false,
+  canRemoveTiles: false,
 })
 
 const emit = defineEmits<{

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -31,6 +31,7 @@
           :refresh-counter="refreshCounter"
           :tile-id="tile.id"
           @edit-tile="onEditTile(tile)"
+          @remove-tile="onRemoveTile(tile)"
         />
       </template>
     </component>
@@ -65,6 +66,7 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
   (e: 'edit-tile', tile: GridTile<TileDefinition>): void
+  (e: 'remove-tile', tile: GridTile<TileDefinition>): void
   (e: 'update-tiles', tiles: TileConfig[]): void
 }>()
 
@@ -174,6 +176,10 @@ const mergedContext = computed<DashboardRendererContextInternal>(() => {
 
 const onEditTile = (tile: GridTile<TileDefinition>) => {
   emit('edit-tile', tile)
+}
+
+const onRemoveTile = (tile: GridTile<TileDefinition>) => {
+  emit('remove-tile', tile)
 }
 
 const refreshTiles = () => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -23,6 +23,7 @@
         </div>
         <DashboardTile
           v-else
+          :can-remove-tile="canRemoveTiles"
           class="tile-container"
           :context="mergedContext"
           :definition="tile.meta"

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -7,7 +7,7 @@
       {{ i18n.t('renderer.noQueryBridge') }}
     </KAlert>
     <component
-      :is="draggable ? DraggableGridLayout : GridLayout"
+      :is="canEdit ? DraggableGridLayout : GridLayout"
       v-else
       :grid-size="config.gridSize"
       :tile-height="config.tileHeight"
@@ -23,7 +23,7 @@
         </div>
         <DashboardTile
           v-else
-          :can-remove-tile="canRemoveTiles"
+          :can-remove-tile="canEdit"
           class="tile-container"
           :context="mergedContext"
           :definition="tile.meta"
@@ -60,11 +60,9 @@ import { KUI_SPACE_70 } from '@kong/design-tokens'
 const props = withDefaults(defineProps<{
   context: DashboardRendererContext,
   config: DashboardConfig,
-  draggable?: boolean,
-  canRemoveTiles?: boolean,
+  canEdit?: boolean,
 }>(), {
-  draggable: false,
-  canRemoveTiles: false,
+  canEdit: false,
 })
 
 const emit = defineEmits<{

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -141,11 +141,19 @@ const gridTiles = computed(() => {
       }
     }
 
+    if (props.canEdit && !tile.id) {
+      console.warn(
+        'No id provided for tile. One will be generated automatically,',
+        'however tracking changes to this tile may not work as expected.',
+        tile,
+      )
+    }
+
     return {
       layout: tile.layout,
       meta: tileMeta,
       // Add a unique key to each tile internally.
-      id: i,
+      id: tile.id ?? crypto.randomUUID(),
     } as GridTile<TileDefinition>
   })
 })
@@ -195,6 +203,7 @@ const refreshTiles = () => {
 const handleUpdateTiles = (tiles: GridTile<TileDefinition>[]) => {
   const updatedTiles = tiles.map(tile => {
     return {
+      id: tile.id,
       layout: tile.layout,
       definition: tile.meta,
     } as TileConfig

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -68,6 +68,7 @@
               </span>
             </KDropdownItem>
             <KDropdownItem
+              v-if="hasDashboardsNextAccess"
               :data-testid="`remove-tile-${tileId}`"
               @click="removeTile"
             >
@@ -146,6 +147,7 @@ const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
 const { evaluateFeatureFlag } = composables.useEvaluateFeatureFlag()
 const { i18n } = composables.useI18n()
 const hasKebabMenuAccess = evaluateFeatureFlag('ma-3043-analytics-chart-kebab-menu', false)
+const hasDashboardsNextAccess = evaluateFeatureFlag('ma-3601-custom-dashboards-next', false)
 
 const chartData = ref<ExploreResultV4>()
 const exportModalVisible = ref<boolean>(false)

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -68,7 +68,7 @@
               </span>
             </KDropdownItem>
             <KDropdownItem
-              v-if="canRemoveTile"
+              v-if="editable"
               :data-testid="`remove-tile-${tileId}`"
               @click="removeTile"
             >
@@ -134,10 +134,10 @@ const props = withDefaults(defineProps<{
   queryReady: boolean,
   refreshCounter: number,
   tileId: string | number,
-  canRemoveTile?: boolean,
+  editable?: boolean,
 }>(), {
   height: DEFAULT_TILE_HEIGHT,
-  canRemoveTile: false,
+  editable: false,
 })
 
 const emit = defineEmits<{
@@ -265,13 +265,17 @@ const exportCsv = () => {
   height: v-bind('`${height}px`');
   overflow: hidden;
 
+  &:hover {
+    .tile-header {
+      background: $kui-color-background-neutral-weakest;
+    }
+  }
+
   .tile-header {
     align-items: center;
     display: flex;
     justify-content: space-between;
-    margin-bottom: var(--kui-space-30, $kui-space-30);
-    // So any "handlers" for the tile header includes the padding
-    padding-top: var(--kui-space-70, $kui-space-70);
+    padding: var(--kui-space-70, $kui-space-70) var(--kui-space-30, $kui-space-30) var(--kui-space-70, $kui-space-70) var(--kui-space-70, $kui-space-70);
     right: 0;
     width: 100%;
 
@@ -334,6 +338,7 @@ const exportCsv = () => {
 
   .tile-content {
     flex-grow: 1;
+    margin: var(--kui-space-60, $kui-space-60);
     overflow: hidden;
   }
 }

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="tile-boundary"
+    :class="{ 'editable': context.editable }"
     :data-testid="`tile-${tileId}`"
   >
     <div
@@ -68,7 +69,7 @@
               </span>
             </KDropdownItem>
             <KDropdownItem
-              v-if="editable"
+              v-if="context.editable"
               :data-testid="`remove-tile-${tileId}`"
               @click="removeTile"
             >
@@ -134,10 +135,8 @@ const props = withDefaults(defineProps<{
   queryReady: boolean,
   refreshCounter: number,
   tileId: string | number,
-  editable?: boolean,
 }>(), {
   height: DEFAULT_TILE_HEIGHT,
-  editable: false,
 })
 
 const emit = defineEmits<{
@@ -265,7 +264,7 @@ const exportCsv = () => {
   height: v-bind('`${height}px`');
   overflow: hidden;
 
-  &:hover {
+  &.editable:hover {
     .tile-header {
       background: $kui-color-background-neutral-weakest;
     }

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -67,6 +67,12 @@
                 {{ i18n.t('csvExport.exportAsCsv') }}
               </span>
             </KDropdownItem>
+            <KDropdownItem
+              :data-testid="`remove-tile-${tileId}`"
+              @click="removeTile"
+            >
+              {{ i18n.t('renderer.remove') }}
+            </KDropdownItem>
           </template>
         </KDropdown>
       </div>
@@ -133,6 +139,7 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
   (e: 'edit-tile', tile: TileDefinition): void
+  (e: 'remove-tile', tile: TileDefinition): void
 }>()
 
 const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
@@ -229,6 +236,10 @@ const chartDataGranularity = computed(() => {
 
 const editTile = () => {
   emit('edit-tile', props.definition)
+}
+
+const removeTile = () => {
+  emit('remove-tile', props.definition)
 }
 
 const onChartData = (data: ExploreResultV4) => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -275,7 +275,7 @@ const exportCsv = () => {
     align-items: center;
     display: flex;
     justify-content: space-between;
-    padding: var(--kui-space-70, $kui-space-70) var(--kui-space-30, $kui-space-30) var(--kui-space-70, $kui-space-70) var(--kui-space-70, $kui-space-70);
+    padding: var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60) var(--kui-space-20, $kui-space-20) var(--kui-space-60, $kui-space-60);
     right: 0;
     width: 100%;
 
@@ -338,7 +338,7 @@ const exportCsv = () => {
 
   .tile-content {
     flex-grow: 1;
-    margin: var(--kui-space-60, $kui-space-60);
+    margin: var(--kui-space-20, $kui-space-20) var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60);
     overflow: hidden;
   }
 }

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -68,7 +68,7 @@
               </span>
             </KDropdownItem>
             <KDropdownItem
-              v-if="hasDashboardsNextAccess"
+              v-if="canRemoveTile"
               :data-testid="`remove-tile-${tileId}`"
               @click="removeTile"
             >
@@ -134,8 +134,10 @@ const props = withDefaults(defineProps<{
   queryReady: boolean,
   refreshCounter: number,
   tileId: string | number,
+  canRemoveTile?: boolean,
 }>(), {
   height: DEFAULT_TILE_HEIGHT,
+  canRemoveTile: false,
 })
 
 const emit = defineEmits<{
@@ -147,7 +149,6 @@ const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
 const { evaluateFeatureFlag } = composables.useEvaluateFeatureFlag()
 const { i18n } = composables.useI18n()
 const hasKebabMenuAccess = evaluateFeatureFlag('ma-3043-analytics-chart-kebab-menu', false)
-const hasDashboardsNextAccess = evaluateFeatureFlag('ma-3601-custom-dashboards-next', false)
 
 const chartData = ref<ExploreResultV4>()
 const exportModalVisible = ref<boolean>(false)

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -11,8 +11,8 @@
       :gs-h="tile.layout.size.rows"
       :gs-lazy-load="true"
       :gs-w="tile.layout.size.cols"
-      :gs-x="tile.layout.position.col"
-      :gs-y="tile.layout.position.row"
+      :gs-x="tile.layout.position.col >= 0 ? tile.layout.position.col : undefined"
+      :gs-y="tile.layout.position.row >= 0 ? tile.layout.position.row : undefined"
     >
       <div class="grid-stack-item-content">
         <slot

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -69,7 +69,7 @@ onMounted(() => {
     grid = GridStack.init({
       column: props.gridSize.cols,
       cellHeight: props.tileHeight,
-      resizable: { handles: 'se' },
+      resizable: { handles: 'se, sw' },
       lazyLoad: true,
       handle: '.tile-header',
 
@@ -120,7 +120,7 @@ watch(() => props.tiles, async (tiles) => {
       }
     }
   }
-})
+}, { deep: true })
 
 </script>
 
@@ -128,4 +128,18 @@ watch(() => props.tiles, async (tiles) => {
 :deep(.tile-header) {
   cursor: move;
 }
+$rotate-values: (
+  'se': 0deg,
+  'sw': 90deg,
+);
+
+@each $direction, $rotate in $rotate-values {
+  :deep(.ui-resizable-#{$direction}) {
+    background-image: url('../../icons/arrows_more_down.svg');
+    cursor: se-resize;
+    margin: 5px;
+    transform: rotate($rotate);
+  }
+}
+
 </style>

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -26,7 +26,8 @@
 
 <script lang='ts' setup generic="T">
 import { onMounted, onUnmounted, ref, watch, nextTick } from 'vue'
-import { GridStack, type GridStackNode } from 'gridstack'
+import { GridStack } from 'gridstack'
+import type { GridStackElement, GridStackNode } from 'gridstack'
 import type { GridSize, GridTile } from 'src/types'
 import 'gridstack/dist/gridstack.min.css'
 import 'gridstack/dist/gridstack-extra.min.css'
@@ -78,6 +79,10 @@ onMounted(() => {
       const updatedTiles = makeTilesFromGridstackNodes(items)
       emit('update-tiles', updatedTiles)
     })
+    grid.on('removed', async (_, items) => {
+      const updatedTiles = makeTilesFromGridstackNodes(items)
+      emit('update-tiles', updatedTiles)
+    })
   }
 })
 
@@ -100,6 +105,15 @@ watch(() => props.tiles.length, async (newLen, oldLen) => {
       } as GridStackNode
     })
     grid.load(nodesToAdd)
+  } else if (newLen < oldLen && grid) {
+    const tileToRemove = props.tiles.slice(newLen)
+    const elementsToRemove = tileToRemove.map(e => {
+      return gridContainer.value?.querySelector(`[data-id="${e.id}"]`) as GridStackElement
+    })
+    elementsToRemove.forEach(e => {
+      grid?.removeWidget(e)
+    })
+
   }
 })
 </script>

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -24,7 +24,7 @@
   </div>
 </template>
 
-<script lang='ts' setup>
+<script lang='ts' setup generic="T">
 import { onMounted, onUnmounted, ref, watch, nextTick } from 'vue'
 import { GridStack } from 'gridstack'
 import { useDebounceFn } from '@vueuse/core'
@@ -32,21 +32,20 @@ import type { GridStackNode } from 'gridstack'
 import type { GridSize, GridTile } from 'src/types'
 import 'gridstack/dist/gridstack.min.css'
 import 'gridstack/dist/gridstack-extra.min.css'
-import type { TileDefinition } from '@kong-ui-public/analytics-utilities'
 
 export type DraggableGridLayoutExpose = {
   removeWidget: (id: number | string) => void
 }
 
 const props = withDefaults(defineProps<{
-  tiles: GridTile<TileDefinition>[],
+  tiles: GridTile<T>[],
   gridSize: GridSize,
   tileHeight?: number,
 }>(), {
   tileHeight: 200,
 })
 const emit = defineEmits<{
-  (e: 'update-tiles', tiles: GridTile<TileDefinition>[]): void,
+  (e: 'update-tiles', tiles: GridTile<T>[]): void,
 }>()
 
 const gridContainer = ref<HTMLDivElement | null>(null)
@@ -65,7 +64,7 @@ const makeTilesFromGridstackNodes = (items: GridStackNode[]) => {
           position: { col: Number(item.x), row: Number(item.y) },
           size: { cols: Number(item.w), rows: Number(item.h) },
         },
-      } satisfies GridTile<TileDefinition>
+      } satisfies GridTile<T>
     }
     return tile
   })
@@ -76,7 +75,7 @@ const removeTile = (items: GridStackNode[]) => {
     return !items.find(item => {
       return item.el?.id === `tile-${tile.id}`
     })
-  }) as GridTile<TileDefinition>[]
+  })
 }
 
 const changeHandler = useDebounceFn((_: Event, items: GridStackNode[]) => {

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -115,7 +115,7 @@ onUnmounted(() => {
   }
 })
 
-const removeWidget = async (id: number | string) => {
+const removeWidget = (id: number | string) => {
   if (grid && gridContainer.value) {
     const el = gridContainer.value.querySelector(makeSelector(id)) as HTMLElement
     if (el) {

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -123,22 +123,6 @@ watch(() => props.tiles.length, async (newLen, oldLen) => {
   }
 })
 
-// watch(() => props.tiles, async (tiles) => {
-//   if (grid && gridContainer.value) {
-//     for (const tile of tiles) {
-//       const el = gridContainer.value.querySelector(`#tile-${tile.id}`) as HTMLElement
-//       if (el) {
-//         grid.update(el, {
-//           x: tile.layout.position.col,
-//           y: tile.layout.position.row,
-//           w: tile.layout.size.cols,
-//           h: tile.layout.size.rows,
-//         })
-//       }
-//     }
-//   }
-// }, { deep: true })
-
 const removeWidget = (id: number | string) => {
   if (grid && gridContainer.value) {
     const el = gridContainer.value.querySelector(`#tile-${id}`) as HTMLElement

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -27,7 +27,7 @@
 <script lang='ts' setup generic="T">
 import { onMounted, onUnmounted, ref, watch, nextTick } from 'vue'
 import { GridStack } from 'gridstack'
-import type { GridStackElement, GridStackNode } from 'gridstack'
+import type { GridStackNode } from 'gridstack'
 import type { GridSize, GridTile } from 'src/types'
 import 'gridstack/dist/gridstack.min.css'
 import 'gridstack/dist/gridstack-extra.min.css'
@@ -106,14 +106,8 @@ watch(() => props.tiles.length, async (newLen, oldLen) => {
     })
     grid.load(nodesToAdd)
   } else if (newLen < oldLen && grid) {
-    const tileToRemove = props.tiles.slice(newLen)
-    const elementsToRemove = tileToRemove.map(e => {
-      return gridContainer.value?.querySelector(`[data-id="${e.id}"]`) as GridStackElement
-    })
-    elementsToRemove.forEach(e => {
-      grid?.removeWidget(e)
-    })
-
+    await nextTick()
+    grid.compact()
   }
 })
 </script>

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -90,14 +90,16 @@ onUnmounted(() => {
 watch(() => props.tiles.length, async (newLen, oldLen) => {
   if (newLen > oldLen && grid) {
     await nextTick()
-    const tileToAdd = props.tiles[newLen - 1]
-    const el = gridContainer.value?.querySelector(`[data-id="${tileToAdd.id}"]`)
-    grid.load([{
-      w: tileToAdd.layout.size.cols,
-      h: tileToAdd.layout.size.rows,
-      autoPosition: true,
-      el: el as HTMLElement,
-    } as GridStackNode])
+    const tileToAdd = props.tiles.slice(oldLen)
+    const nodesToAdd = tileToAdd.map(e => {
+      return {
+        w: e.layout.size.cols,
+        h: e.layout.size.rows,
+        autoPosition: true,
+        el: gridContainer.value?.querySelector(`[data-id="${e.id}"]`) as HTMLElement,
+      } as GridStackNode
+    })
+    grid.load(nodesToAdd)
   }
 })
 </script>

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -32,6 +32,10 @@ import type { GridSize, GridTile } from 'src/types'
 import 'gridstack/dist/gridstack.min.css'
 import 'gridstack/dist/gridstack-extra.min.css'
 
+export type DraggableGridLayoutExpose = {
+  removeWidget: (id: number | string) => void
+}
+
 const props = withDefaults(defineProps<{
   tiles: GridTile<T>[],
   gridSize: GridSize,
@@ -55,10 +59,10 @@ const makeTilesFromGridstackNodes = (items: GridStackNode[]) => {
       return {
         ...tile,
         layout: {
-          position: { col: item.x, row: item.y },
-          size: { cols: item.w, rows: item.h },
+          position: { col: Number(item.x), row: Number(item.y) },
+          size: { cols: Number(item.w), rows: Number(item.h) },
         },
-      } as GridTile<any>
+      } satisfies GridTile<T>
     }
     return tile
   })
@@ -121,6 +125,18 @@ watch(() => props.tiles, async (tiles) => {
     }
   }
 }, { deep: true })
+
+const removeWidget = (id: number | string) => {
+  if (grid && gridContainer.value) {
+    const el = gridContainer.value.querySelector(`#tile-${id}`) as HTMLElement
+    if (el) {
+      grid.removeWidget(el)
+      grid.compact('compact', false)
+    }
+  }
+}
+
+defineExpose({ removeWidget })
 
 </script>
 

--- a/packages/analytics/dashboard-renderer/src/icons/arrows_more_down.svg
+++ b/packages/analytics/dashboard-renderer/src/icons/arrows_more_down.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_4440_21061" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<rect width="24" height="24" transform="matrix(-1 0 0 1 24 0)" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_4440_21061)">
+<path d="M19 21V10H17V19H8V21H19ZM14 16V5H12V14H3V16H14Z" fill="#3A3F51"/>
+</g>
+</svg>

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -6,7 +6,8 @@
       "7d": "Last 7-Day Summary",
       "30d": "Last 30-Day Summary"
     },
-    "edit": "Edit"
+    "edit": "Edit",
+    "remove": "Remove"
   },
   "queryDataProvider": {
     "timeRangeExceeded":  "The time range for this report is outside of your organization's data retention period"


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-3668
https://konghq.atlassian.net/browse/MA-3622
https://konghq.atlassian.net/browse/MA-3621

- Tiles passed into the gridstack grid layout component inform the initial state of the dashboard.
- Use a copy of the passed in tiles in order to prevent circular event loops
- Gridstack responsible for all things related to position and dimensions of tiles. On the appropriate gridstack events, regenerate tile definitions with updated layout and emit them so the host app can update the dashboard definition
- Watch for changes to provided tile's length to handle adding new tiles. Wait for the dom to be updated `await nextTick()` then use `makeWidget` to make the newly added tile into a gridstack widget.
- Watch for changes to the provided tile's metadata and update the appropriate tile (to handle changes to content) eg query, chart title, chart type etc
- Use a single `can-edit` prop
- Add new sandbox page for editable dashboard, remove changes to "static" dashboard sandbox
- Track unique IDs by allowing dashboard schema tiles to provide unique ids to the grid layout

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
