### PR TITLE
fix(style): fix style in upstream target form

### DIFF
--- a/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
@@ -339,6 +339,7 @@ watch(() => props.targetId, () => {
   }
 
   :deep(.k-card.kong-ui-entity-base-form) {
+    background-color: transparent;
     border: none;
     padding: $kui-space-0;
   }


### PR DESCRIPTION
# Summary

KM-1156

Upstream target form has wrong style inheritance so that is shows white background.

**Before:**
<img width="502" alt="截屏2025-04-10 上午9 41 40" src="https://github.com/user-attachments/assets/ba68a3d8-a488-43bc-84a2-ea03a5dd1c1b" />


**After:**
<img width="502" alt="截屏2025-04-10 上午9 41 49" src="https://github.com/user-attachments/assets/734017af-1ea6-486f-a6a6-6d52b27eb356" />
