### PR TITLE
fix(upstreams-targets): should returns timeouts disable active health [KM-1056]

### DIFF
--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.cy.ts
@@ -910,7 +910,7 @@ describe('<UpstreamsForm/>', { viewportHeight: 700, viewportWidth: 700 }, () => 
 
       cy.wait('@updateUpstream').then((interception) => {
         const { body: { healthchecks } } = interception.request
-        expect(healthchecks).to.deep.equal(JSON.parse('{"threshold":2,"active":{"type":"http","headers":{},"healthy":{"interval":0,"successes":0},"unhealthy":{"interval":0,"http_failures":0,"tcp_failures":0}},"passive":{"type":"http","healthy":{"successes":0},"unhealthy":{"timeouts":0,"tcp_failures":0,"http_failures":0}}}'))
+        expect(healthchecks).to.deep.equal(JSON.parse('{"threshold":2,"active":{"type":"http","headers":{},"healthy":{"interval":0,"successes":0},"unhealthy":{"interval":0,"http_failures":0,"tcp_failures":0,"timeouts":0}},"passive":{"type":"http","healthy":{"successes":0},"unhealthy":{"timeouts":0,"tcp_failures":0,"http_failures":0}}}'))
       })
     })
 

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
@@ -304,6 +304,7 @@ const activeHealthChecks = computed((): UpstreamActivePayload | undefined => {
           interval: 0,
           http_failures: 0,
           tcp_failures: 0,
+          timeouts: 0,
         },
       }
     }


### PR DESCRIPTION
# Summary
This PR fixed where disabling the active healthy didn't include the timeout field in the request body.
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
