### PR TITLE
fix(entities-routes): update form tooltip content

### DIFF
--- a/packages/entities/entities-routes/src/components/rules-composer/TraditionalRules.vue
+++ b/packages/entities/entities-routes/src/components/rules-composer/TraditionalRules.vue
@@ -42,10 +42,14 @@
         :disabled="!fields.paths?.some(Boolean)"
         :label="t('form.fields.strip_path.label')"
         :label-attributes="{
-          info: t('form.fields.strip_path.tooltip'),
           tooltipAttributes: { maxWidth: '320' },
         }"
-      />
+      >
+        <template #tooltip>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <span v-html="t('form.fields.strip_path.tooltip')" />
+        </template>
+      </KCheckbox>
 
       <!-- methods -->
       <MethodRules
@@ -112,63 +116,87 @@
           :items="PATH_HANDLING_OPTIONS"
           :label="t('form.fields.path_handling.label')"
           :label-attributes="{
-            info: t('form.fields.path_handling.tooltip'),
             tooltipAttributes: { maxWidth: '320' },
           }"
           :readonly="readonly"
           width="100%"
-        />
+        >
+          <template #label-tooltip>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <span v-html="t('form.fields.path_handling.tooltip')" />
+          </template>
+        </KSelect>
         <KSelect
           v-model="fields.https_redirect_status_code"
           data-testid="route-form-http-redirect-status-code"
           :items="HTTP_REDIRECT_STATUS_CODES"
           :label="t('form.fields.https_redirect_status_code.label')"
           :label-attributes="{
-            info: t('form.fields.https_redirect_status_code.tooltip'),
             tooltipAttributes: { maxWidth: '320' },
           }"
           :readonly="readonly"
           width="100%"
-        />
+        >
+          <template #label-tooltip>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <span v-html="t('form.fields.https_redirect_status_code.tooltip')" />
+          </template>
+        </KSelect>
         <KInput
           v-model="fields.regex_priority"
           autocomplete="off"
           data-testid="route-form-regex-priority"
           :label="t('form.fields.regex_priority.label')"
           :label-attributes="{
-            info: t('form.fields.regex_priority.tooltip'),
             tooltipAttributes: { maxWidth: '320' },
           }"
           :readonly="readonly"
           type="number"
-        />
+        >
+          <template #label-tooltip>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <span v-html="t('form.fields.regex_priority.tooltip')" />
+          </template>
+        </KInput>
         <KCheckbox
           v-model="fields.preserve_host"
           data-testid="route-form-preserve-host"
           :label="t('form.fields.preserve_host.label')"
           :label-attributes="{
-            info: t('form.fields.preserve_host.tooltip'),
             tooltipAttributes: { maxWidth: '320' },
           }"
-        />
+        >
+          <template #tooltip>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <span v-html="t('form.fields.preserve_host.tooltip')" />
+          </template>
+        </KCheckbox>
         <KCheckbox
           v-model="fields.request_buffering"
           data-testid="route-form-request-buffering"
           :label="t('form.fields.request_buffering.label')"
           :label-attributes="{
-            info: t('form.fields.request_buffering.tooltip'),
             tooltipAttributes: { maxWidth: '320' },
           }"
-        />
+        >
+          <template #tooltip>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <span v-html="t('form.fields.request_buffering.tooltip')" />
+          </template>
+        </KCheckbox>
         <KCheckbox
           v-model="fields.response_buffering"
           data-testid="route-form-response-buffering"
           :label="t('form.fields.response_buffering.label')"
           :label-attributes="{
-            info: t('form.fields.response_buffering.tooltip'),
             tooltipAttributes: { maxWidth: '320' },
           }"
-        />
+        >
+          <template #tooltip>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <span v-html="t('form.fields.response_buffering.tooltip')" />
+          </template>
+        </KCheckbox>
       </div>
     </template>
   </KCard>

--- a/packages/entities/entities-routes/src/components/rules-composer/rules/DestinationRules.vue
+++ b/packages/entities/entities-routes/src/components/rules-composer/rules/DestinationRules.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="routing-rule-container">
-    <KLabel :info="t('form.fields.destinations.tooltip')">
+    <KLabel
+      :tooltip-attributes="{ maxWidth: '320' }"
+    >
+      <template #tooltip>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <span v-html="t('form.fields.destinations.tooltip')" />
+      </template>
       {{ t('form.fields.destinations.label') }}
     </KLabel>
     <TransitionGroup name="appear">

--- a/packages/entities/entities-routes/src/components/rules-composer/rules/HeaderRules.vue
+++ b/packages/entities/entities-routes/src/components/rules-composer/rules/HeaderRules.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="routing-rule-container">
-    <KLabel :info="t('form.fields.headers.tooltip')">
+    <KLabel
+      :tooltip-attributes="{ maxWidth: '320' }"
+    >
+      <template #tooltip>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <span v-html="t('form.fields.headers.tooltip')" />
+      </template>
       {{ t('form.fields.headers.label') }}
     </KLabel>
     <TransitionGroup name="appear">

--- a/packages/entities/entities-routes/src/components/rules-composer/rules/HostRules.vue
+++ b/packages/entities/entities-routes/src/components/rules-composer/rules/HostRules.vue
@@ -1,9 +1,12 @@
 <template>
   <div class="routing-rule-container">
     <KLabel
-      :info="t('form.fields.hosts.tooltip')"
       :tooltip-attributes="{ maxWidth: '320' }"
     >
+      <template #tooltip>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <span v-html="t('form.fields.hosts.tooltip')" />
+      </template>
       {{ configType === 'basic' ? t('form.fields.hosts.label_singular') : t('form.fields.hosts.label') }}
     </KLabel>
     <TransitionGroup name="appear">

--- a/packages/entities/entities-routes/src/components/rules-composer/rules/MethodRules.vue
+++ b/packages/entities/entities-routes/src/components/rules-composer/rules/MethodRules.vue
@@ -4,9 +4,12 @@
     data-testid="route-form-methods"
   >
     <KLabel
-      :info="t('form.fields.methods.tooltip')"
       :tooltip-attributes="{ maxWidth: '320' }"
     >
+      <template #tooltip>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <span v-html="t('form.fields.methods.tooltip')" />
+      </template>
       {{ t('form.fields.methods.label') }}
     </KLabel>
     <div class="routing-rule-input">

--- a/packages/entities/entities-routes/src/components/rules-composer/rules/PathRules.vue
+++ b/packages/entities/entities-routes/src/components/rules-composer/rules/PathRules.vue
@@ -1,9 +1,12 @@
 <template>
   <div class="routing-rule-container">
     <KLabel
-      :info="t('form.fields.paths.tooltip')"
       :tooltip-attributes="{ maxWidth: '320' }"
     >
+      <template #tooltip>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <span v-html="t('form.fields.paths.tooltip')" />
+      </template>
       {{ configType === 'basic' ? t('form.fields.paths.label_singular') : t('form.fields.paths.label') }}
     </KLabel>
     <TransitionGroup name="appear">

--- a/packages/entities/entities-routes/src/components/rules-composer/rules/SniRules.vue
+++ b/packages/entities/entities-routes/src/components/rules-composer/rules/SniRules.vue
@@ -1,9 +1,12 @@
 <template>
   <div class="routing-rule-container">
     <KLabel
-      :info="t('form.fields.snis.tooltip')"
       :tooltip-attributes="{ maxWidth: '320' }"
     >
+      <template #tooltip>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <span v-html="t('form.fields.snis.tooltip')" />
+      </template>
       {{ t('form.fields.snis.label') }}
     </KLabel>
     <TransitionGroup name="appear">

--- a/packages/entities/entities-routes/src/components/rules-composer/rules/SourceRules.vue
+++ b/packages/entities/entities-routes/src/components/rules-composer/rules/SourceRules.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="routing-rule-container">
-    <KLabel :info="t('form.fields.sources.tooltip')">
+    <KLabel
+      :tooltip-attributes="{ maxWidth: '320' }"
+    >
+      <template #tooltip>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <span v-html="t('form.fields.sources.tooltip')" />
+      </template>
       {{ t('form.fields.sources.label') }}
     </KLabel>
     <TransitionGroup name="appear">

--- a/packages/entities/entities-routes/src/locales/en.json
+++ b/packages/entities/entities-routes/src/locales/en.json
@@ -141,19 +141,19 @@
       },
       "https_redirect_status_code": {
         "label": "HTTPS Redirect Status Code",
-        "tooltip": "Specifies the HTTP status code for redirecting requests from HTTP to HTTPS. Use `301` or `308` for permanent redirects, `302` or `307` for temporary redirects."
+        "tooltip": "Specifies the HTTP status code for redirecting requests from HTTP to HTTPS. Use <code>301</code> or <code>308</code> for permanent redirects, <code>302</code> or <code>307</code> for temporary redirects."
       },
       "regex_priority": {
         "label": "Regex Priority",
-        "tooltip": "Regex priority is determined by length first (longer patterns win), and when lengths are the same, more specific regexes are preferred.  When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used."
+        "tooltip": "Regex priority is determined by length first (longer patterns win), and when lengths are the same, more specific regexes are preferred.  When two routes match the path and have the same <code>regex_priority</code>, the older one (lowest <code>created_at</code>) is used."
       },
       "strip_path": {
         "label": "Strip Path",
-        "tooltip": "When enabled, Kong removes the portion of the request path that matches the route's path before forwarding the request to the upstream. If the request exactly matches the route, the result is `/`. Disable if that's not desired."
+        "tooltip": "When enabled, Kong removes the portion of the request path that matches the route's path before forwarding the request to the upstream. If the request exactly matches the route, the result is <code>/</code>. Disable if that's not desired."
       },
       "preserve_host": {
         "label": "Preserve Host",
-        "tooltip": "Keeps the original `Host` header when proxying requests. Enable this if the upstream service requires the client's `Host` value. Disable if the service expects its own hostname."
+        "tooltip": "Keeps the original <code>Host</code> header when proxying requests. Enable this if the upstream service requires the client's <code>Host</code> value. Disable if the service expects its own hostname."
       },
       "paths": {
         "add": "Add a path",
@@ -161,7 +161,7 @@
         "label_singular": "Path",
         "placeholder": "e.g. /api/v1",
         "singular": "path",
-        "tooltip": "Match specific URL paths, such as /api/v1. Prefix with ~ to enable regex-based matching."
+        "tooltip": "Match specific URL paths, such as <code>/api/v1</code>. Prefix with <code>~</code> to enable regex-based matching."
       },
       "snis": {
         "add": "Add an SNI",
@@ -176,7 +176,7 @@
         "label_singular": "Host",
         "placeholder": "e.g. example.com",
         "singular": "host",
-        "tooltip": "Match specific domain names, such as `api.example.com`. Prefix with `~` to enable regex-based matching."
+        "tooltip": "Match specific domain names, such as <code>api.example.com</code>."
       },
       "methods": {
         "label": "Methods",
@@ -194,7 +194,7 @@
         "add": "Add a header",
         "label": "Headers",
         "singular": "header",
-        "tooltip": "Match specific headers, such as `x-api-version` or `x-region`. Doesn't accept the `Host` header. Provide only one entry and prefix with `~` to enable regex-based matching.",
+        "tooltip": "Match specific headers, such as <code>x-api-version</code> or <code>x-region</code>. Doesn't accept the <code>Host</code> header. Provide only one entry and prefix with <code>~</code> to enable regex-based matching.",
         "name": {
           "placeholder": "e.g. x-api-version"
         },


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

1. Removed "Prefix with \`~\` to enable regex-based matching." from the tooltip for `hosts`.
2. Added code format support for route form tooltips.

KM-1398
