### PR TITLE
fix(entities-plugins): delete empty `basic` before submitting

### DIFF
--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -26,6 +26,9 @@ import { vaultAuthSchema } from '../definitions/schemas/VaultAuth'
 import { kafkaUpstreamSchema } from '../definitions/schemas/KafkaUpstream'
 import { genKeyAuthSchema } from '../definitions/schemas/KeyAuth'
 import { confluentSchema } from '../definitions/schemas/Confluent'
+import { confluentConsumeSchema } from '../definitions/schemas/ConfluentConsume'
+import { kafkaConsumeSchema } from '../definitions/schemas/KafkaConsume'
+import { kafkaLogSchema } from '../definitions/schemas/KafkaLog'
 import ZipkinSchema from '../definitions/schemas/Zipkin'
 import typedefs from '../definitions/schemas/typedefs'
 import { type CustomSchemas } from '../types'
@@ -228,6 +231,18 @@ export const useSchemas = (options?: UseSchemasOptions) => {
 
     'confluent': {
       ...confluentSchema,
+    },
+
+    'confluent-consume': {
+      ...confluentConsumeSchema,
+    },
+
+    'kafka-consume': {
+      ...kafkaConsumeSchema,
+    },
+
+    'kafka-log': {
+      ...kafkaLogSchema,
     },
   }
 

--- a/packages/entities/entities-plugins/src/definitions/schemas/Confluent.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/Confluent.ts
@@ -1,5 +1,6 @@
 import type { ConfluentSchema } from '../../types/plugins/confluent'
 import { ArrayInputFieldSchema } from './ArrayInputFieldSchema'
+import { stripEmptyBasicFields } from '../../utils/helper'
 
 export const confluentSchema: ConfluentSchema = {
   'config-message_by_lua_functions': {
@@ -9,5 +10,12 @@ export const confluentSchema: ConfluentSchema = {
       type: 'textarea',
       max: false,
     },
+  },
+
+  // Clean up empty authentication fields in the payload before submission.
+  // This removes the empty 'basic' authentication object
+  // when both username and password are not provided.
+  shamefullyTransformPayload: ({ payload }) => {
+    stripEmptyBasicFields(payload.config?.schema_registry)
   },
 }

--- a/packages/entities/entities-plugins/src/definitions/schemas/ConfluentConsume.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/ConfluentConsume.ts
@@ -1,0 +1,15 @@
+import type { CommonSchemaFields } from '../../types/plugins/shared'
+import { stripEmptyBasicFields, type SchemaRegistry } from '../../utils/helper'
+
+export const confluentConsumeSchema: CommonSchemaFields = {
+  // Clean up empty authentication fields in the payload before submission.
+  // This removes the empty 'basic' authentication object
+  // when both username and password are not provided.
+  shamefullyTransformPayload: ({ payload }) => {
+    stripEmptyBasicFields(payload.config?.schema_registry)
+
+    payload.config?.topics?.forEach((topic: { schema_registry: SchemaRegistry }) => {
+      stripEmptyBasicFields(topic?.schema_registry)
+    })
+  },
+}

--- a/packages/entities/entities-plugins/src/definitions/schemas/KafkaConsume.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/KafkaConsume.ts
@@ -1,0 +1,15 @@
+import type { CommonSchemaFields } from '../../types/plugins/shared'
+import { stripEmptyBasicFields, type SchemaRegistry } from '../../utils/helper'
+
+export const kafkaConsumeSchema: CommonSchemaFields = {
+  // Clean up empty authentication fields in the payload before submission.
+  // This removes the empty 'basic' authentication object
+  // when both username and password are not provided.
+  shamefullyTransformPayload: ({ payload }) => {
+    stripEmptyBasicFields(payload.config?.schema_registry)
+
+    payload.config?.topics?.forEach((topic: { schema_registry: SchemaRegistry }) => {
+      stripEmptyBasicFields(topic?.schema_registry)
+    })
+  },
+}

--- a/packages/entities/entities-plugins/src/definitions/schemas/KafkaLog.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/KafkaLog.ts
@@ -1,0 +1,11 @@
+import type { CommonSchemaFields } from '../../types/plugins/shared'
+import { stripEmptyBasicFields } from '../../utils/helper'
+
+export const kafkaLogSchema: CommonSchemaFields = {
+  // Clean up empty authentication fields in the payload before submission.
+  // This removes the empty 'basic' authentication object
+  // when both username and password are not provided.
+  shamefullyTransformPayload: ({ payload }) => {
+    stripEmptyBasicFields(payload.config?.schema_registry)
+  },
+}

--- a/packages/entities/entities-plugins/src/definitions/schemas/KafkaUpstream.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/KafkaUpstream.ts
@@ -1,5 +1,6 @@
 import type { KafkaUpstreamSchema } from '../../types/plugins/kafka-upstream'
 import { ArrayInputFieldSchema } from './ArrayInputFieldSchema'
+import { stripEmptyBasicFields } from '../../utils/helper'
 
 export const kafkaUpstreamSchema: KafkaUpstreamSchema = {
   'config-message_by_lua_functions': {
@@ -9,5 +10,12 @@ export const kafkaUpstreamSchema: KafkaUpstreamSchema = {
       type: 'textarea',
       max: false,
     },
+  },
+
+  // Clean up empty authentication fields in the payload before submission.
+  // This removes the empty 'basic' authentication object
+  // when both username and password are not provided.
+  shamefullyTransformPayload: ({ payload }) => {
+    stripEmptyBasicFields(payload.config?.schema_registry)
   },
 }

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -226,6 +226,9 @@ export interface CustomSchemas {
   'kafka-upstream': KafkaUpstreamSchema
   'key-auth': ReturnType<typeof genKeyAuthSchema>
   'confluent': ConfluentSchema
+  'confluent-consume': CommonSchemaFields
+  'kafka-consume': CommonSchemaFields
+  'kafka-log': CommonSchemaFields
 }
 
 export enum PluginPartialType {

--- a/packages/entities/entities-plugins/src/utils/helper.ts
+++ b/packages/entities/entities-plugins/src/utils/helper.ts
@@ -1,0 +1,21 @@
+export interface SchemaRegistry {
+  confluent?: {
+    authentication?: {
+      basic?: {
+        username?: string
+        password?: string
+      }
+    }
+  }
+}
+
+export const stripEmptyBasicFields = (schemaRegistry: SchemaRegistry) => {
+  const basicFields = schemaRegistry?.confluent?.authentication?.basic
+  if (!basicFields) {
+    return
+  }
+
+  if (!basicFields.password && !basicFields.username) {
+    delete schemaRegistry!.confluent!.authentication!.basic
+  }
+}


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

A new field `schema_registry` was [added](https://github.com/Kong/gateway-schema-watcher/pull/141) to 5 plugins: we are facing the same problem as `ai-proxy-advanced` where a non-required parent object has required fields. Before submitting, we need to check the payload and delete the parent object if it's empty.

https://github.com/user-attachments/assets/e8779b03-d65d-422b-88f5-45283c91e071
