### PR TITLE
fix: remove pnpm-lock file from the list of config files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
             ./vite.config.shared.ts
             ./cypress.config.ts
             ./cypress/**
-            ./pnpm-lock.yaml
+            ./package.json
             ./eslintrc.cjs
             ./.stylelintrc.js
 


### PR DESCRIPTION
# Summary

We do not need to force rebuild-all when ppm-lock  is changed. ppm-lock is changed every time when dependency of the single package is changed, and only that package (and it's dependents) needs to be rebuild. 

instead of tracking pnpm-lock file we will track root package.json and force re-build all if something in that package is changed. we already do it in `konnect-ui-apps` and `shared-ui-components`