### PR TITLE
fix(free-form): scope data overwritten by free form

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/ConfigForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/ConfigForm.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-import { cloneDeep, omit } from 'lodash-es'
+import { cloneDeep } from 'lodash-es'
 import { FIELD_RENDERERS } from '../shared/composables'
 import { getCalloutId } from './utils'
 import ArrayField from '../shared/ArrayField.vue'
@@ -114,7 +114,7 @@ function getNameMap(callouts: Callout[], reverse: boolean = false) {
 
 // replace callout names in `depends_on` with freshly generated ids
 function prepareFormData(data: RequestCalloutPlugin) {
-  const pluginConfig = omit(cloneDeep(data), 'created_at', 'updated_at', 'id')
+  const pluginConfig = cloneDeep(data)
 
   if (!pluginConfig.config?.callouts) {
     return pluginConfig

--- a/packages/entities/entities-plugins/src/components/free-form/RequestCallout/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/RequestCallout/types.ts
@@ -1,10 +1,6 @@
-export interface RequestCalloutPlugin {
-  config?: RequestCallout
-  partials?: Array<{ id: string }>
-  instance_name?: string
-  protocols?: string[]
-  tags?: string[]
-}
+import type { FreeFormPluginData } from '../../../types/plugins/free-form'
+
+export type RequestCalloutPlugin = FreeFormPluginData<RequestCallout>
 
 export interface RequestCallout {
   callouts: Callout[]

--- a/packages/entities/entities-plugins/src/types/plugins/free-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/free-form.ts
@@ -1,0 +1,7 @@
+export type FreeFormPluginData<T extends Record<string, any> = any> = {
+  config?: T
+  instance_name?: string
+  partials?: Array<{ id: string }>
+  protocols?: string[]
+  tags?: string[]
+}


### PR DESCRIPTION
# Summary

* Fixing the `scope` can't be updated when users edit a plugin.
* Optimizing the type definition of free form `data` props