### PR TITLE
feat(tracing): split upstream node into three nodes

### DIFF
--- a/packages/core/tracing/sandbox/fixtures/trace-batches.json
+++ b/packages/core/tracing/sandbox/fixtures/trace-batches.json
@@ -1,1 +1,420 @@
-{"batches":[{"resource":{"attributes":[{"key":"service.instance.id","value":{"stringValue":"5172bbbc-6cd8-4420-a50f-a577526ea0e9"}},{"key":"service.version","value":{"stringValue":"10.0.0.1"}},{"key":"session.id","value":{"stringValue":"01946dfc-621e-7a8d-a649-a96bde2b9b3b"}},{"key":"service.name","value":{"stringValue":"kong"}}]},"scopeSpans":[{"scope":{"name":"kong-internal","version":"0.1.0"},"spans":[{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"PlJdvA1w0NY=","name":"kong","kind":"SPAN_KIND_SERVER","startTimeUnixNano":"1737012063735000064","endTimeUnixNano":"1737012064268748800","attributes":[{"key":"proxy.kong.consumer.id","value":{"stringValue":"26c55ffc-ff1e-44ee-8c1d-a57d0efed5bb"}},{"key":"proxy.kong.upstream.id","value":{"stringValue":"unknown"}},{"key":"http.request.size","value":{"stringValue":"177"}},{"key":"proxy.kong.upstream.addr","value":{"stringValue":"10.0.0.1"}},{"key":"proxy.kong.upstream.host","value":{"stringValue":"10.0.0.1:80"}},{"key":"network.peer.port","value":{"doubleValue":80}},{"key":"http.request.header.host","value":{"stringValue":"localhost"}},{"key":"proxy.kong.target.id","value":{"stringValue":"unknown"}},{"key":"proxy.kong.latency.3p.dns.total_io","value":{"doubleValue":0.084992}},{"key":"proxy.kong.request.id","value":{"stringValue":"46fd9c6da641347b774489549b1d5b23"}},{"key":"http.request.method","value":{"stringValue":"GET"}},{"key":"url.scheme","value":{"stringValue":"http"}},{"key":"http.response.status_code","value":{"doubleValue":200}},{"key":"http.route","value":{"stringValue":"/"}},{"key":"proxy.kong.latency.upstream.ttfb","value":{"doubleValue":275}},{"key":"network.protocol.version","value":{"stringValue":"1.1"}},{"key":"network.protocol.name","value":{"stringValue":"http"}},{"key":"network.peer.address","value":{"stringValue":"10.0.0.1"}},{"key":"proxy.kong.latency.upstream","value":{"doubleValue":529.015380859375}},{"key":"proxy.kong.latency.client","value":{"doubleValue":1.183232}},{"key":"proxy.kong.latency.internal","value":{"doubleValue":1.716395140624968}},{"key":"proxy.kong.latency.total","value":{"doubleValue":532}},{"key":"proxy.kong.latency.3p.redis.total_io","value":{"doubleValue":0}},{"key":"proxy.kong.latency.3p.tcpsock.total_io","value":{"doubleValue":0}},{"key":"proxy.kong.latency.3p.http_client.total_io","value":{"doubleValue":0}},{"key":"client.port","value":{"stringValue":"57836"}},{"key":"proxy.kong.latency.3p.total_io","value":{"doubleValue":0.084992}},{"key":"client.address","value":{"stringValue":"10.0.0.1"}},{"key":"proxy.kong.latency.upstream.read_response_duration","value":{"doubleValue":2}},{"key":"url.full","value":{"stringValue":"http://localhost:8000/headers"}},{"key":"proxy.kong.service.id","value":{"stringValue":"1e4a129d-fc17-454f-91ae-e9e337d91ef7"}},{"key":"proxy.kong.route.id","value":{"stringValue":"d4783d0e-f7bd-41e5-b676-4bea060a4482"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"tnji/Xjuc5U=","parentSpanId":"PlJdvA1w0NY=","name":"kong.read_client_http_headers","kind":"SPAN_KIND_SERVER","startTimeUnixNano":"1737012063734999808","endTimeUnixNano":"1737012063735664640","attributes":[{"key":"proxy.kong.http.request.headers.size","value":{"doubleValue":128}},{"key":"proxy.kong.http.request.headers.count","value":{"doubleValue":6}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"KABO6jvGrOc=","parentSpanId":"PlJdvA1w0NY=","name":"kong.phase.rewrite","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012063735715072","endTimeUnixNano":"1737012063735957504","status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"jUGQG4aeSWY=","parentSpanId":"PlJdvA1w0NY=","name":"kong.phase.access","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012063735988224","endTimeUnixNano":"1737012063737374976","status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"gwkzFiK+bhA=","parentSpanId":"jUGQG4aeSWY=","name":"kong.router","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012063736274432","endTimeUnixNano":"1737012063736316928","attributes":[{"key":"proxy.kong.router.upstream_path","value":{"stringValue":"/"}},{"key":"proxy.kong.route.id","value":{"stringValue":"d4783d0e-f7bd-41e5-b676-4bea060a4482"}},{"key":"proxy.kong.service.id","value":{"stringValue":"1e4a129d-fc17-454f-91ae-e9e337d91ef7"}},{"key":"proxy.kong.router.matched","value":{"boolValue":true}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"9MJGOwmvirk=","parentSpanId":"jUGQG4aeSWY=","name":"kong.access.plugin.basic-auth","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012063736385536","endTimeUnixNano":"1737012063736750592","attributes":[{"key":"proxy.kong.plugin.id","value":{"stringValue":"9159d5cf-a5c2-4b52-9b7b-ef8364738bd5"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"rqWMYAf1GhQ=","parentSpanId":"jUGQG4aeSWY=","name":"kong.access.plugin.rate-limiting","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012063736785152","endTimeUnixNano":"1737012063736923648","attributes":[{"key":"proxy.kong.plugin.id","value":{"stringValue":"6def3c80-02b6-4c06-9cc8-aa4b6054083d"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"6aEnuEAVYF8=","parentSpanId":"jUGQG4aeSWY=","name":"kong.access.plugin.response-ratelimiting","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012063736942336","endTimeUnixNano":"1737012063737008640","attributes":[{"key":"proxy.kong.plugin.id","value":{"stringValue":"627e56c6-b0e0-4022-b0ec-ef75c6ff97c8"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"saTq34cmFao=","parentSpanId":"jUGQG4aeSWY=","name":"kong.access.plugin.request-transformer","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012063737024256","endTimeUnixNano":"1737012063737257728","attributes":[{"key":"proxy.kong.plugin.id","value":{"stringValue":"a20e552b-a9ec-442e-8112-519fd4cba2cd"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"iVdEOjv2pkk=","parentSpanId":"jUGQG4aeSWY=","name":"kong.dns","kind":"SPAN_KIND_CLIENT","startTimeUnixNano":"1737012063737279488","endTimeUnixNano":"1737012063737369344","attributes":[{"key":"proxy.kong.dns.record.port","value":{"doubleValue":80}},{"key":"proxy.kong.dns.tries","value":{"arrayValue":{"values":[{"kvlistValue":{"values":[{"key":"qname","value":{"stringValue":"(short)httpbin.org"}},{"key":"msg","value":{"arrayValue":{"values":[{"stringValue":"cache-hit"},{"stringValue":"stale"}]}}}]}},{"kvlistValue":{"values":[{"key":"qname","value":{"stringValue":"httpbin.org"}},{"key":"qtype","value":{"doubleValue":1}},{"key":"msg","value":{"arrayValue":{"values":[{"stringValue":"cache-hit"},{"stringValue":"stale"},{"stringValue":"scheduled"},{"stringValue":"querying"}]}}}]}}]}}},{"key":"proxy.kong.dns.record.domain","value":{"stringValue":"httpbin.org"}},{"key":"proxy.kong.dns.record.ip","value":{"stringValue":"10.0.0.1"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"GfgzIwTBnnI=","parentSpanId":"PlJdvA1w0NY=","name":"kong.read_client_http_body","kind":"SPAN_KIND_SERVER","startTimeUnixNano":"1737012063737388288","endTimeUnixNano":"1737012063737437952","status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"oRSks0X4Xho=","parentSpanId":"PlJdvA1w0NY=","name":"kong.phase.header_filter","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012064264947456","endTimeUnixNano":"1737012064266276864","status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"pjyF8Du1IV4=","parentSpanId":"oRSks0X4Xho=","name":"kong.header_filter.plugin.response-ratelimiting","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012064265157376","endTimeUnixNano":"1737012064265587968","attributes":[{"key":"proxy.kong.plugin.id","value":{"stringValue":"627e56c6-b0e0-4022-b0ec-ef75c6ff97c8"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"aXSc4RRKc90=","parentSpanId":"oRSks0X4Xho=","name":"kong.header_filter.plugin.response-transformer","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012064265982720","endTimeUnixNano":"1737012064266212608","attributes":[{"key":"proxy.kong.plugin.id","value":{"stringValue":"6bd5b000-87d5-46a5-8cc1-568745b48d42"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"APRqpeq1G+E=","parentSpanId":"PlJdvA1w0NY=","name":"kong.phase.body_filter","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012064266512128","endTimeUnixNano":"1737012064267863040","status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"QVhBEGGYaIo=","parentSpanId":"APRqpeq1G+E=","name":"kong.body_filter.plugin.response-transformer","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1737012064266919424","endTimeUnixNano":"1737012064267851264","attributes":[{"key":"chunks","value":{"arrayValue":{"values":[{"kvlistValue":{"values":[{"key":"execution_time","value":{"doubleValue":429312}},{"key":"chunk_n","value":{"doubleValue":1}}]}},{"kvlistValue":{"values":[{"key":"execution_time","value":{"doubleValue":930304}},{"key":"chunk_n","value":{"doubleValue":2}}]}}]}}},{"key":"num_chunks","value":{"doubleValue":2}},{"key":"proxy.kong.plugin.id","value":{"stringValue":"6bd5b000-87d5-46a5-8cc1-568745b48d42"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"1YkYd/pQCDc=","parentSpanId":"PlJdvA1w0NY=","name":"kong.upstream.selection","kind":"SPAN_KIND_CLIENT","startTimeUnixNano":"1737012063737440256","endTimeUnixNano":"1737012063989455360","attributes":[{"key":"try_count","value":{"doubleValue":1}},{"key":"proxy.kong.upstream.lb_algorithm","value":{"stringValue":"unknown"}},{"key":"proxy.kong.upstream.id","value":{"stringValue":"unknown"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"pYe3qpAKqN4=","parentSpanId":"1YkYd/pQCDc=","name":"kong.upstream.try_select","kind":"SPAN_KIND_CLIENT","startTimeUnixNano":"1737012063737440256","endTimeUnixNano":"1737012063989455360","attributes":[{"key":"proxy.kong.latency.upstream.connect_duration","value":{"doubleValue":252}},{"key":"network.peer.port","value":{"doubleValue":80}},{"key":"network.peer.name","value":{"stringValue":"httpbin.org"}},{"key":"network.peer.address","value":{"stringValue":"10.0.0.1"}},{"key":"try_count","value":{"doubleValue":1}},{"key":"keepalive","value":{"boolValue":true}},{"key":"proxy.kong.target.id","value":{"stringValue":"unknown"}}],"status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"AoIpvq3b5LA=","parentSpanId":"PlJdvA1w0NY=","name":"kong.upstream.ttfb","kind":"SPAN_KIND_CLIENT","startTimeUnixNano":"1737012063989455360","endTimeUnixNano":"1737012064264455424","status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"srU1v8lnHac=","parentSpanId":"PlJdvA1w0NY=","name":"kong.upstream.read_response","kind":"SPAN_KIND_CLIENT","startTimeUnixNano":"1737012064264455424","endTimeUnixNano":"1737012064266455552","status":{}},{"traceId":"Crcy6p9C3wDk15CqZHlomQ==","spanId":"0PPLb7VDL6E=","parentSpanId":"PlJdvA1w0NY=","name":"kong.wait_for_client_read","kind":"SPAN_KIND_SERVER","startTimeUnixNano":"1737012064267863040","endTimeUnixNano":"1737012064268331776","status":{}}]}]}]}
+{
+  "batches": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.version", "value": { "stringValue": "3.10.0.0" } },
+          { "key": "session.id", "value": { "stringValue": "01951c12-e71c-7267-98e3-973ddcf1df64" } },
+          { "key": "service.instance.id", "value": { "stringValue": "4bf06728-ea98-48fe-af3e-ab2e4d888710" } },
+          { "key": "service.name", "value": { "stringValue": "kong" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": { "name": "kong-internal", "version": "0.1.0" },
+          "spans": [
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "jj/XTXTFu6s=",
+              "name": "kong",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1739932819947000064",
+              "endTimeUnixNano": "1739932820720426240",
+              "attributes": [
+                { "key": "proxy.kong.latency.total", "value": { "doubleValue": 770 } },
+                { "key": "proxy.kong.latency.3p.redis.total_io", "value": { "doubleValue": 0 } },
+                { "key": "proxy.kong.latency.3p.tcpsock.total_io", "value": { "doubleValue": 0 } },
+                { "key": "proxy.kong.latency.3p.http_client.total_io", "value": { "doubleValue": 0 } },
+                { "key": "proxy.kong.latency.3p.dns.total_io", "value": { "doubleValue": 0.138752 } },
+                { "key": "proxy.kong.latency.3p.total_io", "value": { "doubleValue": 0.138752 } },
+                { "key": "proxy.kong.client.keepalive", "value": { "boolValue": false } },
+                { "key": "proxy.kong.http.request.body.size", "value": { "doubleValue": 0 } },
+                { "key": "proxy.kong.http.response.body.size", "value": { "stringValue": "534" } },
+                { "key": "server.address", "value": { "stringValue": "10.88.0.14" } },
+                { "key": "proxy.kong.upstream.status_code", "value": { "doubleValue": 200 } },
+                { "key": "network.peer.port", "value": { "doubleValue": 80 } },
+                { "key": "http.request.size", "value": { "stringValue": "177" } },
+                { "key": "network.peer.address", "value": { "stringValue": "3.214.119.249" } },
+                { "key": "http.response.status_code", "value": { "doubleValue": 200 } },
+                { "key": "client.port", "value": { "stringValue": "53478" } },
+                { "key": "client.address", "value": { "stringValue": "10.88.0.14" } },
+                { "key": "url.full", "value": { "stringValue": "http://localhost:8000/headers" } },
+                { "key": "http.route", "value": { "stringValue": "/" } },
+                { "key": "proxy.kong.service.id", "value": { "stringValue": "c9ba713f-4dff-4e36-953d-3a446d2ec5a9" } },
+                { "key": "http.request.header.host", "value": { "stringValue": "localhost" } },
+                { "key": "proxy.kong.consumer.id", "value": { "stringValue": "a28fb362-5fa3-4dbe-b4da-3dd15e5e5c9a" } },
+                { "key": "proxy.kong.upstream.id", "value": { "stringValue": "unknown" } },
+                { "key": "http.response.size", "value": { "stringValue": "1146" } },
+                { "key": "proxy.kong.upstream.addr", "value": { "stringValue": "3.214.119.249" } },
+                { "key": "proxy.kong.upstream.host", "value": { "stringValue": "3.214.119.249:80" } },
+                { "key": "http.request.method", "value": { "stringValue": "GET" } },
+                { "key": "proxy.kong.target.id", "value": { "stringValue": "unknown" } },
+                { "key": "url.scheme", "value": { "stringValue": "http" } },
+                { "key": "server.port", "value": { "stringValue": "8000" } },
+                { "key": "proxy.kong.request.id", "value": { "stringValue": "331bfb04117adc39f70b227a0df26615" } },
+                { "key": "network.protocol.name", "value": { "stringValue": "http" } },
+                { "key": "network.protocol.version", "value": { "stringValue": "1.1" } },
+                {
+                  "key": "proxy.kong.latency.upstream.read_headers_duration",
+                  "value": { "doubleValue": 500.82898139953613 }
+                },
+                {
+                  "key": "proxy.kong.latency.upstream.read_body_duration",
+                  "value": { "doubleValue": 41.87798500061035 }
+                },
+                { "key": "proxy.kong.route.id", "value": { "stringValue": "5d165982-9d3a-4e76-87a7-31d03bae4582" } },
+                { "key": "proxy.kong.latency.upstream", "value": { "doubleValue": 764.5189762115479 } },
+                { "key": "proxy.kong.latency.client", "value": { "doubleValue": 2.043648 } },
+                { "key": "proxy.kong.latency.internal", "value": { "doubleValue": 3.2986237884522325 } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "+qbhUgVE45g=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.read_client_http_headers",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1739932819947000064",
+              "endTimeUnixNano": "1739932819948075776",
+              "attributes": [
+                { "key": "proxy.kong.http.request.headers.size", "value": { "doubleValue": 152 } },
+                { "key": "proxy.kong.http.request.headers.count", "value": { "doubleValue": 6 } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "uyMu073vn4U=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.phase.rewrite",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932819948089600",
+              "endTimeUnixNano": "1739932819948149760",
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "XlFPNHQuh30=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.phase.access",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932819948167424",
+              "endTimeUnixNano": "1739932819949595904",
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "g8n41XgnlQI=",
+              "parentSpanId": "XlFPNHQuh30=",
+              "name": "kong.router",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932819948232448",
+              "endTimeUnixNano": "1739932819948302848",
+              "attributes": [
+                { "key": "proxy.kong.service.id", "value": { "stringValue": "c9ba713f-4dff-4e36-953d-3a446d2ec5a9" } },
+                { "key": "proxy.kong.route.id", "value": { "stringValue": "5d165982-9d3a-4e76-87a7-31d03bae4582" } },
+                { "key": "proxy.kong.router.matched", "value": { "boolValue": true } },
+                { "key": "proxy.kong.router.upstream_path", "value": { "stringValue": "/" } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "IPBkOIbFg/c=",
+              "parentSpanId": "XlFPNHQuh30=",
+              "name": "kong.access.plugin.basic-auth",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932819948345088",
+              "endTimeUnixNano": "1739932819948483328",
+              "attributes": [
+                { "key": "proxy.kong.plugin.id", "value": { "stringValue": "6c27de60-9bb4-4170-9fea-089babcb7393" } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "yqCvmrBypiM=",
+              "parentSpanId": "XlFPNHQuh30=",
+              "name": "kong.access.plugin.rate-limiting-advanced",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932819948597504",
+              "endTimeUnixNano": "1739932819948750080",
+              "attributes": [
+                { "key": "proxy.kong.plugin.id", "value": { "stringValue": "8da3e4ec-33aa-4088-91ab-4b029b4adfaf" } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "Jqu+QBVpIIU=",
+              "parentSpanId": "XlFPNHQuh30=",
+              "name": "kong.access.plugin.response-ratelimiting",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932819948765952",
+              "endTimeUnixNano": "1739932819948977664",
+              "attributes": [
+                { "key": "proxy.kong.plugin.id", "value": { "stringValue": "5a6798a6-d3d9-405d-bb20-091884a78ba8" } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "MA1Zq7hsxaU=",
+              "parentSpanId": "XlFPNHQuh30=",
+              "name": "kong.access.plugin.request-transformer",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932819948995328",
+              "endTimeUnixNano": "1739932819949235712",
+              "attributes": [
+                { "key": "proxy.kong.plugin.id", "value": { "stringValue": "98dd4d55-8534-4f20-81a4-56308e43e49f" } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "HQvDxV2ZKIk=",
+              "parentSpanId": "XlFPNHQuh30=",
+              "name": "kong.dns",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1739932819949340416",
+              "endTimeUnixNano": "1739932819949479168",
+              "attributes": [
+                { "key": "proxy.kong.dns.domain", "value": { "stringValue": "httpbin.org" } },
+                {
+                  "key": "proxy.kong.dns.tries",
+                  "value": {
+                    "arrayValue": {
+                      "values": [
+                        {
+                          "kvlistValue": {
+                            "values": [
+                              { "key": "resolver", "value": { "stringValue": "cache" } },
+                              { "key": "qname", "value": { "stringValue": "httpbin.org" } },
+                              { "key": "cache?", "value": { "boolValue": true } }
+                            ]
+                          }
+                        },
+                        {
+                          "kvlistValue": {
+                            "values": [
+                              { "key": "resolver", "value": { "stringValue": "cache" } },
+                              { "key": "type", "value": { "stringValue": "A" } },
+                              { "key": "qname", "value": { "stringValue": "httpbin.org" } },
+                              {
+                                "key": "result",
+                                "value": {
+                                  "arrayValue": {
+                                    "values": [
+                                      {
+                                        "kvlistValue": {
+                                          "values": [
+                                            { "key": "type", "value": { "stringValue": "A" } },
+                                            { "key": "ttl", "value": { "doubleValue": 0 } },
+                                            { "key": "ip", "value": { "stringValue": "3.208.239.150" } }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "kvlistValue": {
+                                          "values": [
+                                            { "key": "type", "value": { "stringValue": "A" } },
+                                            { "key": "ttl", "value": { "doubleValue": 0 } },
+                                            { "key": "ip", "value": { "stringValue": "3.214.119.249" } }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              { "key": "cache?", "value": { "boolValue": true } }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "8EOCcoaEKpE=",
+              "parentSpanId": "XlFPNHQuh30=",
+              "name": "kong.read_client_http_body",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1739932819949507072",
+              "endTimeUnixNano": "1739932819949566976",
+              "attributes": [{ "key": "proxy.kong.http.content_length", "value": { "doubleValue": 0 } }],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "nnmbqaM5eKA=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.phase.header_filter",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932820672342528",
+              "endTimeUnixNano": "1739932820673000192",
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "CPi58wpuEzw=",
+              "parentSpanId": "nnmbqaM5eKA=",
+              "name": "kong.header_filter.plugin.response-ratelimiting",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932820672492288",
+              "endTimeUnixNano": "1739932820672909824",
+              "attributes": [
+                { "key": "proxy.kong.plugin.id", "value": { "stringValue": "5a6798a6-d3d9-405d-bb20-091884a78ba8" } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "c8epqkNRTCo=",
+              "parentSpanId": "nnmbqaM5eKA=",
+              "name": "kong.header_filter.plugin.response-transformer",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932820672936192",
+              "endTimeUnixNano": "1739932820672959744",
+              "attributes": [
+                { "key": "proxy.kong.plugin.id", "value": { "stringValue": "41994551-eac9-4c3a-8f8a-ff2cac1c1dc0" } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "CXKbw+ZEFvw=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.phase.body_filter",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932820712829440",
+              "endTimeUnixNano": "1739932820717224448",
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "e6lAJnnxcjw=",
+              "parentSpanId": "CXKbw+ZEFvw=",
+              "name": "kong.body_filter.plugin.response-transformer",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1739932820713841664",
+              "endTimeUnixNano": "1739932820716990720",
+              "attributes": [
+                {
+                  "key": "chunks",
+                  "value": {
+                    "arrayValue": {
+                      "values": [
+                        {
+                          "kvlistValue": {
+                            "values": [
+                              { "key": "chunk_n", "value": { "doubleValue": 1 } },
+                              { "key": "execution_time", "value": { "doubleValue": 277504 } }
+                            ]
+                          }
+                        },
+                        {
+                          "kvlistValue": {
+                            "values": [
+                              { "key": "chunk_n", "value": { "doubleValue": 2 } },
+                              { "key": "execution_time", "value": { "doubleValue": 843520 } }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                { "key": "proxy.kong.plugin.id", "value": { "stringValue": "41994551-eac9-4c3a-8f8a-ff2cac1c1dc0" } },
+                { "key": "num_chunks", "value": { "doubleValue": 2 } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "bC+p6NC4pT8=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.upstream.selection",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1739932819949614080",
+              "endTimeUnixNano": "1739932820171426048",
+              "attributes": [
+                { "key": "try_count", "value": { "doubleValue": 1 } },
+                { "key": "proxy.kong.upstream.id", "value": { "stringValue": "unknown" } },
+                { "key": "proxy.kong.upstream.lb_algorithm", "value": { "stringValue": "unknown" } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "77M8++P459Q=",
+              "parentSpanId": "bC+p6NC4pT8=",
+              "name": "kong.find_upstream",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1739932819949614080",
+              "endTimeUnixNano": "1739932820171426048",
+              "attributes": [
+                { "key": "try_count", "value": { "doubleValue": 1 } },
+                {
+                  "key": "proxy.kong.latency.upstream.connect_duration",
+                  "value": { "doubleValue": 221.81200981140137 }
+                },
+                { "key": "keepalive", "value": { "boolValue": true } },
+                { "key": "network.peer.port", "value": { "doubleValue": 80 } },
+                { "key": "network.peer.name", "value": { "stringValue": "httpbin.org" } },
+                { "key": "network.peer.address", "value": { "stringValue": "3.214.119.249" } },
+                { "key": "proxy.kong.target.id", "value": { "stringValue": "unknown" } }
+              ],
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "P0xcZxNW79g=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.send_request_to_upstream",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1739932820171426048",
+              "endTimeUnixNano": "1739932820672240128",
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "UbTWqkAUqvM=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.read_headers_from_upstream",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1739932820672240128",
+              "endTimeUnixNano": "1739932820672254976",
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "+v1IwJpQZog=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.read_body_from_upstream",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1739932820672254976",
+              "endTimeUnixNano": "1739932820714132992",
+              "status": {}
+            },
+            {
+              "traceId": "f1PA1H4PEgUZVrgFp2ljYw==",
+              "spanId": "8PXmSGT1tzI=",
+              "parentSpanId": "jj/XTXTFu6s=",
+              "name": "kong.wait_for_client_read",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1739932820717224448",
+              "endTimeUnixNano": "1739932820718132480",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/tracing/src/components/lifecycle/LifecycleView.vue
+++ b/packages/core/tracing/src/components/lifecycle/LifecycleView.vue
@@ -34,7 +34,7 @@
         :show-interactive="false"
         @fit-view="fitFlow"
       />
-      <Background variant="lines" />
+      <Background />
     </VueFlow>
   </div>
 </template>
@@ -105,7 +105,9 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
   let clientNode: GraphNode | undefined
   let clientOutNode: GraphNode | undefined
   let requestGroupNode: GraphNode | undefined
+  let upstreamInNode: GraphNode | undefined
   let upstreamNode: GraphNode | undefined
+  let upstreamOutNode: GraphNode | undefined
   let responseGroupNode: GraphNode | undefined
   let clientInNode: GraphNode | undefined
 
@@ -163,11 +165,23 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
           requestGroupMetrics.innerHeight = node.dimensions.height
         }
         break
+      case LifecycleNodeType.UPSTREAM_IN:
+        node.targetPosition = Position.Left
+        node.sourcePosition = Position.Right
+
+        upstreamInNode = node
+        break
       case LifecycleNodeType.UPSTREAM:
         node.targetPosition = Position.Top
         node.sourcePosition = Position.Bottom
 
         upstreamNode = node
+        break
+      case LifecycleNodeType.UPSTREAM_OUT:
+        node.targetPosition = Position.Right
+        node.sourcePosition = Position.Left
+
+        upstreamOutNode = node
         break
       case LifecycleNodeType.RESPONSE_GROUP:
         node.targetPosition = Position.Right
@@ -200,8 +214,12 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
     throw new Error('Missing the client node')
   } else if (!clientOutNode) {
     throw new Error('Missing the client out node')
+  } else if (!upstreamInNode) {
+    throw new Error('Missing the upstream in node')
   } else if (!upstreamNode) {
     throw new Error('Missing the upstream node')
+  } else if (!upstreamOutNode) {
+    throw new Error('Missing the upstream out node')
   } else if (!clientInNode) {
     throw new Error('Missing the client in node')
   }
@@ -209,7 +227,7 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
   // >>> Layout - Request Group
   if (requestGroupNode) {
     requestGroupMetrics.innerOffsetY = requestGroupNode.dimensions.height - NODE_GROUP_PADDING + NODE_GROUP_ROW_GAP
-    requestGroupMetrics.width = requestGroupMetrics.innerWidth + NODE_GROUP_PADDING * 2
+    requestGroupMetrics.width = Math.max(requestGroupNode.dimensions.width, requestGroupMetrics.innerWidth + NODE_GROUP_PADDING * 2)
     requestGroupMetrics.height = requestGroupNode.dimensions.height + NODE_GROUP_ROW_GAP + requestGroupMetrics.innerHeight
     requestGroupNode.width = requestGroupMetrics.width
     requestGroupNode.height = requestGroupMetrics.height
@@ -230,7 +248,7 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
   // >>> Layout - Response Group
   if (responseGroupNode) {
     responseGroupMetrics.innerOffsetY = NODE_GROUP_PADDING
-    responseGroupMetrics.width = responseGroupMetrics.innerWidth + NODE_GROUP_PADDING * 2
+    responseGroupMetrics.width = Math.max(responseGroupNode.dimensions.width, responseGroupMetrics.innerWidth + NODE_GROUP_PADDING * 2)
     responseGroupMetrics.height = responseGroupNode.dimensions.height + NODE_GROUP_ROW_GAP + responseGroupMetrics.innerHeight
     responseGroupNode.width = responseGroupMetrics.width
     responseGroupNode.height = responseGroupMetrics.height
@@ -271,6 +289,11 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
   }
   canvasX += requestsResponsesMaxWidth + CANVAS_COLUMN_GAP
 
+  const upstreamInOutMaxWidth = Math.max(upstreamInNode.dimensions.width, upstreamOutNode.dimensions.width)
+  upstreamInNode.position.x = canvasX + (upstreamInOutMaxWidth - upstreamInNode.dimensions.width) / 2
+  upstreamOutNode.position.x = canvasX + (upstreamInOutMaxWidth - upstreamOutNode.dimensions.width) / 2
+  canvasX += upstreamInOutMaxWidth + CANVAS_COLUMN_GAP
+
   // Upstream
   upstreamNode.position.x = canvasX
   // <<< Layout along X-axis
@@ -278,15 +301,30 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
   // >>> Layout along Y-axis
   let layoutY = CANVAS_PADDING
 
-  // Client Out / Request Group (They are vertically center-aligned)
-  const upperInnerMaxHeight = Math.max(clientOutNode.dimensions.height, requestGroupMetrics.innerHeight)
-  clientOutNode.position.y = layoutY + requestGroupMetrics.innerOffsetY + (upperInnerMaxHeight - clientOutNode.dimensions.height) / 2
+  // Client Out / Request Group / Upstream In (They are vertically center-aligned)
+  // If align with the child node in the request group:
+  // const upperInnerMaxHeight = Math.max(clientOutNode.dimensions.height, requestGroupMetrics.innerHeight, upstreamInNode.dimensions.height)
+  // clientOutNode.position.y = layoutY + requestGroupMetrics.innerOffsetY + (upperInnerMaxHeight - clientOutNode.dimensions.height) / 2
+  // if (requestGroupNode) {
+  //   requestGroupNode.position.y = layoutY + (upperInnerMaxHeight - requestGroupMetrics.innerHeight) / 2
+  // }
+  // upstreamInNode.position.y = layoutY + requestGroupMetrics.innerOffsetY + (upperInnerMaxHeight - upstreamInNode.dimensions.height) / 2
+  // layoutY = Math.max(
+  //   clientOutNode.position.y + clientOutNode.dimensions.height,
+  //   requestGroupNode ? requestGroupNode.position.y + requestGroupMetrics.height : 0,
+  //   upstreamInNode.position.y + upstreamInNode.dimensions.height,
+  // ) + CANVAS_ROW_GAP
+  // If align with the request group itself:
+  const upperInnerMaxHeight = Math.max(clientOutNode.dimensions.height, requestGroupMetrics.height, upstreamInNode.dimensions.height)
+  clientOutNode.position.y = layoutY + (upperInnerMaxHeight - clientOutNode.dimensions.height) / 2
   if (requestGroupNode) {
-    requestGroupNode.position.y = layoutY + (upperInnerMaxHeight - requestGroupMetrics.innerHeight) / 2
+    requestGroupNode.position.y = layoutY + (upperInnerMaxHeight - requestGroupMetrics.height) / 2
   }
+  upstreamInNode.position.y = layoutY + (upperInnerMaxHeight - upstreamInNode.dimensions.height) / 2
   layoutY = Math.max(
     clientOutNode.position.y + clientOutNode.dimensions.height,
     requestGroupNode ? requestGroupNode.position.y + requestGroupMetrics.height : 0,
+    upstreamInNode.position.y + upstreamInNode.dimensions.height,
   ) + CANVAS_ROW_GAP
 
   // Client / Upstream (They are vertically center-aligned)
@@ -295,12 +333,22 @@ const layout = (nodes: LifecycleNode[]): LifecycleNode[] => {
   upstreamNode.position.y = layoutY + (clientUpstreamMaxHeight - upstreamNode.dimensions.height) / 2
   layoutY += clientUpstreamMaxHeight + CANVAS_ROW_GAP
 
-  // Client In / Response Group (They are vertically center-aligned)
-  const lowerInnerMaxHeight = Math.max(clientInNode.dimensions.height, responseGroupMetrics.innerHeight)
-  clientInNode.position.y = layoutY + responseGroupMetrics.innerOffsetY + (lowerInnerMaxHeight - clientInNode.dimensions.height) / 2
+  // Client In / Response Group / Upstream Out (They are vertically center-aligned)
+  // If align with the child node in the response group:
+  // const lowerInnerMaxHeight = Math.max(clientInNode.dimensions.height, responseGroupMetrics.innerHeight, upstreamOutNode.dimensions.height)
+  // clientInNode.position.y = layoutY + responseGroupMetrics.innerOffsetY + (lowerInnerMaxHeight - clientInNode.dimensions.height) / 2
+  // if (responseGroupNode) {
+  //   responseGroupNode.position.y = layoutY + (lowerInnerMaxHeight - responseGroupMetrics.innerHeight) / 2
+  // }
+  // upstreamOutNode.position.y = layoutY + responseGroupMetrics.innerOffsetY + (lowerInnerMaxHeight - upstreamOutNode.dimensions.height) / 2
+  // If align with the response group itself:
+  const lowerInnerMaxHeight = Math.max(clientInNode.dimensions.height, responseGroupMetrics.height, upstreamOutNode.dimensions.height)
+  clientInNode.position.y = layoutY + (lowerInnerMaxHeight - clientInNode.dimensions.height) / 2
   if (responseGroupNode) {
-    responseGroupNode.position.y = layoutY + (lowerInnerMaxHeight - responseGroupMetrics.innerHeight) / 2
+    responseGroupNode.position.y = layoutY + (lowerInnerMaxHeight - responseGroupMetrics.height) / 2
   }
+  upstreamOutNode.position.y = layoutY + (lowerInnerMaxHeight - upstreamOutNode.dimensions.height) / 2
+
   // <<< Layout along Y-axis
 
   return nodes

--- a/packages/core/tracing/src/components/lifecycle/LifecycleViewNode.vue
+++ b/packages/core/tracing/src/components/lifecycle/LifecycleViewNode.vue
@@ -9,10 +9,23 @@
     </KBadge>
 
     <div
-      v-if="data.label"
+      v-if="data.labelKey || data.label"
       class="label"
     >
-      <span>{{ data.label }}</span>
+      <span class="label-primary">
+        {{ `${
+          data.labelKey ? t(data.labelKey) : data.label
+        }${
+          data.emptyGroup && data.emptyGroupMessageKey ? ': ' : ''
+        }` }}
+      </span>
+
+      <span
+        v-if="data.emptyGroup && data.emptyGroupMessageKey"
+        class="label-secondary"
+      >
+        {{ t(data.emptyGroupMessageKey) }}
+      </span>
 
       <KTooltip
         v-if="data.labelTooltipKey"
@@ -45,7 +58,7 @@
 
   <!-- aka. In -->
   <Handle
-    v-if="!isGroupNode && targetPosition"
+    v-if="targetPosition"
     class="handle"
     :connectable="false"
     :position="targetPosition"
@@ -55,7 +68,7 @@
 
   <!-- aka. Out -->
   <Handle
-    v-if="!isGroupNode && sourcePosition"
+    v-if="sourcePosition"
     class="handle"
     :connectable="false"
     :position="sourcePosition"
@@ -72,7 +85,7 @@ import type { Position } from '@vue-flow/core'
 import { Handle } from '@vue-flow/core'
 import { computed } from 'vue'
 import composables from '../../composables'
-import { LifecycleNodeType, NODE_GROUP_PADDING, NODE_GROUP_ROW_GAP } from '../../constants'
+import { LifecycleNodeType, NODE_GROUP_PADDING } from '../../constants'
 import type { LifecycleNodeData } from '../../types'
 import { getDurationFormatter, getNodeStripeColor } from '../../utils'
 
@@ -110,6 +123,10 @@ const rootClasses = computed(() => {
     )
   }
 
+  if (props.data.emptyGroup) {
+    classes.push('empty-group')
+  }
+
   return classes
 })
 
@@ -126,7 +143,7 @@ const nodeStripeColor = computed(() => getNodeStripeColor(props.data.durationNan
 .lifecycle-view-node {
   $stripe-width: 8px;
 
-  align-items: center;
+  align-items: flex-start;
   background-color: $kui-color-background;
   /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
   border: $kui-border-width-10 solid $kui-color-background-neutral-stronger;
@@ -172,7 +189,7 @@ const nodeStripeColor = computed(() => getNodeStripeColor(props.data.durationNan
     max-width: 200px;
   }
 
-  &:not(.type-client):not(.type-request-group):not(.type-response-group) {
+  &:not(.type-client):not(.type-request-group):not(.type-upstream):not(.type-response-group) {
     padding-left: calc($kui-space-40 + $stripe-width);
 
     > ::after {
@@ -186,22 +203,12 @@ const nodeStripeColor = computed(() => getNodeStripeColor(props.data.durationNan
     }
   }
 
-  &.label-top {
+  &.label-top:not(.empty-group) {
     justify-content: flex-start;
-    padding-top: v-bind('`${NODE_GROUP_ROW_GAP}px`'); // For visual compensation. Does not affect layout calculation.
   }
 
-  &.label-right {
-    align-items: flex-end;
-  }
-
-  &.label-bottom {
+  &.label-bottom:not(.empty-group) {
     justify-content: flex-end;
-    padding-bottom: v-bind('`${NODE_GROUP_ROW_GAP}px`'); // For visual compensation. Does not affect layout calculation.
-  }
-
-  &.label-left {
-    align-items: flex-start;
   }
 
   .badge {
@@ -219,7 +226,14 @@ const nodeStripeColor = computed(() => getNodeStripeColor(props.data.durationNan
 
   .label {
     font-size: $kui-font-size-30;
-    font-weight: $kui-font-weight-semibold;
+
+    .label-primary {
+      font-weight: $kui-font-weight-semibold;
+    }
+
+    .label-primary, .label-secondary {
+      flex-shrink: 0;
+    }
   }
 
   .duration {

--- a/packages/core/tracing/src/constants/lifecycle.ts
+++ b/packages/core/tracing/src/constants/lifecycle.ts
@@ -19,6 +19,8 @@ export enum LifecycleNodeType {
   CLIENT_OUT = 'clientOut',
   REQUEST = 'request',
   UPSTREAM = 'upstream',
+  UPSTREAM_IN = 'upstreamIn',
+  UPSTREAM_OUT = 'upstreamOut',
   RESPONSE = 'response',
   REQUEST_GROUP = 'requestGroup',
   RESPONSE_GROUP = 'responseGroup',

--- a/packages/core/tracing/src/constants/spans.ts
+++ b/packages/core/tracing/src/constants/spans.ts
@@ -43,6 +43,7 @@ export const SPAN_NAMES = {
    * - `kong.upstream.read_response`
    */
   KONG_READ_RESPONSE_FROM_UPSTREAM: 'kong.read_response_from_upstream',
+  KONG_SEND_REQUEST_TO_UPSTREAM: 'kong.send_request_to_upstream',
   KONG_UPSTREAM_SELECTION: 'kong.upstream.selection',
 
   /**

--- a/packages/core/tracing/src/locales/en.json
+++ b/packages/core/tracing/src/locales/en.json
@@ -4,15 +4,32 @@
     "title": "Title of the header"
   },
   "lifecycle": {
+    "client": {
+      "label": "Client"
+    },
     "client_in": {
       "tooltip": "Time taken for client to read the response from Kong. A high value here may be indicative of a slow network or connectivity issue."
     },
     "client_out": {
       "tooltip": "Time taken for the client to write the request to Kong. A high value here may be indicative of a slow network or connectivity issue."
     },
-    "request": "Request",
-    "response": "Response",
-    "total": "Total"
+    "none_were_executed": "None were executed",
+    "request": {
+      "label": "Request"
+    },
+    "response": {
+      "label": "Response"
+    },
+    "total": "Total",
+    "upstream": {
+      "label": "Upstream"
+    },
+    "upstream_in": {
+      "tooltip": "Time taken for the Kong to write the request to upstream. A high value here may be indicative of a slow network or connectivity issue."
+    },
+    "upstream_out": {
+      "tooltip": "Time taken for Kong to read the response from upstream. A high value here may be indicative of a slow network or connectivity issue."
+    }
   },
   "payload": {
     "request_body": "Request body",

--- a/packages/core/tracing/src/types/lifecycle.ts
+++ b/packages/core/tracing/src/types/lifecycle.ts
@@ -13,7 +13,11 @@ export interface LifecycleGraphNodeTree {
     node: LifecycleNode
     children: LifecycleNode[]
   }
-  upstream: LifecycleNode
+  upstream: {
+    node: LifecycleNode
+    in: LifecycleNode
+    out: LifecycleNode
+  }
   responses?: {
     node: LifecycleNode
     children: LifecycleNode[]
@@ -22,16 +26,19 @@ export interface LifecycleGraphNodeTree {
 
 export interface LifecycleNodeData<T extends LifecycleNodeType = LifecycleNodeType> {
   label?: string
+  labelKey?: TranslationKey
   type: T
   badge?: string
   durationNano?: number
   spans?: SpanNode[]
   tree?: LifecycleGraphNodeTree
-  labelPlacement?: `${'top' | 'bottom'} ${'left' | 'right'}`
+  labelPlacement?: 'top' | 'bottom'
   labelTooltipKey?: TranslationKey
   durationTooltipKey?: TranslationKey
   showTargetHandle?: boolean
   showSourceHandle?: boolean
+  emptyGroup?: boolean
+  emptyGroupMessageKey?: TranslationKey
 }
 
 export interface LifecycleNode extends Node<LifecycleNodeData, any, LifecycleNodeType> {

--- a/packages/core/tracing/src/utils/spans.ts
+++ b/packages/core/tracing/src/utils/spans.ts
@@ -14,7 +14,7 @@ const MAPPED_SPAN_NAMES: Record<string, string> = {
   [SPAN_NAMES.KONG_READ_RESPONSE_FROM_UPSTREAM]: SPAN_NAMES.KONG_READ_BODY_FROM_UPSTREAM,
 }
 
-const compareSpanNode = (a: SpanNode, b: SpanNode) => {
+export const compareSpanNode = (a: SpanNode, b: SpanNode) => {
   if (a.span.startTimeUnixNano !== undefined && b.span.startTimeUnixNano !== undefined) {
     return Number(a.span.startTimeUnixNano - b.span.startTimeUnixNano)
   }


### PR DESCRIPTION
# Summary

This pull request splits the "Upstream" node into three nodes

### Fix

* Incorrect node ordering

### Misc

* Request/Response group will show a message if empty
* Use the dotted background

<img width="1028" alt="Screenshot 2025-02-24 at 15 18 18" src="https://github.com/user-attachments/assets/d7805886-8282-4e28-b039-9181487eee9a" />

<img width="1030" alt="Screenshot 2025-02-24 at 15 19 04" src="https://github.com/user-attachments/assets/19fd0f25-a20a-47e2-b6b7-dc4c2ce7a3a5" />

KM-959