### PR TITLE
feat(entities-plugins): add free form support and request callout

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue
@@ -50,7 +50,7 @@
         @update="onUpdate"
       />
 
-      <!-- <h2>Kong Manager API</h2>
+      <h2>Kong Manager API</h2>
       <PluginForm
         :key="formKey"
         :config="kongManagerConfig"
@@ -59,7 +59,7 @@
         plugin-type=""
         :schema="schema"
         @update="onUpdate"
-      /> -->
+      />
     </section>
     <pre
       v-else

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue
@@ -44,14 +44,13 @@
         :key="formKey"
         :config="konnectConfig"
         enable-vault-secret-picker
-        is-wizard-step
         :plugin-type="pluginType || ''"
         :schema="schema"
         use-custom-names-for-plugin
         @update="onUpdate"
       />
 
-      <h2>Kong Manager API</h2>
+      <!-- <h2>Kong Manager API</h2>
       <PluginForm
         :key="formKey"
         :config="kongManagerConfig"
@@ -60,7 +59,7 @@
         plugin-type=""
         :schema="schema"
         @update="onUpdate"
-      />
+      /> -->
     </section>
     <pre
       v-else
@@ -70,7 +69,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onErrorCaptured, ref, useTemplateRef, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onErrorCaptured,
+  ref,
+  useTemplateRef,
+  watch,
+} from 'vue'
 import { useRouter } from 'vue-router'
 import type {
   KonnectPluginFormConfig,
@@ -89,15 +95,24 @@ const pluginTypes = [
     value: key,
   })),
 ].sort((a, b) => a.label.localeCompare(b.label))
-const pluginType = ref<string>()
+
+const storedPluginType =
+  localStorage.getItem('plugin-form-playground:pluginType') || ''
+const pluginType = ref<string>(
+  pluginTypes.find(({ value }) => value === storedPluginType)
+    ? storedPluginType
+    : '',
+)
 
 const defaultSchema = {
   fields: [],
 }
 const schemaOpen = ref(false)
-const schemaText = ref(JSON.stringify(defaultSchema, null, 2))
 
-watch(schemaOpen, async open => {
+const storedSchema = localStorage.getItem('plugin-form-playground:schema')
+const schemaText = ref(storedSchema || JSON.stringify(defaultSchema, null, 2))
+
+watch(schemaOpen, async (open) => {
   if (open) {
     await nextTick()
     text.value?.$el.querySelector('textarea').select()
@@ -155,8 +170,14 @@ const onUpdate = (payload: Record<string, any>) => {
   router.push({ name: 'home' })
 }
 
+watch(pluginType, () => {
+  localStorage.setItem('plugin-form-playground:pluginType', pluginType.value)
+})
+
 watch(schemaText, () => {
   renderError.value = ''
+
+  localStorage.setItem('plugin-form-playground:schema', schemaText.value)
 })
 
 onErrorCaptured((error) => {

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -153,7 +153,7 @@ export default defineComponent({
 
 <script setup lang="ts">
 const emit = defineEmits<{
-  (e: 'loading', isLoading: boolean): void;
+  (e: 'loading', isLoading: boolean): void,
   (e: 'model-updated',
     payload: {
       model: Record<string, any>,
@@ -264,9 +264,7 @@ const buildGetOneUrl = (entityType: string, entityId: string): string => {
 }
 // define endpoints for use by KFG
 const buildGetAllUrl = (entityType: string): string => {
-  let url = `${props.config.apiBaseUrl}${
-    endpoints.form[props.config.app].entityGetAll
-  }`
+  let url = `${props.config.apiBaseUrl}${endpoints.form[props.config.app].entityGetAll}`
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
@@ -301,7 +299,7 @@ const getAll = (entityType: string, params: AxiosRequestConfig['params']): Promi
   // Currently hardcoded to fetch 1000 records, and filter
   // client side. If more than 1000 records, this won't work
   if (props.config.app === 'konnect') {
-    return axiosInstance.get(url).then((res) => {
+    return axiosInstance.get(url).then(res => {
       const { data: { data } } = res
 
       delete params.size
@@ -490,7 +488,8 @@ const getModel = (): Record<string, any> => {
             // if the value is an object (not an array or null), recursively call this function
             if (o[key] && typeof o[key] === 'object' && !Array.isArray(o[key]) && o[key] !== null) {
               deepOmitNil(o[key])
-            } else if (o[key] === undefined || o[key] === null || (typeof o[key] === 'number' && isNaN(o[key])) || (typeof o[key] === 'string' && o[key].trim().length === 0)) {
+            } else if (o[key] === undefined || o[key] === null || (typeof o[key] === 'number' && isNaN(o[key]))
+              || (typeof o[key] === 'string' && o[key].trim().length === 0)) {
               delete o[key]
             }
           })
@@ -731,10 +730,7 @@ const initFormModel = (): void => {
     for (const entity in props.entityMap) {
       const id = props.entityMap[entity].id
       const idField = props.entityMap[entity].idField
-      const key =
-        idField === 'consumer_group_id'
-          ? 'consumer_group-id'
-          : JSON.parse(JSON.stringify(idField).replace('_', '-'))
+      const key = idField === 'consumer_group_id' ? 'consumer_group-id' : JSON.parse(JSON.stringify(idField).replace('_', '-'))
 
       // ex. set consumer-id: <entityId>
       if (Object.prototype.hasOwnProperty.call(formModel, key)) {
@@ -784,9 +780,7 @@ watch(() => props.schema, (newSchema, oldSchema) => {
   sharedFormName.value = getSharedFormName(form.model.name)
 
   initFormModel()
-},
-{ immediate: true, deep: true },
-)
+}, { immediate: true, deep: true })
 
 onBeforeMount(() => {
   form.value = parseSchema(props.schema)

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -70,21 +70,16 @@
       >
         <template #plugin-config-empty-state>
           <div class="plugin-config-empty-state">
-            {{ t("plugins.form.grouping.plugin_configuration.empty") }}
+            {{ t('plugins.form.grouping.plugin_configuration.empty') }}
           </div>
         </template>
 
         <!-- For the opentelemetry plugin, we only need to show rule alerts with its new schema -->
         <template
-          v-if="
-            PLUGIN_METADATA[formModel.name]?.fieldRules &&
-              (props.config.isNewOtelSchema || formModel.name !== 'opentelemetry')
-          "
+          v-if="PLUGIN_METADATA[formModel.name]?.fieldRules && (props.config.isNewOtelSchema || formModel.name !== 'opentelemetry')"
           #plugin-config-before-content
         >
-          <PluginFieldRuleAlerts
-            :rules="PLUGIN_METADATA[formModel.name].fieldRules!"
-          />
+          <PluginFieldRuleAlerts :rules="PLUGIN_METADATA[formModel.name].fieldRules!" />
         </template>
 
         <template
@@ -104,7 +99,7 @@
   <VaultSecretPicker
     :config="props.config"
     :setup="vaultSecretPickerSetup"
-    @cancel="() => (vaultSecretPickerSetup = false)"
+    @cancel="() => vaultSecretPickerSetup = false"
     @proceed="handleVaultSecretPickerAutofill"
   />
 </template>
@@ -127,25 +122,12 @@ import {
 } from '@kong-ui-public/forms'
 import '@kong-ui-public/forms/dist/style.css'
 import type { AxiosRequestConfig, AxiosResponse } from 'axios'
-import {
-  computed,
-  defineComponent,
-  onBeforeMount,
-  provide,
-  reactive,
-  ref,
-  watch,
-  type PropType,
-} from 'vue'
+import { computed, defineComponent, onBeforeMount, provide, reactive, ref, watch, type PropType } from 'vue'
 import composables from '../composables'
 import useI18n from '../composables/useI18n'
 import { PLUGIN_METADATA } from '../definitions/metadata'
 import endpoints from '../plugins-endpoints'
-import type {
-  KongManagerPluginFormConfig,
-  KonnectPluginFormConfig,
-  PluginEntityInfo,
-} from '../types'
+import type { KongManagerPluginFormConfig, KonnectPluginFormConfig, PluginEntityInfo } from '../types'
 import PluginFieldRuleAlerts from './PluginFieldRuleAlerts.vue'
 import * as freeForm from './free-form'
 import { getFreeFormName } from '../utils/free-form'
@@ -172,12 +154,11 @@ export default defineComponent({
 <script setup lang="ts">
 const emit = defineEmits<{
   (e: 'loading', isLoading: boolean): void;
-  (
-    e: 'model-updated',
+  (e: 'model-updated',
     payload: {
-      model: Record<string, any>;
-      originalModel: Record<string, any>;
-      data: Record<string, any>;
+      model: Record<string, any>,
+      originalModel: Record<string, any>,
+      data: Record<string, any>
     }
   ): void,
   (e: 'showNewPartialModal', redisType: string): void,
@@ -186,18 +167,12 @@ const emit = defineEmits<{
 const props = defineProps({
   /** The base konnect or kongManger config. Pass additional config props in the shared entity component as needed. */
   config: {
-    type: Object as PropType<
-      KonnectPluginFormConfig | KongManagerPluginFormConfig
-    >,
+    type: Object as PropType<KonnectPluginFormConfig | KongManagerPluginFormConfig>,
     required: true,
-    validator: (
-      config: KonnectPluginFormConfig | KongManagerPluginFormConfig,
-    ): boolean => {
-      if (!config || !['konnect', 'kongManager'].includes(config?.app))
-        return false
+    validator: (config: KonnectPluginFormConfig | KongManagerPluginFormConfig): boolean => {
+      if (!config || !['konnect', 'kongManager'].includes(config?.app)) return false
       if (config.app === 'konnect' && !config.controlPlaneId) return false
-      if (config.app === 'kongManager' && typeof config.workspace !== 'string')
-        return false
+      if (config.app === 'kongManager' && typeof config.workspace !== 'string') return false
       return true
     },
   },
@@ -269,23 +244,16 @@ const { parseSchema } = composables.useSchemas({
 const { convertToDotNotation, unFlattenObject, dismissField, isObjectEmpty, unsetNullForeignKey } = composables.usePluginHelpers()
 
 const { objectsAreEqual } = useHelpers()
-const {
-  i18n: { t },
-} = useI18n()
+const { i18n: { t } } = useI18n()
 
 // define endpoints for use by KFG
 const buildGetOneUrl = (entityType: string, entityId: string): string => {
-  let url = `${props.config.apiBaseUrl}${
-    endpoints.form[props.config.app].entityGetOne
-  }`
+  let url = `${props.config.apiBaseUrl}${endpoints.form[props.config.app].entityGetOne}`
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
   } else if (props.config.app === 'kongManager') {
-    url = url.replace(
-      /\/{workspace}/gi,
-      props.config.workspace ? `/${props.config.workspace}` : '',
-    )
+    url = url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
   }
 
   // replace the entity type and id
@@ -303,10 +271,7 @@ const buildGetAllUrl = (entityType: string): string => {
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
   } else if (props.config.app === 'kongManager') {
-    url = url.replace(
-      /\/{workspace}/gi,
-      props.config.workspace ? `/${props.config.workspace}` : '',
-    )
+    url = url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
   }
 
   // replace the entity type
@@ -320,10 +285,7 @@ const buildGetAllUrl = (entityType: string): string => {
  * @param {entityId} string - the id of the entity to look up
  * @returns {Promise<import('axios').AxiosResponse<T>>}
  */
-const getOne = (
-  entityType: string,
-  entityId: string,
-): Promise<AxiosResponse> => {
+const getOne = (entityType: string, entityId: string): Promise<AxiosResponse> => {
   const url = buildGetOneUrl(entityType, entityId)
 
   return axiosInstance.get(url)
@@ -333,19 +295,14 @@ const getOne = (
  * @param {entityType} string - the entity query path WITHOUT leading/trailing slash (ex. 'routes')
  * @returns {Promise<import('axios').AxiosResponse<T>>}
  */
-const getAll = (
-  entityType: string,
-  params: AxiosRequestConfig['params'],
-): Promise<AxiosResponse> => {
+const getAll = (entityType: string, params: AxiosRequestConfig['params']): Promise<AxiosResponse> => {
   const url = buildGetAllUrl(entityType)
 
   // Currently hardcoded to fetch 1000 records, and filter
   // client side. If more than 1000 records, this won't work
   if (props.config.app === 'konnect') {
     return axiosInstance.get(url).then((res) => {
-      const {
-        data: { data },
-      } = res
+      const { data: { data } } = res
 
       delete params.size
       delete params.offset
@@ -354,9 +311,7 @@ const getAll = (
         const queryKey = Object.keys(params)[0]
         const filteredData = data.filter((instance: Record<string, any>) => {
           if (instance[queryKey]) {
-            return !!instance[queryKey]
-              .toLowerCase()
-              .includes(params[queryKey].toLowerCase())
+            return !!instance[queryKey].toLowerCase().includes(params[queryKey].toLowerCase())
           }
 
           return false
@@ -389,12 +344,8 @@ const formModel = reactive<Record<string, any>>({})
 const formOptions = computed(() => form.value?.options)
 
 const vaultSecretPickerSetup = ref<string | false>(false)
-const vaultSecretPickerAutofillAction =
-  ref<(secretRef: string) => void | undefined>()
-const setUpVaultSecretPicker = (
-  setupValue: string,
-  autofillAction: (secretRef: string) => void,
-) => {
+const vaultSecretPickerAutofillAction = ref<(secretRef: string) => void | undefined>()
+const setUpVaultSecretPicker = (setupValue: string, autofillAction: (secretRef: string) => void) => {
   vaultSecretPickerSetup.value = setupValue ?? ''
   vaultSecretPickerAutofillAction.value = autofillAction
 }
@@ -438,7 +389,7 @@ const getModel = (): Record<string, any> => {
 
   // Iterate over each field in the form, transform each field value to match the
   // Kong Admin APIs request expectations for submission
-  formModelFields.forEach((fieldName) => {
+  formModelFields.forEach(fieldName => {
     if (!schema[fieldName]) {
       // special handling for partials
       if (fieldName === 'partials') {
@@ -450,20 +401,12 @@ const getModel = (): Record<string, any> => {
     const fieldSchema = schema[fieldName]
     let fieldValue = inputModel[fieldName]
     const originalValue = origModel[fieldName]
-    const fieldValueType = Array.isArray(fieldValue)
-      ? 'array'
-      : typeof fieldValue
+    const fieldValueType = Array.isArray(fieldValue) ? 'array' : typeof fieldValue
     const fieldSchemaValueType = fieldSchema ? fieldSchema.valueType : null
-    const fieldSchemaArrayValueType = fieldSchema
-      ? fieldSchema.valueArrayType
-      : null
+    const fieldSchemaArrayValueType = fieldSchema ? fieldSchema.valueArrayType : null
     const transformer = fieldSchema ? fieldSchema.transform : null
 
-    if (
-      fieldValue == null &&
-      originalValue == null &&
-      !fieldSchema.submitWhenNull
-    ) {
+    if (fieldValue == null && originalValue == null && !fieldSchema.submitWhenNull) {
       return
     }
 
@@ -488,12 +431,12 @@ const getModel = (): Record<string, any> => {
                 if (fieldSchemaArrayValueType === 'boolean') {
                   // Convert string based boolean values ('true', 'false') to boolean type
                   if (typeof value === 'string') {
-                    return value.toLowerCase() === 'true' || value === '1'
+                    return (value.toLowerCase() === 'true' || value === '1')
                   }
 
                   // Handle a numerical value, just in-case someone fudged an input type.
                   if (typeof value === 'number') {
-                    return value === 1
+                    return (value === 1)
                   }
                 }
 
@@ -502,7 +445,7 @@ const getModel = (): Record<string, any> => {
             }
 
             // We only want to set array fields to empty if the field is empty
-            if (!fieldValue || !fieldValue.length) {
+            if ((!fieldValue || !fieldValue.length)) {
               fieldValue = fieldSchema.submitWhenNull ? null : []
             }
 
@@ -517,24 +460,23 @@ const getModel = (): Record<string, any> => {
           case 'boolean':
             // Convert string based boolean values ('true', 'false') to boolean type
             if (fieldValueType === 'string') {
-              fieldValue =
-                fieldValue.toLowerCase() === 'true' || fieldValue === '1'
+              fieldValue = (fieldValue.toLowerCase() === 'true' || fieldValue === '1')
             }
 
             // Handle a numerical value, just in-case someone fudged an input type.
             if (fieldValueType === 'number') {
-              fieldValue = fieldValue === 1
+              fieldValue = (fieldValue === 1)
             }
 
             break
 
           // Handle values that aren't strings but should be.
           case 'string':
-            fieldValue = fieldValue == null ? '' : String(fieldValue)
+            fieldValue = (fieldValue == null) ? '' : String(fieldValue)
             break
         }
       } else if (fieldSchemaValueType === 'array') {
-        if (!fieldValue || !fieldValue.length) {
+        if ((!fieldValue || !fieldValue.length)) {
           fieldValue = fieldSchema.submitWhenNull ? null : []
         } else if (fieldSchema.inputAttributes?.type === 'number') {
           fieldValue = fieldValue.map((value: string) => Number(value))
@@ -548,12 +490,7 @@ const getModel = (): Record<string, any> => {
             // if the value is an object (not an array or null), recursively call this function
             if (o[key] && typeof o[key] === 'object' && !Array.isArray(o[key]) && o[key] !== null) {
               deepOmitNil(o[key])
-            } else if (
-              o[key] === undefined ||
-              o[key] === null ||
-              (typeof o[key] === 'number' && isNaN(o[key])) ||
-              (typeof o[key] === 'string' && o[key].trim().length === 0)
-            ) {
+            } else if (o[key] === undefined || o[key] === null || (typeof o[key] === 'number' && isNaN(o[key])) || (typeof o[key] === 'string' && o[key].trim().length === 0)) {
               delete o[key]
             }
           })
@@ -564,15 +501,11 @@ const getModel = (): Record<string, any> => {
       }
 
       // Format Advanced Object for submission
-      if (
-        fieldSchema.type === 'object-advanced' &&
-        fieldSchema.fields &&
-        fieldValue !== null
-      ) {
+      if (fieldSchema.type === 'object-advanced' && fieldSchema.fields && fieldValue !== null) {
         if (Object.entries(fieldValue).length === 0) {
           fieldValue = null
         } else {
-          Object.keys(fieldValue).forEach((key) => {
+          Object.keys(fieldValue).forEach(key => {
             if (Array.isArray(fieldValue[key])) return
 
             fieldValue[key] = fieldValue[key].split(',')
@@ -588,17 +521,13 @@ const getModel = (): Record<string, any> => {
     // If the field name originally has dashes, they were converted to underscores during initiation.
     // Now we need to convert them back to dashes because the Admin API expects dashes
     if (fieldSchema.fieldNameHasDashes) {
-      const [keyToBeConverted, ...rest] = fieldNameDotNotation
-        .split('.')
-        .reverse()
+      const [keyToBeConverted, ...rest] = fieldNameDotNotation.split('.').reverse()
 
-      fieldNameDotNotation = [keyToBeConverted.replace(/_/g, '-'), ...rest]
-        .reverse()
-        .join('.')
+      fieldNameDotNotation = [keyToBeConverted.replace(/_/g, '-'), ...rest].reverse().join('.')
     }
 
     if (fieldSchemaValueType === 'object-expand') {
-      let key;
+      let key
 
       [fieldNameDotNotation, key] = fieldNameDotNotation.split('.')
 
@@ -618,16 +547,11 @@ const getModel = (): Record<string, any> => {
     // or reset this value to it's default.
 
     // Include if field is empty & field has been modified from orginal value
-    if (
-      originalValue !== undefined &&
-      fieldValue === '' &&
-      fieldValue !== originalValue
-    ) {
+    if (originalValue !== undefined && fieldValue === '' && fieldValue !== originalValue) {
       // We need to determine what type of 'empty' value to set for modified nested inputs,
       // if we do not the model will not preserve its structure
       // (this change may be able to be removed when core updates its reset default handling)
-      outputModel[fieldNameDotNotation] =
-        fieldSchemaValueType === 'object' ? {} : null
+      outputModel[fieldNameDotNotation] = fieldSchemaValueType === 'object' ? {} : null
 
       // If empty & field is a checklist array, set as [] to prevent all options being selected
     } else if (fieldSchema.type === 'checklist' && fieldValue === '') {
@@ -677,7 +601,7 @@ const onModelUpdated = (model: any, schema: string) => {
 
 // special handling for problematic fields before we emit
 const updateModel = (data: Record<string, any>, parent?: string) => {
-  Object.keys(data).forEach((key) => {
+  Object.keys(data).forEach(key => {
     let modelKey = parent ? `${parent}-${key}` : key
     let scheme = props.schema[modelKey]
 
@@ -687,9 +611,7 @@ const updateModel = (data: Record<string, any>, parent?: string) => {
     // 3. or `parent` is already a schema key and `key` is a nested key of its value object
     // For reasons 2 and 3, we need special logic to find the correct schema key
     if (!scheme) {
-      const underscoredModelKey = parent
-        ? `${parent}-${key.replace(/-/g, '_')}`
-        : key.replace(/-/g, '_')
+      const underscoredModelKey = parent ? `${parent}-${key.replace(/-/g, '_')}` : key.replace(/-/g, '_')
 
       // Here we check if the underscored key exists in the schema and the `fieldNameHasDashes` flag is true
       if (props.schema[underscoredModelKey]?.fieldNameHasDashes) {
@@ -765,9 +687,7 @@ const initFormModel = (): void => {
     // global fields
     updateModel({
       enabled: props.record.enabled ?? true,
-      ...(props.record.instance_name && {
-        instance_name: props.record.instance_name || '',
-      }),
+      ...(props.record.instance_name && { instance_name: props.record.instance_name || '' }),
       ...(props.record.protocols && { protocols: props.record.protocols }),
       ...(props.record.tags && { tags: props.record.tags }),
     })
@@ -782,25 +702,15 @@ const initFormModel = (): void => {
       }
 
       updateModel(props.record)
-    } else if (props.record.config) {
-      // typical plugins
+    } else if (props.record.config) { // typical plugins
       // scope fields
-      if (
-        props.record.consumer_id ||
-        props.record.consumer ||
-        props.record.service_id ||
-        props.record.service ||
-        props.record.route_id ||
-        props.record.route ||
-        props.record.consumer_group_id ||
-        props.record.consumer_group
-      ) {
+      if ((props.record.consumer_id || props.record.consumer) || (props.record.service_id || props.record.service) ||
+        (props.record.route_id || props.record.route) || (props.record.consumer_group_id || props.record.consumer_group)) {
         updateModel({
           service_id: props.record.service_id || props.record.service,
           route_id: props.record.route_id || props.record.route,
           consumer_id: props.record.consumer_id || props.record.consumer,
-          consumer_group_id:
-            props.record.consumer_group_id || props.record.consumer_group,
+          consumer_group_id: props.record.consumer_group_id || props.record.consumer_group,
         })
       }
 
@@ -816,11 +726,7 @@ const initFormModel = (): void => {
 
   // scoping logic, convert _ to - for form model
   // Check if incoming field exists in current model and if so update
-  if (
-    Object.keys(props.entityMap).length &&
-    !props.entityMap.global &&
-    props.schema
-  ) {
+  if (Object.keys(props.entityMap).length && !props.entityMap.global && props.schema) {
     const updateFields: Record<string, any> = {}
     for (const entity in props.entityMap) {
       const id = props.entityMap[entity].id
@@ -859,29 +765,27 @@ watch(loading, (newLoading) => {
 })
 
 // if the schema changed we've got to start over and completely rebuild the form model
-watch(
-  () => props.schema,
-  (newSchema, oldSchema) => {
-    if (objectsAreEqual(newSchema || {}, oldSchema || {})) {
-      return
-    }
-    const form: Record<string, any> = parseSchema(newSchema)
+watch(() => props.schema, (newSchema, oldSchema) => {
+  if (objectsAreEqual(newSchema || {}, oldSchema || {})) {
+    return
+  }
+  const form: Record<string, any> = parseSchema(newSchema)
 
-    Object.assign(formModel, form.model)
+  Object.assign(formModel, form.model)
 
-    formSchema.value = {
-      fields: formSchema.value?.fields?.map((r: Record<string, any>) => {
-        return { ...r, disabled: r.disabled || false }
-      }),
-    }
-    Object.assign(originalModel, JSON.parse(JSON.stringify(form.model)))
+  formSchema.value = {
+    fields: formSchema.value?.fields?.map((r: Record<string, any>) => {
+      return { ...r, disabled: r.disabled || false }
+    }),
+  }
+  Object.assign(originalModel, JSON.parse(JSON.stringify(form.model)))
 
-    freeformName.value = getFreeFormName(form.model.name)
-    sharedFormName.value = getSharedFormName(form.model.name)
+  freeformName.value = getFreeFormName(form.model.name)
+  sharedFormName.value = getSharedFormName(form.model.name)
 
-    initFormModel()
-  },
-  { immediate: true, deep: true },
+  initFormModel()
+},
+{ immediate: true, deep: true },
 )
 
 onBeforeMount(() => {

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -48,8 +48,9 @@
         :enable-redis-partial="enableRedisPartial"
         :enable-vault-secret-picker="props.enableVaultSecretPicker"
         :entity-map="entityMap"
+        :raw-schema="loadedSchema || {}"
         :record="record || undefined"
-        :schema="loadedSchema || {}"
+        :schema="finalSchema || {}"
         @loading="(val: boolean) => formLoading = val"
         @model-updated="handleUpdate"
         @show-new-partial-modal="(redisType: string) => $emit('showNewPartialModal', redisType)"
@@ -308,6 +309,7 @@ const isToggled = ref(false)
 const isEditing = computed(() => !!props.pluginId)
 const formType = computed((): EntityBaseFormType => props.pluginId ? EntityBaseFormType.Edit : EntityBaseFormType.Create)
 const loadedSchema = ref<Record<string, any> | null>(null)
+const finalSchema = ref<Record<string, any> | null>(null)
 const treatAsCredential = computed((): boolean => !!(props.credential && props.config.entityId))
 const record = ref<Record<string, any> | null>(null)
 const configResponse = ref<Record<string, any>>({})
@@ -1109,8 +1111,6 @@ watch([entityMap, initialized], (newData, oldData) => {
 
   // rebuild schema if its not a credential and we either just determined a new entity id, or newly initialized the data
   if (!treatAsCredential.value && formType.value === EntityBaseFormType.Edit && (newEntityData || (newinitialized && newinitialized !== oldinitialized))) {
-    schemaLoading.value = true
-
     const initialFormSchema = buildFormSchema('config', configResponse.value, defaultFormSchema)
     if (isCustomPlugin.value) {
       initialFormSchema._isCustomPlugin = true
@@ -1118,8 +1118,7 @@ watch([entityMap, initialized], (newData, oldData) => {
     if (pluginPartialType.value) {
       initialFormSchema._supported_redis_partial_type = pluginPartialType.value
     }
-    loadedSchema.value = initialFormSchema
-    schemaLoading.value = false
+    finalSchema.value = initialFormSchema
   }
 }, { deep: true })
 
@@ -1236,7 +1235,7 @@ const saveFormData = async (): Promise<void> => {
         originalModel: formFieldsOriginal,
         model: form.fields,
         payload,
-        schema: loadedSchema.value,
+        schema: finalSchema.value,
       })
     }
 
@@ -1306,15 +1305,16 @@ onBeforeMount(async () => {
       const data = CREDENTIAL_SCHEMAS[pluginType]
       credentialType.value = pluginType
 
-      loadedSchema.value = buildFormSchema('', data, {})
+      finalSchema.value = buildFormSchema('', data, {})
       schemaLoading.value = false
     } else { // handling for standard plugins
       const data = props.schema ?? (await axiosInstance.get(schemaUrl.value)).data
+      loadedSchema.value = data
 
       if (data) {
         if (treatAsCredential.value) {
           // credential schema response is structured differently, no `config` object or default schema
-          loadedSchema.value = buildFormSchema('', data, {})
+          finalSchema.value = buildFormSchema('', data, {})
           schemaLoading.value = false
         } else {
           // start from the config part of the schema
@@ -1356,7 +1356,7 @@ onBeforeMount(async () => {
             }
             // pass whether the plugin is a custom plugin to the form schema
             if (isCustomPlugin.value) initialFormSchema._isCustomPlugin = true
-            loadedSchema.value = initialFormSchema
+            finalSchema.value = initialFormSchema
           }
         }
       }

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CacheForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CacheForm.vue
@@ -1,0 +1,56 @@
+<!-- eslint-disable vue/no-mutating-props -->
+<template>
+  <ObjectField
+    appearance="card"
+    label="Cache"
+    :label-attributes="getLabelAttributes('cache')"
+    required
+  >
+    <SelectField
+      v-model="formData.cache.strategy"
+      clearable
+      :items="CACHE_STRATEGIES"
+      label="Cache › Strategy"
+      :label-attributes="getLabelAttributes('cache.strategy')"
+    />
+
+    <ObjectField
+      label="Cache › Memory"
+      :label-attributes="getLabelAttributes('cache.memory')"
+      required
+    >
+      <StringField
+        v-model="formData.cache.memory.dictionary_name"
+        label="Cache › Memory › Dictionary Name"
+        :label-attributes="getLabelAttributes('cache.memory.dictionary_name')"
+        required
+      />
+    </ObjectField>
+
+    <RedisForm />
+
+    <NumberField
+      v-model="formData.cache.cache_ttl"
+      label="Cache › Cache TTL"
+      :label-attributes="getLabelAttributes('cache.cache_ttl')"
+      min="1"
+    />
+  </ObjectField>
+</template>
+
+<script setup lang="ts">
+import { useFormShared } from './composables'
+import ObjectField from '../shared/ObjectField.vue'
+import RedisForm from './RedisForm.vue'
+import { toSelectItems } from './utils'
+import StringField from '../shared/StringField.vue'
+import SelectField from '../shared/EnumField.vue'
+import NumberField from '../shared/NumberField.vue'
+
+const { formData, getLabelAttributes } = useFormShared()
+
+const CACHE_STRATEGIES = toSelectItems([
+  'memory',
+  'disk',
+])
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CacheForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CacheForm.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-mutating-props -->
 <template>
   <ObjectField
     appearance="card"
@@ -6,7 +5,7 @@
     :label-attributes="getLabelAttributes('cache')"
     required
   >
-    <SelectField
+    <EnumField
       v-model="formData.cache.strategy"
       clearable
       :items="CACHE_STRATEGIES"
@@ -44,7 +43,7 @@ import ObjectField from '../shared/ObjectField.vue'
 import RedisForm from './RedisForm.vue'
 import { toSelectItems } from './utils'
 import StringField from '../shared/StringField.vue'
-import SelectField from '../shared/EnumField.vue'
+import EnumField from '../shared/EnumField.vue'
 import NumberField from '../shared/NumberField.vue'
 
 const { formData, getLabelAttributes } = useFormShared()

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutForm.vue
@@ -1,0 +1,88 @@
+<template>
+  <StringField
+    data-1p-ignore
+    data-autofocus
+    label="Name"
+    :label-attributes="getLabelAttributes('callouts.*.name')"
+    :model-value="formData.callouts?.[index]?.name"
+    required
+    @update:model-value="formData.callouts![index].name = $event"
+  />
+
+  <EnumField
+    :items="definedCalloutNames"
+    label="Depends On"
+    :label-attributes="getLabelAttributes('callouts.*.depends_on')"
+    :model-value="formData.callouts?.[index]?.depends_on"
+    multiple
+    placeholder="0 callouts selected"
+    @update:model-value="formData.callouts![index].depends_on = $event"
+  />
+
+  <CalloutRequestForm :callout-index="index" />
+
+  <CalloutResponseForm :callout-index="index" />
+
+  <ObjectField
+    label="Cache"
+    :label-attributes="getLabelAttributes('callouts.*.cache')"
+    @update:added="setCache"
+  >
+    <BooleanField
+      label="Cache › Bypass"
+      :label-attributes="getLabelAttributes('callouts.*.cache.bypass')"
+      :model-value="formData.callouts?.[index].cache?.bypass || false"
+      @update:model-value="updateBypass"
+    />
+  </ObjectField>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useFormShared } from './composables'
+import CalloutRequestForm from './CalloutRequestForm.vue'
+import ObjectField from '../shared/ObjectField.vue'
+import CalloutResponseForm from './CalloutResponseForm.vue'
+import { getDefaultCalloutCache } from './utils'
+import StringField from '../shared/StringField.vue'
+import BooleanField from '../shared/BooleanField.vue'
+import EnumField from '../shared/EnumField.vue'
+
+const props = defineProps<{
+  index: number;
+}>()
+
+const { formData, getLabelAttributes } = useFormShared()
+
+const definedCalloutNames = computed(() => {
+  const { callouts } = formData
+  if (callouts == null) {
+    return []
+  }
+
+  return callouts
+    .filter(({ name }) => name && name !== callouts[props.index]?.name)
+    .map(({ name }) => ({ label: name, value: name }))
+})
+
+function setCache(value: boolean) {
+  const callout = formData.callouts?.[props.index]
+
+  if (callout == null) {
+    return
+  }
+
+  if (value) {
+    callout.cache = getDefaultCalloutCache()
+  } else {
+    delete callout.cache
+  }
+}
+
+function updateBypass(value: boolean) {
+  const cache = formData.callouts?.[props.index].cache
+  if (cache) {
+    cache.bypass = value
+  }
+}
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutRequestForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutRequestForm.vue
@@ -1,0 +1,385 @@
+<template>
+  <ObjectField
+    label="Request"
+  >
+    <StringField
+      label="Request › URL"
+      :label-attributes="getLabelAttributes('callouts.*.request.url')"
+      :model-value="request?.url"
+      required
+      @update:model-value="request!.url = $event"
+    />
+
+    <SelectField
+      clearable
+      :items="METHODS"
+      label="Request › Method"
+      :label-attributes="getLabelAttributes('callouts.*.request.method')"
+      :model-value="request?.method"
+      required
+      @update:model-value="request!.method = $event as typeof METHODS[number]['value']"
+    />
+
+    <ObjectField
+      label="Request › Headers"
+      :label-attributes="getLabelAttributes('callouts.*.request.headers')"
+      @update:added="setHeaders"
+    >
+      <BooleanField
+        label="Request › Headers › Forward"
+        :label-attributes="getLabelAttributes('callouts.*.request.headers.forward')"
+        :model-value="request?.headers?.forward || false"
+        @update:model-value="request!.headers!.forward = $event"
+      />
+
+      <KeyValueField
+        :initial-value="request?.headers?.custom"
+        label="Request › Headers › Custom"
+        :label-attributes="getLabelAttributes('callouts.*.request.headers.custom')"
+        @change="request!.headers!.custom = $event"
+      />
+    </ObjectField>
+
+    <ObjectField
+      label="Request › Query"
+      :label-attributes="getLabelAttributes('callouts.*.request.query')"
+      @update:added="setQuery"
+    >
+      <BooleanField
+        label="Request › Query › Forward"
+        :label-attributes="getLabelAttributes('callouts.*.request.query.forward')"
+        :model-value="request?.query?.forward || false"
+        @update:model-value="request!.query!.forward = $event"
+      />
+
+      <KeyValueField
+        :initial-value="request?.query?.custom"
+        label="Request › Query › Custom"
+        :label-attributes="getLabelAttributes('callouts.*.request.query.custom')"
+        @change="request!.query!.custom = $event"
+      />
+    </ObjectField>
+
+    <ObjectField
+      label="Request › Body"
+      :label-attributes="getLabelAttributes('callouts.*.request.body')"
+      @update:added="setBody"
+    >
+      <BooleanField
+        label="Request › Body › Forward"
+        :label-attributes="getLabelAttributes('callouts.*.request.body.forward')"
+        :model-value="request?.body?.forward || false"
+        @update:model-value="request!.body!.forward = $event"
+      />
+
+      <KeyValueField
+        :initial-value="request?.body?.custom"
+        label="Request › Body › Custom"
+        :label-attributes="getLabelAttributes('callouts.*.request.body.custom')"
+        @change="request!.body!.custom = $event"
+      />
+    </ObjectField>
+
+    <ObjectField
+      label="Request › HTTP Opts"
+      :label-attributes="getLabelAttributes('callouts.*.request.http_opts')"
+      @update:added="setHttpOpts"
+    >
+      <BooleanField
+        label="Request › HTTP Opts › SSL Verify"
+        :label-attributes="getLabelAttributes('callouts.*.request.http_opts.ssl_verify')"
+        :model-value="request?.http_opts?.ssl_verify || false"
+        @update:model-value="request!.http_opts!.ssl_verify = $event"
+      />
+
+      <StringField
+        label="Request › HTTP Opts › SSL Server Name"
+        :label-attributes="getLabelAttributes('callouts.*.request.http_opts.ssl_server_name')"
+        :model-value="request?.http_opts?.ssl_server_name"
+        @update:model-value="request!.http_opts!.ssl_server_name = $event"
+      />
+
+      <ObjectField
+        label="Request › HTTP Opts › Timeouts"
+        :label-attributes="getLabelAttributes('callouts.*.request.http_opts.timeouts')"
+        @update:added="setTimeouts"
+      >
+        <NumberField
+          label="Request › HTTP Opts › Timeouts › Connect"
+          :label-attributes="getLabelAttributes('callouts.*.request.http_opts.timeouts.connect')"
+          max="2147473646"
+          min="0"
+          :model-value="request?.http_opts?.timeouts?.connect"
+          @update:model-value="request!.http_opts!.timeouts!.connect = $event"
+        />
+        <NumberField
+          label="Request › HTTP Opts › Timeouts › Write"
+          :label-attributes="getLabelAttributes('callouts.*.request.http_opts.timeouts.write')"
+          max="2147473646"
+          min="0"
+          :model-value="request?.http_opts?.timeouts?.write"
+          @update:model-value="request!.http_opts!.timeouts!.write = $event"
+        />
+        <NumberField
+          label="Request › HTTP Opts › Timeouts › Read"
+          :label-attributes="getLabelAttributes('callouts.*.request.http_opts.timeouts.read')"
+          max="2147473646"
+          min="0"
+          :model-value="request?.http_opts?.timeouts?.read"
+          @update:model-value="request!.http_opts!.timeouts!.read = $event"
+        />
+      </ObjectField>
+
+      <ObjectField
+        label="Request › HTTP Opts › Proxy"
+        :label-attributes="getLabelAttributes('callouts.*.request.http_opts.proxy')"
+        @update:added="setProxy"
+      >
+        <StringField
+          label="Request › HTTP Opts › Proxy › Auth Username"
+          :label-attributes="getLabelAttributes('callouts.*.request.http_opts.proxy.auth_username')"
+          :model-value="request?.http_opts?.proxy?.auth_username"
+          show-vault-secret-picker
+          @update:model-value="request!.http_opts!.proxy!.auth_username = $event"
+        />
+        <StringField
+          label="Request › HTTP Opts › Proxy › Auth Password"
+          :label-attributes="getLabelAttributes('callouts.*.request.http_opts.proxy.auth_password')"
+          :model-value="request?.http_opts?.proxy?.auth_password"
+          show-vault-secret-picker
+          @update:model-value="request!.http_opts!.proxy!.auth_password = $event"
+        />
+        <StringField
+          label="Request › HTTP Opts › Proxy › Http Proxy"
+          :label-attributes="getLabelAttributes('callouts.*.request.http_opts.proxy.http_proxy')"
+          :model-value="request?.http_opts?.proxy?.http_proxy"
+          required
+          @update:model-value="request!.http_opts!.proxy!.http_proxy = $event"
+        />
+        <StringField
+          label="Request › HTTP Opts › Proxy › Https Proxy"
+          :label-attributes="getLabelAttributes('callouts.*.request.http_opts.proxy.https_proxy')"
+          :model-value="request?.http_opts?.proxy?.https_proxy"
+          required
+          @update:model-value="request!.http_opts!.proxy!.https_proxy = $event"
+        />
+      </ObjectField>
+    </ObjectField>
+    <ObjectField
+      label="Request › Error"
+      :label-attributes="getLabelAttributes('callouts.*.request.error')"
+      @update:added="setError"
+    >
+      <SelectField
+        :items="ERROR_STRATEGIES"
+        label="Request › Error › On Error"
+        :label-attributes="getLabelAttributes('callouts.*.request.error.on_error')"
+        :model-value="request?.error?.on_error"
+        @update:model-value="request!.error!.on_error = $event as typeof ERROR_STRATEGIES[number]['value']"
+      />
+
+      <NumberField
+        label="Request › Error › Retries"
+        :label-attributes="getLabelAttributes('callouts.*.request.error.retries')"
+        min="0"
+        :model-value="request?.error?.retries"
+        @update:model-value="request!.error!.retries = $event"
+      />
+
+      <ArrayField
+        :items="request?.error?.http_statuses"
+        label="Request › Error › HTTP Statuses"
+        :label-attributes="getLabelAttributes('callouts.*.request.error.http_statuses')"
+        @add="addHttpStatus"
+        @remove="removeHttpStatus"
+      >
+        <template #item="{ index }">
+          <NumberField
+            data-autofocus
+            :model-value="request?.error?.http_statuses?.[index]"
+            @update:model-value="request!.error!.http_statuses![index] = $event"
+          />
+        </template>
+      </ArrayField>
+
+      <NumberField
+        label="Request › Error › Error Response Code"
+        :label-attributes="getLabelAttributes('callouts.*.request.error.error_response_code')"
+        :model-value="request?.error?.error_response_code"
+        @update:model-value="request!.error!.error_response_code = $event"
+      />
+
+      <StringField
+        label="Request › Error › Error Response Msg"
+        :label-attributes="getLabelAttributes('callouts.*.request.error.error_response_msg')"
+        :model-value="request?.error?.error_response_msg"
+        @update:model-value="request!.error!.error_response_msg = $event"
+      />
+    </ObjectField>
+
+    <StringField
+      autosize
+      class="rc-code"
+      label="Request › By Lua"
+      :label-attributes="getLabelAttributes('callouts.*.request.by_lua')"
+      :model-value="request?.by_lua"
+      multiline
+      placeholder="Enter Lua script here..."
+      @update:model-value="request!.by_lua = $event"
+    />
+  </ObjectField>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import ArrayField from '../shared/ArrayField.vue'
+import KeyValueField from '../shared/KeyValueField.vue'
+import ObjectField from '../shared/ObjectField.vue'
+import { useFormShared } from './composables'
+import { getDefaultCalloutRequestBody, getDefaultCalloutRequestError, getDefaultCalloutRequestHeaders, getDefaultCalloutRequestHttpOpts, getDefaultCalloutRequestHttpOptsProxy, getDefaultCalloutRequestHttpOptsTimeouts, getDefaultCalloutRequestQuery, toSelectItems } from './utils'
+import StringField from '../shared/StringField.vue'
+import BooleanField from '../shared/BooleanField.vue'
+import SelectField from '../shared/EnumField.vue'
+import NumberField from '../shared/NumberField.vue'
+
+const METHODS = toSelectItems([
+  'GET',
+  'POST',
+  'PUT',
+  'DELETE',
+  'PATCH',
+  'HEAD',
+  'OPTIONS',
+  'CONNECT',
+  'TRACE',
+])
+
+const ERROR_STRATEGIES = toSelectItems([
+  'retry',
+  'fail',
+  'continue',
+])
+
+const props = defineProps<{
+  calloutIndex: number;
+}>()
+
+const { formData, getLabelAttributes } = useFormShared()
+
+const request = computed(() => formData.callouts?.[props.calloutIndex]?.request)
+
+function setHeaders(value: boolean) {
+  const request = formData.callouts?.[props.calloutIndex]?.request
+  if (request == null) {
+    return
+  }
+
+  if (value) {
+    request.headers = getDefaultCalloutRequestHeaders()
+  } else {
+    delete request.headers
+  }
+}
+
+function setQuery(value: boolean) {
+  const request = formData.callouts?.[props.calloutIndex]?.request
+  if (request == null) {
+    return
+  }
+
+  if (value) {
+    request.query = getDefaultCalloutRequestQuery()
+  } else {
+    delete request.query
+  }
+}
+
+function setBody(value: boolean) {
+  const request = formData.callouts?.[props.calloutIndex]?.request
+  if (request == null) {
+    return
+  }
+
+  if (value) {
+    request.body = getDefaultCalloutRequestBody()
+  } else {
+    delete request.body
+  }
+}
+
+function setHttpOpts(value: boolean) {
+  const request = formData.callouts?.[props.calloutIndex]?.request
+  if (request == null) {
+    return
+  }
+
+  if (value) {
+    request.http_opts = getDefaultCalloutRequestHttpOpts()
+  } else {
+    delete request.http_opts
+  }
+}
+
+function setTimeouts(value: boolean) {
+  const opts = formData.callouts?.[props.calloutIndex]?.request?.http_opts
+  if (opts == null) {
+    return
+  }
+
+  if (value) {
+    opts.timeouts = getDefaultCalloutRequestHttpOptsTimeouts()
+  } else {
+    delete opts.timeouts
+  }
+}
+
+function setProxy(value: boolean) {
+  const opts = formData.callouts?.[props.calloutIndex]?.request?.http_opts
+  if (opts == null) {
+    return
+  }
+
+  if (value) {
+    opts.proxy = getDefaultCalloutRequestHttpOptsProxy()
+  } else {
+    delete opts.proxy
+  }
+}
+
+function setError(value: boolean) {
+  const request = formData.callouts?.[props.calloutIndex]?.request
+  if (request == null) {
+    return
+  }
+
+  if (value) {
+    request.error = getDefaultCalloutRequestError()
+  } else {
+    delete request.error
+  }
+}
+
+function addHttpStatus() {
+  const request = formData.callouts?.[props.calloutIndex]?.request
+  if (request == null) {
+    return
+  }
+
+  if (request.error?.http_statuses == null) {
+    request.error!.http_statuses = []
+  }
+
+  request.error!.http_statuses.push(null)
+}
+
+function removeHttpStatus(index: number) {
+  const error = formData.callouts?.[props.calloutIndex]?.request?.error
+  if (error?.http_statuses == null) {
+    return
+  }
+  error.http_statuses.splice(index, 1)
+  if (error.http_statuses.length === 0) {
+    delete error.http_statuses
+  }
+}
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutRequestForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutRequestForm.vue
@@ -10,7 +10,7 @@
       @update:model-value="request!.url = $event"
     />
 
-    <SelectField
+    <EnumField
       clearable
       :items="METHODS"
       label="Request › Method"
@@ -170,7 +170,7 @@
       :label-attributes="getLabelAttributes('callouts.*.request.error')"
       @update:added="setError"
     >
-      <SelectField
+      <EnumField
         :items="ERROR_STRATEGIES"
         label="Request › Error › On Error"
         :label-attributes="getLabelAttributes('callouts.*.request.error.on_error')"
@@ -239,7 +239,7 @@ import { useFormShared } from './composables'
 import { getDefaultCalloutRequestBody, getDefaultCalloutRequestError, getDefaultCalloutRequestHeaders, getDefaultCalloutRequestHttpOpts, getDefaultCalloutRequestHttpOptsProxy, getDefaultCalloutRequestHttpOptsTimeouts, getDefaultCalloutRequestQuery, toSelectItems } from './utils'
 import StringField from '../shared/StringField.vue'
 import BooleanField from '../shared/BooleanField.vue'
-import SelectField from '../shared/EnumField.vue'
+import EnumField from '../shared/EnumField.vue'
 import NumberField from '../shared/NumberField.vue'
 
 const METHODS = toSelectItems([

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutResponseForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutResponseForm.vue
@@ -1,0 +1,88 @@
+<template>
+  <ObjectField
+    label="Response"
+    :label-attributes="getLabelAttributes('callouts.*.response')"
+    required
+  >
+    <ObjectField
+      label="Response › Headers"
+      :label-attributes="getLabelAttributes('callouts.*.response.headers')"
+      @update:added="setHeaders"
+    >
+      <BooleanField
+        label="Response › Headers › Store"
+        :label-attributes="getLabelAttributes('callouts.*.response.headers.store')"
+        :model-value="formData.callouts?.[calloutIndex].response.headers?.store ?? false"
+        @update:model-value="formData.callouts![calloutIndex]!.response.headers!.store = $event"
+      />
+    </ObjectField>
+    <ObjectField
+      label="Response › Body"
+      :label-attributes="getLabelAttributes('callouts.*.response.body')"
+      @update:added="setBody"
+    >
+      <BooleanField
+        label="Response › Body › Store"
+        :label-attributes="getLabelAttributes('callouts.*.response.body.store')"
+        :model-value="formData.callouts?.[calloutIndex].response.body?.store ?? false"
+        @update:model-value="formData.callouts![calloutIndex]!.response.body!.store = $event"
+      />
+      <BooleanField
+        label="Response › Body › Decode"
+        :label-attributes="getLabelAttributes('callouts.*.response.body.decode')"
+        :model-value="formData.callouts?.[calloutIndex].response.body?.decode ?? false"
+        @update:model-value="formData.callouts![calloutIndex]!.response.body!.decode = $event"
+      />
+    </ObjectField>
+    <StringField
+      autosize
+      class="rc-code"
+      label="Response › By Lua"
+      :label-attributes="getLabelAttributes('callouts.*.response.by_lua')"
+      :model-value="formData.callouts?.[calloutIndex].response.by_lua ?? ''"
+      multiline
+      placeholder="Enter Lua script here..."
+      @update:model-value="formData.callouts![calloutIndex]!.response.by_lua = $event"
+    />
+  </ObjectField>
+</template>
+
+<script setup lang="ts">
+import BooleanField from '../shared/BooleanField.vue'
+import ObjectField from '../shared/ObjectField.vue'
+import StringField from '../shared/StringField.vue'
+import { useFormShared } from './composables'
+import { getDefaultCalloutResponseBody, getDefaultCalloutResponseHeaders } from './utils'
+
+const props = defineProps<{
+  calloutIndex: number;
+}>()
+
+const { formData, getLabelAttributes } = useFormShared()
+
+function setHeaders(value: boolean) {
+  const response = formData.callouts?.[props.calloutIndex]?.response
+  if (response == null) {
+    return
+  }
+
+  if (value) {
+    response.headers = getDefaultCalloutResponseHeaders()
+  } else {
+    delete response.headers
+  }
+}
+
+function setBody(value: boolean) {
+  const response = formData.callouts?.[props.calloutIndex]?.response
+  if (response == null) {
+    return
+  }
+
+  if (value) {
+    response.body = getDefaultCalloutResponseBody()
+  } else {
+    delete response.body
+  }
+}
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutsForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/CalloutsForm.vue
@@ -1,0 +1,44 @@
+<template>
+  <ArrayField
+    appearance="tabs"
+    :item-label="(callout: Callout) => callout.name || 'New callout'"
+    item-label-field="name"
+    :items="formData.callouts"
+    label="Callouts"
+    :label-attributes="getLabelAttributes('callouts')"
+    sticky-tabs
+    @add="addCallout"
+    @remove="removeCallout"
+  >
+    <template #item="{ index }">
+      <CalloutForm :index="index" />
+    </template>
+  </ArrayField>
+</template>
+
+<script setup lang="ts">
+import { useFormShared } from './composables'
+import ArrayField from '../shared/ArrayField.vue'
+import CalloutForm from './CalloutForm.vue'
+import { getDefaultCallout } from './utils'
+import type { Callout } from './types'
+
+const { formData, getLabelAttributes } = useFormShared()
+
+function addCallout() {
+  if (!formData.callouts) {
+    formData.callouts = []
+  }
+  formData.callouts.push(getDefaultCallout())
+}
+
+function removeCallout(index: number) {
+  if (formData.callouts == null) {
+    return
+  }
+  formData.callouts.splice(index, 1)
+  if (formData.callouts.length === 0) {
+    delete formData.callouts
+  }
+}
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/ConfigForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/ConfigForm.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="rc-config-form">
+    <CalloutsForm />
+    <UpstreamForm />
+    <CacheForm />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch, provide } from 'vue'
+import CalloutsForm from './CalloutsForm.vue'
+import UpstreamForm from './UpstreamForm.vue'
+
+import type { RequestCallout } from './types'
+import { DATA_INJECTION_KEY, SCHEMA_INJECTION_KEY, useSchemaMap } from './composables'
+import { getDefaultRequestCallout } from './utils'
+import CacheForm from './CacheForm.vue'
+
+const props = defineProps<{
+  schema: Record<string, any>
+}>()
+
+const formData = reactive<RequestCallout>(getDefaultRequestCallout())
+provide(DATA_INJECTION_KEY, formData)
+
+const { getSchemaByPath } = useSchemaMap(() => props.schema)
+provide(SCHEMA_INJECTION_KEY, getSchemaByPath)
+
+const emit = defineEmits<{
+  change: [value: RequestCallout]
+}>()
+
+watch(formData, (newVal) => {
+  emit('change', newVal)
+}, { deep: true })
+</script>
+
+<style lang="scss" scoped>
+:deep(.rc-code textarea) {
+  font-family: $kui-font-family-code !important;
+}
+
+:deep(.k-label) {
+  font-weight: $kui-font-weight-medium;
+}
+
+.rc-config-form {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-100;
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/RedisForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/RedisForm.vue
@@ -1,0 +1,212 @@
+<template>
+  <ObjectField
+    label="Cache › Redis"
+    :label-attributes="getLabelAttributes('cache.redis')"
+    required
+  >
+    <StringField
+      v-model="formData.cache.redis.host"
+      label="Cache › Redis › Host"
+      :label-attributes="getLabelAttributes('cache.redis.host')"
+    />
+    <NumberField
+      v-model="formData.cache.redis.port"
+      label="Cache › Redis › Port"
+      :label-attributes="getLabelAttributes('cache.redis.port')"
+      max="65535"
+      min="0"
+    />
+    <NumberField
+      v-model="formData.cache.redis.connect_timeout"
+      label="Cache › Redis › Connect Timeout"
+      :label-attributes="getLabelAttributes('cache.redis.connect_timeout')"
+      max="2147473646"
+      min="0"
+    />
+    <NumberField
+      v-model="formData.cache.redis.send_timeout"
+      label="Cache › Redis › Send Timeout"
+      :label-attributes="getLabelAttributes('cache.redis.send_timeout')"
+      max="2147473646"
+      min="0"
+    />
+    <NumberField
+      v-model="formData.cache.redis.read_timeout"
+      label="Cache › Redis › Read Timeout"
+      :label-attributes="getLabelAttributes('cache.redis.read_timeout')"
+      max="2147473646"
+      min="0"
+    />
+    <StringField
+      v-model="formData.cache.redis.username"
+      label="Cache › Redis › Username"
+      :label-attributes="getLabelAttributes('cache.redis.username')"
+      show-vault-secret-picker
+    />
+    <StringField
+      v-model="formData.cache.redis.password"
+      label="Cache › Redis › Password"
+      :label-attributes="getLabelAttributes('cache.redis.password')"
+      show-vault-secret-picker
+    />
+    <StringField
+      v-model="formData.cache.redis.sentinel_username"
+      label="Cache › Redis › Sentinel Username"
+      :label-attributes="getLabelAttributes('cache.redis.sentinel_username')"
+      show-vault-secret-picker
+    />
+    <StringField
+      v-model="formData.cache.redis.sentinel_password"
+      label="Cache › Redis › Sentinel Password"
+      :label-attributes="getLabelAttributes('cache.redis.sentinel_password')"
+      show-vault-secret-picker
+    />
+    <NumberField
+      v-model="formData.cache.redis.database"
+      label="Cache › Redis › Database"
+      :label-attributes="getLabelAttributes('cache.redis.database')"
+    />
+    <NumberField
+      v-model="formData.cache.redis.keepalive_pool_size"
+      label="Cache › Redis › Keepalive Pool Size"
+      :label-attributes="getLabelAttributes('cache.redis.keepalive_pool_size')"
+      max="2147483646"
+      min="1"
+    />
+    <NumberField
+      v-model="formData.cache.redis.keepalive_backlog"
+      label="Cache › Redis › Keepalive Backlog"
+      :label-attributes="getLabelAttributes('cache.redis.keepalive_backlog')"
+      max="2147483646"
+      min="0"
+    />
+    <StringField
+      v-model="formData.cache.redis.sentinel_master"
+      label="Cache › Redis › Sentinel Master"
+      :label-attributes="getLabelAttributes('cache.redis.sentinel_master')"
+    />
+    <SelectField
+      v-model="formData.cache.redis.sentinel_role"
+      clearable
+      :items="SENTINEL_ROLES"
+      label="Cache › Redis › Sentinel Role"
+      :label-attributes="getLabelAttributes('cache.redis.sentinel_role')"
+    />
+    <ArrayField
+      appearance="card"
+      :items="formData.cache.redis.sentinel_nodes"
+      label="Cache › Redis › Sentinel Nodes"
+      :label-attributes="getLabelAttributes('cache.redis.sentinel_nodes')"
+      @add="addSentinelNode"
+      @remove="removeSentinelNode"
+    >
+      <template #item="{ item }">
+        <StringField
+          v-model="item.host"
+          label="Host"
+          :label-attributes="getLabelAttributes('cache.redis.sentinel_nodes.*.host')"
+          required
+        />
+        <NumberField
+          v-model="item.port"
+          label="Port"
+          :label-attributes="getLabelAttributes('cache.redis.sentinel_nodes.*.port')"
+          max="65535"
+          min="0"
+        />
+      </template>
+    </ArrayField>
+    <ArrayField
+      appearance="card"
+      :items="formData.cache.redis.cluster_nodes"
+      label="Cache › Redis › Cluster Nodes"
+      :label-attributes="getLabelAttributes('cache.redis.cluster_nodes')"
+      @add="addClusterNode"
+      @remove="removeClusterNode"
+    >
+      <template #item="{ item }">
+        <StringField
+          v-model="item.ip"
+          label="IP"
+          :label-attributes="getLabelAttributes('cache.redis.cluster_nodes.*.ip')"
+          required
+        />
+        <NumberField
+          v-model="item.port"
+          label="Port"
+          :label-attributes="getLabelAttributes('cache.redis.cluster_nodes.*.port')"
+          max="65535"
+          min="0"
+        />
+      </template>
+    </ArrayField>
+
+    <BooleanField
+      label="Cache › Redis › SSL"
+      :label-attributes="getLabelAttributes('cache.redis.ssl')"
+      :model-value="formData.cache.redis.ssl || false"
+      @update:model-value="formData.cache.redis.ssl = $event"
+    />
+
+    <BooleanField
+      label="Cache › Redis › SSL Verify"
+      :label-attributes="getLabelAttributes('cache.redis.ssl_verify')"
+      :model-value="formData.cache.redis.ssl_verify || false"
+      @update:model-value="formData.cache.redis.ssl_verify = $event"
+    />
+
+    <StringField
+      v-model="formData.cache.redis.server_name"
+      label="Cache › Redis › Server Name"
+      :label-attributes="getLabelAttributes('cache.redis.server_name')"
+    />
+    <NumberField
+      v-model="formData.cache.redis.cluster_max_redirections"
+      label="Cache › Redis › Cluster Max Redirections"
+      :label-attributes="getLabelAttributes('cache.redis.cluster_max_redirections')"
+    />
+    <BooleanField
+      label="Cache › Redis › Connection Is Proxied"
+      :label-attributes="getLabelAttributes('cache.redis.connection_is_proxied')"
+      :model-value="formData.cache.redis.connection_is_proxied || false"
+      @update:model-value="formData.cache.redis.connection_is_proxied = $event"
+    />
+  </ObjectField>
+</template>
+
+<script setup lang="ts">
+import ArrayField from '../shared/ArrayField.vue'
+import BooleanField from '../shared/BooleanField.vue'
+import StringField from '../shared/StringField.vue'
+import NumberField from '../shared/NumberField.vue'
+import ObjectField from '../shared/ObjectField.vue'
+import SelectField from '../shared/EnumField.vue'
+import { useFormShared } from './composables'
+import { getDefaultRedisClusterNode, getDefaultRedisSentinelNode, toSelectItems } from './utils'
+
+const SENTINEL_ROLES = toSelectItems(['master', 'slave', 'any'])
+
+const { formData, getLabelAttributes } = useFormShared()
+
+function addSentinelNode() {
+  if (!formData.cache.redis.sentinel_nodes) {
+    formData.cache.redis.sentinel_nodes = []
+  }
+  formData.cache.redis.sentinel_nodes.push(getDefaultRedisSentinelNode())
+}
+
+function removeSentinelNode(index: number) {
+  formData.cache.redis.sentinel_nodes?.splice(index, 1)
+}
+
+function addClusterNode() {
+  if (!formData.cache.redis.cluster_nodes) {
+    formData.cache.redis.cluster_nodes = []
+  }
+  formData.cache.redis.cluster_nodes.push(getDefaultRedisClusterNode())
+}
+
+function removeClusterNode(index: number) {
+  formData.cache.redis.cluster_nodes?.splice(index, 1)
+}
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/RedisForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/RedisForm.vue
@@ -85,7 +85,7 @@
       label="Cache › Redis › Sentinel Master"
       :label-attributes="getLabelAttributes('cache.redis.sentinel_master')"
     />
-    <SelectField
+    <EnumField
       v-model="formData.cache.redis.sentinel_role"
       clearable
       :items="SENTINEL_ROLES"
@@ -180,7 +180,7 @@ import BooleanField from '../shared/BooleanField.vue'
 import StringField from '../shared/StringField.vue'
 import NumberField from '../shared/NumberField.vue'
 import ObjectField from '../shared/ObjectField.vue'
-import SelectField from '../shared/EnumField.vue'
+import EnumField from '../shared/EnumField.vue'
 import { useFormShared } from './composables'
 import { getDefaultRedisClusterNode, getDefaultRedisSentinelNode, toSelectItems } from './utils'
 

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/RequestCalloutForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/RequestCalloutForm.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="sc-form-pinned-fields">
+    <VueFormGenerator
+      :model="formModel"
+      :options="formOptions"
+      :schema="pinnedSchema"
+      @model-updated="(value: any, model: string) => onModelUpdated(value, model)"
+    />
+  </div>
+
+  <KCollapse
+    v-model="configCollapse"
+    class="sc-form-config-fields"
+  >
+    <template #title>
+      {{ t('plugins.form.grouping.plugin_configuration.title') }}
+    </template>
+    <template #visible-content>
+      {{ t('plugins.form.grouping.plugin_configuration.description') }}
+    </template>
+
+    <ConfigForm
+      class="sc-form-config-form"
+      :schema="schema"
+      @change="handleChange"
+    />
+
+    <KCollapse
+      v-model="advancedCollapsed"
+      :trigger-label="advancedCollapsed ? t('plugins.form.grouping.advanced_parameters.view') : t('plugins.form.grouping.advanced_parameters.hide')"
+    >
+      <VueFormGenerator
+        :model="formModel"
+        :options="formOptions"
+        :schema="advancedSchema"
+        @model-updated="(value: any, model: string) => onModelUpdated(value, model)"
+      />
+    </KCollapse>
+  </KCollapse>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, toValue, provide, type MaybeRefOrGetter } from 'vue'
+import { createI18n } from '@kong-ui-public/i18n'
+import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
+import { VueFormGenerator } from '@kong-ui-public/forms'
+import { KCollapse } from '@kong/kongponents'
+import english from '../../../locales/en.json'
+import ConfigForm from './ConfigForm.vue'
+import type { RequestCallout } from './types'
+
+const { t } = createI18n<typeof english>('en-us', english)
+
+const props = defineProps<{
+  schema: any
+  formSchema: any
+  model: Record<string, any>
+  formModel: Record<string, any>
+  formOptions: any
+  isEditing: boolean
+  onModelUpdated: (value: any, model: string) => void
+  onConfigChange: (value: RequestCallout) => void
+}>()
+
+const slots = defineSlots<{
+  [K in typeof AUTOFILL_SLOT_NAME]: () => any
+}>()
+
+provide(AUTOFILL_SLOT, slots?.[AUTOFILL_SLOT_NAME])
+
+function usePickedSchema(keys: MaybeRefOrGetter<string[]>) {
+  return computed(() => ({
+    fields: toValue(keys)
+      .map(key => props.formSchema?.fields.find((field: { model: string }) => field.model === key))
+      .filter(Boolean),
+  }))
+}
+
+const PINNED_FIELD_KEYS = ['enabled', 'selectionGroup']
+const topLevelFieldKeys = computed(() => ((props.formSchema?.fields || []) as any[]).map((field: { model: string }) => field.model))
+const configFieldKeys = computed(() => topLevelFieldKeys.value.filter(key => key.startsWith('config-')))
+const advancedFieldKeys = computed(() => topLevelFieldKeys.value.filter(key => !PINNED_FIELD_KEYS.includes(key) && !configFieldKeys.value.includes(key)))
+
+const pinnedSchema = usePickedSchema(PINNED_FIELD_KEYS)
+const advancedSchema = usePickedSchema(advancedFieldKeys)
+
+const configCollapse = ref(false)
+const advancedCollapsed = ref(true)
+
+function handleChange(value: RequestCallout) {
+  props.onConfigChange(value)
+}
+</script>
+
+<style lang="scss" scoped>
+.sc-form-config-fields {
+  border-top: $kui-border-width-10 solid $kui-color-border;
+  margin-top: $kui-space-80;
+  padding-top: $kui-space-80;
+}
+
+.sc-form-config-form {
+  margin: $kui-space-100 0;
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/UpstreamForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/UpstreamForm.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-mutating-props -->
 <template>
   <ObjectField
     appearance="card"

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/UpstreamForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/UpstreamForm.vue
@@ -1,0 +1,96 @@
+<!-- eslint-disable vue/no-mutating-props -->
+<template>
+  <ObjectField
+    appearance="card"
+    label="Upstream"
+    :label-attributes="getLabelAttributes('upstream')"
+    required
+  >
+    <ObjectField
+      label="Upstream › Headers"
+      :label-attributes="getLabelAttributes('upstream.headers')"
+      required
+    >
+      <BooleanField
+        label="Upstream › Headers › Forward"
+        :label-attributes="getLabelAttributes('upstream.headers.forward')"
+        :model-value="formData.upstream.headers.forward ?? false"
+        @update:model-value="formData.upstream.headers.forward = $event"
+      />
+
+      <KeyValueField
+        :initial-value="formData.upstream.headers.custom"
+        label="Upstream › Headers › Custom"
+        :label-attributes="getLabelAttributes('upstream.headers.custom')"
+        @change="handleCustomChange('headers', $event)"
+      />
+    </ObjectField>
+
+    <ObjectField
+      label="Upstream › Query"
+      :label-attributes="getLabelAttributes('upstream.query')"
+      required
+    >
+      <BooleanField
+        label="Upstream › Query › Forward"
+        :label-attributes="getLabelAttributes('upstream.query.forward')"
+        :model-value="formData.upstream.query.forward ?? false"
+        @update:model-value="formData.upstream.query.forward = $event"
+      />
+
+      <KeyValueField
+        :initial-value="formData.upstream.query.custom"
+        label="Upstream › Query › Custom"
+        :label-attributes="getLabelAttributes('upstream.query.custom')"
+        @change="handleCustomChange('query', $event)"
+      />
+    </ObjectField>
+
+    <ObjectField
+      label="Upstream › Body"
+      required
+    >
+      <BooleanField
+        label="Upstream › Body › Forward"
+        :label-attributes="getLabelAttributes('upstream.body.forward')"
+        :model-value="formData.upstream.body.forward ?? false"
+        @update:model-value="formData.upstream.body.forward = $event"
+      />
+
+      <KeyValueField
+        :initial-value="formData.upstream.body.custom"
+        label="Upstream › Body › Custom"
+        :label-attributes="getLabelAttributes('upstream.body.custom')"
+        @change="handleCustomChange('body', $event)"
+      />
+    </ObjectField>
+
+    <StringField
+      v-model="formData.upstream.by_lua"
+      autosize
+      class="rc-code"
+      label="Upstream › By Lua"
+      :label-attributes="getLabelAttributes('upstream.by_lua')"
+      multiline
+      placeholder="Enter Lua script here..."
+    />
+  </ObjectField>
+</template>
+
+<script setup lang="ts">
+import { useFormShared } from './composables'
+import KeyValueField from '../shared/KeyValueField.vue'
+import ObjectField from '../shared/ObjectField.vue'
+import BooleanField from '../shared/BooleanField.vue'
+import StringField from '../shared/StringField.vue'
+
+const { formData, getLabelAttributes } = useFormShared()
+
+function handleCustomChange(type: 'headers' | 'query' | 'body', value: Record<string, string>) {
+  if (Object.keys(value).length === 0) {
+    delete formData.upstream[type].custom
+    return
+  }
+  formData.upstream[type].custom = value
+}
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/composables.ts
@@ -1,0 +1,97 @@
+import { computed, inject, toRaw, toValue, type MaybeRefOrGetter } from 'vue'
+import type { RequestCallout } from './types'
+import { marked } from 'marked'
+
+export const DATA_INJECTION_KEY = Symbol('request-callout-form')
+export const SCHEMA_INJECTION_KEY = Symbol('request-callout-schema')
+
+const SHARED_LABEL_ATTRIBUTES = {
+  tooltipAttributes: {
+    maxWidth: '300px',
+    placement: 'top',
+  },
+} as const
+
+export function useFormShared() {
+  const formData = inject<RequestCallout>(DATA_INJECTION_KEY)
+  const getSchemaByPath = inject<(path: string) => any>(SCHEMA_INJECTION_KEY)
+
+  if (!formData) {
+    throw new Error('useFormShared() called without provider.')
+  }
+
+  if (!getSchemaByPath) {
+    throw new Error('useFormShared() called without schema provider.')
+  }
+
+  function getLabelAttributes(fieldPath: string) {
+    const fieldSchema = getSchemaByPath!(fieldPath)
+    const info = fieldSchema?.description ? marked.parse(fieldSchema.description, { async: false }) : undefined
+    return {
+      ...SHARED_LABEL_ATTRIBUTES,
+      info,
+    }
+  }
+
+  return { formData, getSchemaByPath, getLabelAttributes }
+}
+
+// Construct a map of all fields in a schema, with their full paths as keys
+// eg. { 'cache.memory.dictionary_name': { type: 'string', ... }, ... }
+// Array elements are represented as 'path.*'.
+function buildSchemaMap(schema: any, pathPrefix: string = ''): Record<string, any> {
+  const schemaMap: Record<string, any> = {}
+
+  // Process only if the schema is a record with fields
+  if (schema.type === 'record' && Array.isArray(schema.fields)) {
+    for (const fieldDef of schema.fields) {
+      // Each fieldDef is an object with one key (the field name)
+      const fieldName = Object.keys(fieldDef)[0]
+      const fieldProps = fieldDef[fieldName]
+
+      // Construct the full path for this field
+      const fieldPath = pathPrefix ? `${pathPrefix}.${fieldName}` : fieldName
+
+      // Store the field's metadata in the map
+      schemaMap[fieldPath] = fieldProps
+
+      // Recurse based on field type
+      if (fieldProps.type === 'record' && Array.isArray(fieldProps.fields)) {
+        // For records, process nested fields with the current path as prefix
+        const subMap = buildSchemaMap(fieldProps, fieldPath)
+        Object.assign(schemaMap, subMap)
+      } else if (fieldProps.type === 'array' && fieldProps.elements) {
+        const elementProps = fieldProps.elements
+        const elementPath = `${fieldPath}.*`
+
+        // If array elements are records, process their fields
+        if (elementProps.type === 'record' && Array.isArray(elementProps.fields)) {
+          const subMap = buildSchemaMap(elementProps, elementPath)
+          Object.assign(schemaMap, subMap)
+        }
+      }
+    }
+  }
+
+  return schemaMap
+}
+
+// Given a schema, return a function to retrieve a field's metadata by its full path
+export function useSchemaMap(schema: MaybeRefOrGetter<any>) {
+  const schemaValue = toValue(schema)
+  const schemaMap = computed(() => {
+    const configSchema = schemaValue?.fields?.find((field: any) => 'config' in field)?.config
+    if (!configSchema) {
+      return {}
+    }
+    return buildSchemaMap(toRaw(configSchema))
+  })
+
+  function getSchemaByPath(path: string): any {
+    return schemaMap.value?.[path]
+  }
+
+  return {
+    getSchemaByPath,
+  }
+}

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/index.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RequestCalloutForm.vue'

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/types.ts
@@ -1,0 +1,172 @@
+export interface RequestCallout {
+  callouts?: Callout[]
+  cache: Cache
+  upstream: Upstream
+}
+
+/************************************************
+ *                     Cache                    *
+ ************************************************/
+
+export interface Cache {
+  strategy?: 'memory' | 'redis' | null
+  memory: {
+    dictionary_name: string | null
+  }
+  redis: Redis
+  cache_ttl?: number | null
+}
+
+export interface Redis {
+  host?: string | null
+  port?: number | null
+  connect_timeout?: number | null
+  send_timeout?: number | null
+  read_timeout?: number | null
+  /**
+   * @description referenceable: true
+   */
+  username?: string | null
+  /**
+   * @description referenceable: true
+   */
+  password?: string | null
+  /**
+   * @description referenceable: true
+   */
+  sentinel_username?: string | null
+  /**
+   * @description referenceable: true
+   */
+  sentinel_password?: string | null
+  database?: number | null
+  keepalive_pool_size?: number | null
+  keepalive_backlog?: number | null
+  sentinel_master?: string | null
+  sentinel_role?: 'master' | 'slave' | 'any' | null
+  sentinel_nodes?: RedisSentinelNode[]
+  cluster_nodes?: RedisClusterNode[]
+  ssl?: boolean
+  ssl_verify?: boolean
+  server_name?: string | null
+  cluster_max_redirections?: number | null
+  connection_is_proxied?: boolean
+}
+
+export interface RedisSentinelNode {
+  host: string | null
+  port?: number | null
+}
+
+export interface RedisClusterNode {
+  ip: string | null
+  port?: number | null
+}
+
+/************************************************
+ *                    Callout                   *
+ ************************************************/
+
+export interface Callout {
+  name: string | null
+  depends_on?: string[]
+  request?: CalloutRequest
+  response: CalloutResponse
+  cache?: CalloutCache
+}
+
+export interface CalloutRequest {
+  url: string | null
+  method?: string | null
+  headers?: CalloutRequestHeaders
+  query?: CalloutRequestQuery
+  body?: CalloutRequestBody
+  http_opts?: CalloutRequestHttpOpts
+  error?: CalloutRequestError
+  by_lua?: string | null
+}
+
+export interface CalloutRequestHeaders {
+  forward?: boolean
+  custom?: Record<string, string>
+}
+
+export interface CalloutRequestQuery {
+  forward?: boolean
+  custom?: Record<string, string>
+}
+
+export interface CalloutRequestBody {
+  forward?: boolean
+  decode?: boolean
+  custom?: Record<string, string>
+}
+
+export interface CalloutRequestHttpOpts {
+  ssl_verify?: boolean
+  ssl_server_name?: string | null
+  timeouts?: CalloutRequestTimeouts
+  proxy?: CalloutRequestProxy
+}
+
+export interface CalloutRequestTimeouts {
+  connect?: number | null
+  write?: number | null
+  read?: number | null
+}
+
+export interface CalloutRequestProxy {
+  http_proxy: string | null
+  https_proxy: string | null
+  auth_username?: string | null
+  auth_password?: string | null
+}
+
+export interface CalloutRequestError {
+  on_error?: 'retry' | 'fail' | 'continue' | null
+  retries?: number | null
+  http_statuses?: (number | null)[]
+  error_response_code?: number | null
+  error_response_msg?: string | null
+}
+
+export interface CalloutResponse {
+  headers?: CalloutResponseHeaders
+  body?: CalloutResponseBody
+  by_lua?: string | null
+}
+
+export interface CalloutResponseHeaders {
+  store?: boolean
+}
+
+export interface CalloutResponseBody {
+  store?: boolean
+  decode?: boolean
+}
+
+export interface CalloutCache {
+  bypass?: boolean
+}
+
+/************************************************
+ *                   Upstream                   *
+ ************************************************/
+
+export interface Upstream {
+  headers: {
+    forward?: boolean
+    custom?: Record<string, string>
+  }
+  query: {
+    forward?: boolean
+    custom?: Record<string, string>
+  }
+  body: {
+    forward?: boolean
+    decode?: boolean
+    custom?: Record<string, string>
+  }
+  by_lua?: string | null
+}
+

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/utils.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/utils.ts
@@ -1,0 +1,210 @@
+import type {
+  Cache,
+  Callout,
+  CalloutCache,
+  CalloutRequest,
+  CalloutRequestBody,
+  CalloutRequestError,
+  CalloutRequestHeaders,
+  CalloutRequestHttpOpts,
+  CalloutRequestProxy,
+  CalloutRequestQuery,
+  CalloutRequestTimeouts,
+  CalloutResponse,
+  RedisClusterNode,
+  Redis,
+  RequestCallout,
+  Upstream,
+  RedisSentinelNode,
+  CalloutResponseHeaders,
+  CalloutResponseBody,
+} from './types'
+
+export function getDefaultRequestCallout(): RequestCallout {
+  return {
+    cache: getDefaultCache(),
+    upstream: getDefaultUpstream(),
+  }
+}
+
+/************************************************
+ *                     Cache                    *
+ ************************************************/
+
+export function getDefaultCache(): Cache {
+  return {
+    strategy: 'memory',
+    memory: {
+      dictionary_name: 'kong_db_cache',
+    },
+    redis: getDefaultRedis(),
+    cache_ttl: 300,
+  }
+}
+
+export function getDefaultRedis(): Redis {
+  return {
+    host: '127.0.0.1',
+    port: 6379,
+    connect_timeout: 2000,
+    send_timeout: 2000,
+    read_timeout: 2000,
+    database: 0,
+    keepalive_pool_size: 256,
+    ssl: false,
+    ssl_verify: false,
+    cluster_max_redirections: 5,
+    connection_is_proxied: false,
+  }
+}
+
+export function getDefaultRedisSentinelNode(): RedisSentinelNode {
+  return {
+    host: '127.0.0.1',
+    port: 6379,
+  }
+}
+
+export function getDefaultRedisClusterNode(): RedisClusterNode {
+  return {
+    ip: '127.0.0.1',
+    port: 6379,
+  }
+}
+
+/************************************************
+ *                    Callout                   *
+ ************************************************/
+
+export function getDefaultCallout(): Callout {
+  return {
+    name: '',
+    depends_on: [],
+    request: getDefaultCalloutRequest(),
+    response: getDefaultCalloutResponse(),
+    cache: getDefaultCalloutCache(),
+  }
+}
+
+export function getDefaultCalloutRequest(): CalloutRequest {
+  return {
+    url: '',
+    method: 'GET',
+    headers: getDefaultCalloutRequestHeaders(),
+    query: getDefaultCalloutRequestQuery(),
+    body: getDefaultCalloutRequestBody(),
+    http_opts: getDefaultCalloutRequestHttpOpts(),
+    error: getDefaultCalloutRequestError(),
+    by_lua: '',
+  }
+}
+
+export function getDefaultCalloutRequestHeaders(): CalloutRequestHeaders {
+  return {
+    forward: false,
+    custom: {},
+  }
+}
+
+export function getDefaultCalloutRequestQuery(): CalloutRequestQuery {
+  return {
+    forward: false,
+    custom: {},
+  }
+}
+
+export function getDefaultCalloutRequestBody(): CalloutRequestBody {
+  return {
+    forward: false,
+    decode: false,
+    custom: {},
+  }
+}
+
+export function getDefaultCalloutRequestHttpOpts(): CalloutRequestHttpOpts {
+  return {
+    ssl_verify: true,
+    ssl_server_name: '',
+    timeouts: getDefaultCalloutRequestHttpOptsTimeouts(),
+    proxy: getDefaultCalloutRequestHttpOptsProxy(),
+  }
+}
+
+export function getDefaultCalloutRequestHttpOptsTimeouts(): CalloutRequestTimeouts {
+  return {
+    connect: undefined,
+    write: undefined,
+    read: undefined,
+  }
+}
+
+export function getDefaultCalloutRequestHttpOptsProxy(): CalloutRequestProxy {
+  return {
+    auth_username: '',
+    auth_password: '',
+    http_proxy: '',
+    https_proxy: '',
+  }
+}
+
+export function getDefaultCalloutRequestError(): CalloutRequestError {
+  return {
+    on_error: 'retry',
+    retries: 2,
+    http_statuses: [],
+    error_response_code: 400,
+    error_response_msg: 'service callout error',
+  }
+}
+
+export function getDefaultCalloutResponse(): CalloutResponse {
+  return {
+    headers: getDefaultCalloutResponseHeaders(),
+    body: getDefaultCalloutResponseBody(),
+    by_lua: '',
+  }
+}
+
+export function getDefaultCalloutResponseHeaders(): CalloutResponseHeaders {
+  return {
+    store: false,
+  }
+}
+
+export function getDefaultCalloutResponseBody(): CalloutResponseBody {
+  return {
+    store: true,
+    decode: false,
+  }
+}
+
+export function getDefaultCalloutCache(): CalloutCache {
+  return {
+    bypass: false,
+  }
+}
+
+/************************************************
+ *                   Upstream                   *
+ ************************************************/
+
+export function getDefaultUpstream(): Upstream {
+  return {
+    headers: {
+      forward: true,
+    },
+    query: {
+      forward: true,
+    },
+    body: {
+      forward: true,
+      decode: true,
+    },
+  }
+}
+
+export function toSelectItems<T extends string>(
+  items: T[],
+): { value: T; label: T }[] {
+  return items.map((item) => ({ value: item, label: item }))
+}

--- a/packages/entities/entities-plugins/src/components/free-form/index.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/index.ts
@@ -1,0 +1,1 @@
+export { default as RequestCalloutForm } from './RequestCallout'

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
@@ -1,0 +1,293 @@
+<template>
+  <div
+    ref="root"
+    class="ff-array-field"
+    :class="{
+      [`ff-array-field-${appearance ?? 'default'}`]: true,
+      'ff-array-field-sticky-tabs': stickyTabs,
+    }"
+  >
+    <header class="ff-array-field-header">
+      <KLabel
+        v-if="label"
+        class="ff-array-field-label"
+        v-bind="labelAttributes"
+        :required="required"
+      >
+        {{ label }}
+        <template
+          v-if="labelAttributes?.info"
+          #tooltip
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div v-html="labelAttributes?.info" />
+        </template>
+      </KLabel>
+      <KButton
+        appearance="tertiary"
+        icon
+        @click="addItem"
+      >
+        <AddIcon />
+      </KButton>
+    </header>
+
+    <template
+      v-if="realItems.length"
+    >
+      <div
+        v-if="appearance !== 'tabs'"
+        class="ff-array-field-container"
+      >
+        <ListTag
+          v-for="(item, index) of realItems"
+          :key="getKey(item, index)"
+          class="ff-array-field-item"
+          :data-index="index"
+        >
+          <div class="ff-array-field-item-content">
+            <slot
+              :index="index"
+              :item="item"
+              name="item"
+            />
+          </div>
+          <KButton
+            appearance="tertiary"
+            class="ff-array-field-item-remove"
+            icon
+            @click="removeItem(index)"
+          >
+            <TrashIcon />
+          </KButton>
+        </ListTag>
+      </div>
+      <KCard v-else>
+        <KTabs
+          v-model="activeTab"
+          :tabs="tabs"
+        >
+          <template
+            v-for="(item, index) of realItems"
+            :key="getKey(item, index)"
+            #[getKey(item,index)]
+          >
+            <div
+              class="ff-array-field-item"
+              :data-index="index"
+            >
+              <slot
+                :index="index"
+                :item="item"
+                name="item"
+              />
+            </div>
+          </template>
+          <template
+            v-for="(item, index) of realItems"
+            :key="getKey(item, index)"
+            #[`${getKey(item,index)}-anchor`]
+          >
+            {{ getTabTitle(item, index) }}
+            <KButton
+              appearance="tertiary"
+              class="ff-array-field-item-remove"
+              icon
+              @click.stop="removeItem(index)"
+            >
+              <TrashIcon />
+            </KButton>
+          </template>
+        </KTabs>
+      </KCard>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts" generic="T">
+import { useTemplateRef, nextTick, watch, computed, ref } from 'vue'
+import { AddIcon, TrashIcon } from '@kong/icons'
+import { uniqueId } from 'lodash-es'
+import { KCard, type LabelAttributes } from '@kong/kongponents'
+
+const props = defineProps<{
+  items?: T[]
+  label?: string
+  labelAttributes?: LabelAttributes
+  itemLabel?: string | ((item: T, index: number) => string)
+  required?: boolean
+  appearance?: 'default' | 'card' | 'tabs'
+  stickyTabs?: boolean | string | number
+}>()
+
+const emit = defineEmits<{
+  add: [];
+  remove: [index: number];
+}>()
+
+const keyMap = new Map<T, string>()
+const realItems = computed(() => props.items || [])
+
+const ListTag = computed(() => props.appearance === 'card' ? KCard : 'div')
+
+function generateId() {
+  return uniqueId('ff-array-field-')
+}
+
+function getKey(item: T, index: number) {
+  if (typeof item === 'object') {
+    return keyMap.get(item)
+  }
+
+  return `ff-array-field-${index}`
+}
+
+function getTabTitle(item: T, index: number) {
+  return typeof props.itemLabel === 'function'
+    ? props.itemLabel(item, index)
+    : props.itemLabel || `Item #${index}`
+}
+
+const tabs = computed(() => realItems.value.map((item, index) => {
+  const hash = `#${getKey(item, index)}`
+
+  return {
+    hash,
+    title: '',
+  }
+}))
+const activeTab = ref<string>(tabs.value[0]?.hash)
+
+watch(realItems, (newItems) => {
+  newItems.forEach((item) => {
+    if (!keyMap.has(item)) {
+      keyMap.set(item, generateId())
+    }
+  })
+
+  const current = new Set(newItems)
+  keyMap.keys().forEach((key) => {
+    if (!current.has(key)) {
+      keyMap.delete(key)
+    }
+  })
+}, { immediate: true, deep: true })
+
+const addItem = async () => {
+  emit('add')
+
+  if (props.appearance === 'tabs') {
+    await nextTick()
+    activeTab.value = tabs.value[tabs.value.length - 1]?.hash
+  }
+
+  await nextTick()
+  focus(realItems.value.length + 1)
+}
+
+const removeItem = async (index: number) => {
+  emit('remove', index)
+
+  if (props.appearance === 'tabs') {
+    activeTab.value = tabs.value[Math.max(0, index - 1)]?.hash
+  }
+}
+
+const root = useTemplateRef('root')
+
+function focus(index: number) {
+  if (!root.value) {
+    return
+  }
+
+  const i = Math.max(0, Math.min(index, realItems.value.length - 1))
+  root.value
+    .querySelector<HTMLElement>(`[data-index="${i}"] [data-autofocus]`)
+    ?.focus()
+}
+
+const stickyTop = computed(() => {
+  const { appearance, stickyTabs } = props
+  if (appearance !== 'tabs' || stickyTabs == null || stickyTabs === false) {
+    return null
+  }
+
+  return typeof stickyTabs === 'number'
+    ? `${props.stickyTabs}px`
+    : typeof stickyTabs === 'string'
+      ? stickyTabs
+      : '0'
+})
+</script>
+
+<style lang="scss" scoped>
+.ff-array-field {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-40;
+
+  &-label {
+    margin: 0;
+  }
+
+  &-header {
+    align-items: center;
+    display: flex;
+    gap: $kui-space-40;
+    height: 32px;
+  }
+
+  &-container {
+    display: flex;
+    flex-direction: column;
+    gap: $kui-space-60;
+  }
+
+  &-item {
+    display: flex;
+    padding: $kui-space-50 $kui-space-60;
+
+    &-content {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      gap: $kui-space-60;
+    }
+  }
+
+  &-default > &-container > &-item {
+    align-items: center;
+    flex-direction: row;
+    gap: $kui-space-40;
+    padding: 0;
+  }
+
+  &-card > &-container > &-item :deep(.card-content) {
+    align-items: center;
+    flex-direction: row;
+    gap: $kui-space-40;
+  }
+
+  &-tabs &-item {
+    flex-direction: column;
+    gap: $kui-space-80;
+  }
+
+  &-sticky-tabs {
+    :deep(.k-tabs ul) {
+      background-color: $kui-color-background;
+      position: sticky;
+      top: v-bind('stickyTop');
+      z-index: 10;
+    }
+
+    :deep(.k-tabs .tab-link:has(.k-button:hover):hover) {
+      background-color: transparent;
+    }
+  }
+
+  :deep(.k-tooltip p) {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/BooleanField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/BooleanField.vue
@@ -1,0 +1,46 @@
+<template>
+  <KCheckbox
+    class="ff-boolean-field"
+    v-bind="props"
+    @update:model-value="emit('update:modelValue', $event)"
+  >
+    <template
+      v-if="props.labelAttributes?.info"
+      #tooltip
+    >
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div v-html="props.labelAttributes?.info" />
+    </template>
+  </KCheckbox>
+</template>
+
+<script setup lang="ts">
+import { KCheckbox, type LabelAttributes } from '@kong/kongponents'
+import { watch } from 'vue'
+
+// Vue doesn't support the built-in `InstanceType` utility type, so we have to
+// work around it a bit.
+// Props other than `labelAttributes` and `modelValue` here are passed down to the
+// `KCheckbox` via attribute fallthrough.
+interface InputProps {
+  labelAttributes?: LabelAttributes
+  modelValue: boolean
+}
+
+const props = defineProps<InputProps>()
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
+watch(() => props.modelValue, (newVal) => {
+  console.log(newVal)
+})
+</script>
+
+<style lang="scss" scoped>
+.ff-boolean-field {
+  :deep(.k-tooltip p) {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
@@ -1,0 +1,42 @@
+<template>
+  <SelectComponent
+    class="ff-enum-field"
+    v-bind="props"
+  >
+    <template
+      v-if="props.labelAttributes?.info"
+      #label-tooltip
+    >
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div v-html="props.labelAttributes?.info" />
+    </template>
+  </SelectComponent>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { KSelect, KMultiselect, type LabelAttributes } from '@kong/kongponents'
+
+// Vue doesn't support the built-in `InstanceType` utility type, so we have to
+// work around it a bit.
+// Props other than `labelAttributes` here are passed down to the `KSelect` via
+// attribute fallthrough.
+interface InputProps {
+  labelAttributes?: LabelAttributes
+  multiple?: boolean
+}
+
+const props = defineProps<InputProps>()
+
+const SelectComponent = computed(() => {
+  return props.multiple ? KMultiselect : KSelect
+})
+</script>
+
+<style lang="scss" scoped>
+.ff-enum-field {
+  :deep(.k-tooltip p) {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/KeyValueField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/KeyValueField.vue
@@ -1,0 +1,184 @@
+<template>
+  <div
+    ref="root"
+    class="ff-kv-field"
+  >
+    <header class="ff-kv-field-header">
+      <KLabel
+        v-if="label"
+        class="ff-kv-field-label"
+        v-bind="labelAttributes"
+        :required="required"
+      >
+        {{ label }}
+        <template
+          v-if="labelAttributes?.info"
+          #label-tooltip
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div v-html="labelAttributes?.info" />
+        </template>
+      </KLabel>
+      <KButton
+        appearance="tertiary"
+        icon
+        @click="handleAddClick"
+      >
+        <AddIcon />
+      </KButton>
+    </header>
+
+    <div
+      v-for="(entry, index) of entries"
+      :key="entry.id"
+      class="ff-kv-field-entry"
+    >
+      <KInput
+        v-model.trim="entry.key"
+        class="ff-kv-field-entry-key"
+        :data-key-input="index"
+        :placeholder="keyPlaceholder || 'Key'"
+        @keydown.enter.prevent="focus(index, 'value')"
+      />
+
+      <KInput
+        v-model.trim="entry.value"
+        class="ff-kv-field-entry-value"
+        :data-value-input="index"
+        :placeholder="valuePlaceholder || 'Value'"
+        @keydown.enter.prevent="handleValueEnter(index)"
+      />
+
+      <KButton
+        appearance="tertiary"
+        icon
+        @click="removeEntry(entry.id)"
+      >
+        <TrashIcon />
+      </KButton>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, useTemplateRef, nextTick } from 'vue'
+import { AddIcon, TrashIcon } from '@kong/icons'
+import { uniqueId } from 'lodash-es'
+import type { LabelAttributes } from '@kong/kongponents'
+
+interface KVEntry {
+  id: string;
+  key: string;
+  value: string;
+}
+
+const props = defineProps<{
+  initialValue?: Record<string, string>
+  label?: string
+  required?: boolean
+  keyPlaceholder?: string
+  valuePlaceholder?: string
+  defaultKey?: string
+  defaultValue?: string
+  labelAttributes?: LabelAttributes
+}>()
+
+const emit = defineEmits<{
+  change: [Record<string, string>]
+}>()
+
+const entries = ref<KVEntry[]>(getEntries(props.initialValue || {}))
+
+function generateId() {
+  return uniqueId('ff-kv-field-')
+}
+
+function getEntries(value: Record<string, string>): KVEntry[] {
+  return Object.entries(value).map(([key, value]) => ({
+    id: generateId(),
+    key,
+    value,
+  }))
+}
+
+const addEntry = () => {
+  entries.value.push({ id: generateId(), key: props.defaultKey || '', value: props.defaultValue || '' })
+}
+
+const removeEntry = (id: string) => {
+  const index = entries.value.findIndex((entry) => entry.id === id)
+  if (index !== -1) {
+    entries.value.splice(index, 1)
+  }
+}
+
+const updateValue = () => {
+  const map = Object.fromEntries(entries.value.map(({ key, value }) => [key, value]).filter(([key]) => key))
+  emit('change', map)
+}
+
+const root = useTemplateRef('root')
+
+async function focus(index: number, type: 'key' | 'value' = 'key') {
+  if (!root.value) {
+    return
+  }
+
+  await nextTick()
+  root.value.querySelector<HTMLInputElement>(`[data-${type}-input="${index}"]`)?.focus()
+}
+
+watch(entries, updateValue, { deep: true })
+
+function handleAddClick() {
+  addEntry()
+
+  const index = entries.value.findIndex(({ key }) => !key)
+  focus(index === -1 ? entries.value.length - 1 : index)
+}
+
+function handleValueEnter(index: number) {
+  if (index === entries.value.length - 1) {
+    addEntry()
+  }
+  focus(index + 1)
+}
+
+defineExpose({
+  reset: () => {
+    entries.value = getEntries(props.initialValue || {})
+  },
+  setValue: (value: Record<string, string>) => {
+    entries.value = getEntries(value)
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.ff-kv-field {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-40;
+
+  &-label {
+    margin: 0;
+  }
+
+  &-header {
+    align-items: center;
+    display: flex;
+    gap: $kui-space-40;
+    height: 32px;
+  }
+
+  &-entry {
+    align-items: center;
+    display: flex;
+    gap: $kui-space-40;
+  }
+
+  :deep(.k-tooltip p) {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/NumberField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/NumberField.vue
@@ -1,0 +1,52 @@
+<template>
+  <KInput
+    class="ff-number-field"
+    v-bind="props"
+    :model-value="modelValue ?? ''"
+    type="number"
+    @update:model-value="handleUpdate"
+  >
+    <template
+      v-if="props.labelAttributes?.info"
+      #label-tooltip
+    >
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div v-html="props.labelAttributes?.info" />
+    </template>
+  </KInput>
+</template>
+
+<script setup lang="ts">
+import { KInput, type LabelAttributes } from '@kong/kongponents'
+
+// Vue doesn't support the built-in `InstanceType` utility type, so we have to
+// work around it a bit.
+// Other props are passed down to the `KInput` via attribute fallthrough.
+export interface InputProps {
+  labelAttributes?: LabelAttributes
+  modelValue?: number | null
+}
+
+const { modelValue, ...props } = defineProps<InputProps>()
+const emit = defineEmits<{
+  'update:modelValue': [value: number | null]
+}>()
+
+const initialValue = modelValue
+
+function handleUpdate(value: string) {
+  if (initialValue !== undefined && value === '' && Number(value) !== initialValue) {
+    emit('update:modelValue', null)
+  } else {
+    emit('update:modelValue', Number(value))
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.ff-number-field {
+  :deep(.k-tooltip p) {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ObjectField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ObjectField.vue
@@ -1,0 +1,130 @@
+<template>
+  <div
+    class="ff-object-field"
+    :class="{ 'ff-object-field-collapsed': !realExpanded }"
+  >
+    <header class="ff-object-field-header">
+      <KLabel
+        class="ff-object-field-label"
+        v-bind="labelAttributes"
+      >
+        {{ label }}
+        <template
+          v-if="labelAttributes?.info"
+          #tooltip
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div v-html="labelAttributes?.info" />
+        </template>
+      </KLabel>
+      <div class="ff-object-field-actions">
+        <KButton
+          v-if="collapsible && realAdded"
+          appearance="tertiary"
+          :class="`ff-object-field-button-${realExpanded ? 'collapse' : 'expand'}`"
+          icon
+          @click="expanded = !realExpanded"
+        >
+          <ChevronDownIcon
+            v-if="realAdded"
+            class="ff-object-field-button-icon"
+          />
+        </KButton>
+        <KButton
+          v-if="!required"
+          appearance="tertiary"
+          :class="`ff-object-field-button-${realAdded ? 'remove' : 'add'}`"
+          icon
+          @click="added = !added"
+        >
+          <TrashIcon v-if="realAdded" />
+          <AddIcon v-else />
+        </KButton>
+      </div>
+    </header>
+    <SlideTransition>
+      <div
+        v-if="realExpanded"
+        class="ff-object-field-content"
+      >
+        <slot />
+      </div>
+    </SlideTransition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { KButton, KLabel, type LabelAttributes } from '@kong/kongponents'
+import { TrashIcon, AddIcon, ChevronDownIcon } from '@kong/icons'
+import { computed, watch } from 'vue'
+import SlideTransition from './SlideTransition.vue'
+
+const { defaultExpanded = true, defaultAdded, collapsible = true, required } = defineProps<{
+  label: string
+  labelAttributes?: LabelAttributes
+  required?: boolean
+  defaultExpanded?: boolean
+  defaultAdded?: boolean
+  collapsible?: boolean
+  appearance?: 'card' | 'default'
+}>()
+
+const added = defineModel<boolean>('added', { default: undefined })
+const realAdded = computed(() => !required ? added.value ?? defaultAdded : true)
+
+const expanded = defineModel<boolean>('expanded', { default: undefined })
+const realExpanded = computed(() => realAdded.value && (collapsible ? expanded.value ?? defaultExpanded : false))
+
+watch(realAdded, (value) => {
+  if (!collapsible) {
+    return
+  }
+  expanded.value = value
+})
+</script>
+
+<style lang="scss" scoped>
+.ff-object-field {
+  &-label {
+    margin: 0;
+  }
+
+  &-header {
+    align-items: center;
+    display: flex;
+    gap: $kui-space-40;
+    height: 32px;
+  }
+
+  &-actions {
+    align-items: center;
+    display: flex;
+    gap: $kui-space-20;
+  }
+
+  &-button-expand,
+  &-button-collapse {
+    .ff-object-field-button-icon {
+      transition: transform $kui-animation-duration-20 ease-in-out;
+    }
+  }
+
+  &-button-expand {
+    .ff-object-field-button-icon {
+      transform: rotate(-90deg);
+    }
+  }
+
+  &-content {
+    display: flex;
+    flex-direction: column;
+    gap: $kui-space-80;
+    margin-top: $kui-space-20;
+    padding: $kui-space-60 $kui-space-40 $kui-space-20;
+  }
+
+  :deep(.k-tooltip p) {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/SlideTransition.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/SlideTransition.vue
@@ -1,0 +1,103 @@
+<template>
+  <Transition
+    enter-active-class="ff-slide-active"
+    leave-active-class="ff-slide-active"
+    @after-enter="afterEnter"
+    @after-leave="afterLeave"
+    @before-enter="beforeEnter"
+    @before-leave="beforeLeave"
+    @enter="enter"
+    @leave="leave"
+  >
+    <slot />
+  </Transition>
+</template>
+
+<script setup lang="ts">
+const properties = [
+  'height',
+  'padding-top',
+  'padding-bottom',
+  'margin-top',
+  'margin-bottom',
+  'border-top-width',
+  'border-bottom-width',
+] as const
+
+const auto = Object.fromEntries(properties.map((prop) => [prop, '']))
+const zero = Object.fromEntries(properties.map((prop) => [prop, '0']))
+
+function getComputed(el: HTMLElement) {
+  const styles = getComputedStyle(el)
+  return Object.fromEntries(
+    properties.map((prop) => [prop, styles.getPropertyValue(prop)]),
+  )
+}
+
+function resetStyles(el: HTMLElement) {
+  ['overflow', 'transition', ...properties].forEach((prop) =>
+    el.style.removeProperty(prop),
+  )
+}
+
+function beforeEnter(elem: Element) {
+  const el = elem as HTMLElement
+
+  Object.assign(el.style, {
+    overflow: 'hidden',
+    transition: 'none',
+  })
+}
+
+function enter(elem: Element) {
+  const el = elem as HTMLElement
+
+  Object.assign(el.style, auto)
+
+  const computed = getComputed(el)
+
+  Object.assign(el.style, zero)
+
+  requestAnimationFrame(() => {
+    Object.assign(el.style, {
+      ...computed,
+      transition: '',
+    })
+  })
+}
+
+function afterEnter(elem: Element) {
+  const el = elem as HTMLElement
+
+  resetStyles(el)
+}
+
+function beforeLeave(elem: Element) {
+  const el = elem as HTMLElement
+
+  Object.assign(el.style, {
+    ...getComputed(el),
+    overflow: 'hidden',
+  })
+}
+
+function leave(elem: Element) {
+  const el = elem as HTMLElement
+
+  Object.assign(el.style, zero)
+}
+
+function afterLeave(elem: Element) {
+  const el = elem as HTMLElement
+
+  resetStyles(el)
+}
+</script>
+
+<style lang="scss" scoped>
+.ff-slide-active {
+  transition-duration: $kui-animation-duration-20;
+  transition-property: height, padding, margin, border-width;
+  transition-timing-function: ease-in-out;
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
@@ -1,0 +1,77 @@
+<template>
+  <div>
+    <InputComponent
+      class="ff-string-field"
+      v-bind="{ ...props, ...attrs }"
+      :model-value="modelValue ?? ''"
+      @update:model-value="handleUpdate"
+    >
+      <template
+        v-if="props.labelAttributes?.info"
+        #label-tooltip
+      >
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <div v-html="props.labelAttributes?.info" />
+      </template>
+    </InputComponent>
+    <component
+      :is="autofillSlot"
+      v-if="autofillSlot && showVaultSecretPicker"
+      :schema="schema"
+      :update="handleUpdate"
+      :value="modelValue ?? ''"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, useAttrs } from 'vue'
+import { KInput, KTextArea, type LabelAttributes } from '@kong/kongponents'
+import { AUTOFILL_SLOT, type AutofillSlot } from '@kong-ui-public/forms'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const attrs = useAttrs()
+
+// Vue doesn't support the built-in `InstanceType` utility type, so we have to
+// work around it a bit.
+// Other props are passed down to the `KInput` via attribute fallthrough.
+export interface InputProps {
+  labelAttributes?: LabelAttributes
+  modelValue?: string | null
+  multiline?: boolean
+  showVaultSecretPicker?: boolean
+}
+
+const { modelValue, showVaultSecretPicker, ...props } = defineProps<InputProps>()
+const emit = defineEmits<{
+  'update:modelValue': [value: string | null]
+}>()
+
+const initialValue = modelValue
+
+function handleUpdate(value: string) {
+  if (initialValue !== undefined && value === '' && value !== initialValue) {
+    emit('update:modelValue', null)
+  } else {
+    emit('update:modelValue', value)
+  }
+}
+
+const InputComponent = computed(() => {
+  return props.multiline ? KTextArea : KInput
+})
+
+const autofillSlot = inject<AutofillSlot | undefined>(AUTOFILL_SLOT, undefined)
+const schema = computed(() => ({ referenceable: showVaultSecretPicker }))
+</script>
+
+<style lang="scss" scoped>
+.ff-string-field {
+  :deep(.k-tooltip p) {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
@@ -1,0 +1,8 @@
+import type { ComponentPublicInstance } from 'vue'
+
+type ComponentPublicInstanceConstructor = {
+  new (...args: any[]): ComponentPublicInstance<any>;
+}
+
+export type PropType<T extends ComponentPublicInstanceConstructor> =
+  InstanceType<T>['$props'] & { [key: string]: unknown }

--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -30,6 +30,7 @@ import typedefs from '../definitions/schemas/typedefs'
 import { type CustomSchemas } from '../types'
 import useI18n from './useI18n'
 import usePluginHelpers from './usePluginHelpers'
+import { getFreeFormName } from '../utils/free-form'
 
 export interface Field extends Record<string, any> {
   model: string
@@ -275,7 +276,7 @@ export const useSchemas = (options?: UseSchemasOptions) => {
     formSchema._supported_redis_partial_type = currentSchema._supported_redis_partial_type
     formSchema._redis_partial_path = currentSchema._redis_partial_path
 
-    if (getSharedFormName(pluginName) || metadata?.useLegacyForm || options?.credential) {
+    if (getSharedFormName(pluginName) || getFreeFormName(pluginName) || metadata?.useLegacyForm || options?.credential) {
       /**
        * Do not generate grouped schema when:
        * - The plugin has a custom layout
@@ -417,7 +418,6 @@ export const useSchemas = (options?: UseSchemasOptions) => {
           },
         })
       }
-
       formSchema = {
         groups: fieldGroups,
       }

--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -418,6 +418,7 @@ export const useSchemas = (options?: UseSchemasOptions) => {
           },
         })
       }
+
       formSchema = {
         groups: fieldGroups,
       }

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -510,7 +510,7 @@
       },
       "request-callout": {
         "name": "Request Callout",
-        "description": "Callout to third party apis as part of request processing."
+        "description": "Callout to third party APIs as part of request processing."
       },
       "ai-sanitizer": {
         "name": "AI Sanitizer",

--- a/packages/entities/entities-plugins/src/utils/free-form.ts
+++ b/packages/entities/entities-plugins/src/utils/free-form.ts
@@ -1,0 +1,7 @@
+export function getFreeFormName(modelName: string): string {
+  const mapping: Record<string, string> = {
+    'request-callout': 'RequestCalloutForm',
+  }
+
+  return mapping[modelName]
+}

--- a/packages/entities/entities-vaults/src/components/VaultSecretPickerProvider.vue
+++ b/packages/entities/entities-vaults/src/components/VaultSecretPickerProvider.vue
@@ -16,7 +16,7 @@
   </div>
 </template>
 
-<script setup lang="tsx">
+<script setup lang="ts">
 import composables from '../composables'
 
 type Props = {


### PR DESCRIPTION
# Summary

This PR introduces a new free-form alternative for implementing plugin forms that:

- Allows complete flexibility in form construction, accommodating any custom rendering needs.
- Manages plugin configurations without requiring flatten/unflatten logic.
- Supports future migration to a dual-schema approach (data + UI).

### Implemented Features

- Ability to register a free-form configuration for specific plugins.
- Enhanced field components (`object`, `array`, `key-value`, `string`, `number`, `boolean`, `enum`) for a better user experience.
- Improvements to the plugin form playground, including autosave to local storage.

### Still Missing

- Validation support.
- Entity checks.