### PR TITLE
feat(entities-plugins): datakit visual editor modal

### DIFF
--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -91,6 +91,7 @@
     "@kong-ui-public/entities-routes": "workspace:^",
     "@kong-ui-public/entities-vaults": "workspace:^",
     "@kong-ui-public/forms": "workspace:^",
+    "focus-trap": "^7.6.0",
     "marked": "^14.1.3",
     "monaco-editor": "0.52.2"
   }

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -30,6 +30,8 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.31.0",
     "@kong/kongponents": "^9.34.2",
+    "@vueuse/core": "^13.5.0",
+    "@vueuse/integrations": "^13.5.0",
     "axios": "^1.7.7",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^4.4.5"
@@ -42,6 +44,8 @@
     "@kong/design-tokens": "1.17.4",
     "@kong/icons": "^1.31.0",
     "@kong/kongponents": "9.34.2",
+    "@vueuse/core": "^13.5.0",
+    "@vueuse/integrations": "^13.5.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
@@ -3,7 +3,10 @@
     v-bind="props"
     class="dk-form"
   >
-    <template #plugin-config-extra>
+    <template
+      v-if="enableVisualEditor"
+      #plugin-config-extra
+    >
       <KSegmentedControl
         v-model="editorMode"
         :options="editorModes"
@@ -16,7 +19,7 @@
     </template>
 
     <template #default="formProps">
-      <div v-if="editorMode === 'visual'">
+      <div v-if="finalEditorMode === 'visual'">
         <KButton
           appearance="secondary"
           @click="modalOpen = true"
@@ -27,7 +30,7 @@
       </div>
 
       <Form
-        v-else-if="editorMode === 'code'"
+        v-else-if="finalEditorMode === 'code'"
         v-bind="formProps"
         tag="div"
       >
@@ -70,7 +73,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, useTemplateRef } from 'vue'
+import { computed, ref, useTemplateRef, inject } from 'vue'
 import { KAlert, KSegmentedControl } from '@kong/kongponents'
 import { SparklesIcon, DesignIcon, CodeblockIcon } from '@kong/icons'
 import { createI18n } from '@kong-ui-public/i18n'
@@ -90,7 +93,17 @@ const { t } = createI18n<typeof english>('en-us', english)
 
 const props = defineProps<Props<any>>()
 
+// provided by consumer apps
+// TODO: make the default value to `false` to make it opt-in
+// It's currently set to `true` for testing purposes
+const enableVisualEditor = inject<boolean>('DATAKIT_ENABLE_VISUAL_EDITOR', true)
+
+// Editor mode selection
+
 const { editorMode } = usePreferences()
+const finalEditorMode = computed<EditorMode>(() => {
+  return enableVisualEditor ? editorMode.value : 'code'
+})
 
 const icons = {
   visual: DesignIcon,

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
@@ -3,8 +3,31 @@
     v-bind="props"
     class="dk-form"
   >
+    <template #plugin-config-extra>
+      <KSegmentedControl
+        v-model="editorMode"
+        :options="editorModes"
+      >
+        <template #option-label="{ option }">
+          <component :is="icons[option.value]" />
+          {{ option.label }}
+        </template>
+      </KSegmentedControl>
+    </template>
+
     <template #default="formProps">
+      <div v-if="editorMode === 'visual'">
+        <KButton
+          appearance="secondary"
+          @click="modalOpen = true"
+        >
+          {{ t('plugins.free-form.datakit.visual_editor.cta') }}
+        </KButton>
+        <EditorModal v-model:open="modalOpen" />
+      </div>
+
       <Form
+        v-else-if="editorMode === 'code'"
         v-bind="formProps"
         tag="div"
       >
@@ -13,25 +36,13 @@
             {{ t('plugins.free-form.datakit.description_example') }}
 
             <KButton
+              v-for="(_, key) in examples"
+              :key="key"
               appearance="secondary"
               size="small"
-              @click="setExampleCode('authenticate')"
+              @click="handleExampleClick(key)"
             >
-              {{ t('plugins.free-form.datakit.examples.authenticate') }}
-            </KButton>
-            <KButton
-              appearance="secondary"
-              size="small"
-              @click="setExampleCode('combine')"
-            >
-              {{ t('plugins.free-form.datakit.examples.combine') }}
-            </KButton>
-            <KButton
-              appearance="secondary"
-              size="small"
-              @click="setExampleCode('manipulate')"
-            >
-              {{ t('plugins.free-form.datakit.examples.manipulate') }}
+              {{ t(`plugins.free-form.datakit.examples.${key}`) }}
             </KButton>
           </div>
 
@@ -40,153 +51,109 @@
           </template>
         </KAlert>
 
-        <div
-          ref="editor-root"
+        <CodeEditor
+          ref="code-editor"
           class="editor"
+          :config="props.model.config"
+          :editing="props.isEditing"
+          @change="handleCodeChange"
+          @error="handleCodeError"
         />
       </Form>
     </template>
 
     <template #plugin-config-description>
       <!-- eslint-disable-next-line vue/no-v-html -->
-      <span v-html="t('plugins.free-form.datakit.description')" />
+      <span v-html="description" />
     </template>
   </StandardLayout>
 </template>
 
 <script setup lang="ts">
-import { onMounted, shallowRef, useTemplateRef, toRaw, onBeforeUnmount } from 'vue'
-import * as monaco from 'monaco-editor'
-import type { YAMLException } from 'js-yaml'
-import yaml, { JSON_SCHEMA } from 'js-yaml'
+import { computed, ref, useTemplateRef } from 'vue'
+import { KAlert, KSegmentedControl } from '@kong/kongponents'
+import { SparklesIcon, DesignIcon, CodeblockIcon } from '@kong/icons'
+import { createI18n } from '@kong-ui-public/i18n'
 import english from '../../../locales/en.json'
 import StandardLayout from '../shared/layout/StandardLayout.vue'
 import Form from '../shared/Form.vue'
-import type { Props } from '../shared/layout/StandardLayout.vue'
-import { createI18n } from '@kong-ui-public/i18n'
-import { KAlert } from '@kong/kongponents'
-import { SparklesIcon } from '@kong/icons'
-
-// TODO: Update the `authenticate` example with real code once it's ready
+import EditorModal from './visual-editor/modal/EditorModal.vue'
+import CodeEditor from './CodeEditor.vue'
+import { usePreferences } from './visual-editor/composables'
 import * as examples from './examples'
+
+import type { SegmentedControlOption } from '@kong/kongponents'
+import type { Props } from '../shared/layout/StandardLayout.vue'
+import type { EditorMode } from './visual-editor/types'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
 const props = defineProps<Props<any>>()
 
-const editorRoot = useTemplateRef('editor-root')
-const editorRef = shallowRef<monaco.editor.IStandaloneCodeEditor | null>(null)
-const LINT_SOURCE = 'YAML Syntax'
+const { editorMode } = usePreferences()
 
-const EDIT_SOURCE = 'datakit.insert-example'
-
-/**
- * Sets the example code in the Monaco editor.
- * We do not use `setValue` directly because it will clear the undo stack,
- * which prevents the user from undoing changes after inserting an example.
- */
-function setExampleCode(example: keyof typeof examples) {
-  const editor = editorRef.value
-  const model = editor?.getModel()
-  if (!editor || !model) {
-    return
-  }
-
-  const newCode = examples[example]
-  if (editor.getValue() !== newCode) {
-    const fullRange = model.getFullModelRange()
-
-    editor.pushUndoStop()
-    editor.executeEdits(
-      EDIT_SOURCE,
-      [{ range: fullRange, text: newCode }],
-    )
-    editor.pushUndoStop()
-  }
-
-  editor.focus()
+const icons = {
+  visual: DesignIcon,
+  code: CodeblockIcon,
 }
 
-onMounted(() => {
-  const editor = monaco.editor.create(editorRoot.value!, {
-    language: 'yaml',
-    automaticLayout: true,
-    minimap: {
-      enabled: false,
-    },
-    scrollBeyondLastLine: false,
-    tabSize: 2,
-    scrollbar: {
-      alwaysConsumeMouseWheel: false,
-    },
-    autoIndent: 'keep',
-  })
-  editorRef.value = editor
+const editorModes = [
+  {
+    label: t('plugins.free-form.datakit.visual_editor.mode'),
+    value: 'visual',
+  },
+  {
+    label: t('plugins.free-form.datakit.code_editor.mode'),
+    value: 'code',
+  },
+] as const satisfies Array<SegmentedControlOption<EditorMode>>
 
-  if (props.isEditing) {
-    editor.setValue(yaml.dump(toRaw(props.model.config), {
-      schema: JSON_SCHEMA,
-      noArrayIndent: true,
-    }))
+const description = computed(() => {
+  switch (editorMode.value) {
+    case 'code':
+      return t('plugins.free-form.datakit.description_code')
+    case 'visual':
+      return t('plugins.free-form.datakit.description_visual')
+    default:
+      return ''
   }
+})
 
-  editor.onDidChangeModelContent(() => {
-    const model = editor.getModel()
-    const value = editor.getValue() || ''
-    try {
-      const config = yaml.load(value, {
-        schema: JSON_SCHEMA,
-        json: true,
-      })
+// Visual editor
 
-      monaco.editor.setModelMarkers(model!, LINT_SOURCE, [])
+const modalOpen = ref(false)
 
-      props.onFormChange({
-        config,
-      })
-      props.onValidityChange?.({
-        model: 'config',
-        valid: true,
-      })
-    } catch (error: unknown) {
-      const { message, mark } = error as YAMLException
-      const { line, column } = mark || { line: 0, column: 0 }
+// Code editor
 
-      const simpleMessage = message.split('\n')[0] // Take the first line of the error message
+const codeEditor = useTemplateRef('code-editor')
 
-      const markers: monaco.editor.IMarkerData[] = [
-        {
-          startLineNumber: line + 1,
-          startColumn: column + 1,
-          endLineNumber: line + 1,
-          endColumn: column + 2,
-          message: simpleMessage,
-          severity: monaco.MarkerSeverity.Error,
-          source: LINT_SOURCE,
-        },
-      ]
+function handleExampleClick(example: keyof typeof examples) {
+  codeEditor.value?.setExampleCode(example)
+}
 
-      monaco.editor.setModelMarkers(model!, LINT_SOURCE, markers)
-
-      props.onValidityChange?.({
-        model: 'config',
-        valid: false,
-        error: simpleMessage,
-      })
-    }
+function handleCodeChange(config: any) {
+  props.onFormChange({
+    config,
   })
-})
+  props.onValidityChange?.({
+    model: 'config',
+    valid: true,
+  })
+}
 
-onBeforeUnmount(() => {
-  editorRef.value?.dispose()
-})
+function handleCodeError(msg: string) {
+  props.onValidityChange?.({
+    model: 'config',
+    valid: false,
+    error: msg,
+  })
+}
 </script>
 
 <style lang="scss" scoped>
 .dk-form {
   .editor {
     height: 684px;
-    width: 100%;
   }
 
   .examples {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
@@ -73,7 +73,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, useTemplateRef, inject } from 'vue'
+import { computed, ref, useTemplateRef, inject, type Component } from 'vue'
 import { KAlert, KSegmentedControl } from '@kong/kongponents'
 import { SparklesIcon, DesignIcon, CodeblockIcon } from '@kong/icons'
 import { createI18n } from '@kong-ui-public/i18n'
@@ -105,7 +105,7 @@ const finalEditorMode = computed<EditorMode>(() => {
   return enableVisualEditor ? editorMode.value : 'code'
 })
 
-const icons = {
+const icons: Record<EditorMode, Component> = {
   visual: DesignIcon,
   code: CodeblockIcon,
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/composables.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from '@vueuse/core'
 import type { EditorMode } from './types'
 
-const editorMode = useLocalStorage<EditorMode>('datakit-editor-mode', 'code', {
+const editorMode = useLocalStorage<EditorMode>('datakit-editor-mode', 'visual', {
   listenToStorageChanges: false,
 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/composables.ts
@@ -1,0 +1,17 @@
+import { useLocalStorage } from '@vueuse/core'
+import type { EditorMode } from './types'
+
+const editorMode = useLocalStorage<EditorMode>('datakit-editor-mode', 'code', {
+  listenToStorageChanges: false,
+})
+
+const sidebarExpanded = useLocalStorage<boolean>('datakit-visual-editor-sidebar-expanded', true, {
+  listenToStorageChanges: false,
+})
+
+export function usePreferences() {
+  return {
+    editorMode,
+    sidebarExpanded,
+  }
+}

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/composables.ts
@@ -5,13 +5,13 @@ const editorMode = useLocalStorage<EditorMode>('datakit-editor-mode', 'visual', 
   listenToStorageChanges: false,
 })
 
-const sidebarExpanded = useLocalStorage<boolean>('datakit-visual-editor-sidebar-expanded', true, {
+const sidePanelExpanded = useLocalStorage<boolean>('datakit-visual-editor-sidebar-expanded', true, {
   listenToStorageChanges: false,
 })
 
 export function usePreferences() {
   return {
     editorMode,
-    sidebarExpanded,
+    sidePanelExpanded,
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorContent.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorContent.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="dk-editor-panel">
+  <div class="dk-editor-content">
     <aside
-      class="sidebar"
-      :class="{ expanded: sidebarExpanded }"
+      class="side-panel"
+      :class="{ expanded: sidePanelExpanded }"
     >
       <header class="header">
         <h2 class="title">
@@ -29,26 +29,26 @@ import EditorMain from './EditorMain.vue'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
-const { sidebarExpanded } = usePreferences()
+const { sidePanelExpanded } = usePreferences()
 </script>
 
 <style lang="scss" scoped>
-.dk-editor-panel {
+.dk-editor-content {
   background-color: $kui-color-background-neutral-weakest;
   border-top-left-radius: $kui-border-radius-30;
   display: flex;
   overflow: hidden;
   position: relative;
 
-  .sidebar {
+  .side-panel {
     border-right: 1px solid $kui-color-border;
     display: flex;
     flex-direction: column;
     /* stylelint-disable-next-line custom-property-pattern */
-    margin-left: calc(var(--dk-sidebar-width) * -1);
+    margin-left: calc(var(--dk-side-panel-width) * -1);
     transition: margin-left 0.2s ease-in-out;
     /* stylelint-disable-next-line custom-property-pattern */
-    width: var(--dk-sidebar-width);
+    width: var(--dk-side-panel-width);
 
     &.expanded {
       margin-left: 0;

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorMain.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorMain.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="dk-editor-main">
+    <header class="toolbar">
+      <KButton>
+        {{ t('plugins.free-form.datakit.visual_editor.save') }}
+      </KButton>
+    </header>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createI18n } from '@kong-ui-public/i18n'
+import { KButton } from '@kong/kongponents'
+import english from '../../../../../locales/en.json'
+
+const { t } = createI18n<typeof english>('en-us', english)
+</script>
+
+<style lang="scss" scoped>
+.dk-editor-main {
+  display: flex;
+  flex-direction: column;
+
+  .toolbar {
+    align-items: center;
+    border-bottom: 1px solid $kui-color-border;
+    display: flex;
+    flex: 0 0 auto;
+    /* stylelint-disable-next-line custom-property-pattern */
+    height: var(--dk-header-height);
+    justify-content: flex-end;
+    padding: 0px $kui-space-30 0px $kui-space-50;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorMain.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorMain.vue
@@ -1,16 +1,30 @@
 <template>
   <div class="dk-editor-main">
-    <header class="toolbar">
-      <KButton>
-        {{ t('plugins.free-form.datakit.visual_editor.save') }}
-      </KButton>
+    <header class="header">
+      <div class="actions">
+        <KButton
+          appearance="tertiary"
+          target="_blank"
+          to="https://developer.konghq.com/plugins/datakit/"
+        >
+          {{ t('plugins.free-form.datakit.visual_editor.view_docs') }}
+          <ExternalLinkIcon />
+        </KButton>
+        <KButton>
+          {{ t('plugins.free-form.datakit.visual_editor.save') }}
+        </KButton>
+      </div>
     </header>
+    <div class="body">
+      Flow content goes here
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { createI18n } from '@kong-ui-public/i18n'
 import { KButton } from '@kong/kongponents'
+import { ExternalLinkIcon } from '@kong/icons'
 import english from '../../../../../locales/en.json'
 
 const { t } = createI18n<typeof english>('en-us', english)
@@ -21,7 +35,7 @@ const { t } = createI18n<typeof english>('en-us', english)
   display: flex;
   flex-direction: column;
 
-  .toolbar {
+  .header {
     align-items: center;
     border-bottom: 1px solid $kui-color-border;
     display: flex;
@@ -30,6 +44,11 @@ const { t } = createI18n<typeof english>('en-us', english)
     height: var(--dk-header-height);
     justify-content: flex-end;
     padding: 0px $kui-space-30 0px $kui-space-50;
+  }
+
+  .actions {
+    display: flex;
+    gap: $kui-space-30;
   }
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
@@ -8,7 +8,11 @@
       class="nav"
       @back="handleBack"
     />
-    <EditorPanel class="panel" />
+    <EditorPanel
+      ref="panel"
+      class="panel"
+      tabindex="0"
+    />
   </div>
 </template>
 
@@ -28,9 +32,11 @@ const emit = defineEmits<{
   close: []
 }>()
 
+const panel = useTemplateRef('panel')
 const isLocked = useScrollLock(document)
 const { activate, deactivate } = useFocusTrap(modal, {
   returnFocusOnDeactivate: true,
+  initialFocus: () => panel.value?.$el,
 })
 
 watch(open, async (value) => {
@@ -76,6 +82,7 @@ function handleBack() {
 
   .panel {
     flex-grow: 1;
+    outline: none;
   }
 
   :deep(*) {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     v-if="open"
+    ref="modal"
     class="dk-editor-modal"
   >
     <EditorNav
@@ -13,10 +14,13 @@
 
 <script setup lang="ts">
 import { useScrollLock } from '@vueuse/core'
-import { watch } from 'vue'
+import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
+import { nextTick, useTemplateRef, watch } from 'vue'
 
 import EditorNav from './EditorNav.vue'
 import EditorPanel from './EditorPanel.vue'
+
+const modal = useTemplateRef('modal')
 
 const open = defineModel<boolean>('open')
 
@@ -25,9 +29,20 @@ const emit = defineEmits<{
 }>()
 
 const isLocked = useScrollLock(document)
+const { activate, deactivate } = useFocusTrap(modal, {
+  returnFocusOnDeactivate: true,
+})
 
-watch(open, (value) => {
+watch(open, async (value) => {
   isLocked.value = !!value
+
+  await nextTick()
+
+  if (value) {
+    activate()
+  } else {
+    deactivate()
+  }
 }, { immediate: true })
 
 function handleBack() {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
@@ -60,6 +60,7 @@ function handleBack() {
   left: 0;
   padding-top: $kui-space-40;
   position: fixed;
+  scrollbar-width: thin;
   top: 0;
   width: 100%;
   z-index: 1000;

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
@@ -6,11 +6,11 @@
   >
     <EditorNav
       class="nav"
-      @back="handleBack"
+      @back="close"
     />
     <EditorPanel
-      ref="panel"
-      class="panel"
+      ref="content"
+      class="content"
       tabindex="0"
     />
   </div>
@@ -22,7 +22,7 @@ import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
 import { nextTick, useTemplateRef, watch } from 'vue'
 
 import EditorNav from './EditorNav.vue'
-import EditorPanel from './EditorPanel.vue'
+import EditorPanel from './EditorContent.vue'
 
 const modal = useTemplateRef('modal')
 
@@ -32,11 +32,11 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const panel = useTemplateRef('panel')
+const content = useTemplateRef('content')
 const isLocked = useScrollLock(document)
 const { activate, deactivate } = useFocusTrap(modal, {
   returnFocusOnDeactivate: true,
-  initialFocus: () => panel.value?.$el,
+  initialFocus: () => content.value?.$el,
 })
 
 watch(open, async (value) => {
@@ -51,11 +51,10 @@ watch(open, async (value) => {
   }
 }, { immediate: true })
 
-function handleBack() {
+function close() {
   open.value = false
   emit('close')
 }
-
 </script>
 
 <style lang="scss" scoped>
@@ -72,7 +71,7 @@ function handleBack() {
   z-index: 1000;
 
   /* stylelint-disable custom-property-pattern */
-  --dk-sidebar-width: 220px;
+  --dk-side-panel-width: 220px;
   --dk-header-height: 44px;
   /* stylelint-enable custom-property-pattern */
 
@@ -80,7 +79,7 @@ function handleBack() {
     flex-grow: 0;
   }
 
-  .panel {
+  .content {
     flex-grow: 1;
     outline: none;
   }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorModal.vue
@@ -1,0 +1,69 @@
+<template>
+  <div
+    v-if="open"
+    class="dk-editor-modal"
+  >
+    <EditorNav
+      class="nav"
+      @back="handleBack"
+    />
+    <EditorPanel class="panel" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useScrollLock } from '@vueuse/core'
+import { watch } from 'vue'
+
+import EditorNav from './EditorNav.vue'
+import EditorPanel from './EditorPanel.vue'
+
+const open = defineModel<boolean>('open')
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const isLocked = useScrollLock(document)
+
+watch(open, (value) => {
+  isLocked.value = !!value
+}, { immediate: true })
+
+function handleBack() {
+  open.value = false
+  emit('close')
+}
+
+</script>
+
+<style lang="scss" scoped>
+.dk-editor-modal {
+  background-color: $kui-color-background-inverse;
+  display: flex;
+  height: 100%;
+  left: 0;
+  padding-top: $kui-space-40;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+
+  /* stylelint-disable custom-property-pattern */
+  --dk-sidebar-width: 220px;
+  --dk-header-height: 44px;
+  /* stylelint-enable custom-property-pattern */
+
+  .nav {
+    flex-grow: 0;
+  }
+
+  .panel {
+    flex-grow: 1;
+  }
+
+  :deep(*) {
+    box-sizing: border-box;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorNav.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorNav.vue
@@ -26,24 +26,24 @@
     </div>
     <div class="bottom">
       <div
-        class="sidebar-toggle"
-        :class="{ expanded: sidebarExpanded }"
-        @transitionend.self="sidebarToggling = false"
-        @transitionstart.self="sidebarToggling = true"
+        class="side-panel-toggle"
+        :class="{ expanded: sidePanelExpanded }"
+        @transitionend.self="sidePanelToggling = false"
+        @transitionstart.self="sidePanelToggling = true"
       >
         <KTooltip
-          :label="sidebarToggling ? undefined : toggleLabel"
-          :placement="sidebarExpanded ? 'left' : 'right'"
+          :label="sidePanelToggling ? undefined : toggleLabel"
+          :placement="sidePanelExpanded ? 'left' : 'right'"
         >
           <KButton
             appearance="none"
             class="nav-item nav-item-toggle"
             icon
             size="large"
-            @click="handleSidebarToggle"
+            @click="handlePanelToggle"
           >
             <ChevronDoubleLeftIcon
-              v-if="sidebarExpanded"
+              v-if="sidePanelExpanded"
               decorative
               :size="KUI_ICON_SIZE_40"
             />
@@ -78,30 +78,28 @@ const emit = defineEmits<{
 
 const navItems: EditorModalNavItem[] = [
   {
-    label: t('plugins.free-form.datakit.visual_editor.mode'),
+    label: t('plugins.free-form.datakit.visual_editor.return_to_config'),
     icon: ArrowLeftIcon,
     onClick: () => emit('back'),
   },
 ]
 
-const { sidebarExpanded } = usePreferences()
+const { sidePanelExpanded } = usePreferences()
 
 const toggleLabel = computed(() => {
-  return sidebarExpanded.value
-    ? t('plugins.free-form.datakit.visual_editor.collapse_sidebar')
-    : t('plugins.free-form.datakit.visual_editor.expand_sidebar')
+  return sidePanelExpanded.value
+    ? t('plugins.free-form.datakit.visual_editor.collapse_panel')
+    : t('plugins.free-form.datakit.visual_editor.expand_panel')
 })
 
-const sidebarToggling = ref(false)
+const sidePanelToggling = ref(false)
 
-function handleSidebarToggle() {
-  sidebarExpanded.value = !sidebarExpanded.value
+function handlePanelToggle() {
+  sidePanelExpanded.value = !sidePanelExpanded.value
 }
 </script>
 
 <style lang="scss" scoped>
-$sidebar-width: 220px;
-
 .dk-editor-nav {
   align-items: center;
   display: flex;
@@ -178,7 +176,7 @@ $sidebar-width: 220px;
     }
   }
 
-  .sidebar-toggle {
+  .side-panel-toggle {
     left: 0;
     position: absolute;
     transition: left 0.2s ease-out;
@@ -186,7 +184,7 @@ $sidebar-width: 220px;
 
     &.expanded {
       /* stylelint-disable-next-line custom-property-pattern */
-      left: calc(var(--dk-sidebar-width) - 8px); // Leave space for the scrollbar
+      left: calc(var(--dk-side-panel-width) - 8px); // Leave space for the scrollbar
     }
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorNav.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorNav.vue
@@ -1,0 +1,193 @@
+<template>
+  <nav class="dk-editor-nav">
+    <div class="top">
+      <KTooltip
+        v-for="({ label, to, icon, onClick }) in navItems"
+        :key="label"
+        :kpop-attributes="{ offset: '10px' }"
+        :label="label"
+        placement="right"
+      >
+        <KButton
+          :key="label"
+          appearance="none"
+          class="nav-item"
+          icon
+          :to="to"
+          @click="onClick"
+        >
+          <component
+            :is="icon"
+            decorative
+            :size="KUI_ICON_SIZE_40"
+          />
+        </KButton>
+      </KTooltip>
+    </div>
+    <div class="bottom">
+      <div
+        class="sidebar-toggle"
+        :class="{ expanded: sidebarExpanded }"
+        @transitionend.self="sidebarToggling = false"
+        @transitionstart.self="sidebarToggling = true"
+      >
+        <KTooltip
+          :label="sidebarToggling ? undefined : toggleLabel"
+          :placement="sidebarExpanded ? 'left' : 'right'"
+        >
+          <KButton
+            appearance="none"
+            class="nav-item nav-item-toggle"
+            icon
+            size="large"
+            @click="handleSidebarToggle"
+          >
+            <ChevronDoubleLeftIcon
+              v-if="sidebarExpanded"
+              decorative
+              :size="KUI_ICON_SIZE_40"
+            />
+            <ChevronDoubleRightIcon
+              v-else
+              decorative
+              :size="KUI_ICON_SIZE_40"
+            />
+          </KButton>
+        </KTooltip>
+      </div>
+    </div>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { KButton, KTooltip } from '@kong/kongponents'
+import { ArrowLeftIcon, ChevronDoubleLeftIcon, ChevronDoubleRightIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+import { createI18n } from '@kong-ui-public/i18n'
+import english from '../../../../../locales/en.json'
+import { usePreferences } from '../composables'
+
+import type { EditorModalNavItem } from '../types'
+import { computed, ref } from 'vue'
+
+const { t } = createI18n<typeof english>('en-us', english)
+
+const emit = defineEmits<{
+  back: []
+}>()
+
+const navItems: EditorModalNavItem[] = [
+  {
+    label: t('plugins.free-form.datakit.visual_editor.mode'),
+    icon: ArrowLeftIcon,
+    onClick: () => emit('back'),
+  },
+]
+
+const { sidebarExpanded } = usePreferences()
+
+const toggleLabel = computed(() => {
+  return sidebarExpanded.value
+    ? t('plugins.free-form.datakit.visual_editor.collapse_sidebar')
+    : t('plugins.free-form.datakit.visual_editor.expand_sidebar')
+})
+
+const sidebarToggling = ref(false)
+
+function handleSidebarToggle() {
+  sidebarExpanded.value = !sidebarExpanded.value
+}
+</script>
+
+<style lang="scss" scoped>
+$sidebar-width: 220px;
+
+.dk-editor-nav {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-50;
+  justify-content: space-between;
+  padding: 0 $kui-space-40 $kui-space-40;
+
+  .top,
+  .bottom {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: $kui-space-50;
+    position: relative;
+    width: 100%;
+  }
+
+  .top {
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  .bottom {
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  &:deep(.k-popover) {
+    .popover {
+      pointer-events: none;
+    }
+  }
+
+  .nav-item {
+    align-items: center;
+    background-color: $kui-navigation-color-background;
+    border: $kui-border-width-10 solid $kui-color-border-transparent;
+    border-radius: $kui-border-radius-30;
+    color: $kui-navigation-color-text;
+    cursor: pointer;
+    display: flex;
+    height: 36px;
+    justify-content: center;
+    text-decoration: none;
+    transition: color .2s ease;
+    white-space: nowrap;
+    width: 36px;
+
+    &:hover,
+    &:focus-visible {
+      color: $kui-navigation-color-text-hover;
+
+      :deep(svg) {
+        color: $kui-navigation-color-text-hover;
+      }
+    }
+
+    &:focus-visible {
+      box-shadow: $kui-navigation-shadow-focus;
+      outline: none;
+    }
+
+    :deep(svg) {
+      path {
+        color: currentColor;
+        fill: currentColor;
+        transition: all .2s ease-out;
+      }
+    }
+
+    &-toggle {
+      border-color: $kui-navigation-color-border;
+    }
+  }
+
+  .sidebar-toggle {
+    left: 0;
+    position: absolute;
+    transition: left 0.2s ease-out;
+    z-index: 1;
+
+    &.expanded {
+      /* stylelint-disable-next-line custom-property-pattern */
+      left: calc(var(--dk-sidebar-width) - 8px); // Leave space for the scrollbar
+    }
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorPanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorPanel.vue
@@ -77,7 +77,6 @@ const { sidebarExpanded } = usePreferences()
     .body {
       overflow: auto;
       padding-bottom: 36px + $kui-space-40 * 2; // Leave space for the toggle button in case it covers the content
-      scrollbar-width: thin;
     }
   }
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorPanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/modal/EditorPanel.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="dk-editor-panel">
+    <aside
+      class="sidebar"
+      :class="{ expanded: sidebarExpanded }"
+    >
+      <header class="header">
+        <h2 class="title">
+          {{ t('plugins.free-form.datakit.visual_editor.name') }}
+        </h2>
+      </header>
+      <div class="body">
+        <div class="node-selection-panel">
+          TBD: Node selection panel
+        </div>
+      </div>
+    </aside>
+    <div class="main">
+      <EditorMain />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createI18n } from '@kong-ui-public/i18n'
+import english from '../../../../../locales/en.json'
+import { usePreferences } from '../composables'
+import EditorMain from './EditorMain.vue'
+
+const { t } = createI18n<typeof english>('en-us', english)
+
+const { sidebarExpanded } = usePreferences()
+</script>
+
+<style lang="scss" scoped>
+.dk-editor-panel {
+  background-color: $kui-color-background-neutral-weakest;
+  border-top-left-radius: $kui-border-radius-30;
+  display: flex;
+  overflow: hidden;
+  position: relative;
+
+  .sidebar {
+    border-right: 1px solid $kui-color-border;
+    display: flex;
+    flex-direction: column;
+    /* stylelint-disable-next-line custom-property-pattern */
+    margin-left: calc(var(--dk-sidebar-width) * -1);
+    transition: margin-left 0.2s ease-in-out;
+    /* stylelint-disable-next-line custom-property-pattern */
+    width: var(--dk-sidebar-width);
+
+    &.expanded {
+      margin-left: 0;
+    }
+
+    .header {
+      align-items: center;
+      border-bottom: 1px solid $kui-color-border;
+      display: flex;
+      flex: 0 0 auto;
+      /* stylelint-disable-next-line custom-property-pattern */
+      height: var(--dk-header-height);
+      padding: 0 $kui-space-40;
+    }
+
+    .title {
+      color: $kui-color-text;
+      font-size: $kui-font-size-40;
+      font-weight: $kui-font-weight-bold;
+      /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+      left: $kui-space-40;
+      margin: 0;
+      position: absolute;
+    }
+
+    .body {
+      overflow: auto;
+      padding-bottom: 36px + $kui-space-40 * 2; // Leave space for the toggle button in case it covers the content
+      scrollbar-width: thin;
+    }
+  }
+
+  .main {
+    flex: 1 1 auto;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/visual-editor/types.ts
@@ -1,0 +1,18 @@
+import type { Component } from 'vue'
+import type { ButtonProps } from '@kong/kongponents'
+
+export type EditorMode = 'code' | 'visual'
+
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Keys extends any
+  ? Omit<T, Keys> & { [K in Keys]-?: T[K] }
+  : never
+
+interface EditorModalNavItemBase {
+  label: string
+  icon: Component
+  to?: ButtonProps['to']
+  onClick?: () => void
+}
+
+export type EditorModalNavItem = RequireAtLeastOne<EditorModalNavItemBase, 'to' | 'onClick'>
+

--- a/packages/entities/entities-plugins/src/components/free-form/shared/FormSection.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/FormSection.vue
@@ -13,11 +13,17 @@
             {{ title }}
           </slot>
         </h2>
-        <div class="header-description">
+        <div
+          v-if="description || slots.description"
+          class="header-description"
+        >
           <slot name="description">
             {{ description }}
           </slot>
         </div>
+      </div>
+      <div class="header-extra">
+        <slot name="extra" />
       </div>
     </header>
     <div class="content">
@@ -29,20 +35,22 @@
 <script setup lang="ts">
 defineProps<{
   step?: number
-  title?: string
+  title: string
   description?: string
 }>()
 
-defineSlots<{
+const slots = defineSlots<{
   default?: () => any
   title?: () => any
   description?: () => any
+  extra?: () => any
 }>()
 </script>
 
 <style lang="scss" scoped>
 .ff-form-section {
   .header {
+    align-items: flex-start;
     display: flex;
     gap: $kui-space-40;
   }
@@ -62,7 +70,7 @@ defineSlots<{
   .header-content {
     align-items: flex-start;
     display: flex;
-    flex: 1 0 0;
+    flex: 1 1 auto;
     flex-direction: column;
     gap: $kui-space-40;
     padding-top: $kui-space-20;
@@ -81,6 +89,14 @@ defineSlots<{
     font-size: $kui-font-size-30;
     line-height: $kui-line-height-30;
     margin: 0;
+  }
+
+  .header-extra {
+    align-items: center;
+    display: flex;
+    flex: 0 0 auto;
+    gap: $kui-space-40;
+    justify-content: flex-end;
   }
 
   .content {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/FormSection.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/FormSection.vue
@@ -22,7 +22,10 @@
           </slot>
         </div>
       </div>
-      <div class="header-extra">
+      <div
+        v-if="slots.extra"
+        class="header-extra"
+      >
         <slot name="extra" />
       </div>
     </header>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -65,6 +65,13 @@
       >
         <slot name="general-info-description" />
       </template>
+
+      <template
+        v-if="slots['general-info-extra']"
+        #extra
+      >
+        <slot name="general-info-extra" />
+      </template>
     </FormSection>
     <FormSection
       :description="t('plugins.form.sections.plugin_config.description')"
@@ -83,11 +90,19 @@
       >
         <slot name="plugin-config-title" />
       </template>
+
       <template
         v-if="slots['plugin-config-description']"
         #description
       >
         <slot name="plugin-config-description" />
+      </template>
+
+      <template
+        v-if="slots['plugin-config-extra']"
+        #extra
+      >
+        <slot name="plugin-config-extra" />
       </template>
     </FormSection>
   </div>
@@ -140,8 +155,10 @@ const slots = defineSlots<{
   default: (props: ConfigFormProps<T>) => any
   'general-info-title'?: () => any
   'general-info-description'?: () => any
+  'general-info-extra'?: () => any
   'plugin-config-title'?: () => any
   'plugin-config-description'?: () => any
+  'plugin-config-extra'?: () => any
 }>()
 
 provide(AUTOFILL_SLOT, slots?.[AUTOFILL_SLOT_NAME])

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -676,8 +676,10 @@
           "name": "Datakit Visual Editor",
           "cta": "Go to visual editor",
           "save": "Save",
-          "expand_sidebar": "Expand sidebar",
-          "collapse_sidebar": "Collapse sidebar"
+          "view_docs": "View Docs",
+          "expand_panel": "Expand panel",
+          "collapse_panel": "Collapse panel",
+          "return_to_config": "Return to Plugin configuration"
         },
         "code_editor": {
           "mode": "Code Editor"

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -663,8 +663,8 @@
         "by_lua_placeholder": "Enter Lua script here..."
       },
       "datakit": {
-        "description_code": "Configuration this plugin by using YAML configuration. If you are copy/pasting in examples from the documentation - paste from below the <code>config</code> block.",
-        "description_visual": "Configuration this plugin by using the visual editor.",
+        "description_code": "Configure this plugin by using YAML configuration. If you are copy/pasting in examples from the documentation - paste from below the <code>config</code> block.",
+        "description_visual": "Configure this plugin by using the visual editor.",
         "description_example": "Start with a use case:",
         "examples": {
           "authenticate": "Authenticate Kong to a third-party service",

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -663,12 +663,24 @@
         "by_lua_placeholder": "Enter Lua script here..."
       },
       "datakit": {
-        "description": "Configure Datakit via YAML below. If you are copy/pasting in examples from the documentation - paste from below the <code>config</code> block.",
+        "description_code": "Configuration this plugin by using YAML configuration. If you are copy/pasting in examples from the documentation - paste from below the <code>config</code> block.",
+        "description_visual": "Configuration this plugin by using the visual editor.",
         "description_example": "Start with a use case:",
         "examples": {
           "authenticate": "Authenticate Kong to a third-party service",
           "combine": "Combine multiple API responses",
           "manipulate": "Manipulate request headers"
+        },
+        "visual_editor": {
+          "mode": "Visual Editor",
+          "name": "Datakit Visual Editor",
+          "cta": "Go to visual editor",
+          "save": "Save",
+          "expand_sidebar": "Expand sidebar",
+          "collapse_sidebar": "Collapse sidebar"
+        },
+        "code_editor": {
+          "mode": "Code Editor"
         }
       }
     }

--- a/packages/entities/entities-plugins/vite.config.ts
+++ b/packages/entities/entities-plugins/vite.config.ts
@@ -24,6 +24,8 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
         '@kong-ui-public/entities-plugins-metadata',
         '@kong-ui-public/entities-routes',
         '@kong-ui-public/forms',
+        '@vueuse/core',
+        '@vueuse/integrations',
         'marked',
         'monaco-editor',
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -989,6 +989,12 @@ importers:
       '@kong/kongponents':
         specifier: 9.34.2
         version: 9.34.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.4.5(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))
+      '@vueuse/core':
+        specifier: ^13.5.0
+        version: 13.5.0(vue@3.5.13(typescript@5.6.3))
+      '@vueuse/integrations':
+        specifier: ^13.5.0
+        version: 13.5.0(axios@1.7.7)(focus-trap@7.6.5)(sortablejs@1.15.6)(vue@3.5.13(typescript@5.6.3))
       axios:
         specifier: ^1.7.7
         version: 1.7.7
@@ -1916,6 +1922,7 @@ packages:
 
   '@evilmartians/lefthook@1.8.2':
     resolution: {integrity: sha512-SZdQk3W9q7tcJwnSwEMUubQqVIK7SHxv52hEAnV7o3nPI+xKcmd+rN0hZIJg07wjBaJRAjzdvoQySKQQYPW5Qw==}
+    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -3181,6 +3188,9 @@ packages:
   '@types/web-bluetooth@0.0.20':
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
 
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
   '@types/ws@8.5.12':
     resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
 
@@ -3450,17 +3460,72 @@ packages:
   '@vueuse/core@12.7.0':
     resolution: {integrity: sha512-jtK5B7YjZXmkGNHjviyGO4s3ZtEhbzSgrbX+s5o+Lr8i2nYqNyHuPVOeTdM1/hZ5Tkxg/KktAuAVDDiHMraMVA==}
 
+  '@vueuse/core@13.5.0':
+    resolution: {integrity: sha512-wV7z0eUpifKmvmN78UBZX8T7lMW53Nrk6JP5+6hbzrB9+cJ3jr//hUlhl9TZO/03bUkMK6gGkQpqOPWoabr72g==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/integrations@13.5.0':
+    resolution: {integrity: sha512-7RACJySnlpl0MkSzxbtadioNGSX4TL5/Wl2cUy4nDq/XkeHwPYvVM880HJUSiap/FXhVEup9VKTM9y/n5UspAw==}
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7 || ^8
+      vue: ^3.5.0
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+
   '@vueuse/metadata@10.11.1':
     resolution: {integrity: sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==}
 
   '@vueuse/metadata@12.7.0':
     resolution: {integrity: sha512-4VvTH9mrjXqFN5LYa5YfqHVRI6j7R00Vy4995Rw7PQxyCL3z0Lli86iN4UemWqixxEvYfRjG+hF9wL8oLOn+3g==}
 
+  '@vueuse/metadata@13.5.0':
+    resolution: {integrity: sha512-euhItU3b0SqXxSy8u1XHxUCdQ8M++bsRs+TYhOLDU/OykS7KvJnyIFfep0XM5WjIFry9uAPlVSjmVHiqeshmkw==}
+
   '@vueuse/shared@10.11.1':
     resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
 
   '@vueuse/shared@12.7.0':
     resolution: {integrity: sha512-coLlUw2HHKsm7rPN6WqHJQr18WymN4wkA/3ThFaJ4v4gWGWAQQGK+MJxLuJTBs4mojQiazlVWAKNJNpUWGRkNw==}
+
+  '@vueuse/shared@13.5.0':
+    resolution: {integrity: sha512-K7GrQIxJ/ANtucxIXbQlUHdB0TPA8c+q5i+zbrjxuhJCnJ9GtBg75sBSnvmLSxHKPg2Yo8w62PWksl9kwH0Q8g==}
+    peerDependencies:
+      vue: ^3.5.0
 
   '@webassemblyjs/ast@1.12.1':
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
@@ -8293,7 +8358,7 @@ packages:
   right-pad@1.0.1:
     resolution: {integrity: sha512-bYBjgxmkvTAfgIYy328fmkwhp39v8lwVgWhhrzxPV3yHtcSqyYKe9/XOhvW48UFjATg3VuJbpsp5822ACNvkmw==}
     engines: {node: '>= 0.10'}
-    deprecated: Use String.prototype.padEnd() instead
+    deprecated: Please use String.prototype.padEnd() over this package.
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
@@ -12610,6 +12675,8 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
+  '@types/web-bluetooth@0.0.21': {}
+
   '@types/ws@8.5.12':
     dependencies:
       '@types/node': 18.19.64
@@ -13060,9 +13127,28 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@vueuse/core@13.5.0(vue@3.5.13(typescript@5.6.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 13.5.0
+      '@vueuse/shared': 13.5.0(vue@3.5.13(typescript@5.6.3))
+      vue: 3.5.13(typescript@5.6.3)
+
+  '@vueuse/integrations@13.5.0(axios@1.7.7)(focus-trap@7.6.5)(sortablejs@1.15.6)(vue@3.5.13(typescript@5.6.3))':
+    dependencies:
+      '@vueuse/core': 13.5.0(vue@3.5.13(typescript@5.6.3))
+      '@vueuse/shared': 13.5.0(vue@3.5.13(typescript@5.6.3))
+      vue: 3.5.13(typescript@5.6.3)
+    optionalDependencies:
+      axios: 1.7.7
+      focus-trap: 7.6.5
+      sortablejs: 1.15.6
+
   '@vueuse/metadata@10.11.1': {}
 
   '@vueuse/metadata@12.7.0': {}
+
+  '@vueuse/metadata@13.5.0': {}
 
   '@vueuse/shared@10.11.1(vue@3.5.13(typescript@5.6.3))':
     dependencies:
@@ -13076,6 +13162,10 @@ snapshots:
       vue: 3.5.13(typescript@5.6.3)
     transitivePeerDependencies:
       - typescript
+
+  '@vueuse/shared@13.5.0(vue@3.5.13(typescript@5.6.3))':
+    dependencies:
+      vue: 3.5.13(typescript@5.6.3)
 
   '@webassemblyjs/ast@1.12.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -964,6 +964,9 @@ importers:
       '@kong-ui-public/forms':
         specifier: workspace:^
         version: link:../../core/forms
+      focus-trap:
+        specifier: ^7.6.0
+        version: 7.6.5
       marked:
         specifier: ^14.1.3
         version: 14.1.3
@@ -1922,7 +1925,6 @@ packages:
 
   '@evilmartians/lefthook@1.8.2':
     resolution: {integrity: sha512-SZdQk3W9q7tcJwnSwEMUubQqVIK7SHxv52hEAnV7o3nPI+xKcmd+rN0hZIJg07wjBaJRAjzdvoQySKQQYPW5Qw==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 


### PR DESCRIPTION
# Summary

[KM-1453](https://konghq.atlassian.net/browse/KM-1453)
[KM-1455](https://konghq.atlassian.net/browse/KM-1455)

In this PR:

- Refactored `StandardLayout` to allow adding the editor mode toggle.
- Extracted the YAML code editor into a separate component.
- Added a toggle between code editor and visual editor, with the preference saved to `localStorage`
- Implemented basic functionality to open the visual editor modal from the plugin form
- Built the initial layout and interactions for the editor modal, including sidebar toggle and overall structure, scroll locking, focus trapping, etc.

[KM-1453]: https://konghq.atlassian.net/browse/KM-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KM-1455]: https://konghq.atlassian.net/browse/KM-1455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ