### PR TITLE
chore: auto-assign PR author as assignee [KM-1010]

### DIFF
--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -1,0 +1,11 @@
+name: Add assignee to PRs
+on:
+  pull_request:
+    types: [ opened, reopened ]
+permissions:
+  pull-requests: write
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@2daaeb2988aef24bf37e636fe733f365c046aba0


### PR DESCRIPTION
# Summary
This PR added a CI workflow to auto-assign the PR's author as an assignee.
It can help us easily identify whose PR it is.
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
KM-1010