### PR TITLE
fix(tracing): swap incorrect durations on client in/out nodes

### DIFF
--- a/packages/core/tracing/src/utils/lifecycle.ts
+++ b/packages/core/tracing/src/utils/lifecycle.ts
@@ -159,7 +159,7 @@ export const buildLifecycleGraph = (root: SpanNode): LifecycleGraph => {
           position: { x: 0, y: 0 },
           data: {
             type: LifecycleNodeType.CLIENT_OUT,
-            durationNano: clientInSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0),
+            durationNano: clientOutSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0),
             durationTooltipKey: 'lifecycle.client_out.tooltip',
           },
           zIndex: 10, // Because we may want to show tooltips on this node
@@ -169,7 +169,7 @@ export const buildLifecycleGraph = (root: SpanNode): LifecycleGraph => {
           position: { x: 0, y: 0 },
           data: {
             type: LifecycleNodeType.CLIENT_IN,
-            durationNano: clientOutSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0) + pluginDurationExcluded,
+            durationNano: clientInSpans.reduce((duration, span) => duration + (span.durationNano ?? 0), 0) + pluginDurationExcluded,
             durationTooltipKey: 'lifecycle.client_in.tooltip',
           },
           zIndex: 10, // Because we may want to show tooltips on this node


### PR DESCRIPTION
# Summary

Fix an issue where the durations on client in/out nodes were swapped

## Reproduction screenshots

![image](https://github.com/user-attachments/assets/ec0e4b93-06f8-4d31-a017-5bc8b863a4ab)
![image](https://github.com/user-attachments/assets/ce99b7b3-8202-45bd-a8fe-11bd87352ee5)

KM-975