### PR TITLE
feat(app-layout): grouped sidebar l1 items [KHCP-16758]

### DIFF
--- a/packages/core/app-layout/sandbox/pages/SidebarPage.vue
+++ b/packages/core/app-layout/sandbox/pages/SidebarPage.vue
@@ -113,6 +113,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       to: '/sidebar/?runtime-manager',
       label: 'retail-sandbox-rg', // runtime group name
       key: 'gateway-manager',
+      group: 'connectivity',
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager',
       // TODO: actually when you click on Runtime Manager it would not expand until the user picks a runtime group
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'runtime-manager',
@@ -164,6 +165,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       key: 'servicehub',
       to: '/sidebar/?servicehub',
       label: 'Deloreans',
+      group: 'applications',
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub',
       // TODO: actually when you click on Service Hub it would not expand until the user picks a service
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'servicehub',
@@ -185,6 +187,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       key: 'dev-portal',
       to: '/sidebar/?dev-portal',
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal',
+      group: 'applications',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'dev-portal',
       items: [
@@ -226,6 +229,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       key: 'analytics',
       to: '/sidebar/?analytics',
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics',
+      group: 'applications',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'analytics',
       items: [

--- a/packages/core/app-layout/sandbox/pages/SidebarPage.vue
+++ b/packages/core/app-layout/sandbox/pages/SidebarPage.vue
@@ -110,13 +110,13 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
     },
     {
       name: 'Gateway Manager',
-      to: '/sidebar/?runtime-manager',
+      to: '/sidebar/?gateway-manager',
       label: 'retail-sandbox-rg', // runtime group name
       key: 'gateway-manager',
-      group: 'connectivity',
-      active: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager',
+      group: 'Connectivity',
+      active: (activeItem.value as SidebarPrimaryItem)?.key === 'gateway-manager',
       // TODO: actually when you click on Runtime Manager it would not expand until the user picks a runtime group
-      expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'runtime-manager' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'runtime-manager',
+      expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'gateway-manager' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'gateway-manager',
       items: [
         {
           name: 'Runtime Instances',
@@ -165,7 +165,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       key: 'servicehub',
       to: '/sidebar/?servicehub',
       label: 'Deloreans',
-      group: 'applications',
+      group: 'Applications',
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub',
       // TODO: actually when you click on Service Hub it would not expand until the user picks a service
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'servicehub' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'servicehub',
@@ -187,7 +187,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       key: 'dev-portal',
       to: '/sidebar/?dev-portal',
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal',
-      group: 'applications',
+      group: 'Applications',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'dev-portal' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'dev-portal',
       items: [
@@ -229,7 +229,7 @@ const sidebarItemsTop = computed((): SidebarPrimaryItem[] => {
       key: 'analytics',
       to: '/sidebar/?analytics',
       active: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics',
-      group: 'applications',
+      group: 'Applications',
       // This item can always show the subnav
       expanded: (activeItem.value as SidebarPrimaryItem)?.key === 'analytics' || (activeItem.value as SidebarSecondaryItem)?.parentKey === 'analytics',
       items: [

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -114,11 +114,11 @@ type BottomPrimaryItem = Omit<SidebarPrimaryItem, 'group'>
 
 const props = defineProps({
   topItems: {
-    type: Array as PropType<Array<SidebarPrimaryItem>>,
+    type: Array as PropType<SidebarPrimaryItem[]>,
     default: () => ([]),
   },
   bottomItems: {
-    type: Array as PropType<Array<BottomPrimaryItem>>,
+    type: Array as PropType<BottomPrimaryItem[]>,
     default: () => ([]),
   },
   headerHeight: {
@@ -266,7 +266,11 @@ const toggleSidebar = (isOpen: boolean) => {
   // Add or remove a class from the `body` tag when the sidebar is opened/closed
   // This allows for the consuming app to add CSS to prevent overflow-y while the sidebar is open
 
-  isOpen ? document?.body?.classList.add('kong-ui-app-sidebar-open') : document?.body?.classList.remove('kong-ui-app-sidebar-open')
+  if (isOpen) {
+    document?.body?.classList.add('kong-ui-app-sidebar-open')
+  } else {
+    document?.body?.classList.remove('kong-ui-app-sidebar-open')
+  }
 
   // Always reset to false
   sidebarTogglePending.value = false
@@ -382,7 +386,9 @@ const getScrollbarWidth = (): void => {
 
   // remove inner elements
 
-  outerElement.parentNode && outerElement.parentNode.removeChild(outerElement)
+  if (outerElement.parentNode) {
+    outerElement.parentNode.removeChild(outerElement)
+  }
 
   const scrollbarWidth = widthNoScroll - widthWithScroll
 

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -211,15 +211,16 @@ const bottomNavItems = computed(() => props.bottomItems.length ? prepareNavItems
 
 const topNavGroups = computed((): Map<string, SidebarPrimaryItem[]> => {
   // Create a Map to store grouped items, ensuring insertion order is preserved.
-  const groups = new Map<string | '_ungrouped', SidebarPrimaryItem[]>()
+  const groups = new Map<string, SidebarPrimaryItem[]>()
+  const UNGROUPED_KEY = '_ungrouped'
 
   // Initialize the "_ungrouped" group first to ensure it appears first when iterating through the groups.
   // (Meaning ungrouped L1 navigation items will appear first in the sidebar).
-  groups.set('_ungrouped', [])
+  groups.set(UNGROUPED_KEY, [])
 
   // Loop through all top nav items and organize them by group
   for (const item of topNavItems.value) {
-    const groupKey = item.group || '_ungrouped'
+    const groupKey = item.group || UNGROUPED_KEY
 
     // Initialize the group array if it doesn't exist
     if (!groups.has(groupKey)) {

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -109,13 +109,16 @@ import clonedeep from 'lodash.clonedeep'
 
 const emit = defineEmits(['click', 'toggle'])
 
+/** Prevent adding the `group` property to bottom sidebar items. */
+type BottomPrimaryItem = Omit<SidebarPrimaryItem, 'group'>
+
 const props = defineProps({
   topItems: {
     type: Array as PropType<SidebarPrimaryItem[]>,
     default: () => ([]),
   },
   bottomItems: {
-    type: Array as PropType<Omit<SidebarPrimaryItem, 'group'>[]>,
+    type: Array as PropType<BottomPrimaryItem[]>,
     default: () => ([]),
   },
   headerHeight: {

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -665,6 +665,7 @@ onBeforeUnmount(() => {
     line-height: $kui-line-height-40;
     opacity: 70%; // TODO: We should change this before merge
     padding: $kui-space-0 calc($kui-space-50 + $kui-space-40);
+    user-select: none;
   }
 }
 

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -46,11 +46,12 @@
                 :id="`level-primary-group-${getPrimaryGroupId(groupName)}`"
                 class="level-primary-group-name"
                 data-testid="level-primary-group-name"
+                role="presentation"
               >
                 {{ groupName }}
               </div>
               <ul
-                :aria-labelledby="`level-primary-group-${getPrimaryGroupId(groupName)}`"
+                :aria-labelledby="groupName !== UNGROUPED_NAME ? `level-primary-group-${getPrimaryGroupId(groupName)}` : undefined"
                 class="level-primary top-items"
               >
                 <SidebarItem

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -86,7 +86,7 @@
 <script setup lang="ts">
 import type { PropType } from 'vue'
 import { ref, computed, watch, useSlots, onMounted, onBeforeUnmount, nextTick } from 'vue'
-import type { SidebarPrimaryItem, SidebarPrimaryItemGroup } from '../../types'
+import type { SidebarPrimaryItem } from '../../types'
 import SidebarItem from '../sidebar/SidebarItem.vue'
 import { FocusTrap } from 'focus-trap-vue'
 import { useDebounce } from '../../composables'
@@ -211,7 +211,7 @@ const bottomNavItems = computed(() => props.bottomItems.length ? prepareNavItems
 
 const topNavGroups = computed((): Map<string, SidebarPrimaryItem[]> => {
   // Create a Map to store grouped items, ensuring insertion order is preserved.
-  const groups = new Map<SidebarPrimaryItemGroup | '_ungrouped', SidebarPrimaryItem[]>()
+  const groups = new Map<string | '_ungrouped', SidebarPrimaryItem[]>()
 
   // Initialize the "_ungrouped" group first to ensure it appears first when iterating through the groups.
   // (Meaning ungrouped L1 navigation items will appear first in the sidebar).

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -36,22 +36,21 @@
           <slot name="top" />
         </div>
         <nav aria-label="Main menu">
-          <template v-if="topNavItems.length">
-            <!-- Loop through each group in topNavGroups -->
+          <template v-if="topNavGroups.size > 0">
             <template
               v-for="[groupName, groupItems] in topNavGroups"
               :key="groupName"
             >
               <div
                 v-if="groupName !== UNGROUPED_NAME"
-                :id="`level-primary-group-${groupName}`"
+                :id="`level-primary-group-${getPrimaryGroupId(groupName)}`"
                 class="level-primary-group-name"
                 data-testid="level-primary-group-name"
               >
                 {{ groupName }}
               </div>
               <ul
-                :aria-labelledby="`level-primary-group-${groupName}`"
+                :aria-labelledby="`level-primary-group-${getPrimaryGroupId(groupName)}`"
                 class="level-primary top-items"
               >
                 <SidebarItem
@@ -69,7 +68,7 @@
           </template>
 
           <div
-            v-if="topNavItems.length && bottomNavItems.length"
+            v-if="topNavGroups.size > 0 && bottomNavItems.length"
             class="sidebar-level-divider"
             role="separator"
           />
@@ -226,6 +225,7 @@ const topNavItems = computed(() => props.topItems.length ? prepareNavItems(props
 const bottomNavItems = computed(() => props.bottomItems.length ? prepareNavItems(props.bottomItems) : [])
 
 const UNGROUPED_NAME = '_ungrouped'
+const getPrimaryGroupId = (group: string = '') => group.trim().replace(' ', '').replace(/[^a-z0-9]+/gi, '-').toLowerCase()
 const topNavGroups = computed((): Map<string, SidebarPrimaryItem[]> => {
   // Create a Map to store grouped items, ensuring insertion order is preserved.
   const groups = new Map<string, SidebarPrimaryItem[]>()

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -254,8 +254,6 @@ const topNavGroups = computed((): Map<string, SidebarPrimaryItem[]> => {
   return groups
 })
 
-console.log('topNavGroups', topNavGroups.value)
-
 // Do not manually set the value of `mobileSidebarOpen`; always call `toggleSidebar(true/false)`
 const mobileSidebarOpen = ref<boolean>(props.open)
 const toggleSidebar = (isOpen: boolean) => {

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -36,21 +36,37 @@
           <slot name="top" />
         </div>
         <nav aria-label="Main menu">
-          <ul
-            v-if="topNavItems.length"
-            class="level-primary top-items"
-          >
-            <SidebarItem
-              v-for="item in topNavItems"
-              :key="item.name"
-              :item="item"
-              @click="itemClick"
+          <template v-if="topNavItems.length">
+            <!-- Loop through each group in topNavGroups -->
+            <template
+              v-for="[groupName, groupItems] in topNavGroups"
+              :key="groupName"
             >
-              <template #[`sidebar-icon-${item.key}`]>
-                <slot :name="`sidebar-icon-${(item as SidebarPrimaryItem).key}`" />
-              </template>
-            </SidebarItem>
-          </ul>
+              <div
+                v-if="groupName !== UNGROUPED_NAME"
+                :id="`level-primary-group-${groupName}`"
+                class="level-primary-group-name"
+                data-testid="level-primary-group-name"
+              >
+                {{ groupName }}
+              </div>
+              <ul
+                :aria-labelledby="`level-primary-group-${groupName}`"
+                class="level-primary top-items"
+              >
+                <SidebarItem
+                  v-for="item in groupItems"
+                  :key="item.name"
+                  :item="item"
+                  @click="itemClick"
+                >
+                  <template #[`sidebar-icon-${item.key}`]>
+                    <slot :name="`sidebar-icon-${(item as SidebarPrimaryItem).key}`" />
+                  </template>
+                </SidebarItem>
+              </ul>
+            </template>
+          </template>
 
           <div
             v-if="topNavItems.length && bottomNavItems.length"
@@ -209,26 +225,26 @@ const prepareNavItems = (items: SidebarPrimaryItem[]): SidebarPrimaryItem[] => {
 const topNavItems = computed(() => props.topItems.length ? prepareNavItems(props.topItems) : [])
 const bottomNavItems = computed(() => props.bottomItems.length ? prepareNavItems(props.bottomItems) : [])
 
+const UNGROUPED_NAME = '_ungrouped'
 const topNavGroups = computed((): Map<string, SidebarPrimaryItem[]> => {
   // Create a Map to store grouped items, ensuring insertion order is preserved.
   const groups = new Map<string, SidebarPrimaryItem[]>()
-  const UNGROUPED_KEY = '_ungrouped'
 
   // Initialize the "_ungrouped" group first to ensure it appears first when iterating through the groups.
   // (Meaning ungrouped L1 navigation items will appear first in the sidebar).
-  groups.set(UNGROUPED_KEY, [])
+  groups.set(UNGROUPED_NAME, [])
 
   // Loop through all top nav items and organize them by group
   for (const item of topNavItems.value) {
-    const groupKey = item.group || UNGROUPED_KEY
+    const groupName = item.group || UNGROUPED_NAME
 
     // Initialize the group array if it doesn't exist
-    if (!groups.has(groupKey)) {
-      groups.set(groupKey, [])
+    if (!groups.has(groupName)) {
+      groups.set(groupName, [])
     }
 
     // Add the item to its group
-    groups.get(groupKey)?.push(item)
+    groups.get(groupName)?.push(item)
   }
 
   return groups
@@ -619,6 +635,7 @@ onBeforeUnmount(() => {
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
+    margin-bottom: $kui-space-40;
     padding: $kui-space-0 $kui-space-10 $kui-space-0 $kui-space-50; // if changed, ensure you test in ALL browsers
     width: 100%;
     // Adjust padding for Safari-only
@@ -629,6 +646,15 @@ onBeforeUnmount(() => {
     &:last-of-type {
       margin-bottom: $sidebar-header-spacing * 4;
     }
+  }
+
+  .level-primary-group-name {
+    color: $kui-navigation-color-text;
+    font-size: $kui-font-size-20;
+    font-weight: $kui-font-weight-bold;
+    line-height: $kui-line-height-40;
+    opacity: 70%; // TODO: We should change this before merge
+    padding: $kui-space-0 calc($kui-space-50 + $kui-space-40);
   }
 }
 

--- a/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
+++ b/packages/core/app-layout/src/components/sidebar/AppSidebar.vue
@@ -114,11 +114,11 @@ type BottomPrimaryItem = Omit<SidebarPrimaryItem, 'group'>
 
 const props = defineProps({
   topItems: {
-    type: Array as PropType<SidebarPrimaryItem[]>,
+    type: Array as PropType<Array<SidebarPrimaryItem>>,
     default: () => ([]),
   },
   bottomItems: {
-    type: Array as PropType<BottomPrimaryItem[]>,
+    type: Array as PropType<Array<BottomPrimaryItem>>,
     default: () => ([]),
   },
   headerHeight: {

--- a/packages/core/app-layout/src/types/sidebar.ts
+++ b/packages/core/app-layout/src/types/sidebar.ts
@@ -17,8 +17,6 @@ export interface SidebarSecondaryItem {
   parentKey?: string
 }
 
-export type SidebarPrimaryItemGroup = 'connectivity' | 'applications'
-
 export interface SidebarPrimaryItem extends Omit<SidebarSecondaryItem, 'parentKey' | 'badgeCount'> {
   /** Unique key of top-level navigation item. Auto-generated if not provided. */
   key: string
@@ -27,7 +25,7 @@ export interface SidebarPrimaryItem extends Omit<SidebarSecondaryItem, 'parentKe
   /** Is the top-level sidebar item expanded */
   expanded?: boolean
   /** The top-level navigation group to place the navigation item inside. If not provided, the sidebar item will be rendered standalone, above the L1 navigation groups (e.g. "Overview"). */
-  group?: SidebarPrimaryItemGroup
+  group?: string
   /** Nested sidebar items (children) without icons */
   items?: SidebarSecondaryItem[]
 }

--- a/packages/core/app-layout/src/types/sidebar.ts
+++ b/packages/core/app-layout/src/types/sidebar.ts
@@ -17,6 +17,8 @@ export interface SidebarSecondaryItem {
   parentKey?: string
 }
 
+export type SidebarPrimaryItemGroup = 'connectivity' | 'applications'
+
 export interface SidebarPrimaryItem extends Omit<SidebarSecondaryItem, 'parentKey' | 'badgeCount'> {
   /** Unique key of top-level navigation item. Auto-generated if not provided. */
   key: string
@@ -24,6 +26,8 @@ export interface SidebarPrimaryItem extends Omit<SidebarSecondaryItem, 'parentKe
   label?: string
   /** Is the top-level sidebar item expanded */
   expanded?: boolean
+  /** The top-level navigation group to place the navigation item inside. If not provided, the sidebar item will be rendered standalone, above the L1 navigation groups (e.g. "Overview"). */
+  group?: SidebarPrimaryItemGroup
   /** Nested sidebar items (children) without icons */
   items?: SidebarSecondaryItem[]
 }


### PR DESCRIPTION
# Summary

Support grouped L1 sidebar navigation items.

<img width="255" height="528" alt="image" src="https://github.com/user-attachments/assets/5d39c531-3e1a-4691-9b66-c848ec0ab45d" />
