### PR TITLE
fix(redis): unblock preselect of default redis config

### DIFF
--- a/packages/core/forms/src/components/RedisConfigSelect.vue
+++ b/packages/core/forms/src/components/RedisConfigSelect.vue
@@ -214,8 +214,9 @@ watch(() => redisPartialFetcherKey?.value, async (key) => {
     await loadConfigs()
 })
 
-onBeforeMount(async () => {
-  await loadConfigs()
+onBeforeMount(() => {
+  // load config should not block selecting a default config
+  loadConfigs()
   if (props.defaultRedisConfigItem) {
     redisConfigSelected(props.defaultRedisConfigItem)
   }


### PR DESCRIPTION
# Summary

KM-1087

Pre select of redis config should not be blocked by `loadConfigs`. If the network is too slow, this could cause late update of form model after user toggles to inline redis config fields.
