### PR TITLE
feat(tracing): add prop for view span logs button [KHCP-16669]

### DIFF
--- a/packages/core/tracing/sandbox/pages/TraceViewPage.vue
+++ b/packages/core/tracing/sandbox/pages/TraceViewPage.vue
@@ -60,6 +60,7 @@
             :config="config"
             :root-span="spanTrees.roots[0]"
             :show-skeleton="showSkeleton"
+            :show-view-logs-button="enableViewSpanLogs"
             :url="url"
           />
         </template>
@@ -110,6 +111,11 @@
       <KInputSwitch
         v-model="enablePayloads"
         label="Payloads"
+      />
+
+      <KInputSwitch
+        v-model="enableViewSpanLogs"
+        label="Show 'View Span Logs' button"
       />
     </KCard>
   </div>
@@ -177,6 +183,7 @@ const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 
 const showSkeleton = ref(false)
 const enablePayloads = ref(true)
+const enableViewSpanLogs = ref(true)
 const slideoutVisible = ref(true)
 const tabs = [
   { hash: '#summary', title: 'Summary' },

--- a/packages/core/tracing/src/components/trace/SpanBasicInfo.vue
+++ b/packages/core/tracing/src/components/trace/SpanBasicInfo.vue
@@ -3,7 +3,10 @@
     class="span-basic-info"
     :title="t('trace_viewer.span_basic_info.title')"
   >
-    <template #actions>
+    <template
+      v-if="showViewLogsButton"
+      #actions
+    >
       <KButton
         appearance="secondary"
         size="small"
@@ -54,6 +57,7 @@ defineProps<{
   name: string
   description: string
   spanId: string
+  showViewLogsButton?: boolean
 }>()
 
 defineEmits(['view-logs'])

--- a/packages/core/tracing/src/partials/TraceViewTab.vue
+++ b/packages/core/tracing/src/partials/TraceViewTab.vue
@@ -67,6 +67,7 @@
           v-if="selectedSpan && spanDescription"
           :description="spanDescription"
           :name="selectedSpan.span.name"
+          :show-view-logs-button="showViewLogsButton"
           :span-id="selectedSpan.span.spanId"
           @view-logs="$emit('view-logs', selectedSpan.span.spanId)"
         />
@@ -137,6 +138,7 @@ const props = defineProps<{
   rootSpan?: SpanNode
   url?: string
   showSkeleton?: boolean
+  showViewLogsButton?: boolean
 }>()
 
 defineEmits<{


### PR DESCRIPTION
# Summary

We need to add a prop to `TraceViewTab` to disable the "View span logs" button because the feature is behind a feature flag

## Preview

https://github.com/user-attachments/assets/7395077b-9574-4f66-8417-7611aff317c6

