### PR TITLE
fix(analytics): single value chart show empty when null [KHCP-16024]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/SimpleChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/SimpleChart.cy.ts
@@ -117,6 +117,24 @@ describe('<SimpleChart />', () => {
     cy.getTestId('single-value-chart').contains(value)
   })
 
+  it('Single Value displays empty when value is `null`', () => {
+    const faultyExploreResult = { ...exploreResultTruncated }
+    // @ts-ignore - this is a test
+    faultyExploreResult.data[0].event.TotalRequests = null
+
+    cy.mount(SimpleChart, {
+      props: {
+        chartData: faultyExploreResult,
+        chartOptions: {
+          type: 'single_value',
+        },
+      },
+    })
+
+    cy.getTestId('single-value-chart').should('not.exist')
+    cy.getTestId('no-data-in-report').should('be.visible')
+  })
+
   it('Single Value displays error when value is not a number', () => {
     const faultyExploreResult = { ...exploreResultTruncated }
     // @ts-ignore - this is a test
@@ -139,6 +157,7 @@ describe('<SimpleChart />', () => {
     const value = 255.0004
     const alteredExploreResult = { ...exploreResultTruncated }
     alteredExploreResult.data[0].event.TotalRequests = value
+    cy.log(alteredExploreResult)
 
     cy.mount(SimpleChart, {
       props: {
@@ -152,5 +171,22 @@ describe('<SimpleChart />', () => {
 
     cy.getTestId('single-value-chart').should('be.visible')
     cy.getTestId('single-value-chart').contains(value)
+  })
+
+  it('Single Value displays error when metric name is not provided', () => {
+    const faultyExploreResult = { ...exploreResultTruncated }
+    faultyExploreResult.meta.metric_names = []
+
+    cy.mount(SimpleChart, {
+      props: {
+        chartData: faultyExploreResult,
+        chartOptions: {
+          type: 'single_value',
+        },
+      },
+    })
+
+    cy.getTestId('single-value-chart').should('not.exist')
+    cy.getTestId('single-value-error').should('be.visible')
   })
 })

--- a/packages/analytics/analytics-chart/src/components/SimpleChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/SimpleChart.cy.ts
@@ -157,7 +157,6 @@ describe('<SimpleChart />', () => {
     const value = 255.0004
     const alteredExploreResult = { ...exploreResultTruncated }
     alteredExploreResult.data[0].event.TotalRequests = value
-    cy.log(alteredExploreResult)
 
     cy.mount(SimpleChart, {
       props: {

--- a/packages/analytics/analytics-chart/src/components/SimpleChart.vue
+++ b/packages/analytics/analytics-chart/src/components/SimpleChart.vue
@@ -111,7 +111,16 @@ const isSingleValueChart = computed<boolean>(() => props.chartOptions.type === '
 
 const emptyStateTitle = computed(() => props.emptyStateTitle || i18n.t('noDataAvailableTitle'))
 const hasValidChartData = computed(() => {
-  return props.chartData && props.chartData.meta && props.chartData.data.length
+  const hasChartData = props.chartData && props.chartData.meta && props.chartData.data.length
+
+  // for single value chart, show empty state if the metric value is null
+  if (isSingleValueChart.value) {
+    const metricName = props.chartData.meta?.metric_names?.[0]
+    // ignore the scenario where the metric name is undefined or metric value is not a number, the chart will handle it (display error message)
+    return hasChartData && props.chartData.data[0].event[metricName!] !== null
+  }
+
+  return hasChartData
 })
 </script>
 


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-16024

When metric value is `null`, show empty state instead of error message in SingleValue chart

https://github.com/user-attachments/assets/78a62887-36a1-4772-8dfa-c1a28990d4db

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
