### PR TITLE
chore(consumers): cleaned up feature flags

### DIFF
--- a/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
@@ -166,13 +166,6 @@ A synchronous or asynchronous function, that returns a boolean, that evaluates i
 
 A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
-#### `enableV2EmptyStates`
-
-- type: `boolean`
-- default: `false`
-
-Enables the new empty state design, this prop can be removed when the khcp-14756-empty-states-m2 FF is removed.
-
 ### Events
 
 #### error

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -741,8 +741,8 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getConsumerGroups')
       cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('[data-testid="consumer-groups-entity-empty-state"]').should('be.visible')
-      cy.get('[data-testid="entity-create-button"]').should('be.visible')
+      cy.getTestId('consumer-groups-entity-empty-state').should('be.visible')
+      cy.getTestId('entity-create-button').should('be.visible')
 
     })
 
@@ -762,8 +762,8 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getConsumerGroups')
       cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('[data-testid="consumer-groups-entity-empty-state"]').should('be.visible')
-      cy.get('[data-testid="entity-create-button"]').should('not.exist')
+      cy.getTestId('consumer-groups-entity-empty-state').should('be.visible')
+      cy.getTestId('entity-create-button').should('not.exist')
     })
 
     it('should handle error state', () => {
@@ -1001,8 +1001,8 @@ describe('<ConsumerGroupList />', () => {
       cy.wait('@getGroups')
 
       // click empty state cta
-      cy.get('[data-testid="entity-create-button"]').should('exist')
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('entity-create-button').should('exist')
+      cy.getTestId('entity-create-button').click()
       // add to group modal
       cy.getTestId('add-to-group-modal').should('exist')
     })
@@ -1024,7 +1024,7 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('entity-create-button').click()
       cy.getTestId('add-to-group-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal).vm.$emit('cancel'))
@@ -1051,7 +1051,7 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('entity-create-button').click()
       cy.getTestId('add-to-group-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal).vm.$emit('add:success', expectedData))

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -140,8 +140,8 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getConsumerGroups')
       cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('[data-testid="consumer-groups-entity-empty-state"]').should('be.visible')
-      cy.get('[data-testid="entity-create-button"]').should('be.visible')
+      cy.get('.table-empty-state').should('be.visible')
+      cy.getTestId('empty-state-action').should('be.visible')
     })
 
     it('should hide empty state and create consumer group cta if user can not create', () => {
@@ -160,8 +160,8 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getConsumerGroups')
       cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('[data-testid="consumer-groups-entity-empty-state"]').should('be.visible')
-      cy.get('[data-testid="entity-create-button"]').should('not.exist')
+      cy.get('.table-empty-state').should('be.visible')
+      cy.getTestId('empty-state-action').should('not.exist')
     })
 
     it('should handle error state', () => {
@@ -399,8 +399,8 @@ describe('<ConsumerGroupList />', () => {
       cy.wait('@getGroups')
 
       // click empty state cta
-      cy.get('[data-testid="entity-create-button"]').should('exist')
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('empty-state-action').should('exist')
+      cy.getTestId('empty-state-action').click()
       // add to group modal
       cy.getTestId('add-to-group-modal').should('exist')
     })
@@ -449,7 +449,7 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('empty-state-action').click()
       cy.getTestId('add-to-group-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal).vm.$emit('add:success', expectedData))

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -743,7 +743,6 @@ describe('<ConsumerGroupList />', () => {
       cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
       cy.getTestId('consumer-groups-entity-empty-state').should('be.visible')
       cy.getTestId('entity-create-button').should('be.visible')
-
     })
 
     it('should hide empty state and create consumer group cta if user can not create', () => {
@@ -1080,7 +1079,7 @@ describe('<ConsumerGroupList />', () => {
 
         cy.wait('@getGroups')
 
-        cy.get('[data-testid="entity-create-button"]').click()
+        cy.getTestId('entity-create-button').click()
         cy.getTestId('add-to-group-modal').should('exist')
 
         cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal)

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -422,7 +422,7 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('empty-state-action').click()
       cy.getTestId('add-to-group-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal).vm.$emit('cancel'))
@@ -478,7 +478,7 @@ describe('<ConsumerGroupList />', () => {
 
         cy.wait('@getGroups')
 
-        cy.get('[data-testid="entity-create-button"]').click()
+        cy.getTestId('empty-state-action').click()
         cy.getTestId('add-to-group-modal').should('exist')
 
         cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal)

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -140,8 +140,8 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getConsumerGroups')
       cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('be.visible')
+      cy.get('[data-testid="consumer-groups-entity-empty-state"]').should('be.visible')
+      cy.get('[data-testid="entity-create-button"]').should('be.visible')
     })
 
     it('should hide empty state and create consumer group cta if user can not create', () => {
@@ -160,8 +160,8 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getConsumerGroups')
       cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('not.exist')
+      cy.get('[data-testid="consumer-groups-entity-empty-state"]').should('be.visible')
+      cy.get('[data-testid="entity-create-button"]').should('not.exist')
     })
 
     it('should handle error state', () => {
@@ -399,8 +399,8 @@ describe('<ConsumerGroupList />', () => {
       cy.wait('@getGroups')
 
       // click empty state cta
-      cy.getTestId('empty-state-action').should('exist')
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').should('exist')
+      cy.get('[data-testid="entity-create-button"]').click()
       // add to group modal
       cy.getTestId('add-to-group-modal').should('exist')
     })
@@ -422,7 +422,7 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-to-group-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal).vm.$emit('cancel'))
@@ -449,7 +449,7 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-to-group-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal).vm.$emit('add:success', expectedData))
@@ -478,7 +478,7 @@ describe('<ConsumerGroupList />', () => {
 
         cy.wait('@getGroups')
 
-        cy.getTestId('empty-state-action').click()
+        cy.get('[data-testid="entity-create-button"]').click()
         cy.getTestId('add-to-group-modal').should('exist')
 
         cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal)
@@ -741,8 +741,9 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getConsumerGroups')
       cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('be.visible')
+      cy.get('[data-testid="consumer-groups-entity-empty-state"]').should('be.visible')
+      cy.get('[data-testid="entity-create-button"]').should('be.visible')
+
     })
 
     it('should hide empty state and create consumer group cta if user can not create', () => {
@@ -761,8 +762,8 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getConsumerGroups')
       cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('not.exist')
+      cy.get('[data-testid="consumer-groups-entity-empty-state"]').should('be.visible')
+      cy.get('[data-testid="entity-create-button"]').should('not.exist')
     })
 
     it('should handle error state', () => {
@@ -1000,8 +1001,8 @@ describe('<ConsumerGroupList />', () => {
       cy.wait('@getGroups')
 
       // click empty state cta
-      cy.getTestId('empty-state-action').should('exist')
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').should('exist')
+      cy.get('[data-testid="entity-create-button"]').click()
       // add to group modal
       cy.getTestId('add-to-group-modal').should('exist')
     })
@@ -1023,7 +1024,7 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-to-group-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal).vm.$emit('cancel'))
@@ -1050,7 +1051,7 @@ describe('<ConsumerGroupList />', () => {
 
       cy.wait('@getGroups')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-to-group-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal).vm.$emit('add:success', expectedData))
@@ -1079,7 +1080,7 @@ describe('<ConsumerGroupList />', () => {
 
         cy.wait('@getGroups')
 
-        cy.getTestId('empty-state-action').click()
+        cy.get('[data-testid="entity-create-button"]').click()
         cy.getTestId('add-to-group-modal').should('exist')
 
         cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddToGroupModal)

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -61,29 +61,8 @@
         </Teleport>
       </template>
 
-      <!-- TODO: remove this slot when empty states M2 is cleaned up -->
       <template
-        v-if="!hasRecords && isLegacyLHButton"
-        #outside-actions
-      >
-        <Teleport
-          :disabled="!useActionOutside"
-          to="#kong-ui-app-page-header-action-button"
-        >
-          <KButton
-            appearance="secondary"
-            class="open-learning-hub"
-            data-testid="consumer-groups-learn-more-button"
-            icon
-            @click="$emit('click:learn-more')"
-          >
-            <BookIcon decorative />
-          </KButton>
-        </Teleport>
-      </template>
-
-      <template
-        v-if="!filterQuery && enableV2EmptyStates && config.app === 'konnect'"
+        v-if="!filterQuery && config.app === 'konnect'"
         #empty-state
       >
         <EntityEmptyState
@@ -326,14 +305,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  /**
-   * Enables the new empty state design, this prop can be removed when
-   * the khcp-14756-empty-states-m2 FF is removed.
-   */
-  enableV2EmptyStates: {
-    type: Boolean,
-    default: false,
-  },
 })
 
 const { i18nT, i18n: { t } } = composables.useI18n()
@@ -418,7 +389,6 @@ const { hasRecords, handleStateChange } = useTableState(filterQuery)
 // If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
 // If new empty states are not enabled, show the learning hub button (for Konnect)
 const showHeaderLHButton = computed((): boolean => hasRecords.value && props.config.app === 'konnect')
-const isLegacyLHButton = computed((): boolean => !props.enableV2EmptyStates && props.config.app === 'konnect')
 
 const isConsumerPage = computed<boolean>(() => !!props.config.consumerId)
 const preferencesStorageKey = computed<string>(

--- a/packages/entities/entities-consumers/docs/consumer-list.md
+++ b/packages/entities/entities-consumers/docs/consumer-list.md
@@ -166,13 +166,6 @@ A synchronous or asynchronous function, that returns a boolean, that evaluates i
 
 A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
 
-#### `enableV2EmptyStates`
-
-- type: `boolean`
-- default: `false`
-
-Enables the new empty state design, this prop can be removed when the khcp-14756-empty-states-m2 FF is removed.
-
 ### Events
 
 #### error

--- a/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
@@ -465,7 +465,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.getTestId('empty-state-action').should('exist')
+      cy.getTestId('empty-state-action').click()
       cy.getTestId('add-consumer-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal).vm.$emit('add:success', expectedData))
@@ -494,7 +494,7 @@ describe('<ConsumerList />', () => {
 
         cy.wait('@getGroupConsumers')
 
-        cy.getTestId('empty-state-action').should('exist')
+        cy.getTestId('empty-state-action').click()
         cy.getTestId('add-consumer-modal').should('exist')
 
         cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal)

--- a/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
@@ -140,8 +140,8 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getConsumers')
       cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('be.visible')
+      cy.get('[data-testid="consumers-entity-empty-state"]').should('be.visible')
+      cy.get('[data-testid="entity-create-button"]').should('be.visible')
     })
 
     it('should hide empty state and create consumer cta if user can not create', () => {
@@ -160,8 +160,8 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getConsumers')
       cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('not.exist')
+      cy.get('[data-testid="consumers-entity-empty-state"]').should('be.visible')
+      cy.get('[data-testid="entity-create-button"]').should('not.exist')
     })
 
     it('should handle error state', () => {
@@ -398,7 +398,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.getTestId('empty-state-action').should('exist')
+      cy.get('[data-testid="entity-create-button"]').should('exist')
     })
 
     it('should render AddConsumerModal onclick Add Consumer button when consumerGroupId is provided', () => {
@@ -417,7 +417,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-consumer-modal').should('exist')
     })
 
@@ -438,7 +438,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-consumer-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal).vm.$emit('cancel'))
@@ -465,7 +465,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-consumer-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal).vm.$emit('add:success', expectedData))
@@ -494,7 +494,7 @@ describe('<ConsumerList />', () => {
 
         cy.wait('@getGroupConsumers')
 
-        cy.getTestId('empty-state-action').click()
+        cy.get('[data-testid="entity-create-button"]').click()
         cy.getTestId('add-consumer-modal').should('exist')
 
         cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal)
@@ -757,8 +757,8 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getConsumers')
       cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('be.visible')
+      cy.get('[data-testid="consumers-entity-empty-state"]').should('be.visible')
+      cy.get('[data-testid="entity-create-button"]').should('be.visible')
     })
 
     it('should hide empty state and create consumer cta if user can not create', () => {
@@ -777,8 +777,8 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getConsumers')
       cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('not.exist')
+      cy.get('[data-testid="consumers-entity-empty-state"]').should('be.visible')
+      cy.get('[data-testid="entity-create-button"]').should('not.exist')
     })
 
     it('should handle error state', () => {
@@ -1015,7 +1015,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.getTestId('empty-state-action').should('exist')
+      cy.get('[data-testid="entity-create-button"]').should('exist')
     })
 
     it('should render AddConsumerModal onclick Add Consumer button when consumerGroupId is provided', () => {
@@ -1034,7 +1034,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-consumer-modal').should('exist')
     })
 
@@ -1055,7 +1055,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-consumer-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal).vm.$emit('cancel'))
@@ -1082,7 +1082,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.getTestId('empty-state-action').click()
+      cy.get('[data-testid="entity-create-button"]').click()
       cy.getTestId('add-consumer-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal).vm.$emit('add:success', expectedData))
@@ -1111,7 +1111,7 @@ describe('<ConsumerList />', () => {
 
         cy.wait('@getGroupConsumers')
 
-        cy.getTestId('empty-state-action').click()
+        cy.get('[data-testid="entity-create-button"]').click()
         cy.getTestId('add-consumer-modal').should('exist')
 
         cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal)

--- a/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
@@ -398,7 +398,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.get('[data-testid="entity-create-button"]').should('exist')
+      cy.getTestId('empty-state-action').should('exist')
     })
 
     it('should render AddConsumerModal onclick Add Consumer button when consumerGroupId is provided', () => {

--- a/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
@@ -757,8 +757,8 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getConsumers')
       cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('[data-testid="consumers-entity-empty-state"]').should('be.visible')
-      cy.get('[data-testid="entity-create-button"]').should('be.visible')
+      cy.getTestId('consumers-entity-empty-state').should('be.visible')
+      cy.getTestId('entity-create-button').should('be.visible')
     })
 
     it('should hide empty state and create consumer cta if user can not create', () => {
@@ -777,8 +777,8 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getConsumers')
       cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('[data-testid="consumers-entity-empty-state"]').should('be.visible')
-      cy.get('[data-testid="entity-create-button"]').should('not.exist')
+      cy.getTestId('consumers-entity-empty-state').should('be.visible')
+      cy.getTestId('entity-create-button').should('not.exist')
     })
 
     it('should handle error state', () => {
@@ -1015,7 +1015,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.get('[data-testid="entity-create-button"]').should('exist')
+      cy.getTestId('entity-create-button').should('exist')
     })
 
     it('should render AddConsumerModal onclick Add Consumer button when consumerGroupId is provided', () => {
@@ -1034,7 +1034,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('entity-create-button').click()
       cy.getTestId('add-consumer-modal').should('exist')
     })
 
@@ -1055,7 +1055,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('entity-create-button').click()
       cy.getTestId('add-consumer-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal).vm.$emit('cancel'))
@@ -1082,7 +1082,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('entity-create-button').click()
       cy.getTestId('add-consumer-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal).vm.$emit('add:success', expectedData))
@@ -1111,7 +1111,7 @@ describe('<ConsumerList />', () => {
 
         cy.wait('@getGroupConsumers')
 
-        cy.get('[data-testid="entity-create-button"]').click()
+        cy.getTestId('entity-create-button').click()
         cy.getTestId('add-consumer-modal').should('exist')
 
         cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal)

--- a/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
@@ -140,8 +140,8 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getConsumers')
       cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('[data-testid="consumers-entity-empty-state"]').should('be.visible')
-      cy.get('[data-testid="entity-create-button"]').should('be.visible')
+      cy.get('.table-empty-state').should('be.visible')
+      cy.getTestId('empty-state-action').should('be.visible')
     })
 
     it('should hide empty state and create consumer cta if user can not create', () => {
@@ -160,8 +160,8 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getConsumers')
       cy.get('.kong-ui-entities-consumers-list').should('be.visible')
-      cy.get('[data-testid="consumers-entity-empty-state"]').should('be.visible')
-      cy.get('[data-testid="entity-create-button"]').should('not.exist')
+      cy.get('.table-empty-state').should('be.visible')
+      cy.getTestId('empty-state-action').should('not.exist')
     })
 
     it('should handle error state', () => {
@@ -417,7 +417,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('empty-state-action').click()
       cy.getTestId('add-consumer-modal').should('exist')
     })
 
@@ -438,7 +438,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('empty-state-action').click()
       cy.getTestId('add-consumer-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal).vm.$emit('cancel'))
@@ -465,7 +465,7 @@ describe('<ConsumerList />', () => {
 
       cy.wait('@getGroupConsumers')
 
-      cy.get('[data-testid="entity-create-button"]').click()
+      cy.getTestId('empty-state-action').should('exist')
       cy.getTestId('add-consumer-modal').should('exist')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal).vm.$emit('add:success', expectedData))
@@ -494,7 +494,7 @@ describe('<ConsumerList />', () => {
 
         cy.wait('@getGroupConsumers')
 
-        cy.get('[data-testid="entity-create-button"]').click()
+        cy.getTestId('empty-state-action').should('exist')
         cy.getTestId('add-consumer-modal').should('exist')
 
         cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(AddConsumerModal)

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -63,29 +63,8 @@
         </Teleport>
       </template>
 
-      <!-- TODO: remove this slot when empty states M2 is cleaned up -->
       <template
-        v-if="!hasRecords && isLegacyLHButton"
-        #outside-actions
-      >
-        <Teleport
-          :disabled="!useActionOutside"
-          to="#kong-ui-app-page-header-action-button"
-        >
-          <KButton
-            appearance="secondary"
-            class="open-learning-hub"
-            data-testid="consumers-learn-more-button"
-            icon
-            @click="$emit('click:learn-more')"
-          >
-            <BookIcon decorative />
-          </KButton>
-        </Teleport>
-      </template>
-
-      <template
-        v-if="!filterQuery && enableV2EmptyStates && config.app === 'konnect'"
+        v-if="!filterQuery && config.app === 'konnect'"
         #empty-state
       >
         <EntityEmptyState
@@ -328,14 +307,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  /**
-   * Enables the new empty state design, this prop can be removed when
-   * the khcp-14756-empty-states-m2 FF is removed.
-   */
-  enableV2EmptyStates: {
-    type: Boolean,
-    default: false,
-  },
 })
 
 const { i18nT, i18n: { t } } = composables.useI18n()
@@ -413,7 +384,6 @@ const { hasRecords, handleStateChange } = useTableState(filterQuery)
 // If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
 // If new empty states are not enabled, show the learning hub button (for Konnect)
 const showHeaderLHButton = computed((): boolean => hasRecords.value && props.config.app === 'konnect')
-const isLegacyLHButton = computed((): boolean => !props.enableV2EmptyStates && props.config.app === 'konnect')
 
 const isConsumerGroupPage = computed<boolean>(() => !!props.config.consumerGroupId)
 const preferencesStorageKey = computed<string>(


### PR DESCRIPTION
**Description:**
This PR is dedicated to cleaning up the feature flag `khcp-14756-empty-states-m2`.

**Entities Cleaned Up:**
* **Cosumers**
* **Cosumer Groups**