### PR TITLE
feat(entities-shared): improve display for config card json text

### DIFF
--- a/packages/entities/entities-shared/fixtures/mockData.ts
+++ b/packages/entities/entities-shared/fixtures/mockData.ts
@@ -119,6 +119,7 @@ export const gatewayServiceRecord = {
   tls_verify: true,
   updated_at: 1686157266,
   write_timeout: 60000,
+  extra: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 }
 
 export const emptyKey = 'preferred_chain'

--- a/packages/entities/entities-shared/sandbox/pages/ConfigCardItemPage.vue
+++ b/packages/entities/entities-shared/sandbox/pages/ConfigCardItemPage.vue
@@ -133,6 +133,21 @@
       }"
     />
 
+    <h2>JSON Text</h2>
+    <ConfigCardItem
+      :item="{
+        type: ConfigurationSchemaType.Text,
+        key: 'json-code',
+        label: 'Cat Data',
+        value: {
+          name: 'TK Meowstersmith',
+          species: 'Awesome cat',
+          color: 'All black',
+          awesome: 'true',
+        }
+      }"
+    />
+
     <h2>JSON Object Array</h2>
     <ConfigCardItem
       :item="{

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
@@ -246,6 +246,31 @@ describe('<ConfigCardItem />', () => {
       }
     })
 
+    it('renders JSON text field correctly', () => {
+      const obj: Record<string, string> = {
+        name: 'TK Meowstersmith',
+        species: 'Awesome cat',
+        color: 'All black',
+        awesome: 'true',
+      }
+      const item: RecordItem = {
+        type: ConfigurationSchemaType.Text,
+        key: 'cat_data',
+        label: 'Cat Data',
+        value: obj,
+      }
+
+      cy.mount(ConfigCardItem, {
+        props: {
+          item,
+        },
+      })
+
+      cy.get('.config-card-details-row').should('be.visible')
+      cy.getTestId(`${item.key}-json-code`).should('be.visible')
+      cy.getTestId(`${item.key}-json-code`).should('contain.text', JSON.stringify(obj, null, 2))
+    })
+
     it('renders a JSON Array field correctly', () => {
       const obj: Record<string, string>[] = [{
         name: 'TK Meowstersmith',

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -318,6 +318,7 @@ const componentAttrsData = computed((): ComponentAttrsData => {
             language: 'json',
             code: JSON.stringify(props.item.value, null, '  '),
             maxHeight: '480px',
+            showLineNumbers: false,
           },
         }
       }

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -317,7 +317,6 @@ const componentAttrsData = computed((): ComponentAttrsData => {
             id: `json-code-${uniqueId}`,
             language: 'json',
             code: JSON.stringify(props.item.value, null, '  '),
-            theme: 'dark',
             maxHeight: '480px',
           },
         }

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -162,7 +162,7 @@ const emit = defineEmits<{
   (e: 'navigation-click', record: RecordItem): void,
 }>()
 
-const id = useId()
+const uniqueId = useId()
 
 const slots = useSlots()
 const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
@@ -307,15 +307,14 @@ const componentAttrsData = computed((): ComponentAttrsData => {
         },
       }
 
-    case ConfigurationSchemaType.Text: {
-      // If the schema type is `plain-text` but the value is an object, we want to display it as a JSON code block.
-      // Otherwise, we'll just fallthrough to the default case and display it as plain text.
+    default:
+      // Before fallback to plain text, check if the value is an object, if so, render it as a code block
       if (props.item.value != null && typeof props.item.value === 'object') {
         return {
           tag: 'KCodeBlock',
           attrs: {
             'data-testid': `${props.item.key}-json-code`,
-            id: `json-code-${id}`,
+            id: `json-code-${uniqueId}`,
             language: 'json',
             code: JSON.stringify(props.item.value, null, '  '),
             theme: 'dark',
@@ -323,10 +322,6 @@ const componentAttrsData = computed((): ComponentAttrsData => {
           },
         }
       }
-    }
-
-    // eslint-disable-next-line no-fallthrough
-    default:
       return {
         tag: 'div',
         attrs: {

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -68,7 +68,7 @@
             </div>
 
             <div
-              v-if="componentAttrsData.additionalComponent === 'KCopy'"
+              v-else-if="componentAttrsData.additionalComponent === 'KCopy'"
               class="copy-uuid-array"
               :data-testid="`${item.key}-copy-uuid-array`"
             >
@@ -98,7 +98,7 @@
             </div>
 
             <div
-              v-if="componentAttrsData.additionalComponent === 'JsonCardItem'"
+              v-else-if="componentAttrsData.additionalComponent === 'JsonCardItem'"
               :data-testid="`${props.item.key}-json-array-content`"
             >
               <JsonCardItem
@@ -131,7 +131,7 @@
 
 <script setup lang="ts">
 import type { PropType, Ref } from 'vue'
-import { computed, ref, useSlots } from 'vue'
+import { computed, ref, useId, useSlots } from 'vue'
 import type { RecordItem, ComponentAttrsData } from '../../types'
 import { ConfigurationSchemaType } from '../../types'
 import composables from '../../composables'
@@ -161,6 +161,8 @@ const props = defineProps({
 const emit = defineEmits<{
   (e: 'navigation-click', record: RecordItem): void,
 }>()
+
+const id = useId()
 
 const slots = useSlots()
 const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
@@ -305,6 +307,25 @@ const componentAttrsData = computed((): ComponentAttrsData => {
         },
       }
 
+    case ConfigurationSchemaType.Text: {
+      // If the schema type is `plain-text` but the value is an object, we want to display it as a JSON code block.
+      // Otherwise, we'll just fallthrough to the default case and display it as plain text.
+      if (props.item.value != null && typeof props.item.value === 'object') {
+        return {
+          tag: 'KCodeBlock',
+          attrs: {
+            'data-testid': `${props.item.key}-json-code`,
+            id: `json-code-${id}`,
+            language: 'json',
+            code: JSON.stringify(props.item.value, null, '  '),
+            theme: 'dark',
+            maxHeight: '480px',
+          },
+        }
+      }
+    }
+
+    // eslint-disable-next-line no-fallthrough
     default:
       return {
         tag: 'div',

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
@@ -221,7 +221,7 @@ describe('<EntityBaseConfigCard />', () => {
       // no tooltip
       cy.getTestId(`${unconfiguredKey}-label-tooltip`).should('not.exist')
       // type defaults to plain text
-      cy.getTestId(`${unconfiguredKey}-plain-text`).should('be.visible')
+      cy.getTestId(`${unconfiguredKey}-json-code`).should('be.visible')
     })
 
     it('allows customizing label and label tooltip', () => {

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
@@ -29,6 +29,7 @@ const customizedKey = 'ca_certificates'
 const customTooltip = 'Custom tooltip'
 const customLabel = 'CA Certificates'
 const unconfiguredKey = 'client_certificate'
+const untypedKey = 'extra'
 const configSchema: ConfigurationSchema = {
   protocol: {
     section: ConfigurationSchemaSection.Basic,
@@ -67,6 +68,9 @@ const configSchema: ConfigurationSchema = {
     tooltip: customTooltip,
     order: 6,
     section: ConfigurationSchemaSection.Advanced,
+  },
+  [untypedKey]: {
+    order: 5,
   },
   [unconfiguredKey]: {
     // leave this object empty for tests!!
@@ -222,6 +226,15 @@ describe('<EntityBaseConfigCard />', () => {
       cy.getTestId(`${unconfiguredKey}-label-tooltip`).should('not.exist')
       // type defaults to plain text
       cy.getTestId(`${unconfiguredKey}-json-code`).should('be.visible')
+
+      // section defaults to Advanced (and hidden defaults to false)
+      cy.get(`[data-testid="config-card-details-advanced-props"] [data-testid="${untypedKey}-label"]`).should('exist')
+      // title cases key for the label
+      cy.getTestId(`${untypedKey}-label`).should('contain.text', convertKeyToTitle(untypedKey))
+      // no tooltip
+      cy.getTestId(`${untypedKey}-label-tooltip`).should('not.exist')
+      // type defaults to plain text
+      cy.getTestId(`${untypedKey}-plain-text`).should('be.visible')
     })
 
     it('allows customizing label and label tooltip', () => {


### PR DESCRIPTION
# Summary

[KM-1066](https://konghq.atlassian.net/browse/KM-1066)

| Before | After |
| -- | -- |
| <img width="1626" alt="image" src="https://github.com/user-attachments/assets/e7d8c906-6ab0-4b72-b34d-aa09922a4eab" /> | <img width="1626" alt="image" src="https://github.com/user-attachments/assets/88d12577-57ed-4aac-bd18-a88febd7fe62" /> |



[KM-1066]: https://konghq.atlassian.net/browse/KM-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ