### PR TITLE
fix: keep tile sorted by row/column order

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -49,6 +49,7 @@ const emit = defineEmits<{
 
 const gridContainer = ref<HTMLDivElement | null>(null)
 
+
 const tilesRef = ref<Map<string, GridTile<any>>>(new Map(props.tiles.map(t => [`${t.id}`, t])))
 
 let grid: GridStack | null = null
@@ -82,6 +83,17 @@ const updateTiles = () => {
     updates.forEach((tile) => {
       tilesRef.value.set(`${tile.id}`, tile)
     })
+
+    const tiles = Array.from(tilesRef.value.entries())
+    tiles.sort((a, b) => {
+      const rowDiff = a[1].layout.position.row - b[1].layout.position.row
+      if (rowDiff !== 0) {
+        return rowDiff
+      }
+      return a[1].layout.position.col - b[1].layout.position.col
+    })
+    tilesRef.value = new Map(tiles)
+
     emit('update-tiles', Array.from(tilesRef.value.values()))
   }
 }


### PR DESCRIPTION
# Summary

Note: The indexes appearing on the tiles are just to demonstrate the tiles array now sorted. Change is not included in the PR.
https://www.loom.com/share/e88029be90854f32948776d26eb93f76

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
