### PR TITLE
fix(ext-consumers-are-consumers): Adding realm instead of regional_consumer

### DIFF
--- a/packages/analytics/analytics-utilities/src/types/explore/advanced.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/advanced.ts
@@ -12,7 +12,7 @@ export const queryableExploreDimensions = [
   'upstream_status_code_grouped',
   'response_source',
   'data_plane_node_version',
-  'regional_consumer',
+  'realm',
 ] as const
 
 export type QueryableExploreDimensions = typeof queryableExploreDimensions[number]


### PR DESCRIPTION
regoinal/external consumers will be exposed via the `consumers` dimension.