### PR TITLE
fix(dashboard-renderer): empty csv export dropdown [MA-3523]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -22,7 +22,7 @@
         </div>
       </KTooltip>
       <div
-        v-if="canShowKebabMenu || badgeData"
+        v-if="canShowTitleActions"
         class="tile-actions"
         :data-testid="`tile-actions-${tileId}`"
       >
@@ -38,7 +38,7 @@
           @click="editTile"
         />
         <KDropdown
-          v-if="canShowKebabMenu"
+          v-if="canShowKebabMenu && kebabMenuHasItems"
           class="dropdown"
           :data-testid="`chart-action-menu-${tileId}`"
           :kpop-attributes="{ placement: 'bottom-end' }"
@@ -181,7 +181,11 @@ const exploreLink = computed(() => {
 
 const csvFilename = computed<string>(() => i18n.t('csvExport.defaultFilename'))
 
+const canShowTitleActions = computed((): boolean => (canShowKebabMenu.value && (kebabMenuHasItems.value || props.context.editable)) || !!badgeData.value)
+
 const canShowKebabMenu = computed(() => hasKebabMenuAccess && !['golden_signals', 'top_n', 'gauge'].includes(props.definition.chart.type))
+
+const kebabMenuHasItems = computed((): boolean => !!exploreLink.value || ('allowCsvExport' in props.definition.chart && props.definition.chart.allowCsvExport) || props.context.editable)
 
 const rendererLookup: Record<DashboardTileType, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/MA-3523

Make sure dashboard dropdown only renders when it has items

Before
![Screenshot 2025-02-19 at 3 38 46 PM](https://github.com/user-attachments/assets/1897688c-a031-4519-b0b8-297c7992c033)

After
![Screenshot 2025-02-19 at 3 39 51 PM](https://github.com/user-attachments/assets/d505f042-d152-482e-96b6-dfadd9248ce9)

## Functional verification

1. Open [adoption PR](https://github.com/Kong/konnect-ui-apps/pull/5876) preview deployment
2. Head to service catalog -> service  -> dashboard tab
3. Gateway manager chart dashboard renderer should not have the dropdown menu

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
