### PR TITLE
feat(entities-shared): add a prop to persist format preference

### DIFF
--- a/packages/entities/entities-shared/docs/config-card-display.md
+++ b/packages/entities/entities-shared/docs/config-card-display.md
@@ -38,6 +38,14 @@ The base property configuration when format is structured.
 
 Format to be displayed in the Config Card. Can be `structured`, `json`, or `yaml`.
 
+#### `formatPreferenceKey`
+
+- type: `String`
+- required: `false`
+- default: `''`
+
+The localStorage key to use while persisting the format preference. If omitted, the format will not be persisted.
+
 #### `propListTypes`
 
 - type: `Array as PropType<String[]>`

--- a/packages/entities/entities-shared/sandbox/pages/EntityBaseConfigCardPage.vue
+++ b/packages/entities/entities-shared/sandbox/pages/EntityBaseConfigCardPage.vue
@@ -82,12 +82,14 @@ const konnectConfig = ref<KonnectBaseEntityConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   entityId,
+  formatPreferenceKey: 'konnect-entities-base-config-card-format-sandbox',
 })
 const kongManagerConfig = ref<KongManagerBaseEntityConfig>({
   app: 'kongManager',
   workspace: 'default',
   apiBaseUrl: '/kong-manager', // For local dev server proxy
   entityId,
+  formatPreferenceKey: 'kong-manager-entities-base-config-card-format-sandbox',
 })
 
 const configSchema = ref<ConfigurationSchema>({

--- a/packages/entities/entities-shared/src/types/entity-base-config-card.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-config-card.ts
@@ -31,6 +31,13 @@ export const SupportedEntityTypesArray = Object.values(SupportedEntityType)
 export interface BaseEntityConfig {
   /** the ID of the entity */
   entityId: string
+
+  /**
+   * The localStorage key to use while persisting the config format preference.
+   *
+   * If omitted, the preference will not be persisted.
+   */
+  formatPreferenceKey?: string
 }
 
 /** Konnect base form config */


### PR DESCRIPTION
# Summary

This pull request adds an optional prop to persist the format preference. When omitted, the preference will not be persisted.

KM-1278