### PR TITLE
fix: add negative margin to override gridstack gutters [MA-3955]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -149,7 +149,7 @@ defineExpose({ removeWidget })
 
 <style lang="scss" scoped>
 .grid-stack {
-  margin: -10px;
+  margin: 0 -10px;
 }
 
 :deep(.tile-header) {

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -148,6 +148,10 @@ defineExpose({ removeWidget })
 </script>
 
 <style lang="scss" scoped>
+.grid-stack {
+  margin: -10px;
+}
+
 :deep(.tile-header) {
   cursor: move;
 }


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Fix [MA-3955](https://konghq.atlassian.net/browse/MA-3955)

Gridstack automatically applies positioning to each tile within the stack, which in turn will move the tile inwards 10px on all sides. Within our container for the page, this would leave a 10px space on each side of the full width container causing the tiles to never line up properly with the rest of a page layout.

This will add negative margin to all sides of the `DraggableGridLayout` component.

**Before**

![before-1](https://github.com/user-attachments/assets/456d0751-edc8-41f7-8ae1-43e692bacf05)

**After**

![after-1](https://github.com/user-attachments/assets/fd3ff1e5-c944-477b-bbae-5fcf8339f6c3)

[MA-3955]: https://konghq.atlassian.net/browse/MA-3955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ