### PR TITLE
fix: show tooltip on warning icon and limit size ma-3830 ma-1889

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
@@ -328,17 +328,22 @@ const exploreResult = computed<ExploreResultV4>(() => {
     }
   }, {})
 
+  const metaOverrides: Partial<QueryResponseMeta> = {
+    truncated: limitToggle.value,
+    limit: limitToggle.value ? 10 : 50,
+  }
+
   if (multiDimensionToggle.value) {
     return generateCrossSectionalData([{
       name: selectedMetric.value.name,
       unit: selectedMetric.value.unit,
-    }], dimensionMap)
+    }], dimensionMap, metaOverrides)
   } else {
     return generateCrossSectionalData([{
       name: selectedMetric.value.name,
       unit: selectedMetric.value.unit,
     }, ...(multiMetricToggle.value ? secondaryMetrics.value : [])],
-    dimensionMap)
+    dimensionMap, metaOverrides)
   }
 })
 

--- a/packages/analytics/analytics-chart/sandbox/pages/DonutChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/DonutChartDemo.vue
@@ -237,10 +237,13 @@ const exploreResult = computed<AnalyticsExploreV2Result | null>(() => {
     }
   }
 
-  return generateCrossSectionalData([{
-    name: selectedMetric.value.name,
-    unit: selectedMetric.value.unit,
-  }], { statusCodes: [...statusCodeDimensionValues.value] })
+  return generateCrossSectionalData(
+    [{
+      name: selectedMetric.value.name,
+      unit: selectedMetric.value.unit,
+    }],
+    { statusCodes: [...statusCodeDimensionValues.value] },
+    { truncated: limitToggle.value, limit: limitToggle.value ? 10 : 50 })
 
 })
 

--- a/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
@@ -359,16 +359,22 @@ const exploreResult = computed<ExploreResultV4>(() => {
     }
   }
 
+  const metaOverrides: Partial<QueryResponseMeta> = {
+    truncated: limitToggle.value,
+    limit: limitToggle.value ? 10 : 50,
+  }
+
   if (multiDimensionToggle.value) {
     return generateSingleMetricTimeSeriesData({ name: selectedMetric.value.name, unit: selectedMetric.value.unit },
       {
         statusCode: [...statusCodeDimensionValues.value],
       },
+      metaOverrides,
     )
   } else if (multiMetricToggle.value) {
-    return generateMultipleMetricTimeSeriesData([{ name: selectedMetric.value.name, unit: selectedMetric.value.unit }, ...secondaryMetrics.value])
+    return generateMultipleMetricTimeSeriesData([{ name: selectedMetric.value.name, unit: selectedMetric.value.unit }, ...secondaryMetrics.value], metaOverrides)
   }
-  return generateSingleMetricTimeSeriesData({ name: selectedMetric.value.name, unit: selectedMetric.value.unit })
+  return generateSingleMetricTimeSeriesData({ name: selectedMetric.value.name, unit: selectedMetric.value.unit }, null, metaOverrides)
 })
 
 const colorPalette = ref<AnalyticsChartColors>([...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: lookupStatusCodeColor(dimension) || lookupDatavisColor(rand(0, 5)) }), {}))

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -24,11 +24,12 @@
         >
           <WarningIcon
             :color="`var(--kui-color-text-warning, ${KUI_COLOR_TEXT_WARNING})`"
-            decorative
             :size="KUI_ICON_SIZE_40"
           />
           <template #content>
-            {{ notAllDataShownTooltipContent }}
+            <div class="tooltip-content">
+              {{ notAllDataShownTooltipContent }}
+            </div>
           </template>
         </KTooltip>
       </div>
@@ -432,6 +433,10 @@ provide('legendPosition', toRef(props, 'legendPosition'))
     display: flex;
     margin-left: var(--kui-space-50, $kui-space-50);
     margin-top: var(--kui-space-10, $kui-space-10);
+
+    .tooltip-content {
+      max-width: 40vw;
+    }
   }
 }
 </style>

--- a/packages/analytics/analytics-utilities/src/utils/chartDataGenerator.ts
+++ b/packages/analytics/analytics-utilities/src/utils/chartDataGenerator.ts
@@ -15,7 +15,7 @@ export interface Metric {
   unit: string
 }
 
-export const generateSingleMetricTimeSeriesData = (metric: Metric, dimensionMap?: DimensionMap) => {
+export const generateSingleMetricTimeSeriesData = (metric: Metric, dimensionMap?: DimensionMap, metaOverrides?: Partial<QueryResponseMeta>) => {
   const seed = rand(10, 10000)
   const rng = new SeededRandom(seed)
 
@@ -86,6 +86,7 @@ export const generateSingleMetricTimeSeriesData = (metric: Metric, dimensionMap?
     },
     granularity_ms: 60 * 60 * 1000, // 1 hour in ms
     display: displayBlob,
+    ...(metaOverrides ?? {}),
   }
 
   return {
@@ -94,7 +95,7 @@ export const generateSingleMetricTimeSeriesData = (metric: Metric, dimensionMap?
   } as ExploreResultV4
 }
 
-export const generateMultipleMetricTimeSeriesData = (metrics: Metric[]) => {
+export const generateMultipleMetricTimeSeriesData = (metrics: Metric[], metaOverrides?: Partial<QueryResponseMeta>) => {
   const seed = rand(10, 10000)
   const rng = new SeededRandom(seed)
 
@@ -136,6 +137,7 @@ export const generateMultipleMetricTimeSeriesData = (metrics: Metric[]) => {
     }, {}),
     granularity_ms: 60 * 60 * 1000, // 1 hour in ms
     display: {},
+    ...(metaOverrides ?? {}),
   }
 
   return {
@@ -144,7 +146,7 @@ export const generateMultipleMetricTimeSeriesData = (metrics: Metric[]) => {
   } as ExploreResultV4
 }
 
-export const generateCrossSectionalData = (metrics: Metric[], dimensionMap?: DimensionMap) => {
+export const generateCrossSectionalData = (metrics: Metric[], dimensionMap?: DimensionMap, metaOverrides?: Partial<QueryResponseMeta>) => {
   const seed = Math.floor(Math.random() * (10000 - 10 + 1)) + 10
   const rng = new SeededRandom(seed)
 
@@ -223,6 +225,7 @@ export const generateCrossSectionalData = (metrics: Metric[], dimensionMap?: Dim
     limit: 50,
     display: displayBlob,
     granularity_ms: end - start,
+    ...(metaOverrides ?? {}),
   }
 
   return {


### PR DESCRIPTION
# Summary

Fixes [MA-3830](https://konghq.atlassian.net/browse/MA-3830) and [MA-1889](https://konghq.atlassian.net/browse/MA-1889).

* Limit/truncate warning tooltip works when hovering over the icon
* Tooltip content is restricted to 50% viewport width so it doesn't bleed off screen
* Sandbox "No Limit" toggle now actually does something

The tooltip wasn't working before because if an icon has the `decorative` prop, it applies the css `pointer-events: none` which means hover effects don't actually trigger. In this case, the icon was the only component that could trigger the tooltip. Merely wrapping it in a `<div>` would have fixed it as well, but I figured it was better to just remove the `decorative` prop.

"No Limit" I don't think has been working [since 2023](https://github.com/Kong/public-ui-components/commit/03df6ec7e33daf8596c9b5bf27b7af1109073732#diff-03e87b68d35d6befcad08a5c5df10076996c356dffafbbc413f59510280cf23bL381) (note that `limitToggle` got removed, probably by accident).

Icons have [pointer events none here](https://github.com/Kong/icons/blob/main/src/__template__/ComponentTemplate.vue#L101)

**Behavior after changes**

![tooltip](https://github.com/user-attachments/assets/d5b94309-7239-4ce1-86db-20d48824b377)

![no-limit-after](https://github.com/user-attachments/assets/071abf40-12a2-44cb-a2a6-7c42f7a27b6b)

**No limit behavior before changes**

![no-limit-before](https://github.com/user-attachments/assets/c7334416-d608-4ed8-8a04-2d0e17597080)


[MA-3830]: https://konghq.atlassian.net/browse/MA-3830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MA-3829]: https://konghq.atlassian.net/browse/MA-3829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MA-1889]: https://konghq.atlassian.net/browse/MA-1889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ