### PR TITLE
fix(free-form): keep the original user input to tag field

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/TagField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/TagField.vue
@@ -13,7 +13,7 @@
       :data-1p-ignore="is1pIgnore"
       :data-autofocus="isAutoFocus"
       :data-testid="field.path.value"
-      :model-value="value ?? ''"
+      :model-value="rawInputValue ?? ''"
       @update:model-value="handleUpdate"
     >
       <template
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRef, useAttrs } from 'vue'
+import { computed, ref, toRef, useAttrs, watch } from 'vue'
 import { KInput, type LabelAttributes } from '@kong/kongponents'
 
 import * as utils from './utils'
@@ -65,8 +65,23 @@ const { value: fieldValue, ...field } = useField<string[] | null, ArrayLikeField
 const fieldAttrs = useFieldAttrs(field.path!, toRef({ ...props, ...attrs }))
 const noEmptyArray = computed(() => field.schema?.value?.len_min && field.schema.value.len_min > 0)
 
+const rawInputValue = ref('')
+
+function arrToStr(arr: string[]) {
+  return arr.map(item => item.trim()).filter(Boolean).join(', ')
+}
+
+function strToArr(str: string) {
+  return str.trim().split(',').map(item => item.trim()).filter(Boolean)
+}
+
+if (fieldValue?.value) {
+  rawInputValue.value = arrToStr(fieldValue.value)
+}
+
 function handleUpdate(value: string) {
-  const values = value.trim().split(',').map(item => item.trim()).filter(Boolean)
+  rawInputValue.value = value
+  const values = strToArr(value)
   const finalValue = (!values.length && noEmptyArray.value) ? null : values
   fieldValue!.value = finalValue
   emit('update:modelValue', finalValue)
@@ -79,11 +94,13 @@ const is1pIgnore = computed(() => {
   return utils.getName(name) === 'name'
 })
 
-const value = computed(() => {
-  if (fieldValue?.value == null) {
-    return undefined
+// sync fieldValue to rawInputValue ONLY when their formatted value are different.
+watch(fieldValue!, newValue => {
+  const nv = newValue ? arrToStr(newValue) : ''
+  const ov = arrToStr(strToArr(rawInputValue.value))
+  if (ov !== nv) {
+    rawInputValue.value = nv
   }
-  return fieldValue?.value.join(', ')
 })
 </script>
 


### PR DESCRIPTION
# Summary
## Before
The `TagField` formats the user's input as they type.

## After
The `TagField` always shows the raw content that the user types.