### PR TITLE
feat(analytics-allow-equals): Allow equals at a base level

### DIFF
--- a/packages/analytics/analytics-utilities/src/types/explore/common.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/common.ts
@@ -1,5 +1,5 @@
 
-export const exploreFilterTypesV2 = ['in', 'not_in', 'selector'] as const
+export const exploreFilterTypesV2 = ['in', 'not_in', 'selector', '=', '!='] as const
 
 export type ExploreFilterTypesV2 = typeof exploreFilterTypesV2[number]
 


### PR DESCRIPTION
Allow simple `=` and `!=` fitler types in explore.