### PR TITLE
feat(entities-routes): add prop to hide the protocols selector

### DIFF
--- a/packages/entities/entities-routes/docs/route-form-rules-composer.md
+++ b/packages/entities/entities-routes/docs/route-form-rules-composer.md
@@ -62,6 +62,14 @@ Whether to show the entry to the router playground under the Expressions editor.
 
 Tooltips to show for tabs for each flavor. When there is only one flavor, the tab label and tooltip will not be shown.
 
+#### `hideProtocols`
+
+- type: `boolean`
+- required: `false`
+- default: `undefined`
+
+Whether to hide the protocols selector.
+
 ### Events
 
 #### `notify`

--- a/packages/entities/entities-routes/src/components/RouteFormRulesComposer.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormRulesComposer.vue
@@ -78,6 +78,7 @@
 
     <template v-if="!recordFlavor || !(routeFlavors.traditional && routeFlavors.expressions && recordFlavor !== configFlavor)">
       <KSelect
+        v-if="!hideProtocols"
         data-testid="route-form-protocols"
         :items="protocolOptions"
         :label="t('form.fields.protocols.label')"
@@ -148,6 +149,7 @@ const props = defineProps<{
     [RouteFlavor.EXPRESSIONS]?: string
   }
   isWsSupported?: boolean
+  hideProtocols?: boolean
 }>()
 
 const configType = defineModel<'basic' | 'advanced'>('configType', { required: true })


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Adding a prop to hide the protocols selector. It is useful in AI Manager.

KM-1266
