### PR TITLE
feat(app-layout): expose slot `title` for `<AppAboutSection />`

### DIFF
--- a/packages/core/app-layout/sandbox/pages/PageHeaderPage.vue
+++ b/packages/core/app-layout/sandbox/pages/PageHeaderPage.vue
@@ -42,8 +42,12 @@
       created="2023-02-17"
       description="Some cats are cool, some are not. This one is cool."
       modified="2023-02-17 15:23:34"
-      title="About this Cat"
     >
+      <template #title>
+        About this cat
+        <KBadge>Meow!</KBadge>
+      </template>
+
       <template #actions>
         <EditIcon
           color="#0044f4"

--- a/packages/core/app-layout/src/components/aboutSection/AppAboutSection.cy.ts
+++ b/packages/core/app-layout/src/components/aboutSection/AppAboutSection.cy.ts
@@ -91,6 +91,8 @@ describe('<AppAboutSection />', () => {
     })
 
     cy.get('.kong-ui-app-about-section').should('exist')
+    cy.getTestId('about-section-title').should('be.visible')
+    cy.getTestId('about-section-title').should('contain.text', title)
     cy.getTestId('about-section-actions').should('be.visible')
     cy.getTestId('about-section-actions').should('contain.text', actionsText)
     cy.getTestId('about-section-content').should('be.visible')
@@ -98,6 +100,52 @@ describe('<AppAboutSection />', () => {
     cy.getTestId('about-divider-section').should('be.visible')
     cy.getTestId('about-divider-section-separator').should('be.visible')
     cy.getTestId('about-divider-section').should('contain.text', dividerText)
+  })
+
+  it('should correctly render title in props', () => {
+    const title = 'Cats are Cool'
+
+    cy.mount(AppAboutSection, {
+      props: {
+        title,
+      },
+    })
+
+    cy.get('.kong-ui-app-about-section').should('exist')
+    cy.getTestId('about-section-title').should('be.visible')
+    cy.getTestId('about-section-title').should('contain.text', title)
+  })
+
+  it('should correctly render title in slots', () => {
+    const title = 'Cats are Cool'
+
+    cy.mount(AppAboutSection, {
+      slots: {
+        title,
+      },
+    })
+
+    cy.get('.kong-ui-app-about-section').should('exist')
+    cy.getTestId('about-section-title').should('be.visible')
+    cy.getTestId('about-section-title').should('contain.text', title)
+  })
+
+  it('should correctly render title in both props and slots', () => {
+    const titleProps = 'Cats are Cool'
+    const titleSlot = 'Cats are Awesome'
+
+    cy.mount(AppAboutSection, {
+      props: {
+        title: titleProps,
+      },
+      slots: {
+        title: titleSlot,
+      },
+    })
+
+    cy.get('.kong-ui-app-about-section').should('exist')
+    cy.getTestId('about-section-title').should('be.visible')
+    cy.getTestId('about-section-title').should('contain.text', titleSlot)
   })
 
   it('should not render empty props/slots', () => {

--- a/packages/core/app-layout/src/components/aboutSection/AppAboutSection.vue
+++ b/packages/core/app-layout/src/components/aboutSection/AppAboutSection.vue
@@ -4,14 +4,16 @@
     title-tag="h2"
   >
     <template
-      v-if="title"
+      v-if="$slots.title || title"
       #title
     >
       <span
         class="about-section-title"
         data-testid="about-section-title"
       >
-        {{ title }}
+        <slot name="title">
+          {{ title }}
+        </slot>
       </span>
     </template>
 
@@ -101,35 +103,22 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-const props = defineProps({
-  title: {
-    type: String,
-    default: '',
-  },
-  description: {
-    type: String,
-    default: '',
-  },
-  created: {
-    type: String,
-    default: '',
-  },
-  createdLabel: {
-    type: String,
-    default: 'Created',
-  },
-  modified: {
-    type: String,
-    default: '',
-  },
-  modifiedLabel: {
-    type: String,
-    default: 'Modified',
-  },
-  isLoading: {
-    type: Boolean,
-    default: false,
-  },
+const props = withDefaults(defineProps<{
+  title?: string,
+  description?: string,
+  created?: string,
+  createdLabel?: string,
+  modified?: string,
+  modifiedLabel?: string,
+  isLoading?: boolean,
+}>(), {
+  title: '',
+  description: '',
+  created: '',
+  createdLabel: 'Created',
+  modified: '',
+  modifiedLabel: 'Modified',
+  isLoading: false,
 })
 
 const displayModified = computed(() => {


### PR DESCRIPTION
This can help us do more customization on the title of the `<AppAboutSection />` component.

The `defineProps` now changes to the TypeScript-style definition with `withDefaults`, which makes Cypress typing system happy in the component test file

JIRA: KM-1134

