### PR TITLE
fix(analytics-chart): render timeseries charts with a single point [MA-2682]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -75,6 +75,7 @@ import type { GranularityValues, AbsoluteTimeRangeV4 } from '@kong-ui-public/ana
 import type { Chart } from 'chart.js'
 import { ChartLegendPosition } from '../../enums'
 import { formatByGranularity, generateLegendItems } from '../../utils'
+import { hasExactlyOneDatapoint } from '../../utils/commonOptions'
 
 const props = defineProps({
   chartData: {
@@ -199,6 +200,8 @@ const plugins = computed(() => [
 const remountLineKey = computed(() => `line-${plugins.value.map(p => p.id).join('-')}`)
 const remountBarKey = computed(() => `bar-${plugins.value.map(p => p.id).join('-')}`)
 
+const pointsWithoutHover = computed(() => hasExactlyOneDatapoint(props.chartData))
+
 const { options } = composables.useLinechartOptions({
   tooltipState: tooltipData,
   timeRangeMs: toRef(props, 'timeRangeMs'),
@@ -207,6 +210,7 @@ const { options } = composables.useLinechartOptions({
   stacked: toRef(props, 'stacked'),
   metricAxesTitle: toRef(props, 'metricAxesTitle'),
   dimensionAxesTitle: toRef(props, 'dimensionAxesTitle'),
+  pointsWithoutHover: pointsWithoutHover,
 })
 
 composables.useReportChartDataForSynthetics(toRef(props, 'chartData'), toRef(props, 'syntheticsDataKey'))

--- a/packages/analytics/analytics-chart/src/composables/useLineChartOptions.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useLineChartOptions.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import useLinechartOptions from './useLineChartOptions'
+import { ref, computed } from 'vue'
+
+const mockTooltipState = {
+  showTooltip: false,
+  tooltipContext: 0,
+  tooltipSeries: [],
+  left: 'foo',
+  top: 'bar',
+  units: 'count',
+  translateUnit: (unit: string, value: number) => '',
+  offsetX: 0,
+  offsetY: 0,
+  width: 0,
+  height:0,
+  chartType: 'timeseries_line' as const,
+}
+
+describe('useLineChartOptions', () => {
+
+  it('has no radius without hover when pointsWithoutHover is false', () => {
+    const { options } = useLinechartOptions({
+      tooltipState: mockTooltipState,
+      legendID: 'foo',
+      stacked: ref(false),
+      timeRangeMs: ref(1000),
+      granularity: ref('secondly'),
+      pointsWithoutHover: computed(() => false),
+    })
+
+    expect(options.value.elements.point.radius).toBe(0)
+  })
+
+  it('has a radius without hover when pointsWithoutHover is true', () => {
+    const { options } = useLinechartOptions({
+      tooltipState: mockTooltipState,
+      legendID: 'foo',
+      stacked: ref(false),
+      timeRangeMs: ref(1000),
+      granularity: ref('secondly'),
+      pointsWithoutHover: computed(() => true),
+    })
+
+    expect(options.value.elements.point.radius).toBe(3)
+  })
+})

--- a/packages/analytics/analytics-chart/src/composables/useLineChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useLineChartOptions.ts
@@ -124,7 +124,7 @@ export default function useLinechartOptions(chartOptions: LineChartOptions) {
       },
       elements: {
         point: {
-          radius: 0,
+          radius: chartOptions.pointsWithoutHover?.value ? 3 : 0,
           hitRadius: 4,
           hoverRadius: 4,
         },

--- a/packages/analytics/analytics-chart/src/types/chartjs-options.ts
+++ b/packages/analytics/analytics-chart/src/types/chartjs-options.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import type { Ref, ComputedRef } from 'vue'
 import type { Chart, ChartType as ChartJsChartType, TooltipModel, Color } from 'chart.js'
 import type { ChartType } from './chart-types'
 import type { GranularityValues } from '@kong-ui-public/analytics-utilities'
@@ -47,6 +47,7 @@ export interface BarChartOptions extends BaseChartOptions {
 export interface LineChartOptions extends BaseChartOptions {
   timeRangeMs: Ref<number | undefined>, // time range in seconds
   granularity: Ref<GranularityValues>,
+  pointsWithoutHover?: ComputedRef<boolean | undefined>,
 }
 
 export interface DoughnutChartOptions {

--- a/packages/analytics/analytics-chart/src/utils/commonOptions.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/commonOptions.spec.ts
@@ -1,0 +1,93 @@
+import { hasTimeseriesData } from './commonOptions'
+
+describe('commonOptions.hasTimeseriesData', () => {
+
+  it('is valid for timeseries data with only 1 datapoint', () => {
+    const lineChartData = {
+      datasets: [
+        {
+          rawMetric: 'test1',
+          rawDimension: 'test1',
+          label: 'test1',
+          data: [
+            {
+              x: 1678262400000,
+              y: 10,
+            },
+          ],
+        },
+        {
+          rawMetric: 'test2',
+          rawDimension: 'test2',
+          label: 'test2',
+          data: [
+            {
+              x: 1677744000000,
+              y: 10,
+            },
+          ],
+        },
+      ],
+    }
+
+    const valid = hasTimeseriesData(lineChartData)
+    expect(valid).true
+  })
+
+  it('is not valid for empty series', () => {
+    const lineChartData = {
+      datasets: [
+        {
+          rawMetric: 'test1',
+          rawDimension: 'test1',
+          label: 'test1',
+          data: [
+          ],
+        },
+        {
+          rawMetric: 'test2',
+          rawDimension: 'test2',
+          label: 'test2',
+          data: [
+          ],
+        },
+      ],
+    }
+
+    const valid = hasTimeseriesData(lineChartData)
+    expect(valid).false
+  })
+
+  it('is not valid for non-point-like series', () => {
+    const testChartData = {
+      labels: [
+        'test1',
+        'test2',
+      ],
+      datasets: [
+        {
+          rawDimension: 'test1',
+          rawMetric: 'test1',
+          label: 'test1',
+          data: [
+            10,
+            0,
+          ],
+        },
+        {
+          rawDimension: 'test2',
+          rawMetric: 'test2',
+          label: 'test2',
+          data: [
+            0,
+            20,
+          ],
+        },
+      ],
+    }
+
+    const valid = hasTimeseriesData(testChartData)
+
+    expect(valid).false
+  })
+})

--- a/packages/analytics/analytics-chart/src/utils/commonOptions.ts
+++ b/packages/analytics/analytics-chart/src/utils/commonOptions.ts
@@ -73,12 +73,13 @@ export const hasDatasets = (chartData: KChartData) =>
 export const hasDataInDatasets = (chartData: KChartData) =>
   hasDatasets(chartData) && chartData.datasets.some((ds) => ds.data.length)
 
-export const hasTwoOrMoreDataPoints = (chartData: KChartData) =>
-  hasDataInDatasets(chartData) &&
-  chartData.datasets.some((ds) => ds.data.length > 1)
+export const hasTimeseriesData = (chartData: KChartData) => {
+  return chartData.datasets.some((ds) => ds.data[0] && isValid((ds.data[0] as ScatterDataPoint).x))
+}
 
-export const hasTimeseriesData = (chartData: KChartData) =>
-  hasTwoOrMoreDataPoints(chartData) && chartData.datasets.some((ds) => ds.data[0] && isValid((ds.data[0] as ScatterDataPoint).x))
+export const hasExactlyOneDatapoint = (chartData: KChartData) =>
+  !!hasDataInDatasets(chartData) &&
+  chartData.datasets.some((ds) => ds.data.length == 1)
 
 export const hasMillisecondTimestamps = (chartData: KChartData) =>
   hasTimeseriesData(chartData) &&


### PR DESCRIPTION
# Summary

Second attempt at: https://github.com/Kong/public-ui-components/pull/1872

When a line chart is asked to display a single data point, display that datapoint with a radius smaller than the hover radius instead of displaying a deceptive "No data" error.

Test dataset:

```
{
  "data": [
    {
      "event": {
        "request_count": 100000
      },
      "timestamp": "2024-12-23T07:00:00.000Z"
    }
  ],
  "meta": {
    "start_ms": 1734937200000,
    "end_ms": 1735023600000,
    "limit": 50,
    "granularity_ms": 86400000,
    "metric_names": [
      "request_count"
    ],
    "truncated": false,
    "display": {},
    "metric_units": {
      "request_count": "count"
    }
  }
}
```

Before:
![image](https://github.com/user-attachments/assets/fbdd576e-f33a-42a3-bdeb-cdf4d799527c)

After:
![image](https://github.com/user-attachments/assets/3f38aa1c-3e91-4b09-bde4-bfc832fb9c56)
