### PR TITLE
refactor: avoid declaring the `VueFormGenerator` gloablly

### DIFF
--- a/packages/core/forms/sandbox/index.ts
+++ b/packages/core/forms/sandbox/index.ts
@@ -2,14 +2,9 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import Kongponents from '@kong/kongponents'
 import '@kong/kongponents/dist/style.css'
-import { VueFormGenerator } from '../src'
 
 const app = createApp(App)
 
 app.use(Kongponents)
-
-// For correct rendering, host app should make the component available
-// globally and provide the API endpoints for autosuggest
-app.component('VueFormGenerator', VueFormGenerator)
 
 app.mount('#app')

--- a/packages/core/forms/src/components/FormGenerator.vue
+++ b/packages/core/forms/src/components/FormGenerator.vue
@@ -191,7 +191,7 @@ import formRedis from './FormRedis.vue'
 import formMixin from './FormMixin.vue'
 
 export default {
-  name: 'FormGenerator',
+  name: 'VueFormGenerator',
   components: { formGroup, formRedis },
   mixins: [formMixin],
 

--- a/packages/core/forms/src/components/fields/FieldAdvanced.vue
+++ b/packages/core/forms/src/components/fields/FieldAdvanced.vue
@@ -15,7 +15,7 @@
       class="advanced-field-dropdown"
       :class="openClass"
     >
-      <vue-form-generator
+      <VueFormGenerator
         :model="model"
         :options="{ helpAsHtml: true }"
         :schema="schema"
@@ -25,11 +25,17 @@
   </div>
 </template>
 
+<script setup>
+import VueFormGenerator from '../FormGenerator.vue'
+</script>
+
 <script>
 import abstractField from './abstractField'
 
 export default {
   mixins: [abstractField],
+
+  expose: ['validate', 'clearValidationErrors', 'schema'],
 
   emits: ['model-updated'],
 

--- a/packages/core/forms/src/components/fields/FieldObject.vue
+++ b/packages/core/forms/src/components/fields/FieldObject.vue
@@ -3,7 +3,7 @@
     v-attributes="attributes"
     class="field-object-container"
   >
-    <vue-form-generator
+    <VueFormGenerator
       v-if="schema.schema"
       :model="value"
       :options="formOptions"
@@ -73,11 +73,17 @@
   </div>
 </template>
 
+<script setup>
+import VueFormGenerator from '../FormGenerator.vue'
+</script>
+
 <script>
 import abstractField from './abstractField'
 
 export default {
   mixins: [abstractField],
+
+  expose: ['validate', 'clearValidationErrors', 'schema'],
 
   emits: ['modelUpdated'],
 

--- a/packages/core/forms/src/components/fields/FieldObjectAdvanced.vue
+++ b/packages/core/forms/src/components/fields/FieldObjectAdvanced.vue
@@ -27,7 +27,7 @@
           </div>
           <hr class="divider">
           <div v-if="subSchema">
-            <vue-form-generator
+            <VueFormGenerator
               :model="transformedModel[index]"
               :options="{ helpAsHtml: true }"
               :schema="subSchema"
@@ -92,15 +92,18 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import { TrashIcon } from '@kong/icons'
+import VueFormGenerator from '../FormGenerator.vue'
+</script>
+
+<script>
 import { AUTOFILL_SLOT } from '../../const'
 import abstractField from './abstractField'
+
 export default {
-  components: {
-    TrashIcon,
-  },
   mixins: [abstractField],
+  expose: ['validate', 'clearValidationErrors', 'schema'],
   inject: {
     autofillSlot: {
       from: AUTOFILL_SLOT,

--- a/packages/core/forms/src/components/fields/FieldSelectionGroup.vue
+++ b/packages/core/forms/src/components/fields/FieldSelectionGroup.vue
@@ -46,7 +46,7 @@
         class="option-field"
       >
         <div class="option-field-container">
-          <vue-form-generator
+          <VueFormGenerator
             :model="model"
             :options="{ helpAsHtml: true }"
             :schema="{ fields: option.fields }"
@@ -58,22 +58,23 @@
   </div>
 </template>
 
-<script>
-import abstractField from './abstractField'
+<script setup>
 import { createI18n } from '@kong-ui-public/i18n'
 import english from '../../locales/en.json'
+import VueFormGenerator from '../FormGenerator.vue'
+
+const { t } = createI18n('en-us', english)
+</script>
+
+<script>
+import abstractField from './abstractField'
 
 export default {
   mixins: [abstractField],
 
-  emits: ['model-updated'],
+  expose: ['validate', 'clearValidationErrors', 'schema'],
 
-  setup() {
-    const { t } = createI18n('en-us', english)
-    return {
-      t,
-    }
-  },
+  emits: ['model-updated'],
 
   data() {
     return {

--- a/packages/core/forms/src/index.ts
+++ b/packages/core/forms/src/index.ts
@@ -1,13 +1,5 @@
-import type { App } from 'vue'
 import VueFormGenerator from './components/FormGenerator.vue'
 import * as sharedForms from './components/forms'
-
-// Export Vue plugin as the default
-export default {
-  install: (app: App): void => {
-    app.component('VueFormGenerator', VueFormGenerator)
-  },
-}
 
 export { customFields } from './components/fields/exports'
 export { VueFormGenerator, sharedForms }

--- a/packages/core/forms/vfg.md
+++ b/packages/core/forms/vfg.md
@@ -14,7 +14,7 @@ To write a new custom field...
 import FieldAdvanced from '@/plugins/vfg/FieldAdvanced'
 vue.use('FieldAdvanced', FieldAdvanced)
 ```
-- Define your custom schema so the field renders within `<vue-form-generator>`. The field type is defined with the `type` key.
+- Define your custom schema so the field renders within `<VueFormGenerator>`. The field type is defined with the `type` key.
 ```js
 const schema = {
   'service-id': { label: 'Service ID', type: 'input', inputType: 'text', valueType: 'object-expand', placeholder: 'Enter a Service ID', required: true },

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
-    "@kong-ui-public/entities-vaults": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.17.4",
     "@kong/icons": "^1.26.0",
@@ -83,6 +82,7 @@
     "@kong-ui-public/entities-gateway-services": "workspace:^",
     "@kong-ui-public/entities-plugins-metadata": "workspace:^",
     "@kong-ui-public/entities-routes": "workspace:^",
+    "@kong-ui-public/entities-vaults": "workspace:^",
     "@kong-ui-public/forms": "workspace:^",
     "marked": "^14.1.3",
     "monaco-editor": "0.52.2"

--- a/packages/entities/entities-plugins/sandbox/index.ts
+++ b/packages/entities/entities-plugins/sandbox/index.ts
@@ -2,7 +2,6 @@ import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
 import Kongponents from '@kong/kongponents'
 import '@kong/kongponents/dist/style.css'
-import { VueFormGenerator } from '../src'
 import App from './App.vue'
 
 const app = createApp(App)
@@ -88,7 +87,6 @@ const init = async () => {
   })
 
   app.use(Kongponents)
-  app.component('VueFormGenerator', VueFormGenerator)
   app.use(router)
   app.mount('#app')
 }

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -119,6 +119,7 @@ import {
   customFields,
   getSharedFormName,
   sharedForms,
+  VueFormGenerator,
   type AutofillSlotProps,
 } from '@kong-ui-public/forms'
 import '@kong-ui-public/forms/dist/style.css'

--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -14,7 +14,6 @@ import schemaAiProxy from '../../fixtures/schemas/ai-proxy'
 import schemaCors from '../../fixtures/schemas/cors'
 import schemaMocking from '../../fixtures/schemas/mocking'
 import PluginForm from './PluginForm.vue'
-import { VueFormGenerator } from '../../src'
 
 const baseConfigKonnect: KonnectPluginFormConfig = {
   app: 'konnect',
@@ -175,7 +174,6 @@ describe('<PluginForm />', () => {
       interceptKMSchema()
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'cors',
@@ -246,7 +244,6 @@ describe('<PluginForm />', () => {
       interceptKMSchema({ mockData: schemaMocking })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'mocking',
@@ -327,7 +324,6 @@ describe('<PluginForm />', () => {
       interceptKMSchema({ mockData: schemaAiProxy })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'ai-proxy',
@@ -365,7 +361,6 @@ describe('<PluginForm />', () => {
       interceptKMSchema({ mockData: customPluginSchema })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'custom',
@@ -395,7 +390,6 @@ describe('<PluginForm />', () => {
       interceptKMSchema()
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'cors',
@@ -417,7 +411,6 @@ describe('<PluginForm />', () => {
       interceptKMScopedEntity({ entityType: config.entityType! })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -442,7 +435,6 @@ describe('<PluginForm />', () => {
       interceptKMSchema()
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'cors',
@@ -463,7 +455,6 @@ describe('<PluginForm />', () => {
       interceptKMSchema({ credential: true, mockData: credentialSchema })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'acl',
@@ -499,7 +490,6 @@ describe('<PluginForm />', () => {
       interceptKMScopedEntity({ entityType: config.entityType! })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -524,7 +514,6 @@ describe('<PluginForm />', () => {
       interceptKMCreatePlugin()
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'cors',
@@ -556,7 +545,6 @@ describe('<PluginForm />', () => {
       interceptKMCreatePlugin({ credential: true, entityId: scopedConsumer.item.id })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           credential: true,
@@ -590,7 +578,6 @@ describe('<PluginForm />', () => {
       interceptKMScopedEntity({ entityType: config.entityType! })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -653,7 +640,6 @@ describe('<PluginForm />', () => {
       })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -688,7 +674,6 @@ describe('<PluginForm />', () => {
       interceptKMOperatePlugin({ method: 'PATCH', alias: 'updatePlugin', credential: true, entityId: scopedConsumer.item.id, id: aclCredential1.id })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           credential: true,
@@ -722,7 +707,6 @@ describe('<PluginForm />', () => {
       })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -774,7 +758,6 @@ describe('<PluginForm />', () => {
       ).as('getPluginSchema')
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'cors',
@@ -808,7 +791,6 @@ describe('<PluginForm />', () => {
       ).as('getPlugin')
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginId: 'i-dont-exist',
@@ -856,7 +838,6 @@ describe('<PluginForm />', () => {
       ).as('validate')
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'mocking',
@@ -882,7 +863,6 @@ describe('<PluginForm />', () => {
       interceptKMOperatePlugin({ method: 'PATCH', alias: 'updatePlugin', id: plugin1.id })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKM,
           pluginType: 'cors',
@@ -1056,7 +1036,6 @@ describe('<PluginForm />', () => {
       interceptKonnectSchema()
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'cors',
@@ -1127,7 +1106,6 @@ describe('<PluginForm />', () => {
       interceptKonnectSchema({ mockData: schemaMocking })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'mocking',
@@ -1208,7 +1186,6 @@ describe('<PluginForm />', () => {
       interceptKonnectSchema({ mockData: schemaAiProxy })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'ai-proxy',
@@ -1246,7 +1223,6 @@ describe('<PluginForm />', () => {
       interceptKonnectSchema({ mockData: customPluginSchema })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'custom',
@@ -1276,7 +1252,6 @@ describe('<PluginForm />', () => {
       interceptKonnectSchema()
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'cors',
@@ -1298,7 +1273,6 @@ describe('<PluginForm />', () => {
       interceptKonnectScopedEntity({ entityType: config.entityType! })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -1323,7 +1297,6 @@ describe('<PluginForm />', () => {
       interceptKonnectSchema()
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'cors',
@@ -1343,7 +1316,6 @@ describe('<PluginForm />', () => {
       const config: KonnectPluginFormConfig = { ...baseConfigKonnect, entityId: scopedConsumer.item.id, entityType: 'consumers' }
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'acl',
@@ -1377,7 +1349,6 @@ describe('<PluginForm />', () => {
       interceptKonnectScopedEntity({ entityType: config.entityType! })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -1402,7 +1373,6 @@ describe('<PluginForm />', () => {
       interceptKonnectCreatePlugin()
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'cors',
@@ -1433,7 +1403,6 @@ describe('<PluginForm />', () => {
       interceptKonnectCreatePlugin({ credential: true, entityId: scopedConsumer.item.id })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           credential: true,
@@ -1465,7 +1434,6 @@ describe('<PluginForm />', () => {
       interceptKonnectScopedEntity({ entityType: config.entityType! })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -1528,7 +1496,6 @@ describe('<PluginForm />', () => {
       })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -1562,7 +1529,6 @@ describe('<PluginForm />', () => {
       interceptKonnectOperatePlugin({ method: 'PUT', alias: 'updatePlugin', credential: true, entityId: scopedConsumer.item.id, id: aclCredential1.id })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           credential: true,
@@ -1595,7 +1561,6 @@ describe('<PluginForm />', () => {
       })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config,
           pluginType: 'cors',
@@ -1647,7 +1612,6 @@ describe('<PluginForm />', () => {
       ).as('getPluginSchema')
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'cors',
@@ -1681,7 +1645,6 @@ describe('<PluginForm />', () => {
       ).as('getPlugin')
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginId: 'i-dont-exist',
@@ -1729,7 +1692,6 @@ describe('<PluginForm />', () => {
       ).as('validate')
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'mocking',
@@ -1755,7 +1717,6 @@ describe('<PluginForm />', () => {
       interceptKonnectOperatePlugin({ method: 'PUT', alias: 'updatePlugin', id: plugin1.id })
 
       cy.mount(PluginForm, {
-        global: { components: { VueFormGenerator } },
         props: {
           config: baseConfigKonnect,
           pluginType: 'cors',

--- a/packages/entities/entities-plugins/src/index.ts
+++ b/packages/entities/entities-plugins/src/index.ts
@@ -9,9 +9,6 @@ import composables from './composables'
 import { getPluginIconURL } from './definitions/metadata'
 import pluginEndpoints from './plugins-endpoints'
 
-// expose VueFormGenerator so host app doesn't need @kong-ui-public/forms as a dependency
-export { VueFormGenerator } from '@kong-ui-public/forms'
-
 const { usePluginMetaData, useProvideExperimentalFreeForms } = composables
 
 export {

--- a/packages/entities/entities-plugins/vite.config.ts
+++ b/packages/entities/entities-plugins/vite.config.ts
@@ -18,6 +18,13 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
     },
     rollupOptions: {
       external: [
+        '@kong-ui-public/entities-consumer-groups',
+        '@kong-ui-public/entities-consumers',
+        '@kong-ui-public/entities-gateway-services',
+        '@kong-ui-public/entities-plugins-metadata',
+        '@kong-ui-public/entities-routes',
+        '@kong-ui-public/forms',
+        'marked',
         'monaco-editor',
       ],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -961,6 +961,9 @@ importers:
       '@kong-ui-public/entities-routes':
         specifier: workspace:^
         version: link:../entities-routes
+      '@kong-ui-public/entities-vaults':
+        specifier: workspace:^
+        version: link:../entities-vaults
       '@kong-ui-public/forms':
         specifier: workspace:^
         version: link:../../core/forms
@@ -974,9 +977,6 @@ importers:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
-      '@kong-ui-public/entities-vaults':
-        specifier: workspace:^
-        version: link:../entities-vaults
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n


### PR DESCRIPTION
Two packages were affected by this change:

- `@kong-ui-public/entities-plugins`
   * This package already had the `@kong-ui-public/forms` dependency, so it was straightforward to use the `VueFormGenerator` component locally. The re-export of the `VueFormGenerator` component was removed from this package. Tests were updated accordingly.

- `@kong-ui-public/forms`
   * Fields implemented in the options-style previously had to use the globally registered `<vue-form-generator>` to avoid circular dependencies. This behavior was difficult to track in the past. Now, for options-style components, we use `<script setup>` to import  `<VueFormGenerator>` and explicitly declare the `expose` in the `<script>` section.
   * `VueFormGenerator` was no longer recommended to be used as a global component. So the Vue plugin helper was removed.


These packages are now externalized from `@kong-ui-public/entities-plugins` to reduce the package size:
- `@kong-ui-public/entities-consumer-groups`
- `@kong-ui-public/entities-consumers`
- `@kong-ui-public/entities-gateway-services`
- `@kong-ui-public/entities-plugins-metadata`
- `@kong-ui-public/entities-routes`
- `@kong-ui-public/forms`
- `marked`


JIRA: KM-348
