### PR TITLE
feat(analytics): support dashboard tile duplication [ma-3824]

### DIFF
--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -69,7 +69,7 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "600KB"
+    "errorLimit": "700KB"
   },
   "peerDependencies": {
     "@kong-ui-public/analytics-chart": "workspace:^",

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -70,6 +70,13 @@
             </KDropdownItem>
             <KDropdownItem
               v-if="context.editable"
+              :data-testid="`duplicate-tile-${tileId}`"
+              @click="duplicateTile"
+            >
+              {{ i18n.t('renderer.duplicateTile') }}
+            </KDropdownItem>
+            <KDropdownItem
+              v-if="context.editable"
               :data-testid="`remove-tile-${tileId}`"
               @click="removeTile"
             >
@@ -144,6 +151,7 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
   (e: 'edit-tile', tile: TileDefinition): void
+  (e: 'duplicate-tile', tile: TileDefinition): void
   (e: 'remove-tile', tile: TileDefinition): void
   (e: 'zoom-time-range', newTimeRange: AbsoluteTimeRangeV4): void
 }>()
@@ -271,6 +279,10 @@ const editTile = () => {
   emit('edit-tile', props.definition)
 }
 
+const duplicateTile = () => {
+  emit('duplicate-tile', props.definition)
+}
+
 const removeTile = () => {
   emit('remove-tile', props.definition)
 }
@@ -312,13 +324,13 @@ const exportCsv = () => {
     .title-tooltip {
       margin-right: $kui-space-20;
       overflow: hidden;
+    }
 
-      .title {
-        font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
+    .title {
+      font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .tile-actions {

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -7,6 +7,7 @@
       "30d": "Last 30-Day Summary"
     },
     "edit": "Edit",
+    "duplicateTile": "Duplicate",
     "remove": "Remove"
   },
   "queryDataProvider": {


### PR DESCRIPTION
# Summary

Satisfies [MA-3824](https://konghq.atlassian.net/browse/MA-3824)

* Add a `duplicate-tile` event to `<DashboardTile>`
* Bubble up the `duplicate-tile` event in `<DashboardRenderer>` - anything that uses DashboardRenderer will need to handle this event.
* Slightly refactor `DashboardTile.cy.ts` to have a common `mount` method so that the tests are easier to read.
* **fix**: long tile titles looked very bad (visible in prod). Now they don't.

In action:

https://github.com/user-attachments/assets/036caf05-9563-49e7-bbbf-783f2a6b4c96

**Before tile title fix:**

![Screenshot 2025-05-07 at 4 26 54 PM](https://github.com/user-attachments/assets/20c620e2-e235-471a-96f1-02671af98d98)

**After tile title fix:**

![Screenshot 2025-05-07 at 4 27 14 PM](https://github.com/user-attachments/assets/c54a95fd-58bb-4adb-8df2-af705e48e9cb)


[MA-3824]: https://konghq.atlassian.net/browse/MA-3824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ