### PR TITLE
chore: documentation-content empty-state feature flag cleanup

### DIFF
--- a/packages/core/documentation/docs/DocumentationContent/README.md
+++ b/packages/core/documentation/docs/DocumentationContent/README.md
@@ -149,13 +149,6 @@ yarn add @kong-ui-public/documentation
 - Default: async () => null
 - Use: Denotes which document has been selected
 
-#### `enableV2EmptyStates`
-
-- type: `boolean`
-- default: `false`
-
-Enables the new empty state design, this prop can be removed when the khcp-14756-empty-states-m2 FF is removed.
-
 ## Events
 
 ### `child-change`

--- a/packages/core/documentation/src/components/DocumentationContent.vue
+++ b/packages/core/documentation/src/components/DocumentationContent.vue
@@ -85,7 +85,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import DocumentationDisplay from './DocumentationDisplay.vue'
-import DocumentationPageEmptyState from './DocumentationPageEmptyState.vue'
 import ProductDocumentModal from './ProductDocumentModal.vue'
 import type { PropType } from 'vue'
 import type { DocumentListItem, DocumentTree, FormData } from '../types'
@@ -175,14 +174,6 @@ const props = defineProps({
   selectedDocument: {
     type: Object as PropType<{ document: DocumentTree, ast: Record<string, any>, markdown?: string, status: 'published' | 'unpublished' }>,
     default: () => null,
-  },
-  /**
-   * Enables the new empty state design, this prop can be removed when
-   * the khcp-14756-empty-states-m2 FF is removed.
-   */
-  enableV2EmptyStates: {
-    type: Boolean,
-    default: false,
   },
 })
 

--- a/packages/core/documentation/src/components/DocumentationContent.vue
+++ b/packages/core/documentation/src/components/DocumentationContent.vue
@@ -3,7 +3,6 @@
     <div v-if="documentList && !documentList.length">
       <KCard v-if="emptyStateCard">
         <EntityEmptyState
-          v-if="enableV2EmptyStates"
           :action-button-text="t('documentation.show.empty_state_v2.cta')"
           appearance="secondary"
           :can-create="() => canEdit()"
@@ -21,14 +20,8 @@
             </div>
           </template>
         </EntityEmptyState>
-        <DocumentationPageEmptyState
-          v-else
-          :can-edit="canEdit"
-          @create-documentation="handleAddClick"
-        />
       </KCard>
       <EntityEmptyState
-        v-else-if="enableV2EmptyStates"
         :action-button-text="t('documentation.show.empty_state_v2.cta')"
         appearance="secondary"
         :can-create="() => canEdit()"
@@ -45,11 +38,6 @@
           </div>
         </template>
       </EntityEmptyState>
-      <DocumentationPageEmptyState
-        v-else
-        :can-edit="canEdit"
-        @create-documentation="handleAddClick"
-      />
     </div>
     <div
       v-else
@@ -96,7 +84,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import DocumentationDisplay from './DocumentationDisplay.vue'
-import DocumentationPageEmptyState from './DocumentationPageEmptyState.vue'
 import ProductDocumentModal from './ProductDocumentModal.vue'
 import type { PropType } from 'vue'
 import type { DocumentListItem, DocumentTree, FormData } from '../types'
@@ -186,14 +173,6 @@ const props = defineProps({
   selectedDocument: {
     type: Object as PropType<{ document: DocumentTree, ast: Record<string, any>, markdown?: string, status: 'published' | 'unpublished' }>,
     default: () => null,
-  },
-  /**
-   * Enables the new empty state design, this prop can be removed when
-   * the khcp-14756-empty-states-m2 FF is removed.
-   */
-  enableV2EmptyStates: {
-    type: Boolean,
-    default: false,
   },
 })
 

--- a/packages/core/documentation/src/components/DocumentationContent.vue
+++ b/packages/core/documentation/src/components/DocumentationContent.vue
@@ -22,6 +22,7 @@
         </EntityEmptyState>
       </KCard>
       <EntityEmptyState
+        v-else
         :action-button-text="t('documentation.show.empty_state_v2.cta')"
         appearance="secondary"
         :can-create="() => canEdit()"
@@ -84,6 +85,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import DocumentationDisplay from './DocumentationDisplay.vue'
+import DocumentationPageEmptyState from './DocumentationPageEmptyState.vue'
 import ProductDocumentModal from './ProductDocumentModal.vue'
 import type { PropType } from 'vue'
 import type { DocumentListItem, DocumentTree, FormData } from '../types'
@@ -173,6 +175,14 @@ const props = defineProps({
   selectedDocument: {
     type: Object as PropType<{ document: DocumentTree, ast: Record<string, any>, markdown?: string, status: 'published' | 'unpublished' }>,
     default: () => null,
+  },
+  /**
+   * Enables the new empty state design, this prop can be removed when
+   * the khcp-14756-empty-states-m2 FF is removed.
+   */
+  enableV2EmptyStates: {
+    type: Boolean,
+    default: false,
   },
 })
 


### PR DESCRIPTION
**Description:**
This PR is dedicated to cleaning up the feature flag `khcp-14756-empty-states-m2`.

**Entities Cleaned Up:**
* **Documentation Content**
