### PR TITLE
feat(tracing): display more info in the lifecycle view

### DIFF
--- a/packages/core/tracing/src/components/lifecycle/LifecycleEdgeSeamlessSmoothstep.vue
+++ b/packages/core/tracing/src/components/lifecycle/LifecycleEdgeSeamlessSmoothstep.vue
@@ -1,0 +1,75 @@
+<template>
+  <BaseEdge
+    v-bind="props"
+    :path="path[0]"
+  />
+</template>
+
+<script lang="ts" setup>
+import { BaseEdge, getSmoothStepPath, Position, type EdgeProps, type SmoothStepEdgeProps } from '@vue-flow/core'
+import { computed, defineComponent } from 'vue'
+import type { LifecycleEdgeData } from '../../types'
+
+defineComponent({
+  inheritAttrs: false,
+})
+
+// We are extending the "smoothstep"-typed edge
+const props = defineProps<SmoothStepEdgeProps & Pick<EdgeProps<LifecycleEdgeData>, 'data'>>()
+
+// Hardcoded from VueFlow's source
+const HANDLE_SIZE = 4
+const HANDLE_RADIUS = HANDLE_SIZE / 2
+
+/**
+ * This is to move the source/target X/Y nearer to the node to reduce the gap between edge start/end and the node
+ */
+const path = computed(() => {
+  let {
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  } = props
+
+  switch (sourcePosition) {
+    case Position.Top:
+      sourceY += HANDLE_RADIUS
+      break
+    case Position.Bottom:
+      sourceY -= HANDLE_RADIUS
+      break
+    case Position.Left:
+      sourceX += HANDLE_RADIUS
+      break
+    case Position.Right:
+      sourceX -= HANDLE_RADIUS
+      break
+  }
+
+  switch (targetPosition) {
+    case Position.Top:
+      targetY += HANDLE_RADIUS
+      break
+    case Position.Bottom:
+      targetY -= HANDLE_RADIUS
+      break
+    case Position.Left:
+      targetX += HANDLE_RADIUS
+      break
+    case Position.Right:
+      targetX -= HANDLE_RADIUS
+      break
+  }
+
+  return getSmoothStepPath({
+    ...props,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+  })
+})
+</script>

--- a/packages/core/tracing/src/components/lifecycle/LifecycleLegend.vue
+++ b/packages/core/tracing/src/components/lifecycle/LifecycleLegend.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="legend">
+    <!-- Hide total latency for now -->
+    <div class="latency">
+      <span>{{ t('lifecycle.total') }}: </span>
+      <span>{{ fmt(props.rootSpan.durationNano) }}</span>
+    </div>
+
+    <div
+      v-for="color in colors"
+      :key="color.color"
+      class="color"
+    >
+      <div
+        class="preview"
+        :style="{ backgroundColor: color.color }"
+      />
+
+      <div class="label">
+        {{ color.label }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import composables from '../../composables'
+import { NODE_STRIPE_COLOR_MAPPING, NODE_STRIPE_COLOR_MAPPING_START_EXP } from '../../constants'
+import type { SpanNode } from '../../types'
+import { getDurationFormatter } from '../../utils'
+
+const props = defineProps<{
+  rootSpan: SpanNode
+}>()
+
+const fmt = getDurationFormatter()
+const { i18n: { t } } = composables.useI18n()
+
+// No need to be reactive
+const colors = NODE_STRIPE_COLOR_MAPPING.toReversed().map((color, i) => {
+  const ri = (NODE_STRIPE_COLOR_MAPPING.length - 1 - i)
+  return {
+    label: `${
+      fmt(10 ** (NODE_STRIPE_COLOR_MAPPING_START_EXP + ri))
+    } - ${
+      fmt(10 ** (NODE_STRIPE_COLOR_MAPPING_START_EXP + ri + (i === 0 ? 2 : 1)))
+    }${
+      i === 0 ? '+' : ''
+    }`,
+    color,
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.legend {
+  background-color: $kui-color-background;
+  bottom: 0;
+  box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.08); // Align with VueFlow built-in Control
+  font-size: $kui-font-size-20;
+  margin: $kui-space-60;
+  padding: $kui-space-20 $kui-space-40;
+  position: absolute;
+  right: 0;
+  z-index: 1000;
+
+  .color {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    gap: $kui-space-20;
+    justify-content: flex-start;
+
+    .preview {
+      border-radius: $kui-border-radius-10;
+      height: 10px;
+      width: 10px;
+    }
+
+    .label {
+      font-size: $kui-font-size-20;
+    }
+  }
+}
+</style>

--- a/packages/core/tracing/src/components/lifecycle/LifecycleLegend.vue
+++ b/packages/core/tracing/src/components/lifecycle/LifecycleLegend.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="legend">
-    <!-- Hide total latency for now -->
     <div class="latency">
       <span>{{ t('lifecycle.total') }}: </span>
       <span>{{ fmt(props.rootSpan.durationNano) }}</span>

--- a/packages/core/tracing/src/components/lifecycle/LifecycleView.vue
+++ b/packages/core/tracing/src/components/lifecycle/LifecycleView.vue
@@ -1,14 +1,14 @@
 <template>
-  <div
-    ref="root"
-    class="lifecycle-view"
-  >
+  <div class="lifecycle-view">
     <KSkeleton
       v-if="showSkeleton"
       type="spinner"
     />
     <VueFlow
       v-else
+      ref="flow"
+      :elevate-edges-on-select="false"
+      :elevate-nodes-on-select="false"
       :nodes-connectable="false"
       :nodes-draggable="false"
     >
@@ -20,16 +20,21 @@
         />
       </template>
 
-      <div class="total-latency">
-        <span>{{ t('lifecycle.total_latency') }}:</span>
-        <span>{{ fmt(props.rootSpan.durationNano) }}</span>
-      </div>
+      <template #edge-seamless-smoothstep="edgeProps: SmoothStepEdgeProps & Pick<EdgeProps<LifecycleEdgeData>, 'data'>">
+        <LifecycleEdgeSeamlessSmoothstep v-bind="edgeProps" />
+      </template>
+
+      <LifecycleLegend
+        ref="legend"
+        :root-span="rootSpan"
+      />
 
       <Controls
-        :fit-view-params="fitViewParams"
+        ref="controls"
         :show-interactive="false"
+        @fit-view="fitFlow"
       />
-      <Background />
+      <Background variant="lines" />
     </VueFlow>
   </div>
 </template>
@@ -41,31 +46,37 @@ import {
   Position,
   useVueFlow,
   VueFlow,
+  type EdgeProps,
   type FitViewParams,
   type GraphNode,
   type NodeProps,
+  type SmoothStepEdgeProps,
 } from '@vue-flow/core'
-import { computed, nextTick, onBeforeUnmount, onMounted, useTemplateRef, watch } from 'vue'
-import composables from '../../composables'
-import { LifecycleNodeType } from '../../constants'
-import { type LifecycleNode, type LifecycleNodeData, type SpanNode } from '../../types'
-import { buildLifecycleGraph, getDurationFormatter } from '../../utils'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
+import {
+  CANVAS_COLUMN_GAP,
+  CANVAS_PADDING,
+  CANVAS_ROW_GAP,
+  LifecycleNodeType,
+  NODE_GROUP_COLUMN_GAP,
+  NODE_GROUP_PADDING,
+  NODE_GROUP_ROW_GAP,
+  TOOLBAR_MARGIN,
+} from '../../constants'
+import { type LifecycleEdgeData, type LifecycleNode, type LifecycleNodeData, type SpanNode } from '../../types'
+import { buildLifecycleGraph } from '../../utils'
+import LifecycleEdgeSeamlessSmoothstep from './LifecycleEdgeSeamlessSmoothstep.vue'
+import LifecycleLegend from './LifecycleLegend.vue'
 import LifecycleViewNode from './LifecycleViewNode.vue'
-
-const fmt = getDurationFormatter()
-const { i18n: { t } } = composables.useI18n()
 
 const props = defineProps<{
   rootSpan: SpanNode
   showSkeleton?: boolean
 }>()
 
-const rootRef = useTemplateRef<HTMLDivElement>('root')
-
-const options = {
-  nodeGapX: 30,
-  nodeGapY: 10,
-}
+const flowRef = useTemplateRef<InstanceType<typeof VueFlow>>('flow')
+const controlsRef = useTemplateRef<InstanceType<typeof Controls>>('controls')
+const legendRef = useTemplateRef<InstanceType<typeof LifecycleLegend>>('legend')
 
 const {
   addNodes,
@@ -78,9 +89,9 @@ const {
 
 const { findNode, fitView } = useVueFlow()
 
-const fitViewParams: FitViewParams = {
+const fitViewParams = ref<FitViewParams>({
   maxZoom: 1,
-}
+})
 
 /**
  * This function takes a list of nodes, computes the positions, and updated the nodes in-place.
@@ -92,16 +103,26 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
   }
 
   let clientNode: GraphNode | undefined
+  let clientOutNode: GraphNode | undefined
+  let requestGroupNode: GraphNode | undefined
   let upstreamNode: GraphNode | undefined
+  let responseGroupNode: GraphNode | undefined
+  let clientInNode: GraphNode | undefined
 
   const requestNodes: GraphNode[] = []
-  const requestBox = {
+  const requestGroupMetrics = {
+    innerWidth: 0,
+    innerHeight: 0,
+    innerOffsetY: 0,
     width: 0,
     height: 0,
   }
 
   const responseNodes: GraphNode[] = []
-  const responseBox = {
+  const responseGroupMetrics = {
+    innerWidth: 0,
+    innerHeight: 0,
+    innerOffsetY: 0,
     width: 0,
     height: 0,
   }
@@ -110,127 +131,232 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
     const id = nodes[i].id
     const node = findNode<LifecycleNodeData, any>(id)
     if (!node) {
-      throw new Error(`Graph node with ID "${id}" is not found`)
+      throw new Error(`Graph node with ID "${id}" at index ${i} is not found`)
     }
 
     switch (node.data.type) {
       case LifecycleNodeType.CLIENT:
-        if (i !== 0) {
-          throw new Error('The client node did not appear first')
-        }
-
         node.targetPosition = Position.Bottom
         node.sourcePosition = Position.Top
+
         clientNode = node
         break
-      case LifecycleNodeType.REQUEST:
-        if (!clientNode) {
-          throw new Error('Encountered a request node before the client node')
-        } if (upstreamNode) {
-          throw new Error('Encountered a request node after the upstream node')
-        }
+      case LifecycleNodeType.CLIENT_OUT:
+        node.targetPosition = Position.Left
+        node.sourcePosition = Position.Right
 
+        clientOutNode = node
+        break
+      case LifecycleNodeType.REQUEST_GROUP:
+        node.targetPosition = Position.Left
+        node.sourcePosition = Position.Right
+
+        requestGroupNode = node
+        break
+      case LifecycleNodeType.REQUEST:
         node.targetPosition = Position.Left
         node.sourcePosition = Position.Right
 
         requestNodes.push(node)
-        requestBox.width += node.dimensions.width + (requestBox.width > 0 ? options.nodeGapX : 0)
-        if (node.dimensions.height > requestBox.height) {
-          requestBox.height = node.dimensions.height
+        requestGroupMetrics.innerWidth += node.dimensions.width + (requestGroupMetrics.innerWidth > 0 ? NODE_GROUP_COLUMN_GAP : 0)
+        if (node.dimensions.height > requestGroupMetrics.innerHeight) {
+          requestGroupMetrics.innerHeight = node.dimensions.height
         }
         break
       case LifecycleNodeType.UPSTREAM:
-        if (!clientNode) {
-          throw new Error('Encountered the upstream node before the client node')
-        } else if (upstreamNode) {
-          throw new Error(`Duplicate upstream node at index ${i}`)
-        }
-
         node.targetPosition = Position.Top
         node.sourcePosition = Position.Bottom
 
         upstreamNode = node
         break
-      case LifecycleNodeType.RESPONSE:
-        if (i === 0) {
-          throw new Error('Encountered a response node before the client node')
-        } else if (!upstreamNode) {
-          throw new Error('Encountered a response node before the upstream node')
-        }
+      case LifecycleNodeType.RESPONSE_GROUP:
+        node.targetPosition = Position.Right
+        node.sourcePosition = Position.Left
 
+        responseGroupNode = node
+        break
+      case LifecycleNodeType.RESPONSE:
         node.targetPosition = Position.Right
         node.sourcePosition = Position.Left
 
         responseNodes.push(node)
-        responseBox.width += node.dimensions.width + (responseBox.width > 0 ? options.nodeGapX : 0)
-        if (node.dimensions.height > responseBox.height) {
-          responseBox.height = node.dimensions.height
+        responseGroupMetrics.innerWidth += node.dimensions.width + (responseGroupMetrics.innerWidth > 0 ? NODE_GROUP_COLUMN_GAP : 0)
+        if (node.dimensions.height > responseGroupMetrics.innerHeight) {
+          responseGroupMetrics.innerHeight = node.dimensions.height
         }
         break
+      case LifecycleNodeType.CLIENT_IN:
+        node.targetPosition = Position.Right
+        node.sourcePosition = Position.Left
+
+        clientInNode = node
+        break
       default:
-        throw new Error(`Unknown node type: ${node.data.type}`)
+        throw new Error(`Unknown node type: "${node.data.type}" at index ${i}`)
     }
   }
 
   if (!clientNode) {
     throw new Error('Missing the client node')
+  } else if (!clientOutNode) {
+    throw new Error('Missing the client out node')
   } else if (!upstreamNode) {
     throw new Error('Missing the upstream node')
+  } else if (!clientInNode) {
+    throw new Error('Missing the client in node')
   }
 
-  // "lr" stands for "left and right": refers to the client and upstream nodes
-  const lrHeight = Math.max(clientNode.dimensions.height, upstreamNode.dimensions.height)
-  const lrOffsetY = Math.abs(clientNode.dimensions.height - upstreamNode.dimensions.height) / 2
+  // >>> Layout - Request Group
+  if (requestGroupNode) {
+    requestGroupMetrics.innerOffsetY = requestGroupNode.dimensions.height - NODE_GROUP_PADDING + NODE_GROUP_ROW_GAP
+    requestGroupMetrics.width = requestGroupMetrics.innerWidth + NODE_GROUP_PADDING * 2
+    requestGroupMetrics.height = requestGroupNode.dimensions.height + NODE_GROUP_ROW_GAP + requestGroupMetrics.innerHeight
+    requestGroupNode.width = requestGroupMetrics.width
+    requestGroupNode.height = requestGroupMetrics.height
 
-  // "tb" stands for "top and bottom": refers to the request and response nodes
-  const tbWidth = Math.max(requestBox.width, responseBox.width)
-  const tbOffsetX = Math.abs(requestBox.width - responseBox.width) / 2
-
-  clientNode.position.y = requestBox.height + options.nodeGapY
-
-  let x = clientNode.position.x + clientNode.dimensions.width
-  if (requestBox.width < responseBox.width) {
-    x += tbOffsetX
+    let scopedX = NODE_GROUP_PADDING
+    for (let i = 0; i < requestNodes.length; i++) {
+      const node = requestNodes[i]
+      if (i > 0) {
+        scopedX += NODE_GROUP_COLUMN_GAP
+      }
+      node.position.x = scopedX
+      node.position.y = requestGroupMetrics.innerOffsetY + (requestGroupMetrics.innerHeight - node.dimensions.height) / 2
+      scopedX += node.dimensions.width
+    }
   }
-  for (const node of requestNodes) {
-    x += options.nodeGapX
-    node.position.x = x
-    node.position.y = (requestBox.height - node.dimensions.height) / 2
-    x += node.dimensions.width
-  }
+  // <<< Layout - Request Group
 
-  upstreamNode.position.x = clientNode.position.x + clientNode.dimensions.width + options.nodeGapX + tbWidth + options.nodeGapX
-  upstreamNode.position.y = requestBox.height + options.nodeGapY
+  // >>> Layout - Response Group
+  if (responseGroupNode) {
+    responseGroupMetrics.innerOffsetY = NODE_GROUP_PADDING
+    responseGroupMetrics.width = responseGroupMetrics.innerWidth + NODE_GROUP_PADDING * 2
+    responseGroupMetrics.height = responseGroupNode.dimensions.height + NODE_GROUP_ROW_GAP + responseGroupMetrics.innerHeight
+    responseGroupNode.width = responseGroupMetrics.width
+    responseGroupNode.height = responseGroupMetrics.height
 
-  x = clientNode.position.x + clientNode.dimensions.width + options.nodeGapX + tbWidth + options.nodeGapX
-  if (responseBox.width < requestBox.width) {
-    x -= tbOffsetX
+    let localX = responseGroupMetrics.width - NODE_GROUP_PADDING
+    for (let i = 0; i < responseNodes.length; i++) {
+      const node = responseNodes[i]
+      if (i > 0) {
+        localX -= NODE_GROUP_COLUMN_GAP
+      }
+      localX -= node.dimensions.width
+      node.position.x = localX
+      node.position.y = NODE_GROUP_PADDING + (responseGroupMetrics.innerHeight - node.dimensions.height) / 2
+    }
   }
+  // <<< Layout - Response Group
 
-  const bottomBaseY = requestBox.height + options.nodeGapY + lrHeight + options.nodeGapY
-  for (const node of responseNodes) {
-    x -= options.nodeGapX + node.dimensions.width
-    node.position.x = x
-    node.position.y = bottomBaseY + (responseBox.height - node.dimensions.height) / 2
-  }
+  // >>> Layout along X-axis
+  let canvasX = CANVAS_PADDING
 
-  if (clientNode.dimensions.height < upstreamNode.dimensions.height) {
-    clientNode.position.y += lrOffsetY
-  } else {
-    upstreamNode.position.y += lrOffsetY
+  // Client
+  clientNode.position.x = canvasX
+  canvasX += clientNode.dimensions.width + CANVAS_COLUMN_GAP
+
+  // Client In / Client Out (They are horizontally center-aligned)
+  const clientInOutMaxWidth = Math.max(clientOutNode.dimensions.width, clientInNode.dimensions.width)
+  clientOutNode.position.x = canvasX + (clientInOutMaxWidth - clientOutNode.dimensions.width) / 2
+  clientInNode.position.x = canvasX + (clientInOutMaxWidth - clientInNode.dimensions.width) / 2
+  canvasX += clientInOutMaxWidth + CANVAS_COLUMN_GAP
+
+  // Request Group / Response Group (They are horizontally center-aligned)
+  const requestsResponsesMaxWidth = Math.max(requestGroupMetrics.width, responseGroupMetrics.width)
+  if (requestGroupNode) {
+    requestGroupNode.position.x = canvasX + (requestsResponsesMaxWidth - requestGroupMetrics.width) / 2
   }
+  if (responseGroupNode) {
+    responseGroupNode.position.x = canvasX + (requestsResponsesMaxWidth - responseGroupMetrics.width) / 2
+  }
+  canvasX += requestsResponsesMaxWidth + CANVAS_COLUMN_GAP
+
+  // Upstream
+  upstreamNode.position.x = canvasX
+  // <<< Layout along X-axis
+
+  // >>> Layout along Y-axis
+  let layoutY = CANVAS_PADDING
+
+  // Client Out / Request Group (They are vertically center-aligned)
+  const upperInnerMaxHeight = Math.max(clientOutNode.dimensions.height, requestGroupMetrics.innerHeight)
+  clientOutNode.position.y = layoutY + requestGroupMetrics.innerOffsetY + (upperInnerMaxHeight - clientOutNode.dimensions.height) / 2
+  if (requestGroupNode) {
+    requestGroupNode.position.y = layoutY + (upperInnerMaxHeight - requestGroupMetrics.innerHeight) / 2
+  }
+  layoutY = Math.max(
+    clientOutNode.position.y + clientOutNode.dimensions.height,
+    requestGroupNode ? requestGroupNode.position.y + requestGroupMetrics.height : 0,
+  ) + CANVAS_ROW_GAP
+
+  // Client / Upstream (They are vertically center-aligned)
+  const clientUpstreamMaxHeight = Math.max(clientNode.dimensions.height, upstreamNode.dimensions.height)
+  clientNode.position.y = layoutY + (clientUpstreamMaxHeight - clientNode.dimensions.height) / 2
+  upstreamNode.position.y = layoutY + (clientUpstreamMaxHeight - upstreamNode.dimensions.height) / 2
+  layoutY += clientUpstreamMaxHeight + CANVAS_ROW_GAP
+
+  // Client In / Response Group (They are vertically center-aligned)
+  const lowerInnerMaxHeight = Math.max(clientInNode.dimensions.height, responseGroupMetrics.innerHeight)
+  clientInNode.position.y = layoutY + responseGroupMetrics.innerOffsetY + (lowerInnerMaxHeight - clientInNode.dimensions.height) / 2
+  if (responseGroupNode) {
+    responseGroupNode.position.y = layoutY + (lowerInnerMaxHeight - responseGroupMetrics.innerHeight) / 2
+  }
+  // <<< Layout along Y-axis
 
   return nodes
 }
 
 const currentGraph = computed(() => buildLifecycleGraph(props.rootSpan))
 
+/**
+ * To fit the flow chart into the view, taking the toolbar and legend into account.
+ */
+const fitFlow = () => {
+  const flowEl = flowRef.value?.$el
+  if (!(flowEl instanceof HTMLElement)) {
+    return
+  }
+
+  const controlsEl = controlsRef.value?.$el
+  const legendEl = legendRef.value?.$el
+
+  const flowWidth = flowEl.getBoundingClientRect().width
+  let accumulatedPadding = 0
+  let accumulatedOffsetX = 0
+
+  // Best effort–it's okay to miss this measurement
+  if (controlsEl instanceof HTMLElement) {
+    accumulatedPadding += controlsEl.getBoundingClientRect().width + 2 * TOOLBAR_MARGIN
+    accumulatedOffsetX = controlsEl.getBoundingClientRect().width
+  }
+
+  // Best effort–it's okay to miss this measurement
+  if (legendEl instanceof HTMLElement) {
+    accumulatedPadding += legendEl.getBoundingClientRect().width + 2 * TOOLBAR_MARGIN
+    accumulatedOffsetX -= legendEl.getBoundingClientRect().width
+  }
+
+  fitViewParams.value = {
+    maxZoom: 1,
+    ...flowWidth > 0 && {
+      padding: accumulatedPadding / 2 / flowWidth,
+    }, // Use default value otherwise
+    ...accumulatedOffsetX !== 0 && {
+      offset: {
+        x: accumulatedOffsetX / 2,
+      },
+    }, // Use default value otherwise
+  }
+
+  fitView(fitViewParams.value)
+}
+
 onNodesInitialized((nodes) => {
   for (const diff of layout(nodes as LifecycleNode[])) {
     updateNode(diff.id, diff)
   }
   nextTick(() => {
-    fitView(fitViewParams)
+    fitFlow()
   })
 })
 
@@ -249,11 +375,17 @@ watch(
 let resizeObserver: ResizeObserver | undefined
 
 onMounted(() => {
-  if (rootRef.value) {
-    resizeObserver = new ResizeObserver(() => {
-      fitView(fitViewParams)
-    })
-    resizeObserver.observe(rootRef.value)
+  resizeObserver = new ResizeObserver(() => {
+    fitFlow()
+  })
+  if (flowRef.value && flowRef.value.$el instanceof HTMLElement) {
+    resizeObserver.observe(flowRef.value.$el)
+  }
+  if (controlsRef.value && controlsRef.value.$el instanceof HTMLElement) {
+    resizeObserver.observe(controlsRef.value.$el)
+  }
+  if (legendRef.value && legendRef.value.$el instanceof HTMLElement) {
+    resizeObserver.observe(legendRef.value.$el)
   }
 })
 
@@ -269,7 +401,9 @@ onBeforeUnmount(() => {
 @import '@vue-flow/core/dist/style.css';
 @import '@vue-flow/controls/dist/style.css';
 @import '@vue-flow/core/dist/theme-default.css';
+</style>
 
+<style lang="scss" scoped>
 .lifecycle-view {
   align-items: center;
   display: flex;
@@ -281,30 +415,31 @@ onBeforeUnmount(() => {
     width: auto;
   }
 
-  .total-latency {
-    align-items: center;
-    background-color: $kui-color-background;
-    bottom: 16px; // = $kui-space-60
-    box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.08); // Hardcoding to keep consistent with VueFlow's built-in Control component's style
-    display: flex;
-    flex-direction: row;
-    flex-grow: 1;
-    flex-shrink: 0;
-    font-size: $kui-font-size-20;
-    gap: $kui-space-40;
-    justify-content: flex-start;
-    padding: $kui-space-20 $kui-space-30;
-    position: absolute;
-    right: 16px; // = $kui-space-60
-    z-index: 1000;
+  :deep(.vue-flow__node) {
+    background-color: transparent !important;
+    border: none !important;
+    border-radius: $kui-border-radius-30 !important;
+    padding: 0;
+    width: auto;
+    word-wrap: break-word;
   }
-}
 
-.vue-flow__node {
-  border: $kui-border-width-10 solid #000000; // Hardcoding because we don't have a corresponding token yet
-  border-radius: $kui-border-radius-30;
-  padding: 0;
-  width: auto;
-  word-wrap: break-word;
+  :deep(.vue-flow__controls) {
+    margin: v-bind('`${TOOLBAR_MARGIN}px`') !important;
+  }
+
+  :deep(.vue-flow__edge-path) {
+    /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+    stroke: $kui-color-background-neutral !important;
+  }
+
+  :deep(.vue-flow__arrowhead) {
+    polyline {
+      /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+      fill: $kui-color-background-neutral !important;
+      /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+      stroke: $kui-color-background-neutral !important;
+    }
+  }
 }
 </style>

--- a/packages/core/tracing/src/components/payload/PayloadDisplay.vue
+++ b/packages/core/tracing/src/components/payload/PayloadDisplay.vue
@@ -9,7 +9,7 @@
 
     <template v-else>
       <div
-        class="title-wrapper"
+        :class="['title-wrapper', payload.direction]"
         @click="expanded = !expanded"
       >
         <div
@@ -109,6 +109,14 @@ const payloadContent = computed(() => {
     justify-content: space-between;
     padding: $kui-space-40 v-bind(WATERFALL_ROW_COLUMN_GAP);
     width: 100%;
+
+    &.request {
+      background-color: $kui-color-background-primary-weakest;
+    }
+
+    &.response {
+      background-color: $kui-color-background-decorative-purple-weakest;
+    }
 
     .title {
       font-size: $kui-font-size-30;

--- a/packages/core/tracing/src/constants/lifecycle.ts
+++ b/packages/core/tracing/src/constants/lifecycle.ts
@@ -1,6 +1,63 @@
+import {
+  KUI_COLOR_BACKGROUND_DANGER,
+  KUI_COLOR_BACKGROUND_DANGER_STRONGER,
+  KUI_COLOR_BACKGROUND_DANGER_WEAK,
+  KUI_COLOR_BACKGROUND_DANGER_WEAKER,
+  KUI_COLOR_BACKGROUND_DANGER_WEAKEST,
+  KUI_ICON_COLOR_DANGER,
+  KUI_SPACE_100,
+  KUI_SPACE_20,
+  KUI_SPACE_50,
+  KUI_SPACE_60,
+  KUI_SPACE_80,
+  KUI_STATUS_COLOR_501,
+} from '@kong/design-tokens'
+
 export enum LifecycleNodeType {
   CLIENT = 'client',
+  CLIENT_IN = 'clientIn',
+  CLIENT_OUT = 'clientOut',
   REQUEST = 'request',
   UPSTREAM = 'upstream',
   RESPONSE = 'response',
+  REQUEST_GROUP = 'requestGroup',
+  RESPONSE_GROUP = 'responseGroup',
 }
+
+/** Margin of toolbars for actions, legend, etc. (VueFlow use) */
+export const TOOLBAR_MARGIN = parseFloat(KUI_SPACE_60)
+
+/** Padding to keep a clear zone around the canvas */
+export const CANVAS_PADDING = parseFloat(KUI_SPACE_100)
+
+/** Row gap between top-level nodes (e.g., individual nodes, node groups) */
+export const CANVAS_ROW_GAP = parseFloat(KUI_SPACE_60)
+
+/** Column gap between top-level nodes (e.g., individual nodes, node groups) */
+export const CANVAS_COLUMN_GAP = parseFloat(KUI_SPACE_80)
+
+/** Padding to keep a clear zone inside a node group's inner edge */
+export const NODE_GROUP_PADDING = parseFloat(KUI_SPACE_50)
+
+/** Row gap between nodes inside a node group */
+export const NODE_GROUP_ROW_GAP = parseFloat(KUI_SPACE_20)
+
+/** Column gap between nodes inside a node group */
+export const NODE_GROUP_COLUMN_GAP = parseFloat(KUI_SPACE_50)
+
+export const NODE_STRIPE_COLOR_MAPPING_START_EXP = 3
+
+/**
+ * Color mapping from nanosecond-based duration `t` to a color
+ *
+ * index(t) = min(6, max(0, floor(log10(t)) - 3))
+ */
+export const NODE_STRIPE_COLOR_MAPPING = [
+  KUI_COLOR_BACKGROUND_DANGER_WEAKEST,
+  KUI_COLOR_BACKGROUND_DANGER_WEAKER,
+  KUI_STATUS_COLOR_501,
+  KUI_COLOR_BACKGROUND_DANGER_WEAK,
+  KUI_ICON_COLOR_DANGER,
+  KUI_COLOR_BACKGROUND_DANGER,
+  KUI_COLOR_BACKGROUND_DANGER_STRONGER,
+]

--- a/packages/core/tracing/src/locales/en.json
+++ b/packages/core/tracing/src/locales/en.json
@@ -4,9 +4,15 @@
     "title": "Title of the header"
   },
   "lifecycle": {
+    "client_in": {
+      "tooltip": "Time taken for client to read the response from Kong. A high value here may be indicative of a slow network or connectivity issue."
+    },
+    "client_out": {
+      "tooltip": "Time taken for the client to write the request to Kong. A high value here may be indicative of a slow network or connectivity issue."
+    },
     "request": "Request",
     "response": "Response",
-    "total_latency": "Total latency"
+    "total": "Total"
   },
   "payload": {
     "request_body": "Request body",

--- a/packages/core/tracing/src/partials/SummaryViewTab.vue
+++ b/packages/core/tracing/src/partials/SummaryViewTab.vue
@@ -27,28 +27,28 @@
 
         <PayloadDisplay
           v-if="payloads?.headers?.request"
-          :payload="{ type: 'headers', headers: payloads.headers.request }"
+          :payload="{ direction: 'request', type: 'headers', headers: payloads.headers.request }"
           :show-skeleton="showSkeleton"
           :title="t('payload.request_headers')"
         />
 
         <PayloadDisplay
           v-if="payloads?.body?.request"
-          :payload="{ type: 'body', content: payloads.body.request }"
+          :payload="{ direction: 'request', type: 'body', content: payloads.body.request }"
           :show-skeleton="showSkeleton"
           :title="t('payload.request_body')"
         />
 
         <PayloadDisplay
           v-if="payloads?.headers?.response"
-          :payload="{ type: 'headers', headers: payloads.headers.response }"
+          :payload="{ direction: 'response', type: 'headers', headers: payloads.headers.response }"
           :show-skeleton="showSkeleton"
           :title="t('payload.response_headers')"
         />
 
         <PayloadDisplay
           v-if="payloads?.body?.response"
-          :payload="{ type: 'body', content: payloads.body.response }"
+          :payload="{ direction: 'response', type: 'body', content: payloads.body.response }"
           :show-skeleton="showSkeleton"
           :title="t('payload.response_body')"
         />

--- a/packages/core/tracing/src/types/lifecycle.ts
+++ b/packages/core/tracing/src/types/lifecycle.ts
@@ -1,13 +1,37 @@
 import type { Edge, Node } from '@vue-flow/core'
+import type { TranslationKey } from '../composables/useI18n'
 import type { LifecycleNodeType } from '../constants'
 import type { SpanNode } from './spans'
 
-export interface LifecycleNodeData {
-  label: string
-  type: LifecycleNodeType
+export interface LifecycleGraphNodeTree {
+  client: {
+    node: LifecycleNode
+    in: LifecycleNode
+    out: LifecycleNode
+  }
+  requests?: {
+    node: LifecycleNode
+    children: LifecycleNode[]
+  }
+  upstream: LifecycleNode
+  responses?: {
+    node: LifecycleNode
+    children: LifecycleNode[]
+  }
+}
+
+export interface LifecycleNodeData<T extends LifecycleNodeType = LifecycleNodeType> {
+  label?: string
+  type: T
   badge?: string
   durationNano?: number
   spans?: SpanNode[]
+  tree?: LifecycleGraphNodeTree
+  labelPlacement?: `${'top' | 'bottom'} ${'left' | 'right'}`
+  labelTooltipKey?: TranslationKey
+  durationTooltipKey?: TranslationKey
+  showTargetHandle?: boolean
+  showSourceHandle?: boolean
 }
 
 export interface LifecycleNode extends Node<LifecycleNodeData, any, LifecycleNodeType> {
@@ -15,7 +39,12 @@ export interface LifecycleNode extends Node<LifecycleNodeData, any, LifecycleNod
   data: LifecycleNodeData
 }
 
+export interface LifecycleEdgeData {
+  tooltip?: string
+}
+
 export interface LifecycleGraph {
+  nodeTree: LifecycleGraphNodeTree
   nodes: LifecycleNode[]
   edges: Edge[]
 }

--- a/packages/core/tracing/src/types/payloads.ts
+++ b/packages/core/tracing/src/types/payloads.ts
@@ -1,12 +1,16 @@
+export type Direction = 'request' | 'response'
 export type Headers = Record<string, string>
 export type Body = string
 
-export type Payload =
+export type Payload = {
+  direction: Direction;
+} & (
   | {
-    type: 'headers'
-    headers: Headers
+    type: 'headers';
+    headers: Headers;
   }
   | {
-    type: 'body'
-    content: Body
+    type: 'body';
+    content: Body;
   }
+)

--- a/packages/core/tracing/src/types/payloads.ts
+++ b/packages/core/tracing/src/types/payloads.ts
@@ -3,14 +3,14 @@ export type Headers = Record<string, string>
 export type Body = string
 
 export type Payload = {
-  direction: Direction;
+  direction: Direction
 } & (
   | {
-    type: 'headers';
-    headers: Headers;
+    type: 'headers'
+    headers: Headers
   }
   | {
-    type: 'body';
-    content: Body;
+    type: 'body'
+    content: Body
   }
 )

--- a/packages/core/tracing/src/utils/lifecycle.ts
+++ b/packages/core/tracing/src/utils/lifecycle.ts
@@ -1,8 +1,8 @@
-import { MarkerType, type Edge } from '@vue-flow/core'
-import { KONG_PHASES, LifecycleNodeType, SPAN_NAMES } from '../constants'
+import { KUI_COLOR_BACKGROUND_DISABLED } from '@kong/design-tokens'
+import { MarkerType } from '@vue-flow/core'
+import { KONG_PHASES, LifecycleNodeType, NODE_STRIPE_COLOR_MAPPING, NODE_STRIPE_COLOR_MAPPING_START_EXP, SPAN_NAMES } from '../constants'
 import type { LifecycleGraph, LifecycleNodeData, SpanNode } from '../types'
 import { getPhaseAndPlugin } from './spans'
-import { getDurationFormatter } from './time'
 
 /**
  * Traverse a plugin span tree and build the {@link LifecycleNodeData} for the plugin and accumulate
@@ -14,7 +14,7 @@ import { getDurationFormatter } from './time'
  * @param node The root node of the plugin span tree
  * @returns the node data and the duration that has been excluded
  */
-const buildPluginNodeData = (node: SpanNode): [LifecycleNodeData, number] | undefined => {
+const buildPluginNodeData = (node: SpanNode): [LifecycleNodeData & { id: string }, number] | undefined => {
   // Try to parse the phase and plugin name from the span name
   const pluginSpan = getPhaseAndPlugin(node.span.name)
   if (!pluginSpan || pluginSpan.suffix) {
@@ -61,6 +61,7 @@ const buildPluginNodeData = (node: SpanNode): [LifecycleNodeData, number] | unde
   }
 
   return [{
+    id: `${pluginSpan.plugin}:${pluginSpan.phase}`, // For reference and node generation only
     label: pluginSpan.plugin,
     type: nodeType,
     badge: pluginSpan.phase,
@@ -70,11 +71,10 @@ const buildPluginNodeData = (node: SpanNode): [LifecycleNodeData, number] | unde
 }
 
 export const buildLifecycleGraph = (root: SpanNode): LifecycleGraph => {
-  const fmt = getDurationFormatter()
   const ingressSpans: SpanNode[] = []
   const egressSpans: SpanNode[] = []
-  const requestNodesData: LifecycleNodeData[] = []
-  const responseNodesData: LifecycleNodeData[] = []
+  const requestNodesData: (LifecycleNodeData & { id: string })[] = []
+  const responseNodesData: (LifecycleNodeData & { id: string })[] = []
   const upstreamSpans: SpanNode[] = []
 
   let pluginDurationExcluded = 0
@@ -122,62 +122,235 @@ export const buildLifecycleGraph = (root: SpanNode): LifecycleGraph => {
     }
   }
 
-  const graph: LifecycleGraph = {
-    nodes: [],
+  const graph: Omit<LifecycleGraph, 'nodes'> = {
+    nodeTree: {
+      client: {
+        node: {
+          id: LifecycleNodeType.CLIENT,
+          position: { x: 0, y: 0 },
+          data: {
+            label: 'Client',
+            type: LifecycleNodeType.CLIENT,
+            showSourceHandle: true,
+          },
+          zIndex: 2,
+        },
+        in: {
+          id: LifecycleNodeType.CLIENT_IN,
+          position: { x: 0, y: 0 },
+          data: {
+            type: LifecycleNodeType.CLIENT_IN,
+            durationNano: ingressSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0) + pluginDurationExcluded,
+            durationTooltipKey: 'lifecycle.client_in.tooltip',
+          },
+          zIndex: 10, // Because we may want to show tooltips on this node
+        },
+        out: {
+          id: LifecycleNodeType.CLIENT_OUT,
+          position: { x: 0, y: 0 },
+          data: {
+            type: LifecycleNodeType.CLIENT_OUT,
+            durationNano: egressSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0),
+            durationTooltipKey: 'lifecycle.client_out.tooltip',
+          },
+          zIndex: 10, // Because we may want to show tooltips on this node
+        },
+      },
+      requests: requestNodesData.length > 0 ? {
+        node: {
+          id: LifecycleNodeType.REQUEST_GROUP,
+          position: { x: 0, y: 0 },
+          data: {
+            label: 'Requests',
+            type: LifecycleNodeType.REQUEST_GROUP,
+            labelPlacement: 'top left',
+          },
+          zIndex: 1,
+        },
+        children: requestNodesData.map((nodeData, i) => ({
+          id: `${LifecycleNodeType.REQUEST}:${nodeData.id}`,
+          position: { x: 0, y: 0 },
+          parentNode: LifecycleNodeType.REQUEST_GROUP,
+          data: {
+            ...nodeData,
+            showTargetHandle: i > 0,
+            showSourceHandle: true,
+          },
+          zIndex: 1,
+        })),
+      } : undefined,
+      upstream: {
+        id: LifecycleNodeType.UPSTREAM,
+        position: { x: 0, y: 0 },
+        data: {
+          label: 'Upstream',
+          type: LifecycleNodeType.UPSTREAM,
+          durationNano: upstreamSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0),
+          showSourceHandle: true,
+        },
+        zIndex: 1,
+      },
+      responses: responseNodesData.length > 0 ? {
+        node: {
+          id: LifecycleNodeType.RESPONSE_GROUP,
+          position: { x: 0, y: 0 },
+          data: {
+            label: 'Responses',
+            type: LifecycleNodeType.RESPONSE_GROUP,
+            labelPlacement: 'bottom left',
+          },
+          zIndex: 1,
+        },
+        children: responseNodesData.map((nodeData, i) => ({
+          id: `${LifecycleNodeType.RESPONSE}:${nodeData.id}`,
+          position: { x: 0, y: 0 },
+          parentNode: LifecycleNodeType.RESPONSE_GROUP,
+          data: {
+            ...nodeData,
+            showTargetHandle: i > 0,
+            showSourceHandle: true,
+          },
+          zIndex: 1,
+        })),
+      } : undefined,
+    },
     edges: [],
   }
 
-  graph.nodes.push({
-    id: 'client',
-    position: { x: 0, y: 0 },
-    data: {
-      label: 'Client',
-      type: LifecycleNodeType.CLIENT,
-    },
+  const clientNodes = graph.nodeTree.client
+
+  graph.edges.push({
+    id: `${clientNodes.node.id}->${clientNodes.out.id}`,
+    source: clientNodes.node.id,
+    target: clientNodes.out.id,
+    type: 'seamless-smoothstep',
+    zIndex: 1,
   })
 
-  requestNodesData.forEach((nodeData, i) => {
-    graph.nodes.push({
-      id: `request#${i}`,
-      position: { x: 0, y: 0 },
-      data: nodeData,
-    })
-  })
+  if (graph.nodeTree.requests && graph.nodeTree.requests.children.length > 0) {
+    const children = graph.nodeTree.requests.children
 
-  graph.nodes.push({
-    id: 'upstream',
-    position: { x: 0, y: 0 },
-    data: {
-      label: 'Upstream',
-      type: LifecycleNodeType.UPSTREAM,
-      durationNano: upstreamSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0),
-    },
-  })
-
-  responseNodesData.forEach((nodeData, i) => {
-    graph.nodes.push({
-      id: `response#${i}`,
-      position: { x: 0, y: 0 },
-      data: nodeData,
-    })
-  })
-
-  for (let i = 0; i < graph.nodes.length; i++) {
-    const j = i < graph.nodes.length - 1 ? i + 1 : 0
-    const edge: Edge = {
-      id: `${graph.nodes[i].id}->${graph.nodes[j].id}`,
-      source: graph.nodes[i].id,
-      target: graph.nodes[j].id,
-      type: 'smoothstep',
+    graph.edges.push({
+      id: `${clientNodes.out.id}->${children[0].id}`,
+      source: clientNodes.out.id,
+      target: children[0].id,
+      type: 'seamless-smoothstep',
       markerEnd: MarkerType.ArrowClosed,
+      zIndex: 2,
+    })
+
+    for (let i = 0; i < children.length - 1; i++) {
+      graph.edges.push({
+        id: `${children[i].id}->${children[i + 1].id}`,
+        source: children[i].id,
+        target: children[i + 1].id,
+        type: 'smoothstep', // Using built-in edge type because handles are available on both side–we don't care about the gaps
+        zIndex: 2,
+      })
     }
-    if (i === 0) {
-      edge.label = fmt(ingressSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0) + pluginDurationExcluded)
-    } else if (i === graph.nodes.length - 1) {
-      edge.label = fmt(egressSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0))
-    }
-    graph.edges.push(edge)
+
+    graph.edges.push({
+      id: `${children[children.length - 1].id}->${graph.nodeTree.upstream.id}`,
+      source: children[children.length - 1].id,
+      target: graph.nodeTree.upstream.id,
+      type: 'seamless-smoothstep',
+      markerEnd: MarkerType.ArrowClosed,
+      zIndex: 2,
+    })
+  } else {
+    graph.edges.push(
+      {
+        id: `${clientNodes.out.id}->${graph.nodeTree.upstream.id}`,
+        source: clientNodes.out.id,
+        target: graph.nodeTree.upstream.id,
+        type: 'seamless-smoothstep',
+        markerEnd: MarkerType.ArrowClosed,
+        zIndex: 1,
+      },
+    )
   }
 
-  return graph
+  if (graph.nodeTree.responses) {
+    const children = graph.nodeTree.responses.children
+
+    graph.edges.push({
+      id: `${graph.nodeTree.upstream.id}->${children[0].id}`,
+      source: graph.nodeTree.upstream.id,
+      target: children[0].id,
+      type: 'seamless-smoothstep',
+      markerEnd: MarkerType.ArrowClosed,
+      zIndex: 2,
+    })
+
+    for (let i = 0; i < children.length - 1; i++) {
+      graph.edges.push({
+        id: `${children[i].id}->${children[i + 1].id}`,
+        source: children[i].id,
+        target: children[i + 1].id,
+        type: 'smoothstep', // Using built-in edge type because handles are available on both side–we don't care about the gaps
+        zIndex: 2,
+      })
+    }
+
+    graph.edges.push({
+      id: `${children[children.length - 1].id}->${clientNodes.in.id}`,
+      source: children[children.length - 1].id,
+      target: clientNodes.in.id,
+      type: 'seamless-smoothstep',
+      zIndex: 2,
+    })
+  } else {
+    graph.edges.push({
+      id: `${graph.nodeTree.upstream.id}->${clientNodes.in.id}`,
+      source: graph.nodeTree.upstream.id,
+      target: clientNodes.in.id,
+      type: 'seamless-smoothstep',
+      zIndex: 1,
+    })
+  }
+
+  graph.edges.push({
+    id: `${clientNodes.in.id}->${clientNodes.node.id}`,
+    source: clientNodes.in.id,
+    target: clientNodes.node.id,
+    type: 'seamless-smoothstep',
+    markerEnd: MarkerType.ArrowClosed,
+    zIndex: 1,
+  })
+
+  return {
+    ...graph,
+    nodes: [
+      clientNodes.node,
+      clientNodes.out,
+      ...graph.nodeTree.requests ? [
+        graph.nodeTree.requests.node,
+        ...graph.nodeTree.requests.children,
+      ] : [],
+      graph.nodeTree.upstream,
+      ...graph.nodeTree.responses ? [
+        graph.nodeTree.responses.node,
+        ...graph.nodeTree.responses.children,
+      ] : [],
+      clientNodes.in,
+    ],
+  }
+}
+
+/**
+ * See {@link NODE_STRIPE_COLOR_MAPPING}
+ */
+export const getNodeStripeColor = (durationNano?: number) => {
+  if (durationNano === undefined || durationNano < 0) {
+    return KUI_COLOR_BACKGROUND_DISABLED
+  }
+
+  return NODE_STRIPE_COLOR_MAPPING[
+    Math.min(
+      NODE_STRIPE_COLOR_MAPPING.length - 1,
+      Math.max(
+        NODE_STRIPE_COLOR_MAPPING_START_EXP, Math.floor(Math.log10(durationNano)) - NODE_STRIPE_COLOR_MAPPING_START_EXP,
+      ),
+    )
+  ]
 }

--- a/packages/core/tracing/src/utils/lifecycle.ts
+++ b/packages/core/tracing/src/utils/lifecycle.ts
@@ -348,9 +348,7 @@ export const getNodeStripeColor = (durationNano?: number) => {
   return NODE_STRIPE_COLOR_MAPPING[
     Math.min(
       NODE_STRIPE_COLOR_MAPPING.length - 1,
-      Math.max(
-        NODE_STRIPE_COLOR_MAPPING_START_EXP, Math.floor(Math.log10(durationNano)) - NODE_STRIPE_COLOR_MAPPING_START_EXP,
-      ),
+      Math.max(0, Math.floor(Math.log10(durationNano)) - NODE_STRIPE_COLOR_MAPPING_START_EXP),
     )
   ]
 }


### PR DESCRIPTION
# Summary

* Implement the new design for the lifecycle view
* Custom layout function
* Fix the fit viewport helper to keep clear from the actions toolbar and legend

KM-939

## Showcase

|Full flow|
|:-|
|<img width="1171" alt="Screenshot 2025-02-13 at 18 06 16" src="https://github.com/user-attachments/assets/04722835-796e-42c5-9a81-44c98792f814" />|

|Flow without pre-upstream plugins|
|:-|
|<img width="1170" alt="Screenshot 2025-02-13 at 18 06 46" src="https://github.com/user-attachments/assets/0649f2bf-6ec4-4a88-8de8-6c129ba24cf1" />|

|Flow without post-upstream plugins|
|:-|
|<img width="1173" alt="Screenshot 2025-02-13 at 18 06 33" src="https://github.com/user-attachments/assets/d2b4d49f-ee4d-43fe-8f71-57309fea624d" />|

|Flow without pre and post-upstream phases|
|:-|
|<img width="1173" alt="Screenshot 2025-02-13 at 18 06 58" src="https://github.com/user-attachments/assets/98ef3dbf-a499-48cc-bd68-a8606fb84288" />|

|Tooltip|
|:-|
|<img width="444" alt="Screenshot 2025-02-13 at 16 57 40" src="https://github.com/user-attachments/assets/2418145f-1a5f-425e-8fd5-f5a47f1f8e91" />|