### PR TITLE
fix(upstreams): unable remove some fields' value [KM-970]

### DIFF
--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.cy.ts
@@ -284,27 +284,27 @@ describe('<UpstreamsForm/>', { viewportHeight: 700, viewportWidth: 700 }, () => 
       cy.getTestId('active-healthcheck-concurrency').should('have.value', '13')
       cy.getTestId('active-healthcheck-https-sni').should('have.value', 'test sni')
       cy.getTestId('active-healthcheck-verify-ssl').should('be.checked')
-      cy.getTestId('active-healthcheck-interval').should('have.value', '10')
-      cy.getTestId('active-healthcheck-successes').should('have.value', '5')
-      cy.get('.active-healthcheck-http-statuses .multiselect-list button.selected').should('have.length', 2)
-      cy.get('.active-healthcheck-http-statuses .multiselect-list button[value="200"]').should('have.class', 'selected')
-      cy.get('.active-healthcheck-http-statuses .multiselect-list button[value="302"]').should('have.class', 'selected')
+      cy.getTestId('active-healthcheck-healthy-interval').should('have.value', '10')
+      cy.getTestId('active-healthcheck-healthy-successes').should('have.value', '5')
+      cy.get('.active-healthcheck-healthy-http-statuses .multiselect-list button.selected').should('have.length', 2)
+      cy.get('.active-healthcheck-healthy-http-statuses .multiselect-list button[value="200"]').should('have.class', 'selected')
+      cy.get('.active-healthcheck-healthy-http-statuses .multiselect-list button[value="302"]').should('have.class', 'selected')
       cy.get('.active-healthcheck-unhealthy-http-statuses .multiselect-list button.selected').should('have.length', 2)
       cy.get('.active-healthcheck-unhealthy-http-statuses .multiselect-list button[value="429"]').should('have.class', 'selected')
       cy.get('.active-healthcheck-unhealthy-http-statuses .multiselect-list button[value="404"]').should('have.class', 'selected')
       cy.getTestId('active-healthcheck-unhealthy-interval').should('have.value', '5')
-      cy.getTestId('active-healthcheck-http-failures').should('have.value', '3')
-      cy.getTestId('active-healthcheck-tcp-failures').should('have.value', '3')
+      cy.getTestId('active-healthcheck-unhealthy-http-failures').should('have.value', '3')
+      cy.getTestId('active-healthcheck-unhealthy-tcp-failures').should('have.value', '3')
       cy.getTestId('active-healthcheck-unhealthy-timeouts').should('have.value', '0')
       cy.getTestId('passive-health-switch').should('be.checked')
       cy.get('.passive-healthcheck-type-select input').should('have.value', 'HTTP')
-      cy.getTestId('passive-healthcheck-successes').should('have.value', '4')
-      cy.get('.passive-healthcheck-http-statuses .multiselect-list button.selected').should('have.length', 2)
-      cy.get('.passive-healthcheck-http-statuses .multiselect-list button[value="200"]').should('have.class', 'selected')
-      cy.get('.passive-healthcheck-http-statuses .multiselect-list button[value="201"]').should('have.class', 'selected')
-      cy.getTestId('passive-healthcheck-timeouts').should('have.value', '10')
-      cy.getTestId('passive-healthcheck-http-failures').should('have.value', '2')
-      cy.getTestId('passive-healthcheck-tcp-failures').should('have.value', '2')
+      cy.getTestId('passive-healthcheck-healthy-successes').should('have.value', '4')
+      cy.get('.passive-healthcheck-healthy-http-statuses .multiselect-list button.selected').should('have.length', 2)
+      cy.get('.passive-healthcheck-healthy-http-statuses .multiselect-list button[value="200"]').should('have.class', 'selected')
+      cy.get('.passive-healthcheck-healthy-http-statuses .multiselect-list button[value="201"]').should('have.class', 'selected')
+      cy.getTestId('passive-healthcheck-unhealthy-timeouts').should('have.value', '10')
+      cy.getTestId('passive-healthcheck-unhealthy-http-failures').should('have.value', '2')
+      cy.getTestId('passive-healthcheck-unhealthy-tcp-failures').should('have.value', '2')
       cy.get('.passive-healthcheck-unhealthy-http-statuses .multiselect-list button.selected').should('have.length', 3)
       cy.get('.passive-healthcheck-unhealthy-http-statuses .multiselect-list button[value="500"]').should('have.class', 'selected')
       cy.get('.passive-healthcheck-unhealthy-http-statuses .multiselect-list button[value="503"]').should('have.class', 'selected')
@@ -355,16 +355,16 @@ describe('<UpstreamsForm/>', { viewportHeight: 700, viewportWidth: 700 }, () => 
       cy.getTestId('active-health-switch').check({ force: true })
       cy.getTestId('passive-health-switch').check({ force: true })
 
-      cy.getTestId('active-healthcheck-interval').should('have.value', '5')
-      cy.getTestId('active-healthcheck-successes').should('have.value', '5')
-      cy.getTestId('active-healthcheck-http-failures').should('have.value', '5')
+      cy.getTestId('active-healthcheck-healthy-interval').should('have.value', '5')
+      cy.getTestId('active-healthcheck-healthy-successes').should('have.value', '5')
+      cy.getTestId('active-healthcheck-unhealthy-http-failures').should('have.value', '5')
       cy.getTestId('active-healthcheck-unhealthy-interval').should('have.value', '5')
-      cy.getTestId('active-healthcheck-tcp-failures').should('have.value', '5')
+      cy.getTestId('active-healthcheck-unhealthy-tcp-failures').should('have.value', '5')
 
-      cy.getTestId('passive-healthcheck-timeouts').should('have.value', '5')
-      cy.getTestId('passive-healthcheck-successes').should('have.value', '80')
-      cy.getTestId('passive-healthcheck-tcp-failures').should('have.value', '5')
-      cy.getTestId('passive-healthcheck-http-failures').should('have.value', '5')
+      cy.getTestId('passive-healthcheck-unhealthy-timeouts').should('have.value', '5')
+      cy.getTestId('passive-healthcheck-healthy-successes').should('have.value', '80')
+      cy.getTestId('passive-healthcheck-unhealthy-tcp-failures').should('have.value', '5')
+      cy.getTestId('passive-healthcheck-unhealthy-http-failures').should('have.value', '5')
 
       cy.getTestId('upstream-create-form-submit').click()
 
@@ -413,6 +413,37 @@ describe('<UpstreamsForm/>', { viewportHeight: 700, viewportWidth: 700 }, () => 
       })
     })
 
+    it('Should set correct values for health checks when turned off, then turned on the active health checks again', () => {
+      interceptFetchServices()
+      interceptFetchCertificates()
+      interceptGetUpstream(200, upstreamsResponseFull)
+      interceptValidate()
+      interceptUpdate()
+
+      cy.mount(UpstreamsForm, {
+        props: {
+          config: konnectConfig,
+          upstreamId: 'c372844b-a78a-4317-a81f-0606ba317816',
+        },
+      })
+
+      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'], { timeout: 10000 })
+
+      cy.getTestId('active-health-switch').should('be.checked')
+      cy.getTestId('passive-health-switch').should('be.checked')
+
+      cy.getTestId('active-health-switch').uncheck({ force: true })
+      cy.getTestId('passive-health-switch').uncheck({ force: true })
+
+      cy.getTestId('active-health-switch').check({ force: true })
+
+      cy.getTestId('upstream-edit-form-submit').click()
+
+      cy.wait('@updateUpstream').then((interception) => {
+        const { body: { healthchecks } } = interception.request
+        expect(healthchecks).to.deep.equal(JSON.parse('{"threshold":2,"active":{"type":"http","healthy":{"interval":5,"successes":5,"http_statuses":[200,302]},"unhealthy":{"interval":5,"timeouts":5,"tcp_failures":5,"http_failures":5,"http_statuses":[429,404,500,501,502,503,504,505]},"timeout":1,"concurrency":10,"http_path":"/"}}'))
+      })
+    })
   })
 
   describe('Kong Manager', () => {
@@ -694,27 +725,27 @@ describe('<UpstreamsForm/>', { viewportHeight: 700, viewportWidth: 700 }, () => 
       cy.getTestId('active-healthcheck-headers-value-1').should('have.value', 'v1, v2')
       cy.getTestId('active-healthcheck-https-sni').should('have.value', 'test sni')
       cy.getTestId('active-healthcheck-verify-ssl').should('be.checked')
-      cy.getTestId('active-healthcheck-interval').should('have.value', '10')
-      cy.getTestId('active-healthcheck-successes').should('have.value', '5')
-      cy.get('.active-healthcheck-http-statuses .multiselect-list button.selected').should('have.length', 2)
-      cy.get('.active-healthcheck-http-statuses .multiselect-list button[value="200"]').should('have.class', 'selected')
-      cy.get('.active-healthcheck-http-statuses .multiselect-list button[value="302"]').should('have.class', 'selected')
+      cy.getTestId('active-healthcheck-healthy-interval').should('have.value', '10')
+      cy.getTestId('active-healthcheck-healthy-successes').should('have.value', '5')
+      cy.get('.active-healthcheck-healthy-http-statuses .multiselect-list button.selected').should('have.length', 2)
+      cy.get('.active-healthcheck-healthy-http-statuses .multiselect-list button[value="200"]').should('have.class', 'selected')
+      cy.get('.active-healthcheck-healthy-http-statuses .multiselect-list button[value="302"]').should('have.class', 'selected')
       cy.get('.active-healthcheck-unhealthy-http-statuses .multiselect-list button.selected').should('have.length', 2)
       cy.get('.active-healthcheck-unhealthy-http-statuses .multiselect-list button[value="429"]').should('have.class', 'selected')
       cy.get('.active-healthcheck-unhealthy-http-statuses .multiselect-list button[value="404"]').should('have.class', 'selected')
       cy.getTestId('active-healthcheck-unhealthy-interval').should('have.value', '5')
-      cy.getTestId('active-healthcheck-http-failures').should('have.value', '3')
-      cy.getTestId('active-healthcheck-tcp-failures').should('have.value', '3')
+      cy.getTestId('active-healthcheck-unhealthy-http-failures').should('have.value', '3')
+      cy.getTestId('active-healthcheck-unhealthy-tcp-failures').should('have.value', '3')
       cy.getTestId('active-healthcheck-unhealthy-timeouts').should('have.value', '0')
       cy.getTestId('passive-health-switch').should('be.checked')
       cy.get('.passive-healthcheck-type-select input').should('have.value', 'HTTP')
-      cy.getTestId('passive-healthcheck-successes').should('have.value', '4')
-      cy.get('.passive-healthcheck-http-statuses .multiselect-list button.selected').should('have.length', 2)
-      cy.get('.passive-healthcheck-http-statuses .multiselect-list button[value="200"]').should('have.class', 'selected')
-      cy.get('.passive-healthcheck-http-statuses .multiselect-list button[value="201"]').should('have.class', 'selected')
-      cy.getTestId('passive-healthcheck-timeouts').should('have.value', '10')
-      cy.getTestId('passive-healthcheck-http-failures').should('have.value', '2')
-      cy.getTestId('passive-healthcheck-tcp-failures').should('have.value', '2')
+      cy.getTestId('passive-healthcheck-healthy-successes').should('have.value', '4')
+      cy.get('.passive-healthcheck-healthy-http-statuses .multiselect-list button.selected').should('have.length', 2)
+      cy.get('.passive-healthcheck-healthy-http-statuses .multiselect-list button[value="200"]').should('have.class', 'selected')
+      cy.get('.passive-healthcheck-healthy-http-statuses .multiselect-list button[value="201"]').should('have.class', 'selected')
+      cy.getTestId('passive-healthcheck-unhealthy-timeouts').should('have.value', '10')
+      cy.getTestId('passive-healthcheck-unhealthy-http-failures').should('have.value', '2')
+      cy.getTestId('passive-healthcheck-unhealthy-tcp-failures').should('have.value', '2')
       cy.get('.passive-healthcheck-unhealthy-http-statuses .multiselect-list button.selected').should('have.length', 3)
       cy.get('.passive-healthcheck-unhealthy-http-statuses .multiselect-list button[value="500"]').should('have.class', 'selected')
       cy.get('.passive-healthcheck-unhealthy-http-statuses .multiselect-list button[value="503"]').should('have.class', 'selected')
@@ -825,16 +856,16 @@ describe('<UpstreamsForm/>', { viewportHeight: 700, viewportWidth: 700 }, () => 
       cy.getTestId('active-health-switch').check({ force: true })
       cy.getTestId('passive-health-switch').check({ force: true })
 
-      cy.getTestId('active-healthcheck-interval').should('have.value', '5')
-      cy.getTestId('active-healthcheck-successes').should('have.value', '5')
-      cy.getTestId('active-healthcheck-http-failures').should('have.value', '5')
+      cy.getTestId('active-healthcheck-healthy-interval').should('have.value', '5')
+      cy.getTestId('active-healthcheck-healthy-successes').should('have.value', '5')
+      cy.getTestId('active-healthcheck-unhealthy-http-failures').should('have.value', '5')
       cy.getTestId('active-healthcheck-unhealthy-interval').should('have.value', '5')
-      cy.getTestId('active-healthcheck-tcp-failures').should('have.value', '5')
+      cy.getTestId('active-healthcheck-unhealthy-tcp-failures').should('have.value', '5')
 
-      cy.getTestId('passive-healthcheck-timeouts').should('have.value', '5')
-      cy.getTestId('passive-healthcheck-successes').should('have.value', '80')
-      cy.getTestId('passive-healthcheck-tcp-failures').should('have.value', '5')
-      cy.getTestId('passive-healthcheck-http-failures').should('have.value', '5')
+      cy.getTestId('passive-healthcheck-unhealthy-timeouts').should('have.value', '5')
+      cy.getTestId('passive-healthcheck-healthy-successes').should('have.value', '80')
+      cy.getTestId('passive-healthcheck-unhealthy-tcp-failures').should('have.value', '5')
+      cy.getTestId('passive-healthcheck-unhealthy-http-failures').should('have.value', '5')
 
       cy.getTestId('upstream-create-form-submit').click()
 
@@ -879,7 +910,39 @@ describe('<UpstreamsForm/>', { viewportHeight: 700, viewportWidth: 700 }, () => 
 
       cy.wait('@updateUpstream').then((interception) => {
         const { body: { healthchecks } } = interception.request
-        expect(healthchecks).to.deep.equal(JSON.parse('{"threshold":2,"active":{"type":"https","headers":{},"healthy":{"interval":0,"successes":0},"unhealthy":{"interval":0,"http_failures":0,"tcp_failures":0}},"passive":{"type":"http","healthy":{"successes":0},"unhealthy":{"timeouts":0,"tcp_failures":0,"http_failures":0}}}'))
+        expect(healthchecks).to.deep.equal(JSON.parse('{"threshold":2,"active":{"type":"http","headers":{},"healthy":{"interval":0,"successes":0},"unhealthy":{"interval":0,"http_failures":0,"tcp_failures":0}},"passive":{"type":"http","healthy":{"successes":0},"unhealthy":{"timeouts":0,"tcp_failures":0,"http_failures":0}}}'))
+      })
+    })
+
+    it('Should set correct values for health checks when turned off, then turned on the active health checks again', () => {
+      interceptFetchServices()
+      interceptFetchCertificates()
+      interceptGetUpstream(200, upstreamsResponseFull)
+      interceptValidate()
+      interceptUpdate()
+
+      cy.mount(UpstreamsForm, {
+        props: {
+          config: KMConfig,
+          upstreamId: 'c372844b-a78a-4317-a81f-0606ba317816',
+        },
+      })
+
+      cy.wait(['@getUpstream', '@fetchServices', '@fetchCertificates'], { timeout: 10000 })
+
+      cy.getTestId('active-health-switch').should('be.checked')
+      cy.getTestId('passive-health-switch').should('be.checked')
+
+      cy.getTestId('active-health-switch').uncheck({ force: true })
+      cy.getTestId('passive-health-switch').uncheck({ force: true })
+
+      cy.getTestId('active-health-switch').check({ force: true })
+
+      cy.getTestId('upstream-edit-form-submit').click()
+
+      cy.wait('@updateUpstream').then((interception) => {
+        const { body: { healthchecks } } = interception.request
+        expect(healthchecks).to.deep.equal(JSON.parse('{"threshold":2,"active":{"type":"http","healthy":{"interval":5,"successes":5,"http_statuses":[200,302]},"unhealthy":{"interval":5,"timeouts":5,"tcp_failures":5,"http_failures":5,"http_statuses":[429,404,500,501,502,503,504,505]},"timeout":1,"concurrency":10,"http_path":"/","headers":{}},"passive":{"type":"http","healthy":{"successes":0},"unhealthy":{"timeouts":0,"tcp_failures":0,"http_failures":0}}}'))
       })
     })
   })

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
@@ -7,7 +7,7 @@
       :entity-type="SupportedEntityType.Upstream"
       :error-message="state.errorMessage"
       :fetch-url="fetchUrl"
-      :form-fields="getPayload"
+      :form-fields="upstreamPayload"
       :is-readonly="state.readonly"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"
@@ -53,18 +53,18 @@
         v-if="state.fields.activeHealthSwitch"
         v-model:concurrency="state.fields.activeHealthCheck.concurrency"
         v-model:headers="state.fields.activeHealthCheck.headers"
-        v-model:http-failures="state.fields.activeHealthCheck.httpFailures"
+        v-model:healthy-http-statuses="state.fields.activeHealthCheck.healthy.httpStatuses"
+        v-model:healthy-interval="state.fields.activeHealthCheck.healthy.interval"
+        v-model:healthy-successes="state.fields.activeHealthCheck.healthy.successes"
         v-model:http-path="state.fields.activeHealthCheck.httpPath"
-        v-model:http-statuses="state.fields.activeHealthCheck.httpStatuses"
         v-model:https-sni="state.fields.activeHealthCheck.httpsSni"
-        v-model:interval="state.fields.activeHealthCheck.interval"
-        v-model:successes="state.fields.activeHealthCheck.successes"
-        v-model:tcp-failures="state.fields.activeHealthCheck.tcpFailures"
         v-model:timeout="state.fields.activeHealthCheck.timeout"
         v-model:type="state.fields.activeHealthCheck.type"
-        v-model:unhealthy-http-statuses="state.fields.activeHealthCheck.unhealthyHttpStatuses"
-        v-model:unhealthy-interval="state.fields.activeHealthCheck.unhealthyInterval"
-        v-model:unhealthy-timeouts="state.fields.activeHealthCheck.unhealthyTimeouts"
+        v-model:unhealthy-http-failures="state.fields.activeHealthCheck.unhealthy.httpFailures"
+        v-model:unhealthy-http-statuses="state.fields.activeHealthCheck.unhealthy.httpStatuses"
+        v-model:unhealthy-interval="state.fields.activeHealthCheck.unhealthy.interval"
+        v-model:unhealthy-tcp-failures="state.fields.activeHealthCheck.unhealthy.tcpFailures"
+        v-model:unhealthy-timeouts="state.fields.activeHealthCheck.unhealthy.timeouts"
         v-model:verify-ssl="state.fields.activeHealthCheck.verifySsl"
         :config="config"
         :readonly="state.readonly"
@@ -72,13 +72,13 @@
 
       <UpstreamsFormPassiveHealthCheck
         v-if="state.fields.passiveHealthSwitch"
-        v-model:http-failures="state.fields.passiveHealthCheck.httpFailures"
-        v-model:http-statuses="state.fields.passiveHealthCheck.httpStatuses"
-        v-model:successes="state.fields.passiveHealthCheck.successes"
-        v-model:tcp-failures="state.fields.passiveHealthCheck.tcpFailures"
-        v-model:timeouts="state.fields.passiveHealthCheck.timeouts"
+        v-model:healthy-http-statuses="state.fields.passiveHealthCheck.healthy.httpStatuses"
+        v-model:healthy-successes="state.fields.passiveHealthCheck.healthy.successes"
         v-model:type="state.fields.passiveHealthCheck.type"
-        v-model:unhealthy-http-statuses="state.fields.passiveHealthCheck.unhealthyHttpStatuses"
+        v-model:unhealthy-http-failures="state.fields.passiveHealthCheck.unhealthy.httpFailures"
+        v-model:unhealthy-http-statuses="state.fields.passiveHealthCheck.unhealthy.httpStatuses"
+        v-model:unhealthy-tcp-failures="state.fields.passiveHealthCheck.unhealthy.tcpFailures"
+        v-model:unhealthy-timeouts="state.fields.passiveHealthCheck.unhealthy.timeouts"
         :readonly="state.readonly"
       />
     </EntityBaseForm>
@@ -86,6 +86,9 @@
 </template>
 
 <script lang="ts" setup>
+import { computed, reactive, type PropType } from 'vue'
+import { useRouter } from 'vue-router'
+import type { AxiosError, AxiosResponse } from 'axios'
 import {
   EntityBaseForm,
   EntityBaseFormType,
@@ -99,22 +102,27 @@ import UpstreamsFormHealthChecks from './UpstreamsFormHealthChecks.vue'
 import UpstreamsFormActiveHealthCheck from './UpstreamsFormActiveHealthCheck.vue'
 import UpstreamsFormPassiveHealthCheck from './UpstreamsFormPassiveHealthCheck.vue'
 import '@kong-ui-public/entities-shared/dist/style.css'
-import type { PropType } from 'vue'
-import { computed, reactive } from 'vue'
 import type {
   KongManagerUpstreamsFormConfig,
-  KonnectUpstreamsFormConfig, UpstreamFormFields,
+  KonnectUpstreamsFormConfig,
+  UpstreamFormFields,
   UpstreamFormPayload,
-  UpstreamFormState, UpstreamResponse, UpstreamsFormActions,
+  UpstreamActivePayload,
+  UpstreamPassivePayload,
+  UpstreamFormState,
+  UpstreamResponse,
+  UpstreamsFormActions,
 } from '../types'
 import useHelpers from '../composables/useHelpers'
 import endpoints from '../upstreams-endpoints'
 import {
+  ActiveHealthyHttpStatuses,
+  ActiveUnhealthyHttpStatuses,
+  PassiveHealthyHttpStatuses,
+  PassiveUnhealthyHttpStatuses,
   SlotsMaxNumber,
   SlotsMinNumber,
 } from '../constants'
-import type { AxiosError, AxiosResponse } from 'axios'
-import { useRouter } from 'vue-router'
 
 const props = defineProps({
   /** The base konnect or kongManger config. Pass additional config props in the shared entity component as needed. */
@@ -162,18 +170,29 @@ const changesExist = computed(() => {
 })
 
 const resetOnActiveSwitch = (val: boolean): void => {
-  state.fields.activeHealthCheck.interval = val ? '5' : '0'
-  state.fields.activeHealthCheck.successes = val ? '5' : '0'
-  state.fields.activeHealthCheck.httpFailures = val ? '5' : '0'
-  state.fields.activeHealthCheck.unhealthyInterval = val ? '5' : '0'
-  state.fields.activeHealthCheck.tcpFailures = val ? '5' : '0'
+  state.fields.activeHealthCheck.healthy.interval = val ? '5' : '0'
+  state.fields.activeHealthCheck.healthy.successes = val ? '5' : '0'
+  state.fields.activeHealthCheck.healthy.httpStatuses = val ? ActiveHealthyHttpStatuses : []
+  state.fields.activeHealthCheck.unhealthy.httpStatuses = val ? ActiveUnhealthyHttpStatuses : []
+  state.fields.activeHealthCheck.unhealthy.httpFailures = val ? '5' : '0'
+  state.fields.activeHealthCheck.unhealthy.interval = val ? '5' : '0'
+  state.fields.activeHealthCheck.unhealthy.tcpFailures = val ? '5' : '0'
+  state.fields.activeHealthCheck.unhealthy.timeouts = val ? '5' : '0'
+  state.fields.activeHealthCheck.timeout = val ? '1' : '0'
+  state.fields.activeHealthCheck.concurrency = val ? '10' : '0'
+  state.fields.activeHealthCheck.httpPath = val ? '/' : ''
+  state.fields.activeHealthCheck.httpsSni = ''
+  state.fields.activeHealthCheck.type = 'http'
 }
 
 const resetOnPassiveSwitch = (val: boolean): void => {
-  state.fields.passiveHealthCheck.timeouts = val ? '5' : '0'
-  state.fields.passiveHealthCheck.successes = val ? '80' : '0'
-  state.fields.passiveHealthCheck.tcpFailures = val ? '5' : '0'
-  state.fields.passiveHealthCheck.httpFailures = val ? '5' : '0'
+  state.fields.passiveHealthCheck.healthy.successes = val ? '80' : '0'
+  state.fields.passiveHealthCheck.healthy.httpStatuses = val ? PassiveHealthyHttpStatuses : []
+  state.fields.passiveHealthCheck.unhealthy.timeouts = val ? '5' : '0'
+  state.fields.passiveHealthCheck.unhealthy.tcpFailures = val ? '5' : '0'
+  state.fields.passiveHealthCheck.unhealthy.httpFailures = val ? '5' : '0'
+  state.fields.passiveHealthCheck.unhealthy.httpStatuses = val ? PassiveUnhealthyHttpStatuses : []
+  state.fields.passiveHealthCheck.type = 'http'
 }
 
 const isSlotsValid = computed((): boolean => state.fields.slots
@@ -235,144 +254,46 @@ const fetchErrorHandler = (err: AxiosError): void => {
   emit('error', err)
 }
 
-const getPayload = computed((): UpstreamFormPayload => {
-  const result: UpstreamFormPayload = {
-    name: state.fields.name,
-    slots: Number(state.fields.slots),
-    algorithm: state.fields.algorithm,
-    hash_on: state.fields.hashOn,
-    hash_fallback: state.fields.hashFallback,
-    healthchecks: {},
-  }
-
-  if (state.fields.hostHeader) {
-    result.host_header = state.fields.hostHeader
-  }
-
-  if (state.fields.clientCertificate) {
-    result.client_certificate = { id: state.fields.clientCertificate }
-  }
-
-  if (state.fields.healthchecksThreshold) {
-    result.healthchecks.threshold = Number(state.fields.healthchecksThreshold)
-  }
-
-  if (state.fields.tags) {
-    result.tags = state.fields.tags.split(',')?.map((tag: string) => String(tag || '')
-      .trim())?.filter((tag: string) => tag !== '')
-  }
+const hashingConfig = computed((): Partial<UpstreamFormPayload> => {
+  const payload: Partial<UpstreamFormPayload> = {}
 
   if (state.fields.hashOn === 'header') {
-    result.hash_on_header = state.fields.hashOnHeader
+    payload.hash_on_header = state.fields.hashOnHeader
   }
 
   if (state.fields.hashOn === 'cookie' || state.fields.hashFallback === 'cookie') {
-    result.hash_on_cookie = state.fields.hashOnCookie
-    result.hash_on_cookie_path = state.fields.hashOnCookiePath
+    payload.hash_on_cookie = state.fields.hashOnCookie
+    payload.hash_on_cookie_path = state.fields.hashOnCookiePath
   }
 
   if (state.fields.hashOn === 'query_arg') {
-    result.hash_on_query_arg = state.fields.hashOnQueryArgument
+    payload.hash_on_query_arg = state.fields.hashOnQueryArgument
   }
 
   if (state.fields.hashOn === 'uri_capture') {
-    result.hash_on_uri_capture = state.fields.hashOnUriCapture
+    payload.hash_on_uri_capture = state.fields.hashOnUriCapture
   }
 
   if (state.fields.hashFallback === 'header') {
-    result.hash_fallback_header = state.fields.hashFallbackHeader
+    payload.hash_fallback_header = state.fields.hashFallbackHeader
   }
 
   if (state.fields.hashFallback === 'query_arg') {
-    result.hash_fallback_query_arg = state.fields.hashFallbackQueryArgument
+    payload.hash_fallback_query_arg = state.fields.hashFallbackQueryArgument
   }
 
   if (state.fields.hashFallback === 'uri_capture') {
-    result.hash_fallback_uri_capture = state.fields.hashFallbackUriCapture
+    payload.hash_fallback_uri_capture = state.fields.hashFallbackUriCapture
   }
 
-  if (state.fields.activeHealthSwitch) {
-    result.healthchecks.active = {
-      type: state.fields.activeHealthCheck.type,
-      healthy: {},
-      unhealthy: {},
-    }
+  return payload
+})
 
-    if (state.fields.activeHealthCheck.timeout) {
-      result.healthchecks.active.timeout = Number(state.fields.activeHealthCheck.timeout)
-    }
-
-    if (state.fields.activeHealthCheck.concurrency) {
-      result.healthchecks.active.concurrency = Number(state.fields.activeHealthCheck.concurrency)
-    }
-
-    if (state.fields.activeHealthCheck.type !== 'tcp' && state.fields.activeHealthCheck.httpPath) {
-      result.healthchecks.active.http_path = state.fields.activeHealthCheck.httpPath
-    }
-
-    if (props.config?.app === 'kongManager') {
-      if (state.fields.activeHealthCheck.headers.length === 0) {
-        result.healthchecks.active.headers = []
-      } else {
-        result.healthchecks.active.headers = state.fields.activeHealthCheck.headers.reduce((obj, item) => {
-          if (item.key) {
-            return {
-              ...obj,
-              [item.key]: item.values.split(',')?.map((val: string) => String(val || '')
-                .trim())?.filter((val: string) => val !== ''),
-            }
-          } else {
-            return {
-              ...obj,
-            }
-          }
-        }, {})
-      }
-    }
-
-    if ((state.fields.activeHealthCheck.type === 'https' || state.fields.activeHealthCheck.type === 'grpcs') &&
-      state.fields.activeHealthCheck.httpsSni) {
-      result.healthchecks.active.https_sni = state.fields.activeHealthCheck.httpsSni
-    }
-
-    if ((state.fields.activeHealthCheck.type === 'https' || state.fields.activeHealthCheck.type === 'grpcs')) {
-      result.healthchecks.active.https_verify_certificate = state.fields.activeHealthCheck.verifySsl
-    }
-
-    if (state.fields.activeHealthCheck.interval) {
-      result.healthchecks.active.healthy.interval = Number(state.fields.activeHealthCheck.interval)
-    }
-
-    if (state.fields.activeHealthCheck.successes) {
-      result.healthchecks.active.healthy.successes = Number(state.fields.activeHealthCheck.successes)
-    }
-
-    if (state.fields.activeHealthCheck.type !== 'tcp' && state.fields.activeHealthCheck.httpStatuses) {
-      result.healthchecks.active.healthy.http_statuses = stringToNumberArray(state.fields.activeHealthCheck.httpStatuses)
-    }
-
-    if (state.fields.activeHealthCheck.unhealthyInterval) {
-      result.healthchecks.active.unhealthy.interval = Number(state.fields.activeHealthCheck.unhealthyInterval)
-    }
-
-    if (state.fields.activeHealthCheck.unhealthyTimeouts) {
-      result.healthchecks.active.unhealthy.timeouts = Number(state.fields.activeHealthCheck.unhealthyTimeouts)
-    }
-
-    if (state.fields.activeHealthCheck.type !== 'tcp' && state.fields.activeHealthCheck.unhealthyHttpStatuses) {
-      result.healthchecks.active.unhealthy.http_statuses = stringToNumberArray(state.fields.activeHealthCheck.unhealthyHttpStatuses)
-    }
-
-    if (state.fields.activeHealthCheck.type !== 'tcp' && state.fields.activeHealthCheck.httpFailures) {
-      result.healthchecks.active.unhealthy.http_failures = Number(state.fields.activeHealthCheck.httpFailures)
-    }
-
-    if (state.fields.activeHealthCheck.tcpFailures) {
-      result.healthchecks.active.unhealthy.tcp_failures = Number(state.fields.activeHealthCheck.tcpFailures)
-    }
-  } else {
+const activeHealthChecks = computed((): UpstreamActivePayload | undefined => {
+  if (!state.fields.activeHealthSwitch) {
+    // Return early if active health checks are disabled
     if (props.config?.app === 'kongManager' && formType.value === EntityBaseFormType.Edit) {
-      result.healthchecks.active = {
+      return {
         type: state.fields.activeHealthCheck.type,
         headers: {},
         healthy: {
@@ -386,45 +307,70 @@ const getPayload = computed((): UpstreamFormPayload => {
         },
       }
     }
+    return undefined
   }
 
-  if (state.fields.passiveHealthSwitch) {
-    result.healthchecks.passive = {
-      type: state.fields.passiveHealthCheck.type,
-      healthy: {},
-      unhealthy: {},
-    }
+  const active: UpstreamActivePayload = {
+    type: state.fields.activeHealthCheck.type,
+    healthy: {
+      interval: Number(state.fields.activeHealthCheck.healthy.interval || '0'),
+      successes: Number(state.fields.activeHealthCheck.healthy.successes || '0'),
+    },
+    unhealthy: {
+      interval: Number(state.fields.activeHealthCheck.unhealthy.interval || '0'),
+      timeouts: Number(state.fields.activeHealthCheck.unhealthy.timeouts || '0'),
+      tcp_failures: Number(state.fields.activeHealthCheck.unhealthy.tcpFailures || '0'),
+    },
+    timeout: Number(state.fields.activeHealthCheck.timeout || '1'),
+    concurrency: Number(state.fields.activeHealthCheck.concurrency || '10'),
+  }
 
-    if (state.fields.passiveHealthCheck.successes) {
-      result.healthchecks.passive.healthy.successes = Number(state.fields.passiveHealthCheck.successes)
-    }
+  // Add HTTP-specific configurations
+  if (state.fields.activeHealthCheck.type !== 'tcp') {
+    active.http_path = state.fields.activeHealthCheck.httpPath || '/'
+    active.unhealthy.http_failures = Number(state.fields.activeHealthCheck.unhealthy.httpFailures || '5')
+    // Use default ActiveUnhealthyHttpStatuses if unhealthyHttpStatuses is null, empty, or undefined
+    const unHealthyStatuses = (!state.fields.activeHealthCheck.unhealthy.httpStatuses?.length)
+      ? ActiveUnhealthyHttpStatuses
+      : state.fields.activeHealthCheck.unhealthy.httpStatuses
+    active.unhealthy.http_statuses = stringToNumberArray(unHealthyStatuses)
 
-    if (state.fields.passiveHealthCheck.type !== 'tcp' && state.fields.passiveHealthCheck.httpStatuses) {
-      result.healthchecks.passive.healthy.http_statuses = stringToNumberArray(state.fields.passiveHealthCheck.httpStatuses)
-    }
+    // Use default ActiveHealthyHttpStatuses if httpStatuses is null, empty, or undefined
+    const healthyStatuses = (!state.fields.activeHealthCheck.healthy.httpStatuses?.length)
+      ? ActiveHealthyHttpStatuses
+      : state.fields.activeHealthCheck.healthy.httpStatuses
+    active.healthy.http_statuses = stringToNumberArray(healthyStatuses)
+  }
 
-    if (state.fields.passiveHealthCheck.timeouts) {
-      result.healthchecks.passive.unhealthy.timeouts = Number(state.fields.passiveHealthCheck.timeouts)
-    }
+  // Add HTTPS/GRPCS specific configurations
+  if (['https', 'grpcs'].includes(state.fields.activeHealthCheck.type)) {
+    active.https_sni = state.fields.activeHealthCheck.httpsSni || null
+    active.https_verify_certificate = state.fields.activeHealthCheck.verifySsl
+  }
 
-    if (state.fields.passiveHealthCheck.type !== 'tcp' && state.fields.passiveHealthCheck.unhealthyHttpStatuses) {
-      result.healthchecks.passive.unhealthy.http_statuses = stringToNumberArray(state.fields.passiveHealthCheck.unhealthyHttpStatuses)
-    }
+  // Add headers for Kong Manager
+  if (props.config?.app === 'kongManager') {
+    active.headers = state.fields.activeHealthCheck.headers.reduce((obj, item) => {
+      if (!item.key) return obj
+      return {
+        ...obj,
+        [item.key]: item.values.split(',')
+          ?.map((val: string) => val.trim())
+          ?.filter(Boolean),
+      }
+    }, {})
+  }
 
-    if (state.fields.passiveHealthCheck.type !== 'tcp' && state.fields.passiveHealthCheck.httpFailures) {
-      result.healthchecks.passive.unhealthy.http_failures = Number(state.fields.passiveHealthCheck.httpFailures)
-    }
+  return active
+})
 
-    if (state.fields.passiveHealthCheck.tcpFailures) {
-      result.healthchecks.passive.unhealthy.tcp_failures = Number(state.fields.passiveHealthCheck.tcpFailures)
-    }
-  } else {
+const passiveHealthChecks = computed((): UpstreamPassivePayload | undefined => {
+  if (!state.fields.passiveHealthSwitch) {
+    // Return early if passive health checks are disabled
     if (props.config?.app === 'kongManager' && formType.value === EntityBaseFormType.Edit) {
-      result.healthchecks.passive = {
+      return {
         type: state.fields.passiveHealthCheck.type,
-        healthy: {
-          successes: 0,
-        },
+        healthy: { successes: 0 },
         unhealthy: {
           timeouts: 0,
           tcp_failures: 0,
@@ -432,9 +378,74 @@ const getPayload = computed((): UpstreamFormPayload => {
         },
       }
     }
+    return undefined
   }
 
-  return result
+  const passive: UpstreamPassivePayload = {
+    type: state.fields.passiveHealthCheck.type,
+    healthy: {
+      successes: Number(state.fields.passiveHealthCheck.healthy.successes || '0'),
+    },
+    unhealthy: {
+      timeouts: Number(state.fields.passiveHealthCheck.unhealthy.timeouts || '0'),
+      tcp_failures: Number(state.fields.passiveHealthCheck.unhealthy.tcpFailures || '5'),
+    },
+  }
+
+  if (state.fields.passiveHealthCheck.type !== 'tcp') {
+    passive.unhealthy.http_failures = Number(state.fields.passiveHealthCheck.unhealthy.httpFailures || '5')
+    // Use default PassiveHealthyHttpStatuses if httpStatuses is null, empty, or undefined
+    const healthyStatuses = (!state.fields.passiveHealthCheck.healthy.httpStatuses?.length)
+      ? PassiveHealthyHttpStatuses
+      : state.fields.passiveHealthCheck.healthy.httpStatuses
+    passive.healthy.http_statuses = stringToNumberArray(healthyStatuses)
+
+    // Use default PassiveUnhealthyHttpStatuses if unhealthyHttpStatuses is null, empty, or undefined
+    const unHealthyStatuses = (!state.fields.passiveHealthCheck.unhealthy.httpStatuses?.length)
+      ? PassiveUnhealthyHttpStatuses
+      : state.fields.passiveHealthCheck.unhealthy.httpStatuses
+    passive.unhealthy.http_statuses = stringToNumberArray(unHealthyStatuses)
+  }
+
+  return passive
+})
+
+const upstreamPayload = computed((): UpstreamFormPayload => {
+  const basePayload = {
+    name: state.fields.name,
+    slots: Number(state.fields.slots),
+    algorithm: state.fields.algorithm,
+    hash_on: state.fields.hashOn,
+    hash_fallback: state.fields.hashFallback,
+    healthchecks: {
+      threshold: Number(state.fields.healthchecksThreshold || '0'),
+    },
+    host_header: state.fields.hostHeader || null,
+    client_certificate: state.fields.clientCertificate ? { id: state.fields.clientCertificate } : null,
+  }
+  const active = activeHealthChecks.value
+  const passive = passiveHealthChecks.value
+
+  const payload: UpstreamFormPayload = {
+    ...basePayload,
+    healthchecks: {
+      ...basePayload.healthchecks,
+      active: active || undefined,
+      passive: passive || undefined,
+    },
+  }
+
+  payload.tags = state.fields.tags
+    ? state.fields.tags.split(',')
+      .map((tag: string) => String(tag || '')
+        .trim())
+      .filter((tag: string) => tag !== '')
+    : []
+
+  // Add hashing configuration
+  Object.assign(payload, hashingConfig.value)
+
+  return payload
 })
 
 const getUrl = (action: UpstreamsFormActions): string => {
@@ -455,16 +466,16 @@ const submitData = async (): Promise<void> => {
   try {
     state.readonly = true
 
-    await axiosInstance.post(getUrl('validate'), getPayload.value)
+    await axiosInstance.post(getUrl('validate'), upstreamPayload.value)
 
     let response: AxiosResponse | undefined
 
     if (formType.value === EntityBaseFormType.Create) {
-      response = await axiosInstance.post(getUrl('create'), getPayload.value)
+      response = await axiosInstance.post(getUrl('create'), upstreamPayload.value)
     } else if (formType.value === EntityBaseFormType.Edit) {
       response = props.config?.app === 'konnect'
-        ? await axiosInstance.put(getUrl('edit'), getPayload.value)
-        : await axiosInstance.patch(getUrl('edit'), getPayload.value)
+        ? await axiosInstance.put(getUrl('edit'), upstreamPayload.value)
+        : await axiosInstance.patch(getUrl('edit'), upstreamPayload.value)
     }
 
     emit('update', response?.data as UpstreamResponse)

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsFormActiveHealthCheck.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsFormActiveHealthCheck.cy.ts
@@ -17,11 +17,11 @@ describe('<UpstreamsFormActiveHealthCheck/>', { viewportHeight: 700, viewportWid
     cy.getTestId('active-healthcheck-http-path').should('be.visible')
     cy.getTestId('active-healthcheck-timeout').should('be.visible')
     cy.getTestId('active-healthcheck-concurrency').should('be.visible')
-    cy.getTestId('active-healthcheck-interval').should('be.visible')
-    cy.getTestId('active-healthcheck-successes').should('be.visible')
-    cy.get('.active-healthcheck-http-statuses').should('be.visible')
+    cy.getTestId('active-healthcheck-healthy-interval').should('be.visible')
+    cy.getTestId('active-healthcheck-healthy-successes').should('be.visible')
+    cy.getTestId('active-healthcheck-healthy-http-statuses').should('be.visible')
     cy.getTestId('active-healthcheck-unhealthy-interval').should('be.visible')
-    cy.getTestId('active-healthcheck-http-failures').should('be.visible')
+    cy.getTestId('active-healthcheck-unhealthy-http-failures').should('be.visible')
     cy.getTestId('active-healthcheck-unhealthy-timeouts').should('be.visible')
     cy.get('.active-healthcheck-unhealthy-http-statuses').should('be.visible')
   })
@@ -144,48 +144,48 @@ describe('<UpstreamsFormActiveHealthCheck/>', { viewportHeight: 700, viewportWid
     cy.get('@onUpdateSpy').should('have.been.calledWith', true)
   })
 
-  it('Should bind interval data correctly', () => {
+  it('Should bind healthyInterval data correctly', () => {
     cy.mount(UpstreamsFormActiveHealthCheck, {
       props: {
         type: 'https',
         headers: [{ key: '', values: '' }],
-        'onUpdate:interval': cy.spy().as('onUpdateSpy'),
+        'onUpdate:healthy-interval': cy.spy().as('onUpdateSpy'),
       },
     })
 
-    cy.getTestId('active-healthcheck-interval').type('4', { waitForAnimations: false })
+    cy.getTestId('active-healthcheck-healthy-interval').type('4', { waitForAnimations: false })
 
     cy.get('@onUpdateSpy').should('have.been.calledWith', '4')
   })
 
-  it('Should bind successes data correctly', () => {
+  it('Should bind healthySuccesses data correctly', () => {
     cy.mount(UpstreamsFormActiveHealthCheck, {
       props: {
         type: 'https',
         headers: [{ key: '', values: '' }],
-        'onUpdate:successes': cy.spy().as('onUpdateSpy'),
+        'onUpdate:healthy-successes': cy.spy().as('onUpdateSpy'),
       },
     })
 
-    cy.getTestId('active-healthcheck-successes').type('4', { waitForAnimations: false })
+    cy.getTestId('active-healthcheck-healthy-successes').type('4', { waitForAnimations: false })
 
     cy.get('@onUpdateSpy').should('have.been.calledWith', '4')
   })
 
-  it('Should bind httpStatuses data correctly', () => {
+  it('Should bind healthyHttpStatuses data correctly', () => {
     cy.mount(UpstreamsFormActiveHealthCheck, {
       props: {
         type: 'https',
         headers: [{ key: '', values: '' }],
-        'onUpdate:http-statuses': cy.spy().as('onUpdateSpy'),
+        'onUpdate:healthy-http-statuses': cy.spy().as('onUpdateSpy'),
       },
     })
 
-    cy.get('.active-healthcheck-http-statuses').click({ waitForAnimations: false })
+    cy.get('.active-healthcheck-healthy-http-statuses').click({ waitForAnimations: false })
 
-    cy.get('.active-healthcheck-http-statuses .multiselect-list .multiselect-item').should('have.length', 92)
-    cy.get('.active-healthcheck-http-statuses .multiselect-list [data-testid="multiselect-item-200"]').click({ waitForAnimations: false })
-    cy.get('.active-healthcheck-http-statuses .multiselect-list [data-testid="multiselect-item-201"]').click({ waitForAnimations: false })
+    cy.get('.active-healthcheck-healthy-http-statuses .multiselect-list .multiselect-item').should('have.length', 92)
+    cy.get('.active-healthcheck-healthy-http-statuses .multiselect-list [data-testid="multiselect-item-200"]').click({ waitForAnimations: false })
+    cy.get('.active-healthcheck-healthy-http-statuses .multiselect-list [data-testid="multiselect-item-201"]').click({ waitForAnimations: false })
 
     cy.get('@onUpdateSpy').should('have.been.calledWith', ['200', '201'])
   })
@@ -204,16 +204,16 @@ describe('<UpstreamsFormActiveHealthCheck/>', { viewportHeight: 700, viewportWid
     cy.get('@onUpdateSpy').should('have.been.calledWith', '4')
   })
 
-  it('Should bind httpFailures data correctly', () => {
+  it('Should bind unhealthyHttpFailures data correctly', () => {
     cy.mount(UpstreamsFormActiveHealthCheck, {
       props: {
         type: 'http',
         headers: [{ key: '', values: '' }],
-        'onUpdate:http-failures': cy.spy().as('onUpdateSpy'),
+        'onUpdate:unhealthy-http-failures': cy.spy().as('onUpdateSpy'),
       },
     })
 
-    cy.getTestId('active-healthcheck-http-failures').type('4', { waitForAnimations: false })
+    cy.getTestId('active-healthcheck-unhealthy-http-failures').type('4', { waitForAnimations: false })
 
     cy.get('@onUpdateSpy').should('have.been.calledWith', '4')
   })
@@ -250,7 +250,7 @@ describe('<UpstreamsFormActiveHealthCheck/>', { viewportHeight: 700, viewportWid
     cy.get('@onUpdateSpy').should('have.been.calledWith', '4')
   })
 
-  it('httpPath, httpStatuses and unhealthyHttpStatuses should be hidden and if type === "tcp"', () => {
+  it('httpPath, healthyHttpStatuses and unhealthyHttpStatuses should be hidden and if type === "tcp"', () => {
     cy.mount(UpstreamsFormActiveHealthCheck, {
       props: {
         type: 'tcp',
@@ -259,22 +259,22 @@ describe('<UpstreamsFormActiveHealthCheck/>', { viewportHeight: 700, viewportWid
     })
 
     cy.getTestId('active-healthcheck-http-path').should('not.exist')
-    cy.getTestId('active-healthcheck-http-statuses').should('not.exist')
+    cy.getTestId('active-healthcheck-healthy-http-statuses').should('not.exist')
     cy.getTestId('active-healthcheck-unhealthy-http-statuses').should('not.exist')
   })
 
   PORTOCOLS.forEach((protocol) => {
-    it(`Should bind tcpFailures data correctly if type === "${protocol}"`, () => {
+    it(`Should bind unhealthyTcpFailures data correctly if type === "${protocol}"`, () => {
       cy.mount(UpstreamsFormActiveHealthCheck, {
         props: {
           type: protocol,
           headers: [{ key: '', values: '' }],
-          'onUpdate:tcp-failures': cy.spy().as('onUpdateSpy'),
+          'onUpdate:unhealthy-tcp-failures': cy.spy().as('onUpdateSpy'),
         },
       })
 
-      cy.getTestId('active-healthcheck-tcp-failures').should('be.visible')
-      cy.getTestId('active-healthcheck-tcp-failures').type('4', { waitForAnimations: false })
+      cy.getTestId('active-healthcheck-unhealthy-tcp-failures').should('be.visible')
+      cy.getTestId('active-healthcheck-unhealthy-tcp-failures').type('4', { waitForAnimations: false })
 
       cy.get('@onUpdateSpy').should('have.been.calledWith', '4')
     })
@@ -319,11 +319,11 @@ describe('<UpstreamsFormActiveHealthCheck/>', { viewportHeight: 700, viewportWid
       props: {
         type: 'tcp',
         headers: [{ key: '', values: '' }],
-        'onUpdate:tcp-failures': cy.spy().as('onUpdateTcpFailuresSpy'),
+        'onUpdate:unhealthy-tcp-failures': cy.spy().as('onUpdateUnhealthyTcpFailuresSpy'),
         'onUpdate:https-sni': cy.spy().as('onUpdateHttpsSniSpy'),
         'onUpdate:verify-ssl': cy.spy().as('onUpdateVerifySslSpy'),
         'onUpdate:http-path': cy.spy().as('onUpdateHttpPathSpy'),
-        'onUpdate:http-statuses': cy.spy().as('onUpdateHttpStatusesSpy'),
+        'onUpdate:healthy-http-statuses': cy.spy().as('onUpdateHealthyHttpStatusesSpy'),
         'onUpdate:unhealthy-http-statuses': cy.spy().as('onUpdateUnhealthyHttpStatusesSpy'),
       },
     }).then(({ wrapper }) => wrapper)
@@ -331,13 +331,13 @@ describe('<UpstreamsFormActiveHealthCheck/>', { viewportHeight: 700, viewportWid
 
     cy.get('@vueWrapper').then(async wrapper => {
       await wrapper.setProps({ type: 'https' })
-      cy.get('@onUpdateTcpFailuresSpy').should('have.been.calledWith', '5')
+      cy.get('@onUpdateUnhealthyTcpFailuresSpy').should('have.been.calledWith', '5')
 
       await wrapper.setProps({ type: 'tcp' })
       cy.get('@onUpdateHttpsSniSpy').should('have.been.calledWith', '')
       cy.get('@onUpdateVerifySslSpy').should('have.been.calledWith', false)
       cy.get('@onUpdateHttpPathSpy').should('have.been.calledWith', '/')
-      cy.get('@onUpdateHttpStatusesSpy').should('have.been.calledWith', ActiveHealthyHttpStatuses)
+      cy.get('@onUpdateHealthyHttpStatusesSpy').should('have.been.calledWith', ActiveHealthyHttpStatuses)
       cy.get('@onUpdateUnhealthyHttpStatusesSpy').should('have.been.calledWith', ActiveUnhealthyHttpStatuses)
 
       await wrapper.setProps({ type: 'grpcs' })

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsFormActiveHealthCheck.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsFormActiveHealthCheck.vue
@@ -150,42 +150,43 @@
       <KInput
         autocomplete="off"
         class="margin-bottom-6"
-        data-testid="active-healthcheck-interval"
+        data-testid="active-healthcheck-healthy-interval"
         :help="t('upstreams.form.fields.interval.help')"
         :label="t('upstreams.form.fields.interval.label')"
         :max="IntervalMaxNumber"
         :min="IntervalMinNumber"
-        :model-value="interval"
+        :model-value="healthyInterval"
         :readonly="readonly"
         type="number"
-        @update:model-value="emit('update:interval', $event)"
+        @update:model-value="emit('update:healthy-interval', $event)"
       />
 
       <KInput
         autocomplete="off"
-        data-testid="active-healthcheck-successes"
+        data-testid="active-healthcheck-healthy-successes"
         :label="t('upstreams.form.fields.successes.label')"
         :max="SuccessOrFailureMaxNumber"
         :min="SuccessOrFailureMinNumber"
-        :model-value="successes"
+        :model-value="healthySuccesses"
         :readonly="readonly"
         type="number"
-        @update:model-value="emit('update:successes', $event)"
+        @update:model-value="emit('update:healthy-successes', $event)"
       />
 
       <KMultiselect
         v-if="!isTcp"
         autocomplete="off"
-        class="margin-top-6 active-healthcheck-http-statuses"
+        class="margin-top-6 active-healthcheck-healthy-http-statuses"
+        data-testid="active-healthcheck-healthy-http-statuses"
         enable-item-creation
         :items="HTTPStatuses"
         :label="t('upstreams.form.fields.http_statuses.label')"
-        :model-value="httpStatuses"
+        :model-value="healthyHttpStatuses"
         :readonly="readonly"
         width="100%"
         @item-added="(item: MultiselectItem) => trackHealthyItem(item, true)"
         @item-removed="(item: MultiselectItem) => trackHealthyItem(item, false)"
-        @update:model-value="emit('update:http-statuses', $event)"
+        @update:model-value="emit('update:healthy-http-statuses', $event)"
       />
     </KCard>
 
@@ -214,34 +215,35 @@
       <KInput
         autocomplete="off"
         class="margin-bottom-6"
-        data-testid="active-healthcheck-tcp-failures"
+        data-testid="active-healthcheck-unhealthy-tcp-failures"
         :label="t('upstreams.form.fields.tcp_failures.label')"
         :max="SuccessOrFailureMaxNumber"
         :min="SuccessOrFailureMinNumber"
-        :model-value="tcpFailures"
+        :model-value="unhealthyTcpFailures"
         :readonly="readonly"
         type="number"
-        @update:model-value="emit('update:tcp-failures', $event)"
+        @update:model-value="emit('update:unhealthy-tcp-failures', $event)"
       />
 
       <KInput
         v-if="!isTcp"
         autocomplete="off"
         class="margin-bottom-6"
-        data-testid="active-healthcheck-http-failures"
+        data-testid="active-healthcheck-unhealthy-http-failures"
         :label="t('upstreams.form.fields.http_failures.label')"
         :max="SuccessOrFailureMaxNumber"
         :min="SuccessOrFailureMinNumber"
-        :model-value="httpFailures"
+        :model-value="unhealthyHttpFailures"
         :readonly="readonly"
         type="number"
-        @update:model-value="emit('update:http-failures', $event)"
+        @update:model-value="emit('update:unhealthy-http-failures', $event)"
       />
 
       <KMultiselect
         v-if="!isTcp"
         autocomplete="off"
         class="margin-bottom-6 active-healthcheck-unhealthy-http-statuses"
+        data-testid="active-healthcheck-unhealthy-http-statuses"
         enable-item-creation
         :items="HTTPStatuses"
         :label="t('upstreams.form.fields.http_statuses.label')"
@@ -340,15 +342,15 @@ const props = defineProps({
     type: Array as PropType<ActiveHealthCheckHeader[]>,
     required: true,
   },
-  interval: {
+  healthyInterval: {
     type: String,
     required: true,
   },
-  successes: {
+  healthySuccesses: {
     type: String,
     required: true,
   },
-  httpStatuses: {
+  healthyHttpStatuses: {
     type: Array as PropType<string[]>,
     required: true,
   },
@@ -356,11 +358,11 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  httpFailures: {
+  unhealthyHttpFailures: {
     type: String,
     required: true,
   },
-  tcpFailures: {
+  unhealthyTcpFailures: {
     type: String,
     required: true,
   },
@@ -387,12 +389,12 @@ const emit = defineEmits<{
   (e: 'update:https-sni', val: string): void
   (e: 'update:verify-ssl', val: boolean): void
   (e: 'update:headers', val: ActiveHealthCheckHeader[]): void
-  (e: 'update:interval', val: string): void
-  (e: 'update:successes', val: string): void
-  (e: 'update:http-statuses', val: string[]): void
+  (e: 'update:healthy-interval', val: string): void
+  (e: 'update:healthy-successes', val: string): void
+  (e: 'update:healthy-http-statuses', val: string[]): void
   (e: 'update:unhealthy-interval', val: string): void
-  (e: 'update:http-failures', val: string): void
-  (e: 'update:tcp-failures', val: string): void
+  (e: 'update:unhealthy-http-failures', val: string): void
+  (e: 'update:unhealthy-tcp-failures', val: string): void
   (e: 'update:unhealthy-http-statuses', val: string[]): void
   (e: 'update:unhealthy-timeouts', val: string): void
 }>()
@@ -438,7 +440,7 @@ const {
 watch(() => props.type, (val, oldVal) => {
   // clear tcpFailures value if type !== 'tcp'
   if (oldVal === 'tcp' && val !== oldVal) {
-    emit('update:tcp-failures', '5')
+    emit('update:unhealthy-tcp-failures', '5')
   }
   // clear httpsSni and verifySsl values if type !== 'https' || 'grpcs'
   if ((oldVal === 'https' || oldVal === 'grpcs') && val !== oldVal) {
@@ -448,7 +450,7 @@ watch(() => props.type, (val, oldVal) => {
   // clear httpPath value if type === 'tcp'
   if (oldVal !== 'tcp' && val === 'tcp') {
     emit('update:http-path', '/')
-    emit('update:http-statuses', ActiveHealthyHttpStatuses)
+    emit('update:healthy-http-statuses', ActiveHealthyHttpStatuses)
     emit('update:unhealthy-http-statuses', ActiveUnhealthyHttpStatuses)
   }
 })

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsFormPassiveHealthCheck.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsFormPassiveHealthCheck.cy.ts
@@ -12,11 +12,11 @@ describe('<UpstreamsFormPassiveHealthCheck/>', { viewportHeight: 700, viewportWi
     })
 
     cy.get('.passive-healthcheck-type-select').should('be.visible')
-    cy.getTestId('passive-healthcheck-successes').should('be.visible')
-    cy.get('.passive-healthcheck-http-statuses').should('be.visible')
-    cy.getTestId('passive-healthcheck-timeouts').should('be.visible')
-    cy.getTestId('passive-healthcheck-http-failures').should('be.visible')
-    cy.get('.passive-healthcheck-unhealthy-http-statuses').should('be.visible')
+    cy.getTestId('passive-healthcheck-healthy-successes').should('be.visible')
+    cy.get('.passive-healthcheck-healthy-http-statuses').should('be.visible')
+    cy.getTestId('passive-healthcheck-unhealthy-timeouts').should('be.visible')
+    cy.getTestId('passive-healthcheck-unhealthy-http-failures').should('be.visible')
+    cy.getTestId('passive-healthcheck-unhealthy-http-statuses').should('be.visible')
   })
 
   it('Should bind type data correctly', () => {
@@ -34,58 +34,58 @@ describe('<UpstreamsFormPassiveHealthCheck/>', { viewportHeight: 700, viewportWi
     cy.get('@onUpdateSpy').should('have.been.calledWith', 'tcp')
   })
 
-  it('Should bind successes data correctly', () => {
+  it('Should bind healthySuccesses data correctly', () => {
     cy.mount(UpstreamsFormPassiveHealthCheck, {
       props: {
         type: 'http',
-        'onUpdate:successes': cy.spy().as('onUpdateSpy'),
+        'onUpdate:healthy-successes': cy.spy().as('onUpdateSpy'),
       },
     })
 
-    cy.getTestId('passive-healthcheck-successes').type('10', { waitForAnimations: false })
+    cy.getTestId('passive-healthcheck-healthy-successes').type('10', { waitForAnimations: false })
 
     cy.get('@onUpdateSpy').should('have.been.calledWith', '10')
   })
 
-  it('Should bind httpStatuses data correctly', () => {
+  it('Should bind healthyHttpStatuses data correctly', () => {
     cy.mount(UpstreamsFormPassiveHealthCheck, {
       props: {
         type: 'http',
-        'onUpdate:http-statuses': cy.spy().as('onUpdateSpy'),
+        'onUpdate:healthy-http-statuses': cy.spy().as('onUpdateSpy'),
       },
     })
 
-    cy.get('.passive-healthcheck-http-statuses').click({ waitForAnimations: false })
+    cy.get('.passive-healthcheck-healthy-http-statuses').click({ waitForAnimations: false })
 
-    cy.get('.passive-healthcheck-http-statuses .multiselect-list .multiselect-item').should('have.length', 92)
-    cy.get('.passive-healthcheck-http-statuses .multiselect-list [data-testid="multiselect-item-200"]').click({ waitForAnimations: false })
-    cy.get('.passive-healthcheck-http-statuses .multiselect-list [data-testid="multiselect-item-201"]').click({ waitForAnimations: false })
+    cy.get('.passive-healthcheck-healthy-http-statuses .multiselect-list .multiselect-item').should('have.length', 92)
+    cy.get('.passive-healthcheck-healthy-http-statuses .multiselect-list [data-testid="multiselect-item-200"]').click({ waitForAnimations: false })
+    cy.get('.passive-healthcheck-healthy-http-statuses .multiselect-list [data-testid="multiselect-item-201"]').click({ waitForAnimations: false })
 
     cy.get('@onUpdateSpy').should('have.been.calledWith', ['200', '201'])
   })
 
-  it('Should bind timeouts data correctly', () => {
+  it('Should bind healthyTimeouts data correctly', () => {
     cy.mount(UpstreamsFormPassiveHealthCheck, {
       props: {
         type: 'http',
-        'onUpdate:timeouts': cy.spy().as('onUpdateSpy'),
+        'onUpdate:unhealthy-timeouts': cy.spy().as('onUpdateSpy'),
       },
     })
 
-    cy.getTestId('passive-healthcheck-timeouts').type('4', { waitForAnimations: false })
+    cy.getTestId('passive-healthcheck-unhealthy-timeouts').type('4', { waitForAnimations: false })
 
     cy.get('@onUpdateSpy').should('have.been.calledWith', '4')
   })
 
-  it('Should bind httpFailures data correctly', () => {
+  it('Should bind unhealthyHttpFailures data correctly', () => {
     cy.mount(UpstreamsFormPassiveHealthCheck, {
       props: {
         type: 'http',
-        'onUpdate:http-failures': cy.spy().as('onUpdateSpy'),
+        'onUpdate:unhealthy-http-failures': cy.spy().as('onUpdateSpy'),
       },
     })
 
-    cy.getTestId('passive-healthcheck-http-failures').type('5', { waitForAnimations: false })
+    cy.getTestId('passive-healthcheck-unhealthy-http-failures').type('5', { waitForAnimations: false })
 
     cy.get('@onUpdateSpy').should('have.been.calledWith', '5')
   })
@@ -114,22 +114,22 @@ describe('<UpstreamsFormPassiveHealthCheck/>', { viewportHeight: 700, viewportWi
       },
     })
 
-    cy.get('.passive-healthcheck-http-statuses').should('not.exist')
-    cy.getTestId('passive-healthcheck-http-failures').should('not.exist')
-    cy.get('.passive-healthcheck-unhealthy-http-statuses').should('not.exist')
+    cy.get('.passive-healthcheck-healthy-http-statuses').should('not.exist')
+    cy.getTestId('passive-healthcheck-unhealthy-http-failures').should('not.exist')
+    cy.getTestId('passive-healthcheck-unhealthy-http-statuses').should('not.exist')
   })
 
   PORTOCOLS.forEach((protocol) => {
-    it(`Should bind tcpFailures data correctly if type === "${protocol}"`, () => {
+    it(`Should bind unhealthyTcpFailures data correctly if type === "${protocol}"`, () => {
       cy.mount(UpstreamsFormPassiveHealthCheck, {
         props: {
           type: protocol,
-          'onUpdate:tcp-failures': cy.spy().as('onUpdateSpy'),
+          'onUpdate:unhealthy-tcp-failures': cy.spy().as('onUpdateSpy'),
         },
       })
 
-      cy.getTestId('passive-healthcheck-tcp-failures').should('be.visible')
-      cy.getTestId('passive-healthcheck-tcp-failures').type('10', { waitForAnimations: false })
+      cy.getTestId('passive-healthcheck-unhealthy-tcp-failures').should('be.visible')
+      cy.getTestId('passive-healthcheck-unhealthy-tcp-failures').type('10', { waitForAnimations: false })
 
       cy.get('@onUpdateSpy').should('have.been.calledWith', '10')
     })
@@ -140,8 +140,8 @@ describe('<UpstreamsFormPassiveHealthCheck/>', { viewportHeight: 700, viewportWi
     cy.mount(UpstreamsFormPassiveHealthCheck, {
       props: {
         type: 'tcp',
-        'onUpdate:tcp-failures': cy.spy().as('onUpdateTcpFailuresSpy'),
-        'onUpdate:http-statuses': cy.spy().as('onUpdateHttpStatusesSpy'),
+        'onUpdate:unhealthy-tcp-failures': cy.spy().as('onUpdateUnhealthyTcpFailuresSpy'),
+        'onUpdate:healthy-http-statuses': cy.spy().as('onUpdateHealthyHttpStatusesSpy'),
         'onUpdate:unhealthy-http-statuses': cy.spy().as('onUpdateUnhealthyHttpStatusesSpy'),
       },
     }).then(({ wrapper }) => wrapper)
@@ -149,10 +149,10 @@ describe('<UpstreamsFormPassiveHealthCheck/>', { viewportHeight: 700, viewportWi
 
     cy.get('@vueWrapper').then(async wrapper => {
       await wrapper.setProps({ type: 'https' })
-      cy.get('@onUpdateTcpFailuresSpy').should('have.been.calledWith', '5')
+      cy.get('@onUpdateUnhealthyTcpFailuresSpy').should('have.been.calledWith', '5')
 
       await wrapper.setProps({ type: 'tcp' })
-      cy.get('@onUpdateHttpStatusesSpy').should('have.been.calledWith', PassiveHealthyHttpStatuses)
+      cy.get('@onUpdateHealthyHttpStatusesSpy').should('have.been.calledWith', PassiveHealthyHttpStatuses)
       cy.get('@onUpdateUnhealthyHttpStatusesSpy').should('have.been.calledWith', PassiveUnhealthyHttpStatuses)
     })
   })

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsFormPassiveHealthCheck.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsFormPassiveHealthCheck.vue
@@ -35,28 +35,28 @@
 
       <KInput
         autocomplete="off"
-        data-testid="passive-healthcheck-successes"
+        data-testid="passive-healthcheck-healthy-successes"
         :label="t('upstreams.form.fields.successes.label')"
         :max="SuccessOrFailureMaxNumber"
         :min="SuccessOrFailureMinNumber"
-        :model-value="successes"
+        :model-value="healthySuccesses"
         :readonly="readonly"
         type="number"
-        @update:model-value="emit('update:successes', $event)"
+        @update:model-value="emit('update:healthy-successes', $event)"
       />
 
       <KMultiselect
         v-if="!isTcp"
-        class="margin-top-6 passive-healthcheck-http-statuses"
+        class="margin-top-6 passive-healthcheck-healthy-http-statuses"
         enable-item-creation
         :items="HTTPStatuses"
         :label="t('upstreams.form.fields.http_statuses.label')"
-        :model-value="httpStatuses"
+        :model-value="healthyHttpStatuses"
         :readonly="readonly"
         width="100%"
         @item-added="(item: MultiselectItem) => trackHealthyItem(item, true)"
         @item-removed="(item: MultiselectItem) => trackHealthyItem(item, false)"
-        @update:model-value="emit('update:http-statuses', $event)"
+        @update:model-value="emit('update:healthy-http-statuses', $event)"
       />
     </KCard>
 
@@ -70,47 +70,48 @@
 
       <KInput
         autocomplete="off"
-        data-testid="passive-healthcheck-timeouts"
+        data-testid="passive-healthcheck-unhealthy-timeouts"
         :label="t('upstreams.form.fields.timeouts.label')"
         :max="TimeoutsMaxNumber"
         :min="TimeoutsMinNumber"
-        :model-value="timeouts"
+        :model-value="unhealthyTimeouts"
         :readonly="readonly"
         type="number"
-        @update:model-value="emit('update:timeouts', $event)"
+        @update:model-value="emit('update:unhealthy-timeouts', $event)"
       />
 
       <KInput
         autocomplete="off"
         class="margin-top-6"
-        data-testid="passive-healthcheck-tcp-failures"
+        data-testid="passive-healthcheck-unhealthy-tcp-failures"
         :label="t('upstreams.form.fields.tcp_failures.label')"
         :max="SuccessOrFailureMaxNumber"
         :min="SuccessOrFailureMinNumber"
-        :model-value="tcpFailures"
+        :model-value="unhealthyTcpFailures"
         :readonly="readonly"
         type="number"
-        @update:model-value="emit('update:tcp-failures', $event)"
+        @update:model-value="emit('update:unhealthy-tcp-failures', $event)"
       />
 
       <KInput
         v-if="!isTcp"
         autocomplete="off"
         class="margin-top-6"
-        data-testid="passive-healthcheck-http-failures"
+        data-testid="passive-healthcheck-unhealthy-http-failures"
         :label="t('upstreams.form.fields.http_failures.label')"
         :max="SuccessOrFailureMaxNumber"
         :min="SuccessOrFailureMinNumber"
-        :model-value="httpFailures"
+        :model-value="unhealthyHttpFailures"
         :readonly="readonly"
         type="number"
-        @update:model-value="emit('update:http-failures', $event)"
+        @update:model-value="emit('update:unhealthy-http-failures', $event)"
       />
 
       <KMultiselect
         v-if="!isTcp"
         autocomplete="off"
         class="margin-top-6 passive-healthcheck-unhealthy-http-statuses"
+        data-testid="passive-healthcheck-unhealthy-http-statuses"
         enable-item-creation
         :items="HTTPStatuses"
         :label="t('upstreams.form.fields.http_statuses.label')"
@@ -154,19 +155,19 @@ const props = defineProps({
     type: String as PropType<HealthCheckType>,
     required: true,
   },
-  successes: {
+  healthySuccesses: {
     type: String,
     required: true,
   },
-  httpStatuses: {
+  healthyHttpStatuses: {
     type: Array as PropType<string[]>,
     required: true,
   },
-  timeouts: {
+  unhealthyTimeouts: {
     type: String,
     required: true,
   },
-  httpFailures: {
+  unhealthyHttpFailures: {
     type: String,
     required: true,
   },
@@ -174,7 +175,7 @@ const props = defineProps({
     type: Array as PropType<string[]>,
     required: true,
   },
-  tcpFailures: {
+  unhealthyTcpFailures: {
     type: String,
     required: true,
   },
@@ -187,12 +188,12 @@ const props = defineProps({
 
 const emit = defineEmits<{
   (e: 'update:type', val: HealthCheckType): void
-  (e: 'update:successes', val: string): void
-  (e: 'update:http-statuses', val: string[]): void
-  (e: 'update:timeouts', val: string): void
-  (e: 'update:http-failures', val: string): void
+  (e: 'update:healthy-successes', val: string): void
+  (e: 'update:healthy-http-statuses', val: string[]): void
+  (e: 'update:unhealthy-timeouts', val: string): void
+  (e: 'update:unhealthy-http-failures', val: string): void
   (e: 'update:unhealthy-http-statuses', val: string[]): void
-  (e: 'update:tcp-failures', val: string): void
+  (e: 'update:unhealthy-tcp-failures', val: string): void
 }>()
 
 const typeItems = ref<HealthCheckTypeSelectItem[]>([
@@ -235,11 +236,11 @@ const {
 watch(() => props.type, (val, oldVal) => {
   // clear tcpFailures value if type !== 'tcp'
   if (oldVal === 'tcp' && val !== oldVal) {
-    emit('update:tcp-failures', '5')
+    emit('update:unhealthy-tcp-failures', '5')
   }
   // clear unhealthyHttpStatuses and httpStatuses values if type === 'tcp'
   if (oldVal !== 'tcp' && val === 'tcp') {
-    emit('update:http-statuses', PassiveHealthyHttpStatuses)
+    emit('update:healthy-http-statuses', PassiveHealthyHttpStatuses)
     emit('update:unhealthy-http-statuses', PassiveUnhealthyHttpStatuses)
   }
 })

--- a/packages/entities/entities-upstreams-targets/src/composables/useHelpers.ts
+++ b/packages/entities/entities-upstreams-targets/src/composables/useHelpers.ts
@@ -70,31 +70,39 @@ export default function useHelpers() {
           ? Object.entries(response.healthchecks.active.headers)
             .map(([key, val]) => ({ key, values: val?.join(', ') }))
           : [{ key: '', values: '' }],
-        interval: response?.healthchecks.active?.healthy?.interval?.toString() || '0',
-        successes: response?.healthchecks.active?.healthy?.successes?.toString() || '5',
-        httpStatuses: response?.healthchecks.active?.healthy?.http_statuses
-          ? numberToStringArray(response.healthchecks.active.healthy.http_statuses)
-          : ActiveHealthyHttpStatuses,
-        unhealthyInterval: response?.healthchecks.active?.unhealthy?.interval?.toString() || '0',
-        httpFailures: response?.healthchecks.active?.unhealthy?.http_failures?.toString() || '5',
-        tcpFailures: response?.healthchecks.active?.unhealthy?.tcp_failures?.toString() || '5',
-        unhealthyHttpStatuses: response?.healthchecks.active?.unhealthy?.http_statuses
-          ? numberToStringArray(response.healthchecks.active.unhealthy.http_statuses)
-          : ActiveUnhealthyHttpStatuses,
-        unhealthyTimeouts: response?.healthchecks.active?.unhealthy?.timeouts?.toString() || '0',
+        healthy: {
+          interval: response?.healthchecks.active?.healthy?.interval?.toString() || '0',
+          successes: response?.healthchecks.active?.healthy?.successes?.toString() || '5',
+          httpStatuses: response?.healthchecks.active?.healthy?.http_statuses
+            ? numberToStringArray(response.healthchecks.active.healthy.http_statuses)
+            : ActiveHealthyHttpStatuses,
+        },
+        unhealthy: {
+          interval: response?.healthchecks.active?.unhealthy?.interval?.toString() || '0',
+          httpFailures: response?.healthchecks.active?.unhealthy?.http_failures?.toString() || '5',
+          tcpFailures: response?.healthchecks.active?.unhealthy?.tcp_failures?.toString() || '5',
+          httpStatuses: response?.healthchecks.active?.unhealthy?.http_statuses
+            ? numberToStringArray(response.healthchecks.active.unhealthy.http_statuses)
+            : ActiveUnhealthyHttpStatuses,
+          timeouts: response?.healthchecks.active?.unhealthy?.timeouts?.toString() || '0',
+        },
       },
       passiveHealthCheck: {
         type: response?.healthchecks.passive?.type || 'http',
-        successes: response?.healthchecks.passive?.healthy?.successes?.toString() || '0',
-        httpStatuses: response?.healthchecks.passive?.healthy?.http_statuses
-          ? numberToStringArray(response.healthchecks.passive.healthy.http_statuses)
-          : PassiveHealthyHttpStatuses,
-        timeouts: response?.healthchecks.passive?.unhealthy?.timeouts?.toString() || '0',
-        httpFailures: response?.healthchecks.passive?.unhealthy?.http_failures?.toString() || '5',
-        tcpFailures: response?.healthchecks.passive?.unhealthy?.tcp_failures?.toString() || '5',
-        unhealthyHttpStatuses: response?.healthchecks.passive?.unhealthy?.http_statuses
-          ? numberToStringArray(response.healthchecks.passive.unhealthy.http_statuses)
-          : PassiveUnhealthyHttpStatuses,
+        healthy: {
+          successes: response?.healthchecks.passive?.healthy?.successes?.toString() || '5',
+          httpStatuses: response?.healthchecks.passive?.healthy?.http_statuses
+            ? numberToStringArray(response.healthchecks.passive.healthy.http_statuses)
+            : PassiveHealthyHttpStatuses,
+        },
+        unhealthy: {
+          timeouts: response?.healthchecks.passive?.unhealthy?.timeouts?.toString() || '0',
+          httpFailures: response?.healthchecks.passive?.unhealthy?.http_failures?.toString() || '5',
+          tcpFailures: response?.healthchecks.passive?.unhealthy?.tcp_failures?.toString() || '5',
+          httpStatuses: response?.healthchecks.passive?.unhealthy?.http_statuses
+            ? numberToStringArray(response.healthchecks.passive.unhealthy.http_statuses)
+            : PassiveUnhealthyHttpStatuses,
+        },
       },
     }
 

--- a/packages/entities/entities-upstreams-targets/src/types/upstreams-form.ts
+++ b/packages/entities/entities-upstreams-targets/src/types/upstreams-form.ts
@@ -28,24 +28,32 @@ export interface ActiveHealthCheck {
   httpsSni: string
   verifySsl: boolean
   headers: ActiveHealthCheckHeader[]
-  interval: string
-  successes: string
-  httpStatuses: string[]
-  unhealthyInterval: string
-  httpFailures: string
-  tcpFailures: string
-  unhealthyHttpStatuses: string[]
-  unhealthyTimeouts: string
+  healthy: {
+    interval: string
+    successes: string
+    httpStatuses: string[]
+  },
+  unhealthy: {
+    interval: string
+    timeouts: string
+    tcpFailures: string
+    httpFailures: string
+    httpStatuses: string[]
+  }
 }
 
 export interface PassiveHealthCheck {
   type: HealthCheckType
-  successes: string
-  httpStatuses: string[]
-  timeouts: string
-  httpFailures: string
-  unhealthyHttpStatuses: string[]
-  tcpFailures: string
+  healthy: {
+    successes: string
+    httpStatuses: string[]
+  },
+  unhealthy: {
+    timeouts: string
+    tcpFailures: string
+    httpFailures: string
+    httpStatuses: string[]
+  }
 }
 
 export interface UpstreamFormFields {
@@ -100,7 +108,7 @@ export interface UpstreamActivePayload {
   concurrency?: number
   http_path?: string
   headers?: Record<string, string[]> | []
-  https_sni?: string
+  https_sni?: string | null
   https_verify_certificate?: boolean
   healthy: {
     interval?: number
@@ -137,8 +145,8 @@ export interface UpstreamPassivePayload {
 export interface UpstreamFormPayload {
   name: string
   algorithm: UpstreamAlgorithm
-  host_header?: string
-  client_certificate?: { id: string }
+  host_header?: string | null
+  client_certificate?: { id: string } | null
   tags?: string[]
   slots: number
   hash_on: UpstreamHash


### PR DESCRIPTION

This PR mainly addresses the following issues:


• It fixes the problem where some field values (`client_cerficate`, `tags`, `http_sni`, and `host_header` etc.) cannot be set to null during editing.

• It refactors the type definitions for active health and passive health to avoid confusion between the definitions of Active and Passive.

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
KM-970
FTI-6493
