### PR TITLE
feat(form): add badge array field in form

### DIFF
--- a/packages/core/forms/src/components/fields/FieldBadgeArray.vue
+++ b/packages/core/forms/src/components/fields/FieldBadgeArray.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="badge-container">
+  <div
+    :id="schema.model"
+    class="badge-container"
+    data-testid="field-badge-array"
+  >
     <KBadge
       v-for="(item, index) in badgeArray"
       :key="index"

--- a/packages/core/forms/src/components/fields/FieldBadgeArray.vue
+++ b/packages/core/forms/src/components/fields/FieldBadgeArray.vue
@@ -1,0 +1,181 @@
+<template>
+  <div class="badge-container">
+    <KBadge
+      v-for="(item, index) in badgeArray"
+      :key="index"
+      class="badge"
+      :icon-before="false"
+    >
+      {{ item }}
+      <template #icon>
+        <CloseIcon
+          role="button"
+          tabindex="0"
+          @click="removeElement(index)"
+        />
+      </template>
+    </KBadge>
+    <div class="new-badge-area">
+      <div
+        v-if="addMode"
+        class="new-badge-selector"
+      >
+        <KSelect
+          class="new-badge-select"
+          clearable
+          :items="items"
+          :placeholder="schema.placeholder"
+          @selected="newElement"
+        />
+        <TrashIcon
+          color="#0044f4"
+          @click="addMode = false"
+        />
+      </div>
+
+
+      <AddIcon
+        v-else
+        class="add-badge-icon"
+        color="#0044f4"
+        @click="addMode = true"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref, toRef, type PropType } from 'vue'
+import { AddIcon ,CloseIcon, TrashIcon } from '@kong/icons'
+import composables from '../../composables'
+import type { SelectItem } from '@kong/kongponents/dist/types'
+const props = defineProps({
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  formOptions: {
+    type: Object as PropType<Record<string, any>>,
+    default: () => undefined,
+  },
+  model: {
+    type: Object as PropType<Record<string, any>>,
+    default: () => undefined,
+  },
+  schema: {
+    type: Object as PropType<Record<string, any>>,
+    required: true,
+  },
+  vfg: {
+    type: Object,
+    required: true,
+  },
+  /**
+   * TODO: stronger type
+   * TODO: pass this down to KInput error and errorMessage
+   */
+  errors: {
+    type: Array,
+    default: () => [],
+  },
+  hint: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits<{
+  (event: 'modelUpdated', value: any, model: Record<string, any>): void
+}>()
+
+const modelRef = toRef(props, 'model')
+const addMode = ref(false)
+
+const { clearValidationErrors, updateModelValue, value: badgeArray } = composables.useAbstractFields({
+  model: modelRef,
+  schema: props.schema,
+  formOptions: props.formOptions,
+  emitModelUpdated: (data: { value: any, model: Record<string, any> }): void => {
+    emit('modelUpdated', data.value, data.model)
+  },
+})
+
+const newElement = (item: SelectItem) => {
+  const val = item.value
+  let newBadgeArray = badgeArray.value
+
+  if (!newBadgeArray || !newBadgeArray.push) newBadgeArray = []
+
+  newBadgeArray.push(val)
+
+  updateModelValue(newBadgeArray, badgeArray.value)
+  badgeArray.value = newBadgeArray
+
+  // reset the mode
+  addMode.value = false
+}
+
+const removeElement = (index: number) => {
+  const newBadgeArray = badgeArray.value.filter((_: any, i: number) => i !== index)
+  updateModelValue(newBadgeArray, badgeArray.value)
+  badgeArray.value = newBadgeArray
+}
+
+defineExpose({
+  clearValidationErrors,
+})
+
+const items = computed((): SelectItem[] => {
+  if (props.schema.values) {
+    return props.schema.values
+  }
+
+  if (props.schema.elements?.one_of?.length) {
+    return props.schema.elements.one_of.map((value: string | number | boolean) => ({ label: String(value), value: String(value) } satisfies SelectItem))
+  }
+
+  return []
+})
+</script>
+
+<style lang="scss" scoped>
+.badge-container {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $kui-space-40;
+
+  .badge {
+    line-height: $kui-line-height-60;
+  }
+}
+
+.new-badge-area {
+  align-items: center;
+  display: inline-flex;
+  gap: $kui-space-40;
+
+  .add-badge-icon {
+    color: $kui-color-text-primary;
+    cursor: pointer;
+  }
+
+  .new-badge-selector {
+    align-items: center;
+    display: flex;
+    gap: $kui-space-20;
+
+    .remove-icon {
+      color: $kui-color-text-primary;
+      cursor: pointer;
+    }
+  }
+
+  .new-badge-select {
+    :deep(.input-element-wrapper .before-content-wrapper:has(>.kui-icon:not(button):not([role=button]):only-child)) {
+      cursor: pointer;
+      pointer-events: auto;
+    }
+  }
+}
+</style>

--- a/packages/core/forms/src/utils/fieldsLoader.ts
+++ b/packages/core/forms/src/utils/fieldsLoader.ts
@@ -4,6 +4,7 @@ export { default as FieldArrayCardContainer } from '../components/fields/FieldAr
 export { default as FieldArrayItem } from '../components/fields/FieldArrayItem.vue'
 export { default as FieldArrayMultiItem } from '../components/fields/FieldArrayMultiItem.vue'
 export { default as FieldAutoSuggest } from '../components/fields/FieldAutoSuggest.vue'
+export { default as FieldBadgeArray } from '../components/fields/FieldBadgeArray.vue'
 export { default as FieldCheckbox } from '../components/fields/FieldCheckbox.vue'
 export { default as FieldChecklist } from '../components/fields/FieldChecklist.vue'
 export { default as FieldInput } from '../components/fields/FieldInput.vue'

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -155,7 +155,7 @@ import { computed, onBeforeMount, reactive, ref, watch, type PropType } from 'vu
 import { useRouter } from 'vue-router'
 import composables from '../composables'
 import { CREDENTIAL_METADATA, CREDENTIAL_SCHEMAS, PLUGIN_METADATA } from '../definitions/metadata'
-import { ArrayInputFieldSchema } from '../definitions/schemas/ArrayInputFieldSchema'
+import { ArrayInputFieldSchema, BadgeArrayInputFieldSchema } from '../definitions/schemas/ArrayInputFieldSchema'
 import endpoints from '../plugins-endpoints'
 import {
   EntityTypeIdField,
@@ -735,11 +735,11 @@ const buildFormSchema = (parentKey: string, response: Record<string, any>, initi
 
       initialFormSchema[field].elements = elements
 
-      if (['string', 'integer', 'number'].includes(elements.type) && !elements.one_of) {
-        const { id, help, label, hint, values, referenceable, model } = initialFormSchema[field]
-        const { inputAttributes, ...overrides } = JSON.parse(JSON.stringify(ArrayInputFieldSchema))
+      if (['string', 'integer', 'number'].includes(elements.type)) {
+        const { id, help, label, hint, values, referenceable, model, elements } = initialFormSchema[field]
+        const { inputAttributes, ...overrides } = JSON.parse(JSON.stringify(elements.one_of ? BadgeArrayInputFieldSchema : ArrayInputFieldSchema))
         inputAttributes.type = elements.type === 'string' ? 'text' : 'number'
-        initialFormSchema[field] = { id, help, label, hint, values, referenceable, model, inputAttributes, ...overrides }
+        initialFormSchema[field] = { id, help, label, hint, values, referenceable, model, inputAttributes, elements, ...overrides }
       }
     }
 

--- a/packages/entities/entities-plugins/src/definitions/schemas/ArrayInputFieldSchema.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/ArrayInputFieldSchema.ts
@@ -11,3 +11,9 @@ export const ArrayInputFieldSchema = {
   newElementButtonLabel: '+ Add',
   newElementButtonLabelClasses: 'kong-form-new-element-button-label',
 }
+
+export const BadgeArrayInputFieldSchema = {
+  type: 'badge-array',
+  fieldClasses: 'kong-form-badge-array-field',
+  inputAttributes: { class: 'form-control', style: { minWidth: '200px' } },
+}


### PR DESCRIPTION
# Summary

KM-1069

Currently we use a simple input to render array field with elements of `oneof` type. This isn't ideal. 
This PR tries to render this kind of field with `FieldBadgeArray` for better user experience.
