### PR TITLE
fix(entities-keys): text area char limit

### DIFF
--- a/packages/entities/entities-keys/src/components/KeyForm.vue
+++ b/packages/entities/entities-keys/src/components/KeyForm.vue
@@ -128,6 +128,7 @@
         <KTextArea
           v-if="form.fields.key_format === 'jwk'"
           v-model.trim="form.fields.jwk"
+          :character-limit="false"
           class="key-form-textarea"
           data-testid="key-form-jwk"
           :label="t('keys.form.fields.jwk.label')"
@@ -143,6 +144,7 @@
         <KTextArea
           v-if="form.fields.key_format === 'pem'"
           v-model.trim="form.fields.private_key"
+          :character-limit="false"
           class="key-form-textarea"
           data-testid="key-form-private-key"
           :label="t('keys.form.fields.private_key.label')"
@@ -154,6 +156,7 @@
         <KTextArea
           v-if="form.fields.key_format === 'pem'"
           v-model.trim="form.fields.public_key"
+          :character-limit="false"
           class="key-form-textarea"
           data-testid="key-form-public-key"
           :label="t('keys.form.fields.public_key.label')"


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This PR removes the character limit on all `<KTextArea>` instances on the key form page.

KM-907
