### PR TITLE
fix(dashboard-renderer): fix spacing for slottable tiles

### DIFF
--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong-ui-public/dashboard-renderer",
-  "version": "0.36.1",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/dashboard-renderer.umd.js",
   "module": "./dist/dashboard-renderer.es.js",

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -18,7 +18,7 @@
       <template #tile="{ tile }">
         <div
           v-if="tile.meta.chart.type === 'slottable'"
-          class="tile-container"
+          class="tile-container slottable-tile"
         >
           <slot :name="tile.meta.chart.id" />
         </div>
@@ -218,6 +218,10 @@ defineExpose({ refresh: refreshTiles })
     border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
     border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
     height: 100%;
+
+    &.slottable-tile {
+      padding: var(--kui-space-60, $kui-space-60);
+    }
   }
 }
 </style>


### PR DESCRIPTION
Fixes issue introduced in these commits:

- 82359a25f0acef6378ca0ab575cbf82ad6d9f863
- 0bd52f9560cb912f3def72bf870fa8dc4efd501f

Also set renderer version to 1.0.0 for better tracking of future breaking changes.

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
