### PR TITLE
fix: custom chart plugin states leaking across chart instances

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/index.ts
+++ b/packages/analytics/analytics-chart/sandbox/index.ts
@@ -32,6 +32,11 @@ const router = createRouter({
       name: 'simple',
       component: () => import('./pages/ChartDemoSimple.vue'),
     },
+    {
+      path: '/multichart',
+      name: 'multichart',
+      component: () => import('./pages/MultiChartDemo.vue'),
+    },
   ],
 })
 
@@ -52,6 +57,10 @@ const appLinks: SandboxNavigationItem[] = ([
   {
     name: 'Simple Charts',
     to: { name: 'simple' },
+  },
+  {
+    name: 'Multi Charts',
+    to: { name: 'multichart' },
   },
 ])
 

--- a/packages/analytics/analytics-chart/sandbox/pages/MultiChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/MultiChartDemo.vue
@@ -21,7 +21,9 @@
           chart-title="Timeseries Line Chart - Requests Over Time"
           :legend-position="ChartLegendPosition.Right"
           :show-legend-values="true"
+          :timeseries-zoom="true"
           tooltip-title="Requests"
+          @zoom-time-range="console.log('Zoomed to time range:', $event)"
         />
       </div>
       <div class="chart-container">

--- a/packages/analytics/analytics-chart/sandbox/pages/MultiChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/MultiChartDemo.vue
@@ -1,0 +1,140 @@
+<template>
+  <SandboxLayout
+    :links="appLinks"
+    title="Multiple Charts Demo"
+  >
+    <div class="chart-grid">
+      <div class="chart-container">
+        <AnalyticsChart
+          :chart-data="timeseriesBarChartData"
+          :chart-options="timeSeriesBarChartOptions"
+          chart-title="Line Chart - Request count by Status Code"
+          :legend-position="ChartLegendPosition.Bottom"
+          :show-legend-values="true"
+          tooltip-title="Requests"
+        />
+      </div>
+      <div class="chart-container">
+        <AnalyticsChart
+          :chart-data="timeSeriesLineChartData"
+          :chart-options="timeSeriesLineChartOptions"
+          chart-title="Timeseries Line Chart - Requests Over Time"
+          :legend-position="ChartLegendPosition.Right"
+          :show-legend-values="true"
+          tooltip-title="Requests"
+        />
+      </div>
+      <div class="chart-container">
+        <AnalyticsChart
+          :chart-data="barChartData"
+          :chart-options="barChartOptions"
+          chart-title="Horizontal Bar Chart - Requests by Service"
+          :legend-position="ChartLegendPosition.Bottom"
+          :show-annotations="false"
+          :show-legend-values="true"
+          tooltip-title="Services"
+        />
+      </div>
+      <div class="chart-container">
+        <AnalyticsChart
+          :chart-data="verticalBarChartData"
+          :chart-options="verticalBarChartOptions"
+          chart-title="Vertical Bar Chart - Latency by Status Code"
+          :legend-position="ChartLegendPosition.Right"
+          :show-annotations="false"
+          :show-legend-values="true"
+          tooltip-title="Latency"
+        />
+      </div>
+    </div>
+  </SandboxLayout>
+</template>
+
+<script lang="ts" setup>
+import { inject } from 'vue'
+import {
+  AnalyticsChart,
+  ChartLegendPosition,
+} from '../../src'
+import type { AnalyticsChartOptions } from '../../src/types'
+import {
+  generateCrossSectionalData,
+  generateSingleMetricTimeSeriesData,
+} from '@kong-ui-public/analytics-utilities'
+import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
+
+const appLinks: SandboxNavigationItem[] = inject('app-links', [])
+
+const timeSeriesBarChartOptions: AnalyticsChartOptions = {
+  type: 'timeseries_bar',
+  stacked: true,
+}
+
+const timeSeriesLineChartOptions: AnalyticsChartOptions = {
+  type: 'timeseries_line',
+  stacked: false,
+}
+
+const barChartOptions: AnalyticsChartOptions = {
+  type: 'horizontal_bar',
+  stacked: true,
+}
+
+const verticalBarChartOptions: AnalyticsChartOptions = {
+  type: 'vertical_bar',
+  stacked: false,
+}
+
+const statusCodes = ['200', '300', '400', '500']
+const services = ['service1', 'service2', 'service3', 'service4', 'service5']
+
+const timeseriesBarChartData = generateSingleMetricTimeSeriesData(
+  { name: 'LatencyP99', unit: 'ms' },
+  { status_code: statusCodes },
+)
+
+const timeSeriesLineChartData = generateSingleMetricTimeSeriesData(
+  { name: 'RequestCount', unit: 'count' },
+  { status_code: statusCodes },
+)
+
+const barChartData = generateCrossSectionalData([{
+  name: 'TotalRequests',
+  unit: 'count',
+}], {
+  service: services,
+})
+
+const verticalBarChartData = generateCrossSectionalData([{
+  name: 'LatencyP99',
+  unit: 'ms',
+}], {
+  status_code: statusCodes,
+})
+</script>
+
+<style lang="scss" scoped>
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-gap: 24px;
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+.chart-container {
+  height: 400px;
+  background-color: var(--kui-color-background);
+  border: 1px solid var(--kui-color-border);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 16px;
+}
+
+@media (max-width: 1200px) {
+  .chart-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/DragSelectPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/DragSelectPlugin.ts
@@ -38,7 +38,7 @@ const dispatchEvent = (eventName: string, chart: Chart, pluginInstance: DragSele
 }
 
 
-export const dragSelectPlugin: DragSelectPlugin = {
+export const createDragSelectPlugin = (): DragSelectPlugin => ({
   id: 'dragSelectPlugin',
   isDragging: false,
   startX: 0,
@@ -99,4 +99,4 @@ export const dragSelectPlugin: DragSelectPlugin = {
       drawSelectionArea(chart, this.startX, this.endX)
     }
   },
-}
+})

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/HighlightPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/HighlightPlugin.ts
@@ -31,7 +31,7 @@ const drawHighlight = (chart: Chart, clickedElements: InteractionItem[]) => {
   ctx.restore()
 }
 
-export const highlightPlugin: HighlightPlugin = {
+export const createHighlightPlugin = (): HighlightPlugin => ({
   id: 'highlightPlugin',
   clicked: false,
   afterDatasetsDraw: function(chart: Chart) {
@@ -71,4 +71,4 @@ export const highlightPlugin: HighlightPlugin = {
     chart.options.hover = this.previousHoverOption || chart.options.hover
     this.clicked = false
   },
-}
+})

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/HighlightPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/HighlightPlugin.ts
@@ -1,10 +1,5 @@
 import type { Chart, ChartEvent, InteractionItem, Plugin } from 'chart.js'
 
-interface IHighlightPlugin extends Plugin {
-  clickedElements?: InteractionItem[]
-  previousHoverOption?: Chart['options']['hover']
-  clicked: boolean
-}
 
 const drawHighlight = (chart: Chart, clickedElements: InteractionItem[]) => {
   const ctx = chart.ctx
@@ -31,15 +26,15 @@ const drawHighlight = (chart: Chart, clickedElements: InteractionItem[]) => {
   ctx.restore()
 }
 
-export class HighlightPlugin implements IHighlightPlugin {
+export class HighlightPlugin implements Plugin {
   id = 'highlightPlugin'
-  clickedElements?: InteractionItem[]
-  previousHoverOption?: Chart['options']['hover']
-  clicked = false
+  private _clickedElements?: InteractionItem[]
+  private _previousHoverOption?: Chart['options']['hover']
+  private _clicked = false
 
   afterDatasetsDraw(chart: Chart) {
-    if (this.clickedElements && this.clickedElements.length) {
-      drawHighlight(chart, this.clickedElements)
+    if (this._clickedElements && this._clickedElements.length) {
+      drawHighlight(chart, this._clickedElements)
     }
   }
 
@@ -48,31 +43,31 @@ export class HighlightPlugin implements IHighlightPlugin {
       return
     }
 
-    this.clicked = !this.clicked
+    this._clicked = !this._clicked
 
     const interactionMode = chart.options.interaction?.mode || 'index'
 
     const elementsAtEvent = chart.getElementsAtEventForMode(event.native, interactionMode, { intersect: false }, true)
 
-    if (elementsAtEvent.length && this.clicked) {
+    if (elementsAtEvent.length && this._clicked) {
       // When mode is "index" the last element is the top one.
       // We need the top one to get the correct "y" value for the highlight.
-      this.clickedElements = elementsAtEvent
+      this._clickedElements = elementsAtEvent
 
-      drawHighlight(chart, this.clickedElements)
+      drawHighlight(chart, this._clickedElements)
 
-      this.previousHoverOption = chart.options.hover
+      this._previousHoverOption = chart.options.hover
       // @ts-ignore - disable hovering actions while chart is "locked" need to set hover mode to null (which is invalid, but works)
       chart.options.hover = { mode: null }
     } else {
-      delete this.clickedElements
-      chart.options.hover = this.previousHoverOption || chart.options.hover
-      this.clicked = false
+      delete this._clickedElements
+      chart.options.hover = this._previousHoverOption || chart.options.hover
+      this._clicked = false
     }
   }
   beforeDestroy(chart: Chart) {
-    delete this.clickedElements
-    chart.options.hover = this.previousHoverOption || chart.options.hover
-    this.clicked = false
+    delete this._clickedElements
+    chart.options.hover = this._previousHoverOption || chart.options.hover
+    this._clicked = false
   }
 }

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/HighlightPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/HighlightPlugin.ts
@@ -1,6 +1,6 @@
 import type { Chart, ChartEvent, InteractionItem, Plugin } from 'chart.js'
 
-interface HighlightPlugin extends Plugin {
+interface IHighlightPlugin extends Plugin {
   clickedElements?: InteractionItem[]
   previousHoverOption?: Chart['options']['hover']
   clicked: boolean
@@ -31,15 +31,19 @@ const drawHighlight = (chart: Chart, clickedElements: InteractionItem[]) => {
   ctx.restore()
 }
 
-export const createHighlightPlugin = (): HighlightPlugin => ({
-  id: 'highlightPlugin',
-  clicked: false,
-  afterDatasetsDraw: function(chart: Chart) {
+export class HighlightPlugin implements IHighlightPlugin {
+  id = 'highlightPlugin'
+  clickedElements?: InteractionItem[]
+  previousHoverOption?: Chart['options']['hover']
+  clicked = false
+
+  afterDatasetsDraw(chart: Chart) {
     if (this.clickedElements && this.clickedElements.length) {
       drawHighlight(chart, this.clickedElements)
     }
-  },
-  afterEvent: function(chart: Chart, { event }: { event: ChartEvent }) {
+  }
+
+  afterEvent(chart: Chart, { event }: { event: ChartEvent }) {
     if (event.type !== 'click' || !event.native) {
       return
     }
@@ -65,10 +69,10 @@ export const createHighlightPlugin = (): HighlightPlugin => ({
       chart.options.hover = this.previousHoverOption || chart.options.hover
       this.clicked = false
     }
-  },
-  beforeDestroy(chart) {
+  }
+  beforeDestroy(chart: Chart) {
     delete this.clickedElements
     chart.options.hover = this.previousHoverOption || chart.options.hover
     this.clicked = false
-  },
-})
+  }
+}

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/VerticalLinePlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/VerticalLinePlugin.ts
@@ -1,6 +1,6 @@
 import type { Chart, ChartType, Plugin, TooltipItem } from 'chart.js'
 
-interface VerticalLinePlugin extends Plugin {
+interface IVerticalLinePlugin extends Plugin {
   clickedSegment?: TooltipItem<ChartType>
   pause?: boolean
 }
@@ -16,23 +16,26 @@ const drawLine = (ctx: CanvasRenderingContext2D, x: number, top: number, bottom:
   ctx.stroke()
   ctx.restore()
 }
+export class VerticalLinePlugin implements IVerticalLinePlugin {
+  id = 'verticalLinePlugin'
+  clickedSegment?: TooltipItem<ChartType>
+  pause = false
 
-export const createVerticalLinePlugin = (): VerticalLinePlugin => ({
-  id: 'linePlugin',
-  afterDatasetsDraw: function(chartInstance: Chart) {
-    if (!this.pause && chartInstance.tooltip && chartInstance.tooltip.getActiveElements() && chartInstance.tooltip.getActiveElements().length && !this.clickedSegment) {
-      const { x } = chartInstance.tooltip.dataPoints[0].element
-      const ctx = chartInstance.ctx
-      drawLine(ctx, x, chartInstance.scales.y.top, chartInstance.scales.y.bottom)
+  afterDatasetsDraw(chart: Chart) {
+    if (!this.pause && chart.tooltip && chart.tooltip.getActiveElements() && chart.tooltip.getActiveElements().length && !this.clickedSegment) {
+      const { x } = chart.tooltip.dataPoints[0].element
+      const ctx = chart.ctx
+      drawLine(ctx, x, chart.scales.y.top, chart.scales.y.bottom)
     }
 
     if (!this.pause && this.clickedSegment) {
       const { x } = (this.clickedSegment as TooltipItem<ChartType>).element
-      const ctx = chartInstance.ctx
-      drawLine(ctx, x, chartInstance.scales.y.top, chartInstance.scales.y.bottom)
+      const ctx = chart.ctx
+      drawLine(ctx, x, chart.scales.y.top, chart.scales.y.bottom)
     }
-  },
+  }
+
   beforeDestroy() {
     delete this.clickedSegment
-  },
-})
+  }
+}

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/VerticalLinePlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/VerticalLinePlugin.ts
@@ -17,7 +17,7 @@ const drawLine = (ctx: CanvasRenderingContext2D, x: number, top: number, bottom:
   ctx.restore()
 }
 
-export const verticalLinePlugin: VerticalLinePlugin = {
+export const createVerticalLinePlugin = (): VerticalLinePlugin => ({
   id: 'linePlugin',
   afterDatasetsDraw: function(chartInstance: Chart) {
     if (!this.pause && chartInstance.tooltip && chartInstance.tooltip.getActiveElements() && chartInstance.tooltip.getActiveElements().length && !this.clickedSegment) {
@@ -35,4 +35,4 @@ export const verticalLinePlugin: VerticalLinePlugin = {
   beforeDestroy() {
     delete this.clickedSegment
   },
-}
+})

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/VerticalLinePlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/VerticalLinePlugin.ts
@@ -1,10 +1,5 @@
 import type { Chart, ChartType, Plugin, TooltipItem } from 'chart.js'
 
-interface IVerticalLinePlugin extends Plugin {
-  clickedSegment?: TooltipItem<ChartType>
-  pause?: boolean
-}
-
 const drawLine = (ctx: CanvasRenderingContext2D, x: number, top: number, bottom: number) => {
 
   ctx.save()
@@ -16,26 +11,47 @@ const drawLine = (ctx: CanvasRenderingContext2D, x: number, top: number, bottom:
   ctx.stroke()
   ctx.restore()
 }
-export class VerticalLinePlugin implements IVerticalLinePlugin {
+export class VerticalLinePlugin implements Plugin {
   id = 'verticalLinePlugin'
-  clickedSegment?: TooltipItem<ChartType>
-  pause = false
+  private _clickedSegment?: TooltipItem<ChartType> | undefined
+  private _pause = false
 
   afterDatasetsDraw(chart: Chart) {
-    if (!this.pause && chart.tooltip && chart.tooltip.getActiveElements() && chart.tooltip.getActiveElements().length && !this.clickedSegment) {
+    if (!this._pause && chart.tooltip && chart.tooltip.getActiveElements() && chart.tooltip.getActiveElements().length && !this.clickedSegment) {
       const { x } = chart.tooltip.dataPoints[0].element
       const ctx = chart.ctx
       drawLine(ctx, x, chart.scales.y.top, chart.scales.y.bottom)
     }
 
-    if (!this.pause && this.clickedSegment) {
-      const { x } = (this.clickedSegment as TooltipItem<ChartType>).element
+    if (!this._pause && this._clickedSegment) {
+      const { x } = (this._clickedSegment as TooltipItem<ChartType>).element
       const ctx = chart.ctx
       drawLine(ctx, x, chart.scales.y.top, chart.scales.y.bottom)
     }
   }
 
+  pause() {
+    this._pause = true
+  }
+
+  resume() {
+    this._pause = false
+  }
+
+  set clickedSegment(segment: TooltipItem<ChartType> | undefined) {
+    this._clickedSegment = segment
+  }
+  get clickedSegment(): TooltipItem<ChartType> | undefined {
+    return this._clickedSegment
+  }
+
+  destroyClickedSegment() {
+    delete this._clickedSegment
+  }
+
   beforeDestroy() {
-    delete this.clickedSegment
+    if (this._clickedSegment) {
+      this.destroyClickedSegment()
+    }
   }
 }

--- a/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
@@ -44,7 +44,6 @@ import {
   datavisPalette,
   darkenColor,
 } from '../../utils'
-import { v4 as uuidv4 } from 'uuid'
 import { Doughnut } from 'vue-chartjs'
 import composables from '../../composables'
 import type { AnalyticsChartColors, KChartData, TooltipState } from '../../types'
@@ -91,8 +90,8 @@ const props = defineProps({
 
 const { translateUnit } = composables.useTranslatedUnits()
 
-const legendID = ref(uuidv4())
-const chartID = ref(uuidv4())
+const legendID = crypto.randomUUID()
+const chartID = crypto.randomUUID()
 const legendItems = ref([])
 
 const tooltipData: TooltipState = reactive({
@@ -107,11 +106,12 @@ const tooltipData: TooltipState = reactive({
   offsetY: 0,
   width: 0,
   height: 0,
+  chartID,
   chartType: 'donut',
 })
 
 const htmlLegendPlugin: Plugin = {
-  id: legendID.value,
+  id: legendID,
   afterUpdate(chart: Chart) {
     // @ts-ignore - chart js options internally, are not well typed
     legendItems.value = chart.options.plugins.legend.labels.generateLabels(chart)
@@ -147,7 +147,7 @@ composables.useReportChartDataForSynthetics(toRef(props, 'chartData'), toRef(pro
 
 const { options } = composables.useDonutChartOptions({
   tooltipState: tooltipData,
-  legendID: legendID.value,
+  legendID: legendID,
 })
 
 const chartInstance = ref<Chart>()

--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -4,6 +4,7 @@
     :class="chartFlexClass[legendPosition]"
   >
     <canvas
+      :id="axisCanvasId"
       ref="axis"
       class="axis"
     />
@@ -18,6 +19,7 @@
         :style="{ width: chartWidth, height: chartHeight }"
       >
         <canvas
+          :id="chartCanvasId"
           ref="canvas"
           class="chart-canvas"
         />
@@ -66,7 +68,7 @@ import composables from '../../composables'
 import { v4 as uuidv4 } from 'uuid'
 import { ChartLegendPosition } from '../../enums'
 import type { AxesTooltipState, ChartLegendSortFn, ChartTooltipSortFn, EnhancedLegendItem, KChartData, LegendValues, TooltipEntry, TooltipState } from '../../types'
-import { highlightPlugin } from '../chart-plugins/HighlightPlugin'
+import { createHighlightPlugin } from '../chart-plugins/HighlightPlugin'
 
 const props = defineProps({
   chartData: {
@@ -134,6 +136,8 @@ const props = defineProps({
 
 const { i18n } = composables.useI18n()
 const { translateUnit } = composables.useTranslatedUnits()
+const axisCanvasId = crypto.randomUUID()
+const chartCanvasId = crypto.randomUUID()
 
 // https://www.chartjs.org/chartjs-plugin-annotation/latest/guide/types/label.html#label-annotation-specific-options
 const LABEL_PADDING = 6
@@ -327,7 +331,7 @@ const plugins = [
   htmlLegendPlugin,
   axesTooltipPlugin,
   maxOverflowPlugin,
-  highlightPlugin,
+  createHighlightPlugin(),
   ...(props.annotations ? [reactiveAnnotationsPlugin] : []),
 ]
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -138,7 +138,7 @@ const { i18n } = composables.useI18n()
 const { translateUnit } = composables.useTranslatedUnits()
 const axisCanvasId = crypto.randomUUID()
 const chartCanvasId = crypto.randomUUID()
-const highlighPlugin = new HighlightPlugin()
+const highlightPlugin = new HighlightPlugin()
 
 // https://www.chartjs.org/chartjs-plugin-annotation/latest/guide/types/label.html#label-annotation-specific-options
 const LABEL_PADDING = 6
@@ -333,7 +333,7 @@ const plugins = [
   htmlLegendPlugin,
   axesTooltipPlugin,
   maxOverflowPlugin,
-  highlighPlugin,
+  highlightPlugin,
   ...(props.annotations ? [reactiveAnnotationsPlugin] : []),
 ]
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -68,7 +68,7 @@ import composables from '../../composables'
 import { v4 as uuidv4 } from 'uuid'
 import { ChartLegendPosition } from '../../enums'
 import type { AxesTooltipState, ChartLegendSortFn, ChartTooltipSortFn, EnhancedLegendItem, KChartData, LegendValues, TooltipEntry, TooltipState } from '../../types'
-import { createHighlightPlugin } from '../chart-plugins/HighlightPlugin'
+import { HighlightPlugin } from '../chart-plugins/HighlightPlugin'
 
 const props = defineProps({
   chartData: {
@@ -138,6 +138,7 @@ const { i18n } = composables.useI18n()
 const { translateUnit } = composables.useTranslatedUnits()
 const axisCanvasId = crypto.randomUUID()
 const chartCanvasId = crypto.randomUUID()
+const highlighPlugin = new HighlightPlugin()
 
 // https://www.chartjs.org/chartjs-plugin-annotation/latest/guide/types/label.html#label-annotation-specific-options
 const LABEL_PADDING = 6
@@ -331,7 +332,7 @@ const plugins = [
   htmlLegendPlugin,
   axesTooltipPlugin,
   maxOverflowPlugin,
-  createHighlightPlugin(),
+  highlighPlugin,
   ...(props.annotations ? [reactiveAnnotationsPlugin] : []),
 ]
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -241,6 +241,7 @@ const tooltipData: TooltipState = reactive({
   height: 0,
   locked: false,
   chartType: isHorizontal.value ? 'horizontal_bar' : 'vertical_bar',
+  chartID: chartCanvasId,
   chartTooltipSortFn: props.chartTooltipSortFn,
 })
 const dependsOnChartUpdate = ref(0)

--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -62,9 +62,9 @@ import type { PropType } from 'vue'
 import { reactive, ref, computed, toRef, inject, watch, onUnmounted } from 'vue'
 import 'chartjs-adapter-date-fns'
 import 'chart.js/auto'
-import { createVerticalLinePlugin } from '../chart-plugins/VerticalLinePlugin'
-import { createHighlightPlugin } from '../chart-plugins/HighlightPlugin'
-import { createDragSelectPlugin } from '../chart-plugins/DragSelectPlugin'
+import { VerticalLinePlugin } from '../chart-plugins/VerticalLinePlugin'
+import { HighlightPlugin } from '../chart-plugins/HighlightPlugin'
+import { DragSelectPlugin } from '../chart-plugins/DragSelectPlugin'
 import type { DragSelectEventDetail } from '../chart-plugins/DragSelectPlugin'
 import ToolTip from '../chart-plugins/ChartTooltip.vue'
 import ChartLegend from '../chart-plugins/ChartLegend.vue'
@@ -158,7 +158,9 @@ const emit = defineEmits<{
   (e: 'zoom-time-range', newTimeRange: AbsoluteTimeRangeV4): void,
 }>()
 
-const verticalLinePlugin = createVerticalLinePlugin()
+const verticalLinePlugin = new VerticalLinePlugin()
+const highlightPlugin = new HighlightPlugin()
+const dragSelectPlugin = new DragSelectPlugin()
 const { translateUnit } = composables.useTranslatedUnits()
 const chartInstance = ref<{ chart: Chart }>()
 const legendID = ref(uuidv4())
@@ -194,8 +196,8 @@ const htmlLegendPlugin = {
 
 const plugins = computed(() => [
   htmlLegendPlugin,
-  createHighlightPlugin(),
-  ...(props.zoom ? [createDragSelectPlugin()] : []),
+  highlightPlugin,
+  ...(props.zoom ? [dragSelectPlugin] : []),
   ...(props.type === 'timeseries_line' ? [verticalLinePlugin] : []),
 ])
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -245,16 +245,19 @@ const handleChartClick = () => {
   tooltipData.locked = !tooltipData.locked
 
   if (chartInstance.value && chartInstance.value.chart.tooltip?.dataPoints?.length) {
-    verticalLinePlugin.clickedSegment = tooltipData.locked
-      ? chartInstance.value.chart.tooltip?.dataPoints[0]
-      : undefined
+
+    if (tooltipData.locked) {
+      verticalLinePlugin.clickedSegment = chartInstance.value.chart.tooltip.dataPoints[0]
+    } else {
+      verticalLinePlugin.destroyClickedSegment()
+    }
   }
 }
 
 watch(() => props.type, () => {
   tooltipData.locked = false
   tooltipData.showTooltip = false
-  delete verticalLinePlugin.clickedSegment
+  verticalLinePlugin.destroyClickedSegment()
 })
 
 const handleDragSelect = (event: Event) => {
@@ -264,12 +267,12 @@ const handleDragSelect = (event: Event) => {
   }
   isDoingSelection.value = false
   handleChartClick()
-  verticalLinePlugin.pause = false
+  verticalLinePlugin.resume()
 }
 
 const handleDragMove = () => {
   isDoingSelection.value = true
-  verticalLinePlugin.pause = true
+  verticalLinePlugin.pause()
 }
 
 watch(() => chartInstance.value?.chart, () => {
@@ -286,6 +289,8 @@ onUnmounted(() => {
     chartInstance.value.chart.canvas.removeEventListener('dragSelect', handleDragSelect)
     chartInstance.value.chart.canvas.removeEventListener('dragSelectMove', handleDragMove)
   }
+
+  verticalLinePlugin
 })
 
 </script>

--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -62,9 +62,10 @@ import type { PropType } from 'vue'
 import { reactive, ref, computed, toRef, inject, watch, onUnmounted } from 'vue'
 import 'chartjs-adapter-date-fns'
 import 'chart.js/auto'
-import { verticalLinePlugin } from '../chart-plugins/VerticalLinePlugin'
-import { highlightPlugin } from '../chart-plugins/HighlightPlugin'
-import { dragSelectPlugin, type DragSelectEventDetail } from '../chart-plugins/DragSelectPlugin'
+import { createVerticalLinePlugin } from '../chart-plugins/VerticalLinePlugin'
+import { createHighlightPlugin } from '../chart-plugins/HighlightPlugin'
+import { createDragSelectPlugin } from '../chart-plugins/DragSelectPlugin'
+import type { DragSelectEventDetail } from '../chart-plugins/DragSelectPlugin'
 import ToolTip from '../chart-plugins/ChartTooltip.vue'
 import ChartLegend from '../chart-plugins/ChartLegend.vue'
 import { v4 as uuidv4 } from 'uuid'
@@ -157,6 +158,7 @@ const emit = defineEmits<{
   (e: 'zoom-time-range', newTimeRange: AbsoluteTimeRangeV4): void,
 }>()
 
+const verticalLinePlugin = createVerticalLinePlugin()
 const { translateUnit } = composables.useTranslatedUnits()
 const chartInstance = ref<{ chart: Chart }>()
 const legendID = ref(uuidv4())
@@ -192,8 +194,8 @@ const htmlLegendPlugin = {
 
 const plugins = computed(() => [
   htmlLegendPlugin,
-  highlightPlugin,
-  ...(props.zoom ? [dragSelectPlugin] : []),
+  createHighlightPlugin(),
+  ...(props.zoom ? [createDragSelectPlugin()] : []),
   ...(props.type === 'timeseries_line' ? [verticalLinePlugin] : []),
 ])
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -68,7 +68,6 @@ import { DragSelectPlugin } from '../chart-plugins/DragSelectPlugin'
 import type { DragSelectEventDetail } from '../chart-plugins/DragSelectPlugin'
 import ToolTip from '../chart-plugins/ChartTooltip.vue'
 import ChartLegend from '../chart-plugins/ChartLegend.vue'
-import { v4 as uuidv4 } from 'uuid'
 import { Line, Bar } from 'vue-chartjs'
 import composables from '../../composables'
 import type { ChartLegendSortFn, ChartTooltipSortFn, EnhancedLegendItem, KChartData, LegendValues, TooltipEntry } from '../../types'
@@ -163,8 +162,8 @@ const highlightPlugin = new HighlightPlugin()
 const dragSelectPlugin = new DragSelectPlugin()
 const { translateUnit } = composables.useTranslatedUnits()
 const chartInstance = ref<{ chart: Chart }>()
-const legendID = ref(uuidv4())
-const chartID = ref(uuidv4())
+const legendID = crypto.randomUUID()
+const chartID = crypto.randomUUID()
 const legendItems = ref<EnhancedLegendItem[]>([])
 const tooltipElement = ref()
 const legendPosition = ref(inject('legendPosition', ChartLegendPosition.Right))
@@ -184,11 +183,12 @@ const tooltipData = reactive({
   height: 0,
   chartType: props.type,
   locked: false,
+  chartID,
   chartTooltipSortFn: props.chartTooltipSortFn,
 })
 
 const htmlLegendPlugin = {
-  id: legendID.value,
+  id: legendID,
   afterUpdate(chart: Chart) {
     legendItems.value = generateLegendItems(chart, props.legendValues, props.chartLegendSortFn)
   },
@@ -210,7 +210,7 @@ const { options } = composables.useLinechartOptions({
   tooltipState: tooltipData,
   timeRangeMs: toRef(props, 'timeRangeMs'),
   granularity: toRef(props, 'granularity'),
-  legendID: legendID.value,
+  legendID: legendID,
   stacked: toRef(props, 'stacked'),
   metricAxesTitle: toRef(props, 'metricAxesTitle'),
   dimensionAxesTitle: toRef(props, 'dimensionAxesTitle'),

--- a/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
@@ -16,9 +16,12 @@ import { computed } from 'vue'
 
 export default function useBarChartOptions(chartOptions: BarChartOptions) {
 
+  const chartID = chartOptions.tooltipState.chartID
+  const positionKey = `barChartTooltipPosition-${chartID}`
+
   const tooltipOptions = {
     enabled: false,
-    position: 'barChartTooltipPosition',
+    position: positionKey,
     callbacks: {
       label: (context: TooltipItem<'bar'>) => {
         return {
@@ -29,8 +32,8 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
     },
   }
 
-  Tooltip.positioners.barChartTooltipPosition = function(elements, position) {
-    if (!elements.length) {
+  Tooltip.positioners[positionKey] = function(elements, position) {
+    if (!elements.length || chartOptions.tooltipState.locked) {
       return false
     }
 
@@ -194,7 +197,7 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
 
 declare module 'chart.js' {
   interface TooltipPositionerMap {
-    barChartTooltipPosition: TooltipPositionerFunction<ChartType>;
+    [key: string]: TooltipPositionerFunction<ChartType>;
   }
   interface InteractionModeMap {
     customInteractionMode: InteractionModeFunction;

--- a/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useBarChartOptions.ts
@@ -12,7 +12,7 @@ import type {
 } from 'chart.js'
 import { isNullOrUndef, getRelativePosition } from 'chart.js/helpers'
 import { FONT_SIZE_SMALL, FONT_SIZE_REGULAR, MAX_LABEL_LENGTH, horizontalTooltipPositioning, tooltipBehavior } from '../utils'
-import { computed } from 'vue'
+import { computed, onUnmounted } from 'vue'
 
 export default function useBarChartOptions(chartOptions: BarChartOptions) {
 
@@ -189,6 +189,12 @@ export default function useBarChartOptions(chartOptions: BarChartOptions) {
       },
       maxBarThickness: 60,
       maintainAspectRatio: false,
+    }
+  })
+
+  onUnmounted(() => {
+    if (Tooltip.positioners[positionKey]) {
+      delete Tooltip.positioners[positionKey]
     }
   })
 

--- a/packages/analytics/analytics-chart/src/composables/useDonutChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useDonutChartOptions.ts
@@ -12,9 +12,13 @@ import {
 import { horizontalTooltipPositioning, tooltipBehavior } from '../utils'
 
 export default function useDonutChartOptions(chartOptions: DonutChartOptions) {
+
+  const chartID = chartOptions.tooltipState.chartID
+  const positionKey = `donutChartTooltipPosition-${chartID}`
+
   const tooltipOptions = {
     enabled: false,
-    position: 'donutChartTooltipPosition',
+    position: positionKey,
     callbacks: {
       label: (context: TooltipItem<'doughnut'>) => {
         return {
@@ -25,7 +29,7 @@ export default function useDonutChartOptions(chartOptions: DonutChartOptions) {
     },
   }
 
-  Tooltip.positioners.donutChartTooltipPosition = function(elements, position) {
+  Tooltip.positioners[positionKey] = function(elements, position) {
     if (!elements.length) {
       return false
     }
@@ -77,6 +81,6 @@ export default function useDonutChartOptions(chartOptions: DonutChartOptions) {
 
 declare module 'chart.js' {
   interface TooltipPositionerMap {
-    donutChartTooltipPosition: TooltipPositionerFunction<ChartType>;
+    [key: string]: TooltipPositionerFunction<ChartType>;
   }
 }

--- a/packages/analytics/analytics-chart/src/composables/useDonutChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useDonutChartOptions.ts
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, onUnmounted } from 'vue'
 import type { DonutChartOptions, ExternalTooltipContext } from '../types'
 import type {
   TooltipItem,
@@ -71,6 +71,12 @@ export default function useDonutChartOptions(chartOptions: DonutChartOptions) {
           },
         },
       },
+    }
+  })
+
+  onUnmounted(() => {
+    if (Tooltip.positioners[positionKey]) {
+      delete Tooltip.positioners[positionKey]
     }
   })
 

--- a/packages/analytics/analytics-chart/src/composables/useLineChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useLineChartOptions.ts
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, onUnmounted } from 'vue'
 import type {
   TooltipPositionerFunction,
   ChartType,
@@ -160,6 +160,12 @@ export default function useLinechartOptions(chartOptions: LineChartOptions) {
         mode: 'index',
         intersect: false,
       },
+    }
+  })
+
+  onUnmounted(() => {
+    if (Tooltip.positioners[positionKey]) {
+      delete Tooltip.positioners[positionKey]
     }
   })
 

--- a/packages/analytics/analytics-chart/src/composables/useLineChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useLineChartOptions.ts
@@ -70,13 +70,15 @@ export default function useLinechartOptions(chartOptions: LineChartOptions) {
     stacked: chartOptions.stacked.value,
   }))
 
+  const chartID = chartOptions.tooltipState.chartID
+  const positionKey = `lineChartTooltipPosition-${chartID}`
+
   const tooltipOptions = {
     enabled: false,
-    position: 'lineChartTooltipPosition',
+    position: positionKey,
   }
 
-  Tooltip.positioners.lineChartTooltipPosition = function(elements, position) {
-    // Happens when nothing is found
+  Tooltip.positioners[positionKey] = function(elements, position) {
     if (!elements.length || chartOptions.tooltipState.locked) {
       return false
     }
@@ -168,6 +170,6 @@ export default function useLinechartOptions(chartOptions: LineChartOptions) {
 
 declare module 'chart.js' {
   interface TooltipPositionerMap {
-    lineChartTooltipPosition: TooltipPositionerFunction<ChartType>;
+    [key: string]: TooltipPositionerFunction<ChartType>;
   }
 }

--- a/packages/analytics/analytics-chart/src/types/chartjs-options.ts
+++ b/packages/analytics/analytics-chart/src/types/chartjs-options.ts
@@ -27,6 +27,7 @@ export interface TooltipState {
   width: number,
   height: number
   chartType: ChartType,
+  chartID: string,
   locked?: boolean,
   chartTooltipSortFn?: ChartTooltipSortFn
 }


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-3723

- Add a new sandbox page displaying multiple charts
- Refactored plugins to use class-based instances. Each chart now creates its own plugin instance rather than relying on a shared singleton.
- Custom tooltip positioning logic was leaking between chart instances of the same type. This was due to Chart.js requiring custom tooltip positioners to be registered globally. As a result, the shared positioner always accessed tooltipState from the last chart instance of that chart type, leading to unexpected behavior. To fix this, each chart instance registers its own unique positioner function. See https://konghq.atlassian.net/browse/MA-3820 
- Cleanup tooltip positioners `onUnomunted`

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
