### PR TITLE
feat(analytics): make explore URL determination async [MA-3590]

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
@@ -203,7 +203,6 @@
         :allow-csv-export="true"
         :chart-data="(exploreResult)"
         :chart-options="analyticsChartOptions"
-        :go-to-explore="(exploreLink)"
         :legend-position="legendPosition"
         :show-annotations="showAnnotationsToggle"
         :show-legend-values="showLegendValuesToggle"
@@ -336,7 +335,6 @@ const exportCsv = () => {
   setModalVisibility(true)
 }
 
-const exploreLink: string = 'https://cloud.konghq.tech/us/analytics/explorer'
 provide(INJECT_QUERY_PROVIDER, { evaluateFeatureFlagFn: () => true })
 
 const exploreResultText = ref('')

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -27,11 +27,12 @@ export interface AnalyticsBridge {
   configFn: () => Promise<AnalyticsConfigV2>,
 
   // Evaluate feature flags (if applicable)
-  // TODO: Use `NoInfer` once we upgrade to TS 5.4:
-  //  https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#the-noinfer-utility-type
-  //  See note in DashboardRenderer tests.
   evaluateFeatureFlagFn: <T = boolean>(key: string, defaultValue: T) => T,
-  exploreBaseUrl?: () => string,
 
+  // Define the location of explore to enable jump-to-explore.
+  // Async because there might need to be permissions checks.
+  exploreBaseUrl?: () => Promise<string>,
+
+  // Dynamically provide certain components that aren't available in all environments
   fetchComponent?: (name: string) => Promise<Component>,
 }

--- a/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
@@ -56,7 +56,7 @@ const configFn = (): Promise<AnalyticsConfigV2> => {
 
 const evaluateFeatureFlagFn = () => true
 
-const exploreBaseUrl = () => 'https://cloud.konghq.tech/us/analytics/explorer'
+const exploreBaseUrl = async () => 'https://cloud.konghq.tech/us/analytics/explorer'
 
 const fetchComponent = async (name: string): Promise<Component> => {
   return Promise.resolve(EntityLink)

--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -13,7 +13,6 @@
         :chart-data="data"
         :chart-options="options"
         :chart-title="!hasKebabMenuAccess && chartOptions.chartTitle || ''"
-        :go-to-explore="exploreLink"
         legend-position="bottom"
         :show-menu="context.editable"
         :synthetics-data-key="chartOptions.syntheticsDataKey"
@@ -36,19 +35,17 @@
 <script setup lang="ts">
 import type { RendererProps } from '../types'
 import QueryDataProvider from './QueryDataProvider.vue'
-import { computed, defineProps, inject } from 'vue'
+import { computed, defineProps } from 'vue'
 import type { AnalyticsChartOptions } from '@kong-ui-public/analytics-chart'
 import { AnalyticsChart } from '@kong-ui-public/analytics-chart'
 import composables from '../composables'
-import { INJECT_QUERY_PROVIDER } from '../constants'
-import type { AiExploreAggregations, AiExploreQuery, AnalyticsBridge, ExploreAggregations, ExploreQuery, ExploreResultV4, QueryableAiExploreDimensions, QueryableExploreDimensions, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
+import type { ExploreResultV4 } from '@kong-ui-public/analytics-utilities'
 
 const props = defineProps<RendererProps<any> & { extraProps?: Record<string, any> }>()
 const emit = defineEmits<{
   (e: 'edit-tile'): void
   (e: 'chart-data', chartData: ExploreResultV4): void
 }>()
-const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
 const { i18n } = composables.useI18n()
 const { evaluateFeatureFlag } = composables.useEvaluateFeatureFlag()
 
@@ -60,22 +57,6 @@ const options = computed((): AnalyticsChartOptions => ({
   chartDatasetColors: props.chartOptions.chartDatasetColors,
   threshold: props.chartOptions.threshold,
 }))
-
-const exploreLink = computed(() => {
-  if (queryBridge && queryBridge.exploreBaseUrl) {
-    const exploreQuery: ExploreQuery | AiExploreQuery = {
-      filters: [...props.context.filters, ...props.query.filters ?? []],
-      metrics: props.query.metrics as ExploreAggregations[] | AiExploreAggregations[] ?? [],
-      dimensions: props.query.dimensions as QueryableExploreDimensions[] | QueryableAiExploreDimensions[] ?? [],
-      time_range: props.query.time_range as TimeRangeV4 || props.context.timeSpec,
-    } as ExploreQuery | AiExploreQuery
-    // Explore only supports advanced or ai
-    const datasource = ['advanced', 'ai'].includes(props.query.datasource) ? props.query.datasource : 'advanced'
-    return `${queryBridge.exploreBaseUrl()}?q=${JSON.stringify(exploreQuery)}&d=${datasource}&c=${props.chartOptions.type}`
-  }
-
-  return ''
-})
 
 const editTile = () => {
   emit('edit-tile')

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -106,9 +106,8 @@ describe('<DashboardRenderer />', () => {
       return Promise.resolve(config)
     }
 
-    // @ts-ignore: TS doesn't infer things correctly.  NoInfer may help.
     const evaluateFeatureFlagFn: AnalyticsBridge['evaluateFeatureFlagFn'] = (key) => {
-      return true
+      return true as any
     }
 
     const fetchComponentFn = (name: string) => {


### PR DESCRIPTION
- Allow permissions checks to happen before generating an explore URL.
- Clean up dead code.

BREAKING CHANGE: change signature of analytics bridge

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
