### PR TITLE
feat: make gridSize optional (and unused) calculate from tiles instead [ma-3916]

### DIFF
--- a/packages/analytics/analytics-utilities/src/dashboardSchema.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.ts
@@ -553,7 +553,7 @@ export const dashboardConfigSchema = {
     },
     global_filter: filtersFn([...new Set([...filterableExploreDimensions, ...filterableBasicExploreDimensions, ...filterableAiExploreDimensions])]),
   },
-  required: ['tiles', 'gridSize'],
+  required: ['tiles'],
   additionalProperties: false,
 } as const satisfies JSONSchema
 

--- a/packages/analytics/analytics-utilities/src/format.ts
+++ b/packages/analytics/analytics-utilities/src/format.ts
@@ -35,7 +35,7 @@ export function formatTime(ts: number | string, options: TimeFormatOptions = {})
     // Otherwise, unit tests can fail depending on the tz of the dev's computer (or in CI), etc.
     // Even if we don't care about timezones, timezones care about us.  :/
     return formatInTimeZone(date, tz, timeFormat)
-  } catch (exc) {
+  } catch {
     console.error('Invalid value passed to formatTime', ts)
 
     return '(invalid date)'

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -92,11 +92,6 @@ const context: DashboardRendererContext = {
 }
 
 const config: DashboardConfig = {
-  // 4 x 1 grid
-  gridSize: {
-    cols: 4,
-    rows: 1,
-  },
   tiles: [
     {
       id: 'unique-tile-id', // Required for editable dashboards
@@ -116,9 +111,9 @@ const config: DashboardConfig = {
           col: 0,
           row: 0,
         },
-        // Spans 2 columns and 1 rows
+        // Spans 3 columns and 1 rows
         size: {
-          cols: 2,
+          cols: 3,
           rows: 1,
         }
       }
@@ -138,14 +133,14 @@ const config: DashboardConfig = {
         },
       },
       layout: {
-        // Position at column 2, row 0
+        // Position at column 3, row 0
         position: {
-          col: 2,
+          col: 3,
           row: 0,
         },
-        // Spans 2 columns and 1 rows
+        // Spans 3 columns and 1 rows
         size: {
-          cols: 2,
+          cols: 3,
           rows: 1,
         }
       }
@@ -184,11 +179,6 @@ const context: DashboardRendererContext = {
 }
 
 const config: DashboardConfig = {
-  // 4 x 1 grid
-  gridSize: {
-    cols: 4,
-    rows: 1,
-  },
   tiles: [
     {
       // Line chart
@@ -208,9 +198,9 @@ const config: DashboardConfig = {
           col: 0,
           row: 0,
         },
-        // Spans 2 columns and 1 rows
+        // Spans 3 columns and 1 rows
         size: {
-          cols: 2,
+          cols: 3,
           rows: 1,
         }
       }
@@ -225,14 +215,14 @@ const config: DashboardConfig = {
         query: {},
       },
       layout: {
-        // Position at column 2, row 0
+        // Position at column 3, row 0
         position: {
-          col: 2,
+          col: 3,
           row: 0,
         },
-        // Spans 2 columns and 1 rows
+        // Spans 3 columns and 1 rows
         size: {
-          cols: 2,
+          cols: 3,
           rows: 1,
         }
       }
@@ -263,11 +253,6 @@ const context: DashboardRendererContext = {
 }
 
 const config: DashboardConfig = {
-  // 4 x 1 grid
-  gridSize: {
-    cols: 4,
-    rows: 1,
-  },
   tiles: [
     {
       definition: {
@@ -284,7 +269,7 @@ const config: DashboardConfig = {
           row: 0,
         },
         size: {
-          cols: 3,
+          cols: 4,
           rows: 1,
           fitToContent: true,
         },
@@ -305,7 +290,7 @@ const config: DashboardConfig = {
           row: 0,
         },
         size: {
-          cols: 3,
+          cols: 2,
           rows: 1,
           fitToContent: true,
         },
@@ -328,10 +313,6 @@ const context: DashboardRendererContext = {
 }
 
 const config = ref<DashboardConfig>({
-  gridSize: {
-    cols: 4,
-    rows: 1,
-  },
   tiles: [
     {
       id: 'unique-tile-id', // Required for editable dashboards
@@ -350,7 +331,7 @@ const config = ref<DashboardConfig>({
           row: 0,
         },
         size: {
-          cols: 2,
+          cols: 3,
           rows: 1,
         }
       }
@@ -433,10 +414,6 @@ The root configuration type for a dashboard.
 interface DashboardConfig {
   tiles: TileConfig[]         // Array of tile configurations
   tileHeight?: number         // Optional height of each tile in pixels
-  gridSize: {                 // Required grid layout configuration
-    cols: number              // Number of columns in the grid
-    rows: number              // Number of rows in the grid
-  }
 }
 ```
 
@@ -564,10 +541,6 @@ interface TileLayout {
 
 ```typescript
 const dashboardConfig: DashboardConfig = {
-  gridSize: {
-    cols: 4,
-    rows: 2
-  },
   tiles: [{
     id: 'requests-by-route',
     definition: {
@@ -583,7 +556,7 @@ const dashboardConfig: DashboardConfig = {
     },
     layout: {
       position: { col: 0, row: 0 },
-      size: { cols: 2, rows: 1 }
+      size: { cols: 3, rows: 1 }
     }
   }]
 }

--- a/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
@@ -240,13 +240,9 @@ export const timeSeriesExploreResponse: ExploreResultV4 = {
 }
 
 export const summaryDashboardConfig: DashboardConfig = {
-  gridSize: {
-    cols: 6,
-    rows: 9,
-  },
   tileHeight: 167,
   tiles: [
-    // 3 x Metric cards
+    // one 6 x 1 Metric cards
     {
       definition: {
         chart: {
@@ -267,7 +263,7 @@ export const summaryDashboardConfig: DashboardConfig = {
       },
     } as TileConfig,
 
-    // 2 x Timeseries
+    // two 3 x 2 Timeseries
     {
       definition: {
         chart: {
@@ -336,7 +332,7 @@ export const summaryDashboardConfig: DashboardConfig = {
       },
     } as unknown as TileConfig, // TODO: MA-2987: Remove default datasource concept and associated tests.
 
-    // 1 x Timeseries
+    // one 6 x 2 Timeseries
     {
       definition: {
         chart: {
@@ -372,13 +368,9 @@ export const summaryDashboardConfig: DashboardConfig = {
 }
 
 export const simpleConfigNoFilters: DashboardConfig = {
-  gridSize: {
-    cols: 6,
-    rows: 2,
-  },
   tileHeight: 167,
   tiles: [
-    // 3 x Metric cards
+    // one 6 x 1 Metric cards
     {
       definition: {
         chart: {
@@ -401,6 +393,7 @@ export const simpleConfigNoFilters: DashboardConfig = {
         },
       },
     },
+    // one 6 x 1 timeseries
     {
       definition: {
         chart: {
@@ -487,10 +480,6 @@ export const routeExploreResponse: ExploreResultV4 = {
 }
 
 export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
-  gridSize: {
-    cols: 8,
-    rows: 6,
-  },
   tileHeight: 167,
   tiles: [
     {
@@ -508,7 +497,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
           row: 0,
         },
         size: {
-          cols: 4,
+          cols: 3,
           rows: 2,
         },
       },
@@ -525,11 +514,11 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
       },
       layout: {
         position: {
-          col: 4,
+          col: 3,
           row: 0,
         },
         size: {
-          cols: 4,
+          cols: 3,
           rows: 2,
         },
       },
@@ -550,7 +539,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
           row: 4,
         },
         size: {
-          cols: 4,
+          cols: 3,
           rows: 2,
         },
       },
@@ -567,11 +556,11 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
       },
       layout: {
         position: {
-          col: 4,
+          col: 3,
           row: 4,
         },
         size: {
-          cols: 4,
+          cols: 3,
           rows: 2,
         },
       },
@@ -581,10 +570,6 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
 }
 
 export const oneTileDashboardConfig: DashboardConfig = {
-  gridSize: {
-    cols: 6,
-    rows: 2,
-  },
   tileHeight: 167,
   tiles: [
     {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -77,10 +77,6 @@ const context = computed<DashboardRendererContext>(() => ({
 }))
 
 const dashboardConfig = ref <DashboardConfig>({
-  gridSize: {
-    cols: 6,
-    rows: 7,
-  },
   tileHeight: 167,
   tiles: [
     {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -64,10 +64,6 @@ const context: DashboardRendererContext = {
 }
 
 const dashboardConfig = ref <DashboardConfig>({
-  gridSize: {
-    cols: 6,
-    rows: 7,
-  },
   tileHeight: 167,
   tiles: [
     {

--- a/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
@@ -58,7 +58,7 @@ const evaluateFeatureFlagFn = () => true
 
 const exploreBaseUrl = async () => 'https://cloud.konghq.tech/us/analytics/explorer'
 
-const fetchComponent = async (name: string): Promise<Component> => {
+const fetchComponent = async (): Promise<Component> => {
   return Promise.resolve(EntityLink)
 }
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -134,10 +134,6 @@ describe('<DashboardRenderer />', () => {
         },
       },
       modelValue: {
-        gridSize: {
-          cols: 2,
-          rows: 4,
-        },
         tiles: [
           {
             definition: {
@@ -379,7 +375,6 @@ describe('<DashboardRenderer />', () => {
         timeSpec: customTimeframe.v4Query(),
       },
       modelValue: {
-        gridSize: { cols: 3, rows: 2 },
         tiles: [
           {
             definition: {
@@ -433,7 +428,6 @@ describe('<DashboardRenderer />', () => {
         timeSpec: customTimeframe.v4Query(),
       },
       modelValue: {
-        gridSize: { cols: 3, rows: 2 },
         tiles: [
           {
             definition: {
@@ -660,10 +654,6 @@ describe('<DashboardRenderer />', () => {
         },
       },
       modelValue: {
-        gridSize: {
-          cols: 6,
-          rows: 4,
-        },
         tileHeight: 167,
         tiles: [
           {
@@ -871,7 +861,6 @@ describe('<DashboardRenderer />', () => {
   })
 
   it('tiles maintain row-column order after reordering', () => {
-
     const configRef = ref<DashboardConfig>(fourByFourDashboardConfigJustCharts)
     const props = {
       context: {
@@ -909,121 +898,6 @@ describe('<DashboardRenderer />', () => {
     cy.wrap(configRef).should((ref: Ref<DashboardConfig>) => {
       const currentOrder = ref.value.tiles.map((tile: TileConfig) => tile.id)
       expect(currentOrder).to.deep.equal(updatedTileIDOrder)
-    })
-  })
-
-  it('Update gridsize when tile added', () => {
-    const configRef = ref<DashboardConfig>(fourByFourDashboardConfigJustCharts)
-    const props = {
-      context: {
-        filters: [],
-        timeSpec: {
-          type: 'relative',
-          time_range: '15m',
-        },
-        editable: true,
-      },
-      modelValue: configRef.value,
-    }
-
-    cy.mount(DashboardRenderer, {
-      props,
-      global: {
-        provide: {
-          [INJECT_QUERY_PROVIDER]: mockQueryProvider(),
-        },
-      },
-    })
-
-    expect(configRef.value.gridSize).to.deep.equal({ cols: 8, rows: 6 })
-
-    cy.wrap(configRef).should((ref: Ref<DashboardConfig>) => {
-      ref.value.tiles.push({
-        id: crypto.randomUUID(),
-        definition: {
-          chart: {
-            type: 'timeseries_line',
-            chartTitle: 'New Tile',
-          },
-          query: {
-            metrics: ['request_count'],
-            dimensions: ['time'],
-            filters: [],
-          },
-        },
-        layout: {
-          position: {
-            col: 0,
-            row: 0,
-          },
-          size: {
-            cols: 4,
-            rows: 4,
-          },
-        },
-      })
-    })
-
-    cy.wrap(configRef).should((ref: Ref<DashboardConfig>) => {
-      expect(ref.value.gridSize).to.deep.equal({ cols: 8, rows: 8 })
-    })
-  })
-
-  it('Preserve column counts', () => {
-    const configRef = ref<DashboardConfig>(oneTileDashboardConfig)
-
-    const props = {
-      context: {
-        filters: [],
-        timeSpec: {
-          type: 'relative',
-          time_range: '15m',
-        },
-        editable: true,
-      },
-      modelValue: configRef.value,
-    }
-
-    cy.mount(DashboardRenderer, {
-      props,
-      global: {
-        provide: {
-          [INJECT_QUERY_PROVIDER]: mockQueryProvider(),
-        },
-      },
-    })
-
-    expect(configRef.value.gridSize).to.deep.equal({ cols: 6, rows: 2 })
-
-    cy.wrap(configRef).should((ref: Ref<DashboardConfig>) => {
-      ref.value.tiles.push({
-        id: crypto.randomUUID(),
-        definition: {
-          chart: {
-            type: 'timeseries_line',
-            chartTitle: 'New Tile',
-          },
-          query: {
-            metrics: ['request_count'],
-            dimensions: ['time'],
-            filters: [],
-          },
-        },
-        layout: {
-          position: {
-            col: 0,
-            row: 2,
-          },
-          size: {
-            cols: 4,
-            rows: 4,
-          },
-        },
-      })
-    })
-
-    cy.wrap(configRef).should((ref: Ref<DashboardConfig>) => {
-      expect(ref.value.gridSize).to.deep.equal({ cols: 6, rows: 6 })
     })
   })
 })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
@@ -2,16 +2,12 @@ import { describe, it, expect } from 'vitest'
 import Ajv from 'ajv'
 import { dashboardConfigSchema } from '@kong-ui-public/analytics-utilities'
 
-const ajv = new Ajv()
+const ajv = new Ajv({ allowUnionTypes: true })
 const validate = ajv.compile(dashboardConfigSchema)
 
 describe('Dashboard schemas', () => {
   it('successfully validates bar chart schemas', () => {
     const definition: any = {
-      gridSize: {
-        cols: 2,
-        rows: 2,
-      },
       tiles: [
         {
           definition: {
@@ -41,10 +37,6 @@ describe('Dashboard schemas', () => {
 
   it('successfully validates gauge chart schemas', () => {
     const definition: any = {
-      gridSize: {
-        cols: 2,
-        rows: 2,
-      },
       tiles: [
         {
           definition: {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -10,7 +10,6 @@
       :is="context.editable ? DraggableGridLayout : GridLayout"
       v-else
       ref="gridLayoutRef"
-      :grid-size="model.gridSize"
       :tile-height="model.tileHeight"
       :tiles="gridTiles"
       @update-tiles="handleUpdateTiles"
@@ -249,9 +248,6 @@ const handleUpdateTiles = (tiles: GridTile<TileDefinition>[]) => {
     } as TileConfig
   })
 
-  // Update `rows` to match the number of tiles we've placed.
-  // `columns` remains fixed; this is set by design requirements rather than the number of tiles.
-  model.value.gridSize.rows = Math.max(1, ...updatedTiles.map(t => t.layout.position.row + t.layout.size.rows))
   model.value.tiles = updatedTiles.sort(tileSortFn)
 }
 

--- a/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
@@ -49,7 +49,7 @@ const AsyncEntityLink = defineAsyncComponent(async () => {
   if (queryBridge?.fetchComponent) {
     try {
       return await queryBridge.fetchComponent('EntityLink')
-    } catch (e) {
+    } catch {
       return FallbackEntityLink
     }
   }

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.cy.ts
@@ -1,7 +1,7 @@
 import { ref, type ComponentPublicInstance } from 'vue'
 import { dragTile } from '../../test-utils'
 import DraggableGridLayout, { type DraggableGridLayoutExpose } from './DraggableGridLayout.vue'
-import type { GridSize, GridTile } from 'src/types'
+import type { GridTile } from 'src/types'
 
 describe('<DraggableGridLayout />', () => {
   const mockTiles: GridTile<string>[] = [
@@ -23,16 +23,10 @@ describe('<DraggableGridLayout />', () => {
     },
   ]
 
-  const gridSize: GridSize = {
-    cols: 12,
-    rows: 12,
-  }
-
   it('should render grid container and tiles', () => {
     cy.mount(DraggableGridLayout, {
       props: {
         tiles: mockTiles,
-        gridSize,
       },
     })
 
@@ -44,7 +38,6 @@ describe('<DraggableGridLayout />', () => {
     cy.mount(DraggableGridLayout, {
       props: {
         tiles: mockTiles,
-        gridSize,
       },
     })
 
@@ -65,7 +58,6 @@ describe('<DraggableGridLayout />', () => {
     cy.mount(DraggableGridLayout, {
       props: {
         tiles: mockTiles,
-        gridSize,
       },
       attrs: {
         onUpdateTiles: cy.spy().as('updateTilesSpy'),
@@ -81,7 +73,6 @@ describe('<DraggableGridLayout />', () => {
     cy.mount(DraggableGridLayout, {
       props: {
         tiles: mockTiles,
-        gridSize,
       },
     }).then(({ component }) => {
       // Access the exposed method
@@ -100,7 +91,6 @@ describe('<DraggableGridLayout />', () => {
     cy.mount(DraggableGridLayout, {
       props: {
         tiles: tilesRef.value,
-        gridSize,
       },
     }).then(() => {
 

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -29,22 +29,21 @@
 import { onMounted, onUnmounted, ref, watch, nextTick, watchEffect } from 'vue'
 import { GridStack } from 'gridstack'
 import type { GridStackNode } from 'gridstack'
-import type { GridSize, GridTile } from 'src/types'
+import type { GridTile } from 'src/types'
+import { DASHBOARD_COLS, DEFAULT_TILE_HEIGHT } from '../../constants'
 import 'gridstack/dist/gridstack.min.css'
 import 'gridstack/dist/gridstack-extra.min.css'
 
 export type DraggableGridLayoutExpose<T> = {
   removeWidget: (id: number | string) => void
   tiles: GridTile<T>[]
-  gridSize: GridSize
 }
 
 const props = withDefaults(defineProps<{
   tiles: GridTile<T>[]
-  gridSize: GridSize
   tileHeight?: number
 }>(), {
-  tileHeight: 200,
+  tileHeight: DEFAULT_TILE_HEIGHT,
 })
 const emit = defineEmits<{
   (e: 'update-tiles', tiles: GridTile<T>[]): void
@@ -95,11 +94,11 @@ const removeHandler = (_: Event, items: GridStackNode[]) => {
 onMounted(() => {
   if (gridContainer.value) {
     grid = GridStack.init({
-      column: props.gridSize.cols,
+      margin: 10,
+      column: DASHBOARD_COLS,
       cellHeight: props.tileHeight,
       resizable: { handles: 'se, sw' },
       handle: '.tile-header',
-
     }, gridContainer.value)
     grid.on('change', updateTiles)
     grid.on('added', updateTiles)

--- a/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
@@ -23,15 +23,11 @@
 
 <script lang="ts" setup generic="T">
 import { computed, type PropType, ref, onMounted, onUnmounted } from 'vue'
-import type { GridSize, Cell, GridTile } from 'src/types'
-import { DEFAULT_TILE_HEIGHT } from '../../constants'
+import type { Cell, GridTile } from 'src/types'
+import { DASHBOARD_COLS, DEFAULT_TILE_HEIGHT } from '../../constants'
 import { calculateRowDefs } from './grid-utils'
 
 const props = defineProps({
-  gridSize: {
-    type: Object as PropType<GridSize>,
-    required: true,
-  },
   tileHeight: {
     type: Number,
     required: false,
@@ -72,7 +68,7 @@ onUnmounted(() => {
 })
 
 const rowDefinition = computed<string>(() => {
-  const rowDefs = calculateRowDefs(props.gridSize?.rows, props.tileHeight, props.tiles)
+  const rowDefs = calculateRowDefs(props.tileHeight, props.tiles)
 
   return rowDefs.join(' ')
 })
@@ -98,7 +94,7 @@ const gridCells = computed<Cell<T>[]>(() => {
 .kong-ui-public-grid-layout {
   display: grid;
   gap: var(--kui-space-70, $kui-space-70);
-  grid-template-columns: repeat(v-bind('gridSize.cols'), 1fr);
+  grid-template-columns: repeat(v-bind('DASHBOARD_COLS'), 1fr);
   grid-template-rows: v-bind('rowDefinition');
   width: 100%;
 }

--- a/packages/analytics/dashboard-renderer/src/components/layout/grid-utils.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/layout/grid-utils.spec.ts
@@ -1,88 +1,36 @@
 import { calculateRowDefs } from './grid-utils'
+import type { GridTile } from '../../types'
 import { describe, it, expect } from 'vitest'
 
 describe('calculateRowDefs', () => {
+  const getMockTile = (col: number, row: number, cols: number, rows: number, fitToContent?: boolean):GridTile<unknown> => ({
+    layout: {
+      position: {
+        col,
+        row,
+      },
+      size: {
+        cols,
+        rows,
+        ...(fitToContent !== undefined ? { fitToContent } : {}),
+      },
+    },
+    id: `test-tile-${col}-${row}-${cols}-${rows}-${fitToContent}`,
+    meta: {},
+  })
+
   it('auto-fits rows', () => {
-    expect(calculateRowDefs(2, 100, [
-      {
-        layout: {
-          position: {
-            col: 0,
-            row: 0,
-          },
-          size: {
-            rows: 1,
-            cols: 2,
-            fitToContent: true,
-          },
-        },
-        id: 'blah',
-        meta: {},
-      },
-      {
-        layout: {
-          position: {
-            col: 3,
-            row: 0,
-          },
-          size: {
-            rows: 1,
-            cols: 2,
-            fitToContent: true,
-          },
-        },
-        id: 'blah',
-        meta: {},
-      },
-      {
-        layout: {
-          position: {
-            col: 0,
-            row: 1,
-          },
-          size: {
-            rows: 1,
-            cols: 4,
-          },
-        },
-        id: 'blah',
-        meta: {},
-      },
+    expect(calculateRowDefs(100, [
+      getMockTile(0, 0, 2, 1, true),
+      getMockTile(3, 0, 2, 1, true),
+      getMockTile(0, 1, 4, 1),
     ])).toEqual(['auto', '100px'])
   })
 
   it("doesn't auto-fit if a tile spans multiple rows", () => {
-    expect(calculateRowDefs(2, 100, [
-      {
-        layout: {
-          position: {
-            col: 0,
-            row: 0,
-          },
-          size: {
-            rows: 2,
-            cols: 2,
-            fitToContent: true,
-          },
-        },
-        id: 'blah',
-        meta: {},
-      },
-      {
-        layout: {
-          position: {
-            col: 3,
-            row: 0,
-          },
-          size: {
-            rows: 1,
-            cols: 2,
-            fitToContent: true,
-          },
-        },
-        id: 'blah',
-        meta: {},
-      },
+    expect(calculateRowDefs(100, [
+      getMockTile(0, 0, 2, 2, true),
+      getMockTile(3, 0, 2, 1, true),
     ])).toEqual(['100px', '100px'])
   })
 })

--- a/packages/analytics/dashboard-renderer/src/components/layout/grid-utils.ts
+++ b/packages/analytics/dashboard-renderer/src/components/layout/grid-utils.ts
@@ -1,12 +1,15 @@
 import type { GridTile } from '../../types'
 
-export const calculateRowDefs = (rowCount: number, tileHeight: number, tiles: GridTile<unknown>[]): string[] => {
+export const calculateRowDefs = (tileHeight: number, tiles: GridTile<unknown>[]): string[] => {
+  let rowCount = 0
   const rowMap = new Map<number, boolean>()
 
   tiles.forEach(t => {
     const row = t.layout.position.row
     const existingVal = rowMap.get(row)
     const eligibleForAutofit = t.layout.size.rows === 1 && !!t.layout.size.fitToContent
+
+    rowCount = Math.max(rowCount, row + t.layout.size.rows)
 
     if (existingVal === undefined) {
       rowMap.set(row, eligibleForAutofit)

--- a/packages/analytics/dashboard-renderer/src/constants.ts
+++ b/packages/analytics/dashboard-renderer/src/constants.ts
@@ -1,5 +1,6 @@
 // Default tile height and width - approximated from the figma design.
 export const DEFAULT_TILE_HEIGHT = 170
+export const DASHBOARD_COLS = 6
 export const INJECT_QUERY_PROVIDER = 'analytics-query-provider'
 export const ENTITY_ID_TOKEN = '{entity-id}'
 export const CP_ID_TOKEN = '{cp-id}'

--- a/packages/analytics/dashboard-renderer/src/types/grid-layout-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/grid-layout-types.ts
@@ -16,10 +16,6 @@ export interface GridTile<T> {
   meta: T
 }
 
-export interface GridSize {
-  rows: number
-  cols: number
-}
 export interface Cell<T> {
   key: string
   tile: GridTile<T>


### PR DESCRIPTION
# Summary

[satisfies ma-3916](https://konghq.atlassian.net/browse/MA-3916)

* set default columns in a dashboard to 6 (using the `DASHBOARD_COLS` constant
* remove `gridSize` everywhere it exists in this repo
* calculate the values of gridsize where it was used from tile definitions instead

After this is merged, will need to merge the following PRs as well, please consider reviewing them:

* https://github.com/Kong/flink-jobs/pull/1639
* https://github.com/Kong/konnect-ui-apps/pull/6829
* https://github.com/Kong/kanalytics/pull/948
* https://github.com/Kong/portal/pull/1120