### PR TITLE
fix: record fields can also include array of objects

### DIFF
--- a/packages/analytics/analytics-utilities/src/types/explore/result.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/result.ts
@@ -38,7 +38,7 @@ export interface ExploreResultV4 {
 }
 
 export interface RecordEvent {
-  [field: string]: string | number | null
+  [field: string]: string | number | null | Array<{ [field: string]: string | number | null }>
 }
 
 export interface AnalyticsExploreRecord {


### PR DESCRIPTION
# Summary

The `ai` field in request responses can also be an array of objects. Example: 
```
...
			"response_source": "upstream",
			"sse": 0,
			"websocket": 0,
			"ai": [
				{
					"cost": 0.7148,
					"pluginId": "964e0b81-d088-4bf3-95ae-cae1738b12a7",
					"embeddingsProvider": "redis",
					"fetchLatency": 13,
					"embeddingsTokens": 48,
					"costCaching": 0.07148167793601955,
					"cacheStatus": "Hit",
					"embeddingsModel": "embeddings_model",
					"totalTokens": 123,
					"embeddingsLatency": 56,
					"requestModel": "request_model2",
					"pluginName": "ai_mock",
					"responseModel": "response_model2",
					"promptTokens": 79,
					"llmLatency": 69,
					"providerName": "openai",
					"completionTokens": 44
				}
			],
			"ai_count": 1,
			"asn": 1103,
			"as_organization": "SURFNET-NL SURFnet, The Netherlands",
			
...
```

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
