### PR TITLE
chore: add Harden Runner to all workflows

### DIFF
--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -8,4 +8,8 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - uses: toshimaru/auto-author-assign@2daaeb2988aef24bf37e636fe733f365c046aba0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,10 @@ jobs:
       GH_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       # if previous run did create comment with the reference to PR preview package
       # this comment is removed in this step
       - name: Remove preview consumption comment
@@ -342,6 +346,10 @@ jobs:
         container: ${{ fromJSON(needs.build.outputs.componentTestMatrix) }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Checkout Source Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -398,6 +406,10 @@ jobs:
       GH_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Successful tests
         if: ${{ !(contains(needs.*.result, 'failure')) }}
         run: exit 0
@@ -489,6 +501,10 @@ jobs:
     needs:
       - finish-test-and-publish
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Checkout Source Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 

--- a/.github/workflows/pr-on-close.yaml
+++ b/.github/workflows/pr-on-close.yaml
@@ -8,6 +8,10 @@ jobs:
     name: remove previews comments for PR
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Checkout Source Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 

--- a/.github/workflows/pr-packages.yaml
+++ b/.github/workflows/pr-packages.yaml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 


### PR DESCRIPTION
This PR adds the Step Security Harden Runner step to all GitHub Actions workflows.