### PR TITLE
fix: keep tiles prop and map synced

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang='ts' setup generic="T">
-import { onMounted, onUnmounted, ref, watch, nextTick } from 'vue'
+import { onMounted, onUnmounted, ref, watch, nextTick, watchEffect } from 'vue'
 import { GridStack } from 'gridstack'
 import type { GridStackNode } from 'gridstack'
 import type { GridSize, GridTile } from 'src/types'
@@ -132,6 +132,13 @@ watch(() => props.tiles.length, async (newLen, oldLen) => {
       })
     }
   }
+})
+
+// Keep tilesRef in sync with props.tiles
+watchEffect(() => {
+  props.tiles.forEach(tile => {
+    tilesRef.value.set(`${tile.id}`, tile)
+  })
 })
 
 defineExpose({ removeWidget })


### PR DESCRIPTION
# Summary

Changes to a tile's meta properties are done externally so whenever props.tiles changes it needs to be synced with the internal map.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
