### PR TITLE
fix(entities-routes): expressions playground tooltip on entry

### DIFF
--- a/packages/entities/entities-routes/src/components/RouteFormExpressionsEditor.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormExpressionsEditor.vue
@@ -35,13 +35,15 @@
  */
 import { ExpressionsEditor, HTTP_BASED_PROTOCOLS, PROTOCOL_TO_SCHEMA, RouterPlaygroundModal, type Schema } from '@kong-ui-public/expressions'
 import { computed, ref } from 'vue'
+import composables from '../composables'
 
 import '@kong-ui-public/expressions/dist/style.css'
+
+const { i18n: { t } } = composables.useI18n()
 
 const props = defineProps<{
   protocol?: string
   showExpressionsModalEntry?: boolean
-  hintText: string
 }>()
 const expression = defineModel<string>({ required: true })
 const emit = defineEmits<{
@@ -63,7 +65,11 @@ const isHttpBasedProtocol = computed(() => {
 })
 
 const tooltipText = computed(() => {
-  return (props.showExpressionsModalEntry && !isHttpBasedProtocol.value) ? `${props.hintText}${HTTP_BASED_PROTOCOLS}` : undefined
+  if (!props.showExpressionsModalEntry || isHttpBasedProtocol.value) {
+    return undefined
+  }
+
+  return t('form.expression_playground.supported_protocols_hint', { protocols: HTTP_BASED_PROTOCOLS.join(', ') })
 })
 
 const handleCommit = (expr: string) => {

--- a/packages/entities/entities-routes/src/components/RouteFormExpressionsEditorLoader.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormExpressionsEditorLoader.vue
@@ -12,7 +12,6 @@
   <RouteFormExpressionsEditor
     v-else
     v-model="expression"
-    :hint-text="t('form.expression_playground.supported_protocols_hint')"
     :protocol="props.protocol"
     :show-expressions-modal-entry="showExpressionsModalEntry"
     @notify="emit('notify', $event)"


### PR DESCRIPTION
A tiny fix

Before|After
-|-
<img width="573" alt="Screenshot 2025-05-12 at 13 12 41" src="https://github.com/user-attachments/assets/074f7e04-9426-43e8-badc-8e07429cac6b" />|<img width="580" alt="Screenshot 2025-05-12 at 13 22 24" src="https://github.com/user-attachments/assets/1a1a9422-405f-4bda-ba0e-ce2324551d0f" />
