### PR TITLE
chore: export gateway service composables

### DIFF
--- a/packages/entities/entities-gateway-services/src/index.ts
+++ b/packages/entities/entities-gateway-services/src/index.ts
@@ -2,7 +2,16 @@ import GatewayServiceList from './components/GatewayServiceList.vue'
 import LegacyGatewayServiceForm from './components/LegacyGatewayServiceForm.vue'
 import GatewayServiceConfigCard from './components/GatewayServiceConfigCard.vue'
 import GatewayServiceForm from './components/GatewayServiceForm.vue'
+import composables from './composables'
 
+// Extract specific composables to export
+const { useUrlValidators } = composables
+
+// Components
 export { GatewayServiceList, GatewayServiceForm, GatewayServiceConfigCard, LegacyGatewayServiceForm }
 
+// composables
+export { useUrlValidators }
+
+// Types
 export * from './types'


### PR DESCRIPTION
# Summary

The useUrlValidators composable was exported to improve reusability, as part of [this PR](https://github.com/Kong/konnect-ui-apps/pull/6363).