### PR TITLE
refactor(free-form): handle advanced fields in free form [KM-1265]

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/ConfigForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/ConfigForm.vue
@@ -66,11 +66,13 @@
         </template>
       </ObjectField>
     </ObjectField>
+
+    <AdvancedFields />
   </Form>
 </template>
 
 <script setup lang="ts">
-import { cloneDeep, pick } from 'lodash-es'
+import { cloneDeep, omit } from 'lodash-es'
 import { FIELD_RENDERERS } from '../shared/composables'
 import { getCalloutId } from './utils'
 import ArrayField from '../shared/ArrayField.vue'
@@ -80,6 +82,7 @@ import Form from '../shared/Form.vue'
 import ObjectField from '../shared/ObjectField.vue'
 import StringField from '../shared/StringField.vue'
 import useI18n from '../../../composables/useI18n'
+import AdvancedFields from '../shared/AdvancedFields.vue'
 
 import type { Callout, RequestCalloutPlugin } from './types'
 import type { FormConfig } from '../shared/types'
@@ -111,7 +114,7 @@ function getNameMap(callouts: Callout[], reverse: boolean = false) {
 
 // replace callout names in `depends_on` with freshly generated ids
 function prepareFormData(data: RequestCalloutPlugin) {
-  const pluginConfig = pick(cloneDeep(data), 'config', 'partials')
+  const pluginConfig = omit(cloneDeep(data), 'created_at', 'updated_at', 'id')
 
   if (!pluginConfig.config?.callouts) {
     return pluginConfig

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/types.ts
@@ -1,6 +1,9 @@
 export interface RequestCalloutPlugin {
   config?: RequestCallout
   partials?: Array<{ id: string }>
+  instance_name?: string
+  protocols?: string[]
+  tags?: string[]
 }
 
 export interface RequestCallout {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/AdvancedFields.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/AdvancedFields.vue
@@ -12,7 +12,7 @@
         v-if="getSchema('protocols')"
         name="protocols"
       />
-      <StringField
+      <TagField
         v-if="getSchema('tags')"
         help="e.g. tag1, tag2, tag3"
         name="tags"
@@ -30,7 +30,7 @@ import { createI18n } from '@kong-ui-public/i18n'
 import { KCollapse } from '@kong/kongponents'
 import english from '../../../locales/en.json'
 import { useFormShared } from './composables'
-import StringField from './StringField.vue'
+import TagField from './TagField.vue'
 
 const { t } = createI18n<typeof english>('en-us', english)
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/AdvancedFields.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/AdvancedFields.vue
@@ -1,0 +1,45 @@
+<template>
+  <KCollapse
+    v-model="advancedCollapsed"
+    :trigger-label="advancedCollapsed ? t('plugins.form.grouping.advanced_parameters.view') : t('plugins.form.grouping.advanced_parameters.hide')"
+  >
+    <div class="ff-advanced-fields">
+      <Field
+        v-if="getSchema('instance_name')"
+        name="instance_name"
+      />
+      <Field
+        v-if="getSchema('protocols')"
+        name="protocols"
+      />
+      <Field
+        v-if="getSchema('tags')"
+        name="tags"
+      />
+      <slot />
+    </div>
+  </KCollapse>
+</template>
+
+<script setup lang="ts">
+import Field from '../shared/Field.vue'
+import { ref } from 'vue'
+import { createI18n } from '@kong-ui-public/i18n'
+import { KCollapse } from '@kong/kongponents'
+import english from '../../../locales/en.json'
+import { useFormShared } from './composables'
+
+const { t } = createI18n<typeof english>('en-us', english)
+
+const { getSchema } = useFormShared()
+
+const advancedCollapsed = ref(true)
+</script>
+
+<style lang="scss" scoped>
+.ff-advanced-fields {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-80;
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/AdvancedFields.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/AdvancedFields.vue
@@ -12,9 +12,11 @@
         v-if="getSchema('protocols')"
         name="protocols"
       />
-      <Field
+      <StringField
         v-if="getSchema('tags')"
+        help="e.g. tag1, tag2, tag3"
         name="tags"
+        :placeholder="t('plugins.form.fields.tags.placeholder')"
       />
       <slot />
     </div>
@@ -28,6 +30,7 @@ import { createI18n } from '@kong-ui-public/i18n'
 import { KCollapse } from '@kong/kongponents'
 import english from '../../../locales/en.json'
 import { useFormShared } from './composables'
+import StringField from './StringField.vue'
 
 const { t } = createI18n<typeof english>('en-us', english)
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
@@ -39,11 +39,13 @@ interface EnumFieldProps {
   labelAttributes?: LabelAttributes
   multiple?: boolean
   items?: SelectItem[]
+  placeholder?: string
 }
 
-const { name, items, ...props } = defineProps<EnumFieldProps>()
+const { name, items, multiple = undefined, ...props } = defineProps<EnumFieldProps>()
 const { getSelectItems } = useFormShared()
 const { value: fieldValue, ...field } = useField<number | string>(toRef(() => name))
+
 const fieldAttrs = useFieldAttrs(field.path!, props)
 
 const realItems = computed<SelectItem[]>(() => {
@@ -55,8 +57,8 @@ const realItems = computed<SelectItem[]>(() => {
 })
 
 const isMultiple = computed(() => {
-  if ('multiple' in props) {
-    return props.multiple
+  if (multiple !== undefined) {
+    return multiple
   }
 
   return field.schema!.value?.type === 'set'

--- a/packages/entities/entities-plugins/src/components/free-form/shared/Field.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/Field.vue
@@ -47,6 +47,7 @@ import ObjectField from './ObjectField.vue'
 import NumberField from './NumberField.vue'
 import EnumField from './EnumField.vue'
 import KeyValueField from './KeyValueField.vue'
+import TagField from './TagField.vue'
 
 defineOptions({ name: 'AutoField' })
 
@@ -76,8 +77,8 @@ const fieldRenderer = computed(() => {
     case 'array':
       return ArrayField
     case 'set':
-      if (utils.isStringSet(field.schema)) {
-        return StringField
+      if (utils.isTagField(field.schema)) {
+        return TagField
       }
       return EnumField
     case 'record':

--- a/packages/entities/entities-plugins/src/components/free-form/shared/Field.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/Field.vue
@@ -76,6 +76,9 @@ const fieldRenderer = computed(() => {
     case 'array':
       return ArrayField
     case 'set':
+      if (utils.isStringSet(field.schema)) {
+        return StringField
+      }
       return EnumField
     case 'record':
       return ObjectField

--- a/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
@@ -94,6 +94,7 @@ const freeFormSchema = computed(() => {
   }, {
     tags: {
       type: 'set',
+      default: [],
       description: t('plugins.form.fields.tags.help'),
       elements: {
         type: 'string',

--- a/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
@@ -26,18 +26,6 @@
         @change="onFormChange"
       />
     </div>
-
-    <KCollapse
-      v-model="advancedCollapsed"
-      :trigger-label="advancedCollapsed ? t('plugins.form.grouping.advanced_parameters.view') : t('plugins.form.grouping.advanced_parameters.hide')"
-    >
-      <VueFormGenerator
-        :model="formModel"
-        :options="formOptions"
-        :schema="advancedSchema"
-        @model-updated="onModelUpdated"
-      />
-    </KCollapse>
   </KCollapse>
 </template>
 
@@ -90,22 +78,43 @@ function usePickedSchema(keys: MaybeRefOrGetter<string[]>) {
 }
 
 const PINNED_FIELD_KEYS = ['enabled', 'selectionGroup']
-const topLevelFieldKeys = computed(() => ((props.formSchema?.fields || []) as any[]).map((field: { model: string }) => field.model))
-const configFieldKeys = computed(() => topLevelFieldKeys.value.filter(key => key.startsWith('config-')))
-const advancedFieldKeys = computed(() => topLevelFieldKeys.value.filter(key => !PINNED_FIELD_KEYS.includes(key) && !configFieldKeys.value.includes(key)))
 
 const pinnedSchema = usePickedSchema(PINNED_FIELD_KEYS)
-const advancedSchema = usePickedSchema(advancedFieldKeys)
 
-const FREE_FORM_SCHEMA_KEYS = ['config']
+const FREE_FORM_SCHEMA_KEYS = ['config', 'protocols']
 const freeFormSchema = computed(() => {
   const result = props.schema
   result.fields = result.fields.filter(item => FREE_FORM_SCHEMA_KEYS.includes(Object.keys(item)[0]))
+
+  result.fields.unshift({
+    instance_name: {
+      type: 'string',
+      description: t('plugins.form.fields.instance_name.help'),
+    },
+  }, {
+    tags: {
+      type: 'set',
+      description: t('plugins.form.fields.tags.help'),
+      help: t('plugins.form.fields.tags.placeholder'),
+      elements: {
+        type: 'string',
+      },
+    },
+  })
+
+  const protocolsField = result.fields.find(item => Object.keys(item)[0] === 'protocols')
+  if (protocolsField) {
+    protocolsField.protocols.help = protocolsField.protocols.default
+      ? t('plugins.form.fields.protocols.placeholderWithDefaultValues', {
+        protocols: protocolsField.protocols.default.join(', '),
+      })
+      : t('plugins.form.fields.protocols.placeholder')
+    protocolsField.protocols.description = t('plugins.form.fields.protocols.help')
+  }
   return result
 })
 
 const configCollapse = ref(false)
-const advancedCollapsed = ref(true)
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
@@ -95,7 +95,6 @@ const freeFormSchema = computed(() => {
     tags: {
       type: 'set',
       description: t('plugins.form.fields.tags.help'),
-      help: t('plugins.form.fields.tags.placeholder'),
       elements: {
         type: 'string',
       },

--- a/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
@@ -16,7 +16,7 @@
       }"
       :data-1p-ignore="is1pIgnore"
       :data-autofocus="isAutoFocus"
-      :model-value="value ?? ''"
+      :model-value="fieldValue ?? ''"
       @update:model-value="handleUpdate"
     >
       <template
@@ -76,10 +76,10 @@ const {
   ...props
 } = defineProps<StringFieldProps>()
 const emit = defineEmits<{
-  'update:modelValue': [value: string | null | string[]]
+  'update:modelValue': [value: string | null]
 }>()
 
-const { value: fieldValue, ...field } = useField<string | null | string[]>(toRef(() => name))
+const { value: fieldValue, ...field } = useField<string | null>(toRef(() => name))
 const fieldAttrs = useFieldAttrs(field.path!, toRef({ ...props, ...attrs }))
 const initialValue = fieldValue?.value
 
@@ -87,10 +87,6 @@ function handleUpdate(value: string) {
   if (initialValue !== undefined && value === '' && value !== initialValue) {
     fieldValue!.value = null
     emit('update:modelValue', null)
-  } else if (isStringSet.value) {
-    const values = value.trim().split(',').map(item => item.trim()).filter(Boolean)
-    fieldValue!.value = values
-    emit('update:modelValue', values)
   } else {
     fieldValue!.value = value.trim()
     emit('update:modelValue', value.trim())
@@ -129,15 +125,6 @@ const isAutoFocus = useIsAutoFocus(field.ancestors)
 const is1pIgnore = computed(() => {
   if (attrs['data-1p-ignore'] !== undefined) return attrs['data-1p-ignore']
   return utils.getName(name) === 'name'
-})
-
-const isStringSet = computed(() => utils.isStringSet(field.schema))
-
-const value = computed(() => {
-  if (isStringSet.value && Array.isArray(fieldValue?.value)) {
-    return fieldValue.value.join(', ')
-  }
-  return fieldValue?.value as string
 })
 </script>
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
@@ -16,7 +16,7 @@
       }"
       :data-1p-ignore="is1pIgnore"
       :data-autofocus="isAutoFocus"
-      :model-value="fieldValue ?? ''"
+      :model-value="value ?? ''"
       @update:model-value="handleUpdate"
     >
       <template
@@ -76,10 +76,10 @@ const {
   ...props
 } = defineProps<StringFieldProps>()
 const emit = defineEmits<{
-  'update:modelValue': [value: string | null]
+  'update:modelValue': [value: string | null | string[]]
 }>()
 
-const { value: fieldValue, ...field } = useField<string | null>(toRef(() => name))
+const { value: fieldValue, ...field } = useField<string | null | string[]>(toRef(() => name))
 const fieldAttrs = useFieldAttrs(field.path!, toRef({ ...props, ...attrs }))
 const initialValue = fieldValue?.value
 
@@ -87,6 +87,10 @@ function handleUpdate(value: string) {
   if (initialValue !== undefined && value === '' && value !== initialValue) {
     fieldValue!.value = null
     emit('update:modelValue', null)
+  } else if (isStringSet.value) {
+    const values = value.trim().split(',').map(item => item.trim()).filter(Boolean)
+    fieldValue!.value = values
+    emit('update:modelValue', values)
   } else {
     fieldValue!.value = value.trim()
     emit('update:modelValue', value.trim())
@@ -125,6 +129,15 @@ const isAutoFocus = useIsAutoFocus(field.ancestors)
 const is1pIgnore = computed(() => {
   if (attrs['data-1p-ignore'] !== undefined) return attrs['data-1p-ignore']
   return utils.getName(name) === 'name'
+})
+
+const isStringSet = computed(() => utils.isStringSet(field.schema))
+
+const value = computed(() => {
+  if (isStringSet.value && Array.isArray(fieldValue?.value)) {
+    return fieldValue.value.join(', ')
+  }
+  return fieldValue?.value as string
 })
 </script>
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/TagField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/TagField.vue
@@ -1,0 +1,95 @@
+<template>
+  <!-- missing schema alert -->
+  <KAlert
+    v-if="field.error"
+    appearance="danger"
+    :message="field.error.message"
+  />
+
+  <div v-else>
+    <KInput
+      class="ff-string-field"
+      v-bind="fieldAttrs"
+      :data-1p-ignore="is1pIgnore"
+      :data-autofocus="isAutoFocus"
+      :model-value="value ?? ''"
+      @update:model-value="handleUpdate"
+    >
+      <template
+        v-if="fieldAttrs.labelAttributes?.info"
+        #label-tooltip
+      >
+        <slot name="tooltip">
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div v-html="fieldAttrs.labelAttributes.info" />
+        </slot>
+      </template>
+    </KInput>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, toRef, useAttrs } from 'vue'
+import { KInput, type LabelAttributes } from '@kong/kongponents'
+
+import * as utils from './utils'
+import { useField, useFieldAttrs, useIsAutoFocus } from './composables'
+import type { ArrayLikeFieldSchema } from 'src/types/plugins/form-schema'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const attrs = useAttrs()
+
+// Vue doesn't support the built-in `InstanceType` utility type, so we have to
+// work around it a bit.
+// Other props are passed down to the `KInput` via attribute fallthrough.
+interface StringFieldProps {
+  name: string
+  labelAttributes?: LabelAttributes
+  multiline?: boolean
+  type?: string
+}
+
+const {
+  name,
+  ...props
+} = defineProps<StringFieldProps>()
+const emit = defineEmits<{
+  'update:modelValue': [value: string[] | null]
+}>()
+
+const { value: fieldValue, ...field } = useField<string[] | null, ArrayLikeFieldSchema>(toRef(() => name))
+const fieldAttrs = useFieldAttrs(field.path!, toRef({ ...props, ...attrs }))
+const noEmptyArray = computed(() => field.schema?.value?.len_min && field.schema.value.len_min > 0)
+
+function handleUpdate(value: string) {
+  const values = value.trim().split(',').map(item => item.trim()).filter(Boolean)
+  const finalValue = (!values.length && noEmptyArray.value) ? null : values
+  fieldValue!.value = finalValue
+  emit('update:modelValue', finalValue)
+}
+
+const isAutoFocus = useIsAutoFocus(field.ancestors)
+
+const is1pIgnore = computed(() => {
+  if (attrs['data-1p-ignore'] !== undefined) return attrs['data-1p-ignore']
+  return utils.getName(name) === 'name'
+})
+
+const value = computed(() => {
+  if (fieldValue?.value === null) {
+    return undefined
+  }
+  return fieldValue?.value.join(', ')
+})
+</script>
+
+<style lang="scss" scoped>
+.ff-string-field {
+  :deep(.k-tooltip p) {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/TagField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/TagField.vue
@@ -79,7 +79,7 @@ const is1pIgnore = computed(() => {
 })
 
 const value = computed(() => {
-  if (fieldValue?.value === null) {
+  if (fieldValue?.value == null) {
     return undefined
   }
   return fieldValue?.value.join(', ')

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables.ts
@@ -174,13 +174,7 @@ export function useSchemaHelpers(schema: MaybeRefOrGetter<FormSchema>) {
   }
 
   function getPlaceholder(fieldPath: string): string | null {
-    const schema = getSchema(fieldPath)
-
-    if (schema?.help) {
-      return schema.help
-    }
-
-    const defaultValue = schema?.default
+    const defaultValue = getSchema(fieldPath)?.default
 
     let stringified = null
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables.ts
@@ -2,7 +2,7 @@ import { computed, inject, provide, ref, toRef, toValue, useAttrs, useSlots, wat
 import { marked } from 'marked'
 import * as utils from './utils'
 import type { LabelAttributes, SelectItem } from '@kong/kongponents'
-import type { FormSchema, RecordFieldSchema, UnionFieldSchema } from '../../../types/plugins/form-schema'
+import type { ArrayLikeFieldSchema, FormSchema, RecordFieldSchema, UnionFieldSchema } from '../../../types/plugins/form-schema'
 import { get, set } from 'lodash-es'
 import type { MatchMap } from './FieldRenderer.vue'
 import type { FormConfig, ResetLabelPathRule } from './types'
@@ -170,11 +170,17 @@ export function useSchemaHelpers(schema: MaybeRefOrGetter<FormSchema>) {
 
   function getSelectItems(fieldPath: string): SelectItem[] {
     const schema = getSchema(fieldPath)
-    return utils.toSelectItems((schema?.one_of || []))
+    return utils.toSelectItems((schema?.one_of || (schema as ArrayLikeFieldSchema).elements?.one_of || []))
   }
 
   function getPlaceholder(fieldPath: string): string | null {
-    const defaultValue = getSchema(fieldPath)?.default
+    const schema = getSchema(fieldPath)
+
+    if (schema?.help) {
+      return schema.help
+    }
+
+    const defaultValue = schema?.default
 
     let stringified = null
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables.ts
@@ -85,8 +85,8 @@ export function useSchemaHelpers(schema: MaybeRefOrGetter<FormSchema>) {
    * @returns The schema for the specified path or the root schema if no path provided
    */
   function getSchema(): FormSchema
-  function getSchema(path: string): UnionFieldSchema | undefined
-  function getSchema(path?: string): FormSchema | UnionFieldSchema | undefined {
+  function getSchema<T extends UnionFieldSchema = UnionFieldSchema>(path: string): T | undefined
+  function getSchema<T extends UnionFieldSchema = UnionFieldSchema>(path?: string): T | UnionFieldSchema | undefined {
     return path == null ? schemaValue : schemaMap.value?.[generalizePath(path)]
   }
 
@@ -442,7 +442,7 @@ export function useFieldAncestors(fieldPath: MaybeRefOrGetter<string>) {
   })
 }
 
-export function useField<T = unknown>(name: MaybeRefOrGetter<string>) {
+export function useField<T = unknown, S extends UnionFieldSchema = UnionFieldSchema>(name: MaybeRefOrGetter<string>) {
   const { getSchema, formData } = useFormShared()
   const fieldPath = useFieldPath(name)
   const renderer = useFieldRenderer(fieldPath)
@@ -451,7 +451,7 @@ export function useField<T = unknown>(name: MaybeRefOrGetter<string>) {
     set: v => set(formData, utils.toArray(fieldPath.value), v),
   })
 
-  const schema = computed(() => getSchema(fieldPath.value))
+  const schema = computed(() => getSchema<S>(fieldPath.value))
 
   if (!schema.value) {
     return {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/utils.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/utils.ts
@@ -32,7 +32,7 @@ export function getName(p: string): string {
   return arr[arr.length - 1]
 }
 
-export function isStringSet(schema: MaybeRefOrGetter<UnionFieldSchema | undefined>): boolean {
+export function isTagField(schema: MaybeRefOrGetter<UnionFieldSchema | undefined>): boolean {
   const schemaVal = toValue(schema)
   if (!schemaVal) return false
   return schemaVal.type === 'set'

--- a/packages/entities/entities-plugins/src/components/free-form/shared/utils.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/utils.ts
@@ -1,9 +1,11 @@
+import type { UnionFieldSchema } from 'src/types/plugins/form-schema'
+import { toValue, type MaybeRefOrGetter } from 'vue'
+
 export function toSelectItems<T extends string>(
   items: T[],
 ): { value: T, label: T }[] {
   return items.map((item) => ({ value: item, label: item }))
 }
-
 
 export const arraySymbol = '*'
 export const rootSymbol = '$'
@@ -28,4 +30,12 @@ export function toArray(p: string): string[] {
 export function getName(p: string): string {
   const arr = toArray(p)
   return arr[arr.length - 1]
+}
+
+export function isStringSet(schema: MaybeRefOrGetter<UnionFieldSchema | undefined>): boolean {
+  const schemaVal = toValue(schema)
+  if (!schemaVal) return false
+  return schemaVal.type === 'set'
+    && schemaVal.elements.type === 'string'
+    && !schemaVal.elements.one_of
 }

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -574,6 +574,10 @@
           "placeholder": "Select valid protocols for the plugin",
           "placeholderWithDefaultValues": "Select valid protocols for the plugin. Default protocols: {protocols}",
           "help": "A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type."
+        },
+        "tags": {
+          "help": "An optional set of strings for grouping and filtering, separated by commas.",
+          "placeholder": "Enter list of tags"
         }
       },
       "scoping": {


### PR DESCRIPTION
# Summary
[KM-1265](https://konghq.atlassian.net/browse/KM-1265)
Let the three fixed advanced fields (instance_name, tags and protocols) be handled by the free form.


[KM-1265]: https://konghq.atlassian.net/browse/KM-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ