### PR TITLE
fix: chart tooltip cutoff when dragged outside chart boundary

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
@@ -138,6 +138,7 @@ watch(() => props.locked, value => {
 function handleMouseDown(e: MouseEvent) {
   if (tooltipEl.value) {
     dragging.value = true
+    document.body.classList.add('no-select')
     // Get computed style and extract transform values
     const style = window.getComputedStyle(tooltipEl.value as HTMLElement)
     // @ts-ignore mozTransform is not in the types
@@ -193,6 +194,7 @@ function handleMouseMove(e: MouseEvent) {
 
 function handleMouseUp() {
   dragging.value = false
+  document.body.classList.remove('no-select')
   if (animationFrameId !== null) {
     window.cancelAnimationFrame(animationFrameId)
   }
@@ -293,5 +295,11 @@ function handleMouseUp() {
       width: 12px;
     }
   }
+}
+</style>
+
+<style lang="css">
+.no-select {
+  user-select: none;
 }
 </style>

--- a/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="chartParentRef"
     class="chart-parent"
     :class="chartFlexClass(legendPosition)"
     data-testid="donut-chart-parent"
@@ -14,15 +15,17 @@
         :options="(options as any)"
         :plugins="(plugins as any)"
       />
-      <ToolTip
-        :left="tooltipData.left"
-        :series="tooltipData.tooltipSeries"
-        :show-tooltip="tooltipData.showTooltip"
-        :tooltip-title="tooltipTitle"
-        :top="tooltipData.top"
-        :unit="metricUnit"
-        @dimensions="tooltipDimensions"
-      />
+      <Teleport to="body">
+        <ToolTip
+          :left="tooltipAbsoluteLeft"
+          :series="tooltipData.tooltipSeries"
+          :show-tooltip="tooltipData.showTooltip"
+          :tooltip-title="tooltipTitle"
+          :top="tooltipAbsoluteTop"
+          :unit="metricUnit"
+          @dimensions="tooltipDimensions"
+        />
+      </Teleport>
     </div>
     <HtmlLegend
       :id="legendID"
@@ -35,7 +38,7 @@
 
 <script setup lang="ts">
 import type { PropType, Ref } from 'vue'
-import { computed, reactive, ref, toRef } from 'vue'
+import { computed, reactive, ref, toRef, useTemplateRef } from 'vue'
 import 'chartjs-adapter-date-fns'
 import 'chart.js/auto'
 import ToolTip from '../chart-plugins/ChartTooltip.vue'
@@ -93,6 +96,7 @@ const { translateUnit } = composables.useTranslatedUnits()
 const legendID = crypto.randomUUID()
 const chartID = crypto.randomUUID()
 const legendItems = ref([])
+const chartParentRef = useTemplateRef('chartParentRef')
 
 const tooltipData: TooltipState = reactive({
   showTooltip: false,
@@ -109,6 +113,11 @@ const tooltipData: TooltipState = reactive({
   chartID,
   chartType: 'donut',
 })
+
+const { tooltipAbsoluteLeft, tooltipAbsoluteTop } = composables.useTooltipAbsolutePosition(
+  chartParentRef,
+  tooltipData,
+)
 
 const htmlLegendPlugin: Plugin = {
   id: legendID,

--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -26,17 +26,17 @@
         />
       </div>
     </div>
-    <div
-      v-if="axesTooltip.show"
-      class="axis-tooltip"
-      :style="{ top: axesTooltip.top, left: axesTooltip.left}"
-      width="auto"
-    >
-      <div class="axis-tooltip-content">
-        {{ axesTooltip.text }}
-      </div>
-    </div>
     <Teleport to="body">
+      <div
+        v-if="axesTooltip.show"
+        class="axis-tooltip"
+        :style="{ top: axesTooltip.top, left: axesTooltip.left}"
+        width="auto"
+      >
+        <div class="axis-tooltip-content">
+          {{ axesTooltip.text }}
+        </div>
+      </div>
       <ToolTip
         :context="tooltipData.tooltipContext"
         :left="tooltipAbsoluteLeft"
@@ -322,7 +322,7 @@ const axesTooltipPlugin = {
         axesTooltip.value.left = indexAxis === 'x'
           ? `${(leftOfCursor > 0 ? leftOfCursor : rightOfCursor) - axesTooltip.value.offset}px`
           : `${(evt.x - textWidthPixels * 0.5) - axesTooltip.value.offset}px`
-        axesTooltip.value.top = `${evt.y - 50}px`
+        axesTooltip.value.top = `${evt.y + 50}px`
         if (label.length > MAX_LABEL_LENGTH) {
           axesTooltip.value.show = true
           axesTooltip.value.text = label

--- a/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/StackedBarChart.vue
@@ -220,7 +220,7 @@ const reactiveAnnotationsID = uuidv4()
 const maxOverflowPluginID = uuidv4()
 const legendItems = ref<EnhancedLegendItem[]>([])
 const legendPosition = ref(inject('legendPosition', ChartLegendPosition.Right))
-const axesTooltip = ref<AxesTooltipState>({
+const axesTooltip = reactive<AxesTooltipState>({
   show: false,
   top: '0px',
   left: '0px',
@@ -293,7 +293,7 @@ const axesTooltipPlugin = {
   // args any because it is not typed by chartjs
   // https://www.chartjs.org/docs/latest/api/interfaces/Plugin.html#parameters
   afterEvent(chart: Chart, args: any) {
-    axesTooltip.value.show = false
+    axesTooltip.show = false
     if (args.event.type === 'mousemove') {
       const evt = args.event
       const indexAxis = chart.options.indexAxis as ('x' | 'y')
@@ -318,22 +318,23 @@ const axesTooltipPlugin = {
 
         const leftOfCursor = Math.abs(Math.round(evt.x - textWidthPixels * 0.5))
         const rightOfCursor = Math.round(evt.x + textWidthPixels * 0.5)
-
-        axesTooltip.value.left = indexAxis === 'x'
-          ? `${(leftOfCursor > 0 ? leftOfCursor : rightOfCursor) - axesTooltip.value.offset}px`
-          : `${(evt.x - textWidthPixels * 0.5) - axesTooltip.value.offset}px`
-        axesTooltip.value.top = `${evt.y + 50}px`
+        const rect = chart.canvas.getBoundingClientRect()
+        const PX_ABOVE_CURSOR = 40
+        axesTooltip.left = indexAxis === 'x'
+          ? `${(leftOfCursor > 0 ? leftOfCursor : rightOfCursor) - axesTooltip.offset + rect.left}px`
+          : `${(evt.x - textWidthPixels * 0.5) - axesTooltip.offset + rect.left}px`
+        axesTooltip.top = `${evt.y - PX_ABOVE_CURSOR + rect.top}px`
         if (label.length > MAX_LABEL_LENGTH) {
-          axesTooltip.value.show = true
-          axesTooltip.value.text = label
+          axesTooltip.show = true
+          axesTooltip.text = label
         } else if (isEmptyLabel) {
-          axesTooltip.value.text = i18n.t('emptyEntityInfo')
-          axesTooltip.value.show = true
+          axesTooltip.text = i18n.t('emptyEntityInfo')
+          axesTooltip.show = true
         } else {
-          axesTooltip.value.show = false
+          axesTooltip.show = false
         }
       } else {
-        axesTooltip.value.show = false
+        axesTooltip.show = false
       }
     }
   },
@@ -542,7 +543,7 @@ const onScrolling = (event: Event) => {
 
   tooltipData.offsetY = target.scrollTop
   tooltipData.offsetX = target.scrollLeft
-  axesTooltip.value.offset = target.scrollLeft
+  axesTooltip.offset = target.scrollLeft
 }
 
 const tooltipDimensions = ({ width, height }: { width: number, height: number }) => {

--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="chartParentRef"
     class="chart-parent"
     :class="chartFlexClass(legendPosition)"
     data-testid="line-chart-parent"
@@ -31,22 +32,24 @@
         :plugins="plugins"
       />
     </div>
-    <ToolTip
-      v-if="!isDoingSelection"
-      ref="tooltipElement"
-      :context="formatTimestamp(tooltipData.tooltipContext)"
-      data-testid="tooltip"
-      :left="tooltipData.left"
-      :locked="tooltipData.locked"
-      :series="tooltipData.tooltipSeries"
-      :show-tooltip="tooltipData.showTooltip"
-      :tooltip-title="tooltipTitle"
-      :top="tooltipData.top"
-      :unit="metricUnit"
-      @dimensions="tooltipDimensions"
-      @left="(left: string) => tooltipData.left = left"
-      @top="(top: string) => tooltipData.top = top"
-    />
+    <Teleport to="body">
+      <ToolTip
+        v-if="!isDoingSelection"
+        ref="tooltipElement"
+        :context="formatTimestamp(tooltipData.tooltipContext)"
+        data-testid="tooltip"
+        :left="tooltipAbsoluteLeft"
+        :locked="tooltipData.locked"
+        :series="tooltipData.tooltipSeries"
+        :show-tooltip="tooltipData.showTooltip"
+        :tooltip-title="tooltipTitle"
+        :top="tooltipAbsoluteTop"
+        :unit="metricUnit"
+        @dimensions="tooltipDimensions"
+        @left="(left: string) => tooltipData.left = left"
+        @top="(top: string) => tooltipData.top = top"
+      />
+    </Teleport>
     <ChartLegend
       :id="legendID"
       :chart-instance="chartInstance"
@@ -168,6 +171,7 @@ const legendItems = ref<EnhancedLegendItem[]>([])
 const tooltipElement = ref()
 const legendPosition = ref(inject('legendPosition', ChartLegendPosition.Right))
 const isDoingSelection = ref(false)
+const chartParentRef = ref<HTMLElement | null>(null)
 
 const tooltipData = reactive({
   showTooltip: false,
@@ -186,6 +190,11 @@ const tooltipData = reactive({
   chartID,
   chartTooltipSortFn: props.chartTooltipSortFn,
 })
+
+const { tooltipAbsoluteLeft, tooltipAbsoluteTop } = composables.useTooltipAbsolutePosition(
+  chartParentRef,
+  tooltipData,
+)
 
 const htmlLegendPlugin = {
   id: legendID,

--- a/packages/analytics/analytics-chart/src/composables/index.ts
+++ b/packages/analytics/analytics-chart/src/composables/index.ts
@@ -10,6 +10,7 @@ import useExploreResultToTimeDataset from './useExploreResultToTimeDatasets'
 import useReportChartDataForSynthetics from './useReportChartDataForSynthetics'
 import useTranslatedUnits from './useTranslatedUnits'
 import useEvaluateFeatureFlag from './useEvauluateFeatureFlag'
+import useTooltipAbsolutePosition from './useTooltipAbsolutePosition'
 
 // All composables must be exported as part of the default object for Cypress test stubs
 export default {
@@ -25,4 +26,5 @@ export default {
   useReportChartDataForSynthetics,
   useTranslatedUnits,
   useEvaluateFeatureFlag,
+  useTooltipAbsolutePosition,
 }

--- a/packages/analytics/analytics-chart/src/composables/useTooltipAbsolutePosition.ts
+++ b/packages/analytics/analytics-chart/src/composables/useTooltipAbsolutePosition.ts
@@ -1,0 +1,20 @@
+import { computed } from 'vue'
+import type { Ref, Reactive } from 'vue'
+
+export default function useTooltipAbsolutePosition(chartParentRef: Ref<HTMLElement | null>, tooltipData: Reactive<{ left: string, top: string }>) {
+  const tooltipAbsoluteLeft = computed(() => {
+    if (!chartParentRef.value) return tooltipData.left
+    const rect = chartParentRef.value.getBoundingClientRect()
+    return `${parseFloat(tooltipData.left) + rect.left + window.scrollX}px`
+  })
+  const tooltipAbsoluteTop = computed(() => {
+    if (!chartParentRef.value) return tooltipData.top
+    const rect = chartParentRef.value.getBoundingClientRect()
+    return `${parseFloat(tooltipData.top) + rect.top + window.scrollY}px`
+  })
+
+  return {
+    tooltipAbsoluteLeft,
+    tooltipAbsoluteTop,
+  }
+}


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-3663

- Teleport tooltip to body, adjust position relative to chart parent container.
- Prevent tooltip drag from selecting text on the page

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
