### PR TITLE
feat(entities-shared): replace pagination props

### DIFF
--- a/packages/entities/entities-shared/docs/entity-base-table.md
+++ b/packages/entities/entities-shared/docs/entity-base-table.md
@@ -8,6 +8,8 @@ A base table component for entity list views.
   - [Props](#props)
   - [`hideToolbar`](#hidetoolbar)
   - [`hidePagination`](#hidepagination)
+  - [`paginationAttributes`](#paginationattributes)
+  - [`hidePaginationWhenOptional`](#hidepaginationwhenoptional)
   - [Slots](#slots)
   - [Events](#events)
   - [Usage example](#usage-example)
@@ -142,6 +144,14 @@ Boolean to hide table toolbar. Defaults to `false`.
 ### `hidePagination`
 
 Boolean to hide table pagination. Defaults to `false`.
+
+### `paginationAttributes`
+
+Object to be passed to underlying pagination component. See [KTableData props](https://kongponents.konghq.com/components/table-view.html#paginationattributes) for more details.
+
+### `hidePaginationWhenOptional`
+
+Hide pagination when the table record count is less than or equal to the page size. Defaults to `true`.
 
 ### Slots
 

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -251,14 +251,14 @@ const props = defineProps({
     default: undefined,
   },
   /**
-   * @deprecated in favor of `paginationAttributes`
+   * @deprecated in favour of `paginationAttributes`
    */
   disablePaginationPageJump: {
     type: Boolean,
     default: undefined,
   },
   /**
-   * @deprecated in favor of `paginationAttributes`
+   * @deprecated in favour of `paginationAttributes`
    */
   paginationType: {
     type: String as PropType<'default' | 'offset'>,

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -25,7 +25,7 @@
       :hide-toolbar="hideToolbar ?? hideTableToolbar"
       :initial-fetcher-params="combinedInitialFetcherParams"
       :loading="isLoading"
-      :pagination-attributes="{ disablePageJump: disablePaginationPageJump, offset: paginationType === 'offset' }"
+      :pagination-attributes="paginationAttributes"
       resize-columns
       :row-attrs="rowAttrs"
       :row-key="rowKey"
@@ -113,7 +113,7 @@ import { computed, ref } from 'vue'
 import type { TableStateParams } from '../../types'
 import composables from '../../composables'
 import { useTablePreferences } from '@kong-ui-public/core'
-import type { HeaderTag, TablePreferences, SortHandlerFunctionParam, TableDataFetcherParams, TableDataProps } from '@kong/kongponents'
+import type { HeaderTag, TablePreferences, SortHandlerFunctionParam, TableDataFetcherParams, TableDataProps, TablePaginationAttributes } from '@kong/kongponents'
 import EntityBaseTableCell from './EntityBaseTableCell.vue'
 
 import type {
@@ -196,16 +196,12 @@ const props = defineProps({
     type: [String, Object] as PropType<string | TableErrorMessage>,
     default: null,
   },
-  disablePaginationPageJump: {
-    type: Boolean,
-    default: undefined,
+  paginationAttributes: {
+    type: Object as PropType<TablePaginationAttributes>,
+    default: () => ({}),
   },
   disableSorting: {
     type: Boolean,
-    default: undefined,
-  },
-  paginationType: {
-    type: String as PropType<'default' | 'offset'>,
     default: undefined,
   },
   // A function for applying attributes to cells

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -21,11 +21,11 @@
       :fetcher-cache-key="String(fetcherCacheKey)"
       :headers="headers"
       :hide-pagination="hidePagination"
-      hide-pagination-when-optional
+      :hide-pagination-when-optional="hidePaginationWhenOptional"
       :hide-toolbar="hideToolbar ?? hideTableToolbar"
       :initial-fetcher-params="combinedInitialFetcherParams"
       :loading="isLoading"
-      :pagination-attributes="paginationAttributes"
+      :pagination-attributes="tablePaginationAttributes"
       resize-columns
       :row-attrs="rowAttrs"
       :row-key="rowKey"
@@ -200,6 +200,10 @@ const props = defineProps({
     type: Object as PropType<TablePaginationAttributes>,
     default: () => ({}),
   },
+  hidePaginationWhenOptional: {
+    type: Boolean,
+    default: true,
+  },
   disableSorting: {
     type: Boolean,
     default: undefined,
@@ -244,6 +248,20 @@ const props = defineProps({
   },
   hideToolbar: {
     type: Boolean,
+    default: undefined,
+  },
+  /**
+   * @deprecated in favor of `paginationAttributes`
+   */
+  disablePaginationPageJump: {
+    type: Boolean,
+    default: undefined,
+  },
+  /**
+   * @deprecated in favor of `paginationAttributes`
+   */
+  paginationType: {
+    type: String as PropType<'default' | 'offset'>,
     default: undefined,
   },
 })
@@ -394,6 +412,12 @@ const handleUpdateTablePreferences = (newTablePreferences: TablePreferences): vo
     setTablePreferences(cacheId.value, newTablePreferences)
   }
 }
+
+const tablePaginationAttributes = computed((): TablePaginationAttributes => ({
+  disablePageJump: props.disablePaginationPageJump,
+  offset: props.paginationType === 'offset',
+  ...props.paginationAttributes,
+}))
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-table/EntityBaseTable.vue
@@ -256,6 +256,12 @@ const props = defineProps({
   disablePaginationPageJump: {
     type: Boolean,
     default: undefined,
+    validator: (value: boolean) => {
+      if (value) {
+        console.warn('EntityBaseTable: `disablePaginationPageJump` is deprecated in favour of `paginationAttributes`. Please update your code to use `paginationAttributes` instead.')
+      }
+      return typeof value === 'boolean'
+    },
   },
   /**
    * @deprecated in favour of `paginationAttributes`
@@ -263,6 +269,12 @@ const props = defineProps({
   paginationType: {
     type: String as PropType<'default' | 'offset'>,
     default: undefined,
+    validator: (value: string) => {
+      if (value) {
+        console.warn('EntityBaseTable: `paginationType` is deprecated in favour of `paginationAttributes`. Please update your code to use `paginationAttributes` instead.')
+      }
+      return ['default', 'offset'].includes(value)
+    },
   },
 })
 


### PR DESCRIPTION
# Summary

EntityBaseTable component changes:
- deprecate `disablePaginationPageJump` prop (still supported for backwards compatibility) in favour of new `paginationAttributes` prop
- deprecate `paginationType` prop (still supported for backwards compatibility) in favour of new `paginationAttributes` prop
- introduce `paginationAttributes` prop
- introduce `hidePaginationWhenOptional` prop

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
