### PR TITLE
fix(key-auth-plugin): temporary add region info to the realm scope

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue
@@ -160,7 +160,7 @@ const konnectConfig = ref<KonnectPluginFormConfig>({
   // entityId: '6f1ef200-d3d4-4979-9376-726f2216d90c',
   cancelRoute: { name: 'home' },
   experimentalRenders: {
-    useKeyAuthIdentityRealmsCustomRenderer: true,
+    keyAuthIdentityRealms: true,
   },
 })
 

--- a/packages/entities/entities-plugins/src/components/fields/KeyAuthIdentityRealms.vue
+++ b/packages/entities/entities-plugins/src/components/fields/KeyAuthIdentityRealms.vue
@@ -58,6 +58,18 @@ const kCurrentCPSelectItem = {
 const formConfig = inject<KonnectBaseFormConfig | KongManagerBaseFormConfig | undefined>(FORMS_CONFIG)
 const { axiosInstance } = useAxios(formConfig?.axiosRequestConfig)
 
+// workaround for the fact that the DP does not support the region: null now
+// we should remove this line when the DP supports it
+const guessRegion = () => {
+  if (formConfig?.app === 'konnect') {
+    const regionMatch = /\b(us|eu|au|me|in)\b/.exec(formConfig?.apiBaseUrl || '')
+    if (regionMatch) {
+      return { region: regionMatch[1] }
+    }
+  }
+  return {}
+}
+
 const isLoadingRealms = ref<boolean>(true)
 const realms = ref<MultiselectItem[]>([kCurrentCPSelectItem])
 
@@ -111,7 +123,7 @@ const onRealmsUpdate = (currentSelected: string[]) => {
     ? currentKonnectRealmSelection.filter((realmId) => !prevKonnectRealmSelection.includes(realmId))
     : currentKonnectRealmSelection
 
-  const nextKonnectRealms = nextKonnectRealmId.map((id) => ({ scope: 'realm', id } as const))
+  const nextKonnectRealms = nextKonnectRealmId.map((id) => ({ ...guessRegion(), scope: 'realm', id } as const))
 
   fieldValue.value = [
     ...nextCPSlice,


### PR DESCRIPTION
This is a workaround to address a DP-side identity realm issue https://kongstrong.slack.com/archives/C06FJ632KJS/p1745429119460859

JIRA: KM-1205

