### PR TITLE
fix(app-layout): fix subnav item badge condition [TDX-5119]

### DIFF
--- a/packages/core/app-layout/src/components/sidebar/SidebarItem.vue
+++ b/packages/core/app-layout/src/components/sidebar/SidebarItem.vue
@@ -123,7 +123,7 @@ const openInNewWindow = computed((): boolean => {
   return props.item.newWindow && (props.item.to.startsWith('http') || props.item.to.startsWith('/'))
 })
 
-const itemHasBadge = computed((): boolean => props.subnavItem && (props.item as SidebarSecondaryItem).badgeCount !== undefined)
+const itemHasBadge = computed((): boolean => props.subnavItem && (props.item as SidebarSecondaryItem).badgeCount !== undefined && (props.item as SidebarSecondaryItem).badgeCount !== 0)
 
 const itemClick = (item: SidebarPrimaryItem | SidebarSecondaryItem): void => {
   emit('click', item)


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/TDX-5119

Fix `itemHasBadge` computed logic in SidebarItem component so that it doesn't give a false positive when `badgeCount` is 0 (in which case badge isn't rendered but truncation class is applied)

Before
![Screenshot 2025-02-20 at 12 18 29 PM](https://github.com/user-attachments/assets/d05a206d-324d-4559-8f7c-06ff7292331e)

After
![Screenshot 2025-02-20 at 12 17 42 PM](https://github.com/user-attachments/assets/ef631297-ae25-4c38-a884-edad6327acfb)
![Screenshot 2025-02-20 at 12 17 53 PM](https://github.com/user-attachments/assets/58745741-3fb6-4be0-b03b-4aa4a2079f20)

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
