### PR TITLE
refactor(request-callout): extract plugin wrapper as a shared component

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/ConfigForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/ConfigForm.vue
@@ -83,12 +83,9 @@ import useI18n from '../../../composables/useI18n'
 
 import type { Callout, RequestCalloutPlugin } from './types'
 import type { FormConfig } from '../shared/types'
-import type { FormSchema } from '../../../types/plugins/form-schema'
+import type { ConfigFormProps } from '../shared/PluginFormWrapper.vue'
 
-defineProps<{
-  schema: FormSchema
-  data?: RequestCalloutPlugin
-}>()
+defineProps<ConfigFormProps<RequestCalloutPlugin>>()
 
 const emit = defineEmits<{
   change: [value: RequestCalloutPlugin]
@@ -168,19 +165,3 @@ function onChange(newVal?: RequestCalloutPlugin) {
   emit('change', pluginConfig)
 }
 </script>
-
-<style lang="scss" scoped>
-:deep(.rc-code textarea) {
-  font-family: $kui-font-family-code !important;
-}
-
-:deep(.k-label) {
-  font-weight: $kui-font-weight-medium;
-}
-
-.rc-config-form {
-  display: flex;
-  flex-direction: column;
-  gap: $kui-space-100;
-}
-</style>

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/RequestCalloutForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/RequestCalloutForm.vue
@@ -1,110 +1,18 @@
 <template>
-  <div class="sc-form-pinned-fields">
-    <VueFormGenerator
-      :model="formModel"
-      :options="formOptions"
-      :schema="pinnedSchema"
-      @model-updated="onModelUpdated"
-    />
-  </div>
-
-  <KCollapse
-    v-model="configCollapse"
-    class="sc-form-config-fields"
+  <PluginFormWrapper
+    v-slot="configFormProps"
+    v-bind="props"
   >
-    <template #title>
-      {{ t('plugins.form.grouping.plugin_configuration.title') }}
-    </template>
-    <template #visible-content>
-      {{ t('plugins.form.grouping.plugin_configuration.description') }}
-    </template>
-
-    <ConfigForm
-      class="sc-form-config-form"
-      :data="model"
-      :schema="freeFormSchema"
-      @change="onFormChange"
-    />
-
-    <KCollapse
-      v-model="advancedCollapsed"
-      :trigger-label="advancedCollapsed ? t('plugins.form.grouping.advanced_parameters.view') : t('plugins.form.grouping.advanced_parameters.hide')"
-    >
-      <VueFormGenerator
-        :model="formModel"
-        :options="formOptions"
-        :schema="advancedSchema"
-        @model-updated="onModelUpdated"
-      />
-    </KCollapse>
-  </KCollapse>
+    <ConfigForm v-bind="configFormProps" />
+  </PluginFormWrapper>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toValue, provide, type MaybeRefOrGetter } from 'vue'
-import { createI18n } from '@kong-ui-public/i18n'
-import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
-import { VueFormGenerator } from '@kong-ui-public/forms'
-import { KCollapse } from '@kong/kongponents'
-import english from '../../../locales/en.json'
 import ConfigForm from './ConfigForm.vue'
+import PluginFormWrapper from '../shared/PluginFormWrapper.vue'
+
+import type { Props } from '../shared/PluginFormWrapper.vue'
 import type { RequestCalloutPlugin } from './types'
-import type { FormSchema } from '../../../types/plugins/form-schema'
 
-const { t } = createI18n<typeof english>('en-us', english)
-
-const props = defineProps<{
-  schema: FormSchema
-  formSchema: any
-  model: Record<string, any>
-  formModel: Record<string, any>
-  formOptions: any
-  isEditing: boolean
-  onModelUpdated: (value: any, model: string) => void
-  onFormChange: (value: RequestCalloutPlugin) => void
-}>()
-
-const slots = defineSlots<{
-  [K in typeof AUTOFILL_SLOT_NAME]: () => any
-}>()
-
-provide(AUTOFILL_SLOT, slots?.[AUTOFILL_SLOT_NAME])
-
-function usePickedSchema(keys: MaybeRefOrGetter<string[]>) {
-  return computed(() => ({
-    fields: toValue(keys)
-      .map(key => props.formSchema?.fields.find((field: { model: string }) => field.model === key))
-      .filter(Boolean),
-  }))
-}
-
-const PINNED_FIELD_KEYS = ['enabled', 'selectionGroup']
-const topLevelFieldKeys = computed(() => ((props.formSchema?.fields || []) as any[]).map((field: { model: string }) => field.model))
-const configFieldKeys = computed(() => topLevelFieldKeys.value.filter(key => key.startsWith('config-')))
-const advancedFieldKeys = computed(() => topLevelFieldKeys.value.filter(key => !PINNED_FIELD_KEYS.includes(key) && !configFieldKeys.value.includes(key)))
-
-const pinnedSchema = usePickedSchema(PINNED_FIELD_KEYS)
-const advancedSchema = usePickedSchema(advancedFieldKeys)
-
-const FREE_FORM_SCHEMA_KEYS = ['config']
-const freeFormSchema = computed(() => {
-  const result = props.schema
-  result.fields = result.fields.filter(item => FREE_FORM_SCHEMA_KEYS.includes(Object.keys(item)[0]))
-  return result
-})
-
-const configCollapse = ref(false)
-const advancedCollapsed = ref(true)
+const props = defineProps<Props<RequestCalloutPlugin>>()
 </script>
-
-<style lang="scss" scoped>
-.sc-form-config-fields {
-  border-top: $kui-border-width-10 solid $kui-color-border;
-  margin-top: $kui-space-80;
-  padding-top: $kui-space-80;
-}
-
-.sc-form-config-form {
-  margin: $kui-space-100 0;
-}
-</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="sc-form-pinned-fields">
+    <VueFormGenerator
+      :model="formModel"
+      :options="formOptions"
+      :schema="pinnedSchema"
+      @model-updated="onModelUpdated"
+    />
+  </div>
+
+  <KCollapse
+    v-model="configCollapse"
+    class="sc-form-config-fields"
+  >
+    <template #title>
+      {{ t('plugins.form.grouping.plugin_configuration.title') }}
+    </template>
+    <template #visible-content>
+      {{ t('plugins.form.grouping.plugin_configuration.description') }}
+    </template>
+
+    <div class="sc-form-config-form">
+      <slot
+        :data="model"
+        :schema="freeFormSchema"
+        @change="onFormChange"
+      />
+    </div>
+
+    <KCollapse
+      v-model="advancedCollapsed"
+      :trigger-label="advancedCollapsed ? t('plugins.form.grouping.advanced_parameters.view') : t('plugins.form.grouping.advanced_parameters.hide')"
+    >
+      <VueFormGenerator
+        :model="formModel"
+        :options="formOptions"
+        :schema="advancedSchema"
+        @model-updated="onModelUpdated"
+      />
+    </KCollapse>
+  </KCollapse>
+</template>
+
+<script lang="ts" generic="T">
+export type Props<T> = {
+  schema: FormSchema
+  formSchema: any
+  model: Record<string, any>
+  formModel: Record<string, any>
+  formOptions: any
+  isEditing: boolean
+  onModelUpdated: (value: any, model: string) => void
+  onFormChange: (value: T) => void
+}
+
+export type ConfigFormProps<T> = {
+  schema: FormSchema
+  data: Record<string, any>
+  onChange: (value: T) => void
+}
+</script>
+
+<script setup lang="ts" generic="T">
+import { computed, ref, toValue, provide, type MaybeRefOrGetter } from 'vue'
+import { createI18n } from '@kong-ui-public/i18n'
+import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
+import { VueFormGenerator } from '@kong-ui-public/forms'
+import { KCollapse } from '@kong/kongponents'
+import english from '../../../locales/en.json'
+import type { FormSchema } from '../../../types/plugins/form-schema'
+
+const { t } = createI18n<typeof english>('en-us', english)
+
+const props = defineProps<Props<T>>()
+
+const slots = defineSlots<{
+  [K in typeof AUTOFILL_SLOT_NAME]: () => any
+} & {
+  default: (props: ConfigFormProps<T>) => any
+}>()
+
+provide(AUTOFILL_SLOT, slots?.[AUTOFILL_SLOT_NAME])
+
+function usePickedSchema(keys: MaybeRefOrGetter<string[]>) {
+  return computed(() => ({
+    fields: toValue(keys)
+      .map(key => props.formSchema?.fields.find((field: { model: string }) => field.model === key))
+      .filter(Boolean),
+  }))
+}
+
+const PINNED_FIELD_KEYS = ['enabled', 'selectionGroup']
+const topLevelFieldKeys = computed(() => ((props.formSchema?.fields || []) as any[]).map((field: { model: string }) => field.model))
+const configFieldKeys = computed(() => topLevelFieldKeys.value.filter(key => key.startsWith('config-')))
+const advancedFieldKeys = computed(() => topLevelFieldKeys.value.filter(key => !PINNED_FIELD_KEYS.includes(key) && !configFieldKeys.value.includes(key)))
+
+const pinnedSchema = usePickedSchema(PINNED_FIELD_KEYS)
+const advancedSchema = usePickedSchema(advancedFieldKeys)
+
+const FREE_FORM_SCHEMA_KEYS = ['config']
+const freeFormSchema = computed(() => {
+  const result = props.schema
+  result.fields = result.fields.filter(item => FREE_FORM_SCHEMA_KEYS.includes(Object.keys(item)[0]))
+  return result
+})
+
+const configCollapse = ref(false)
+const advancedCollapsed = ref(true)
+</script>
+
+<style lang="scss" scoped>
+.sc-form-config-fields {
+  border-top: $kui-border-width-10 solid $kui-color-border;
+  margin-top: $kui-space-80;
+  padding-top: $kui-space-80;
+}
+
+.sc-form-config-form {
+  margin: $kui-space-100 0;
+}
+
+:deep(.rc-code textarea) {
+  font-family: $kui-font-family-code !important;
+}
+
+:deep(.k-label) {
+  font-weight: $kui-font-weight-medium;
+}
+
+:deep(.rc-config-form) {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-100;
+}
+</style>


### PR DESCRIPTION
# Summary
[KM-1261](https://konghq.atlassian.net/browse/KM-1261)
Creating a common plugin form wrapper from the request callout form to reuse it in other free forms.
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/cd5bf38e-3fee-4f1b-ba1e-e0287696fff3" />


[KM-1261]: https://konghq.atlassian.net/browse/KM-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ