### PR TITLE
feat(analytics): move dashboards to version 2 [MA-3935]

### DIFF
--- a/packages/analytics/analytics-metric-provider/src/components/MetricsProvider.cy.ts
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsProvider.cy.ts
@@ -270,7 +270,7 @@ describe('<AnalyticsMetricProvider />', () => {
     cy.mount(MetricsTestHarness, {
       props: {
         render: 'global',
-        datasource: 'advanced',
+        datasource: 'api_usage',
         additionalFilter,
       },
       global: {

--- a/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
+++ b/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
@@ -123,7 +123,7 @@ export default function useMetricFetcher(opts: MetricFetcherOptions): FetcherRes
     () => opts.queryFn({
       // TODO: Use a type guard to validate that if the datasource is basic,
       // the query is a valid basic explore query.
-      datasource: opts.datasource.value as 'advanced',
+      datasource: opts.datasource.value as 'api_usage',
       query: query.value,
     }, opts.abortController ?? new AbortController()),
     {

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -533,10 +533,6 @@ export type TileConfig = FromSchemaWithOptions<typeof tileConfigSchema>
 export const dashboardConfigSchema = {
   type: 'object',
   properties: {
-    version: {
-      type: 'string',
-      enum: ['v2'],
-    },
     tiles: {
       type: 'array',
       items: tileConfigSchema,

--- a/packages/analytics/analytics-utilities/src/index.ts
+++ b/packages/analytics/analytics-utilities/src/index.ts
@@ -1,6 +1,6 @@
 export * from './constants'
-export * from './dashboardSchema'
-export * as dashboardSchemaV2 from './dashboardSchema.v2'
+export * as dashboardsSchemaV1 from './dashboardSchema'
+export * from './dashboardSchema.v2'
 export * from './types'
 export * from './format'
 export * from './granularity'

--- a/packages/analytics/analytics-utilities/src/types/explore/all.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/all.ts
@@ -5,20 +5,20 @@ import { type ExploreAggregations, type ExploreFilterAll, filterableExploreDimen
 export type AllAggregations = BasicExploreAggregations | AiExploreAggregations | ExploreAggregations
 export type AllFilters = BasicExploreFilterAll | AiExploreFilterAll | ExploreFilterAll
 
-export const queryDatasources = ['basic', 'advanced', 'ai'] as const
+export const queryDatasources = ['basic', 'api_usage', 'llm_usage'] as const
 
 export type QueryDatasource = typeof queryDatasources[number]
 
 export interface FilterTypeMap extends Record<QueryDatasource, AllFilters> {
   basic: BasicExploreFilterAll
-  advanced: ExploreFilterAll
-  ai: AiExploreFilterAll
+  api_usage: ExploreFilterAll
+  llm_usage: AiExploreFilterAll
 }
 
 export const datasourceToFilterableDimensions: Record<QueryDatasource, Set<string>> = {
   basic: new Set(filterableBasicExploreDimensions),
-  advanced: new Set(filterableExploreDimensions),
-  ai: new Set(filterableAiExploreDimensions),
+  api_usage: new Set(filterableExploreDimensions),
+  llm_usage: new Set(filterableAiExploreDimensions),
 } as const
 
 // Utility for stripping unknown filters

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -8,12 +8,12 @@ export interface BasicDatasourceQuery {
 }
 
 export interface AdvancedDatasourceQuery {
-  datasource: 'advanced'
+  datasource: 'api_usage'
   query: ExploreQuery
 }
 
 export interface AiDatasourceQuery {
-  datasource: 'ai'
+  datasource: 'llm_usage'
   query: AiExploreQuery
 }
 

--- a/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
@@ -379,7 +379,7 @@ export const simpleConfigNoFilters: DashboardConfig = {
           description: '{timeframe}',
         },
         query: {
-          datasource: 'advanced',
+          datasource: 'api_usage',
         },
       },
       layout: {
@@ -400,7 +400,7 @@ export const simpleConfigNoFilters: DashboardConfig = {
           type: 'timeseries_line',
         },
         query: {
-          datasource: 'advanced',
+          datasource: 'api_usage',
         },
       },
       layout: {
@@ -433,7 +433,7 @@ export const simpleConfigGlobalFilters: DashboardConfig = {
           description: '{timeframe}',
         },
         query: {
-          datasource: 'advanced',
+          datasource: 'api_usage',
         },
       },
       layout: {
@@ -453,7 +453,7 @@ export const simpleConfigGlobalFilters: DashboardConfig = {
           type: 'timeseries_line',
         },
         query: {
-          datasource: 'advanced',
+          datasource: 'api_usage',
         },
       },
       layout: {
@@ -468,7 +468,7 @@ export const simpleConfigGlobalFilters: DashboardConfig = {
       },
     },
   ],
-  global_filters: [{
+  preset_filters: [{
     field: 'control_plane',
     operator: 'in',
     value: ['default_uuid'],
@@ -546,7 +546,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
           type: 'timeseries_line',
         },
         query: {
-          datasource: 'advanced',
+          datasource: 'api_usage',
         },
       },
       layout: {
@@ -567,7 +567,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
           type: 'timeseries_line',
         },
         query: {
-          datasource: 'advanced',
+          datasource: 'api_usage',
         },
       },
       layout: {
@@ -588,7 +588,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
           type: 'timeseries_line',
         },
         query: {
-          datasource: 'advanced',
+          datasource: 'api_usage',
         },
       },
       layout: {
@@ -609,7 +609,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
           type: 'timeseries_line',
         },
         query: {
-          datasource: 'advanced',
+          datasource: 'api_usage',
         },
       },
       layout: {
@@ -636,7 +636,7 @@ export const oneTileDashboardConfig: DashboardConfig = {
           type: 'timeseries_line',
         },
         query: {
-          datasource: 'advanced',
+          datasource: 'api_usage',
         },
       },
       layout: {

--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -9,12 +9,12 @@
   >
     <div class="analytics-chart">
       <AnalyticsChart
-        :allow-csv-export="chartOptions.allowCsvExport"
+        :allow-csv-export="chartOptions.allow_csv_export"
         :chart-data="data"
         :chart-options="options"
         legend-position="bottom"
         :show-menu="context.editable"
-        :synthetics-data-key="chartOptions.syntheticsDataKey"
+        :synthetics-data-key="chartOptions.synthetics_data_key"
         :timeseries-zoom="hasFinegrainedAbsoluteTimerangeAccess && !query.time_range"
         tooltip-title=""
         v-bind="extraProps"
@@ -55,7 +55,7 @@ const hasFinegrainedAbsoluteTimerangeAccess = evaluateFeatureFlag('explore-v4-fi
 const options = computed((): AnalyticsChartOptions => ({
   type: props.chartOptions.type,
   stacked: props.chartOptions.stacked ?? false,
-  chartDatasetColors: props.chartOptions.chartDatasetColors,
+  chartDatasetColors: props.chartOptions.chart_dataset_colors,
   threshold: props.chartOptions.threshold,
 }))
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -24,13 +24,13 @@ import {
   routeExploreResponse,
   summaryDashboardConfig,
   simpleConfigNoFilters,
-  fourByFourDashboardConfigJustCharts, oneTileDashboardConfig,
+  fourByFourDashboardConfigJustCharts,
   simpleConfigGlobalFilters,
 } from '../../sandbox/mock-data'
 import { createPinia, setActivePinia } from 'pinia'
 import { EntityLink } from '@kong-ui-public/entities-shared'
 import { dragTile } from '../test-utils'
-import { ref, watch, type Ref } from 'vue'
+import { ref, type Ref } from 'vue'
 
 interface MockOptions {
   failToResolveConfig?: boolean
@@ -381,7 +381,7 @@ describe('<DashboardRenderer />', () => {
             definition: {
               chart: {
                 type: 'top_n',
-                entityLink: `https://test.com/cp/${CP_ID_TOKEN}/entity/${ENTITY_ID_TOKEN}`,
+                entity_link: `https://test.com/cp/${CP_ID_TOKEN}/entity/${ENTITY_ID_TOKEN}`,
               },
               query: {
                 datasource: 'basic',
@@ -434,7 +434,7 @@ describe('<DashboardRenderer />', () => {
             definition: {
               chart: {
                 type: 'top_n',
-                entityLink: `https://test.com/cp/${CP_ID_TOKEN}/entity/${ENTITY_ID_TOKEN}`,
+                entity_link: `https://test.com/cp/${CP_ID_TOKEN}/entity/${ENTITY_ID_TOKEN}`,
               },
               query: {
                 datasource: 'basic',
@@ -588,7 +588,7 @@ describe('<DashboardRenderer />', () => {
     }).then(() => {
       cy.get('@fetcher').should('have.callCount', 3)
       cy.get('@fetcher').should('always.have.been.calledWithMatch', Cypress.sinon.match({
-        datasource: 'advanced',
+        datasource: 'api_usage',
         query: {
           time_range: { time_range: '7d' },
         },
@@ -628,7 +628,7 @@ describe('<DashboardRenderer />', () => {
       // Extra calls may mean we mistakenly issued queries before knowing the timeSpec.
       cy.get('@fetcher').should('have.callCount', 3)
       cy.get('@fetcher').should('always.have.been.calledWithMatch', Cypress.sinon.match({
-        datasource: 'advanced',
+        datasource: 'api_usage',
         query: {
           filters: [
             {
@@ -671,7 +671,7 @@ describe('<DashboardRenderer />', () => {
       // Extra calls may mean we mistakenly issued queries before knowing the timeSpec.
       cy.get('@fetcher').should('have.callCount', 3)
       cy.get('@fetcher').should('always.have.been.calledWithMatch', Cypress.sinon.match({
-        datasource: 'advanced',
+        datasource: 'api_usage',
         query: {
           filters: [
             {
@@ -710,7 +710,7 @@ describe('<DashboardRenderer />', () => {
             definition: {
               chart: {
                 type: 'timeseries_line',
-                chartTitle: 'Total Traffic over Time',
+                chart_title: 'Total Traffic over Time',
               },
               query: {
                 metrics: [
@@ -747,7 +747,7 @@ describe('<DashboardRenderer />', () => {
             definition: {
               chart: {
                 type: 'timeseries_line',
-                chartTitle: 'Latency Breakdown over Time',
+                chart_title: 'Latency Breakdown over Time',
               },
               query: {
                 metrics: [
@@ -781,7 +781,7 @@ describe('<DashboardRenderer />', () => {
             definition: {
               chart: {
                 type: 'timeseries_line',
-                chartTitle: 'Total Traffic over Time Global Timeframe',
+                chart_title: 'Total Traffic over Time Global Timeframe',
               },
               query: {
                 metrics: [
@@ -809,7 +809,7 @@ describe('<DashboardRenderer />', () => {
             definition: {
               chart: {
                 type: 'top_n',
-                chartTitle: 'TopN',
+                chart_title: 'TopN',
               },
               query: {
                 metrics: [

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
@@ -10,6 +10,7 @@ describe('Dashboard schemas', () => {
     const definition: any = {
       tiles: [
         {
+          type: 'chart',
           definition: {
             chart: {
               type: 'horizontal_bar',
@@ -39,11 +40,12 @@ describe('Dashboard schemas', () => {
     const definition: any = {
       tiles: [
         {
+          type: 'chart',
           definition: {
             chart: {
               type: 'gauge',
-              metricDisplay: 'full',
-              reverseDataset: true,
+              metric_display: 'full',
+              reverse_dataset: true,
               numerator: 0,
             },
             query: {
@@ -71,6 +73,7 @@ describe('Dashboard schemas', () => {
     const definition1: any = {
       tiles: [
         {
+          type: 'chart',
           chart: {
             type: 'gauge',
             blah: 'arrgh',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -10,7 +10,7 @@
       :is="context.editable ? DraggableGridLayout : GridLayout"
       v-else
       ref="gridLayoutRef"
-      :tile-height="model.tileHeight"
+      :tile-height="model.tile_height"
       :tiles="gridTiles"
       @update-tiles="handleUpdateTiles"
     >
@@ -26,7 +26,7 @@
           class="tile-container"
           :context="mergedContext"
           :definition="tile.meta"
-          :height="tile.layout.size.rows * (model.tileHeight || DEFAULT_TILE_HEIGHT) + parseInt(KUI_SPACE_70, 10)"
+          :height="tile.layout.size.rows * (model.tile_height || DEFAULT_TILE_HEIGHT) + parseInt(KUI_SPACE_70, 10)"
           :query-ready="queryReady"
           :refresh-counter="refreshCounter"
           :tile-id="tile.id"
@@ -169,7 +169,7 @@ const gridTiles = computed(() => {
 
 const mergedContext = computed<DashboardRendererContextInternal>(() => {
   let { tz, refreshInterval, editable } = props.context
-  const filters = [...(props.context.filters ?? []), ...(model.value.global_filters ?? [])] as AllFilters[]
+  const filters = [...(props.context.filters ?? []), ...(model.value.preset_filters ?? [])] as AllFilters[]
 
   if (!tz) {
     tz = (new Intl.DateTimeFormat()).resolvedOptions().timeZone
@@ -209,11 +209,12 @@ const onDuplicateTile = (tile: GridTile<TileDefinition>) => {
     ? { ...tile.meta.chart }
     : {
       ...tile.meta.chart,
-      chartTitle: tile.meta.chart.chartTitle ? `Copy of ${tile.meta.chart.chartTitle}` : '',
+      chart_title: tile.meta.chart.chart_title ? `Copy of ${tile.meta.chart.chart_title}` : '',
     }
 
   const newTile: TileConfig = {
     id: crypto.randomUUID(),
+    type: 'chart',
     definition: {
       ...tile.meta,
       chart,

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
@@ -7,11 +7,11 @@ describe('<DashboardTile />', () => {
   const mockTileDefinition: TileDefinition = {
     chart: {
       type: 'timeseries_line',
-      chartTitle: 'Test Chart',
-      allowCsvExport: true,
+      chart_title: 'Test Chart',
+      allow_csv_export: true,
     },
     query: {
-      datasource: 'advanced',
+      datasource: 'api_usage',
       metrics: [],
       filters: [],
     },

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -12,13 +12,13 @@
         class="title-tooltip"
         :disabled="!isTitleTruncated"
         max-width="500"
-        :text="definition.chart.chartTitle"
+        :text="definition.chart.chart_title"
       >
         <div
           ref="titleRef"
           class="title"
         >
-          {{ definition.chart.chartTitle }}
+          {{ definition.chart.chart_title }}
         </div>
       </KTooltip>
       <div
@@ -129,7 +129,12 @@
 </template>
 <script setup lang="ts">
 import type { DashboardRendererContextInternal } from '../types'
-import { type DashboardTileType, formatTime, type TileDefinition, TimePeriods } from '@kong-ui-public/analytics-utilities'
+import {
+  type DashboardTileType,
+  formatTime,
+  type TileDefinition,
+  TimePeriods,
+} from '@kong-ui-public/analytics-utilities'
 import { type Component, computed, inject, nextTick, onMounted, ref, watch } from 'vue'
 import '@kong-ui-public/analytics-chart/dist/style.css'
 import '@kong-ui-public/analytics-metric-provider/dist/style.css'
@@ -208,8 +213,8 @@ const exploreLink = computed(() => {
 
   } as ExploreQuery | AiExploreQuery
 
-  // Explore only supports advanced or ai
-  const datasource = ['advanced', 'ai'].includes(props.definition.query.datasource) ? props.definition.query.datasource : 'advanced'
+  // Explore only supports API usage and LLM usage.
+  const datasource = ['api_usage', 'llm_usage'].includes(props.definition.query.datasource) ? props.definition.query.datasource : 'api_usage'
 
   return `${exploreBaseUrl.value}?q=${JSON.stringify(exploreQuery)}&d=${datasource}&c=${props.definition.chart.type}`
 })
@@ -220,7 +225,7 @@ const canShowTitleActions = computed((): boolean => (canShowKebabMenu.value && (
 
 const canShowKebabMenu = computed(() => !['golden_signals', 'top_n', 'gauge'].includes(props.definition.chart.type))
 
-const kebabMenuHasItems = computed((): boolean => !!exploreLink.value || ('allowCsvExport' in props.definition.chart && props.definition.chart.allowCsvExport) || props.context.editable)
+const kebabMenuHasItems = computed((): boolean => !!exploreLink.value || ('allow_csv_export' in props.definition.chart && props.definition.chart.allow_csv_export) || props.context.editable)
 
 const rendererLookup: Record<DashboardTileType, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -49,7 +49,7 @@ const overrideTimeframe: Ref<Timeframe> = computed(() => {
 
 const options = computed<ProviderProps>(() => {
   const datasource = props.query?.datasource
-  if (datasource && datasource !== 'advanced' && datasource !== 'basic') {
+  if (datasource && datasource !== 'api_usage' && datasource !== 'basic') {
     throw new Error(`Invalid datasource value: ${datasource}`)
   }
   return {
@@ -57,8 +57,8 @@ const options = computed<ProviderProps>(() => {
     overrideTimeframe: overrideTimeframe.value,
     tz: props.context.tz,
     additionalFilter: props.context.filters as ExploreFilterAll[], // TODO: Decide how to handle metric card filters.
-    longCardTitles: props.chartOptions.longCardTitles,
-    percentileLatency: props.chartOptions.percentileLatency,
+    longCardTitles: props.chartOptions.long_card_titles,
+    percentileLatency: props.chartOptions.percentile_latency,
     refreshInterval: props.context.refreshInterval,
     queryReady: props.queryReady,
     refreshCounter: props.refreshCounter,

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
@@ -130,7 +130,7 @@ const { data: v4Data, error, isValidating } = useSWRV(queryKey, async () => {
     // matches the datasource.  Currently, this block effectively pretends all queries
     // are advanced in order to make the types work out.
     const mergedQuery: DatasourceAwareQuery = {
-      datasource: datasource as 'advanced',
+      datasource: datasource as 'api_usage',
       query: {
         ...rest as ExploreQuery,
         time_range,

--- a/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.vue
@@ -13,7 +13,7 @@
       <SimpleChart
         :chart-data="data"
         :chart-options="chartOptions"
-        :synthetics-data-key="isSingleValueChart ? undefined : (chartOptions as GaugeChartOptions).syntheticsDataKey"
+        :synthetics-data-key="isSingleValueChart ? undefined : (chartOptions as GaugeChartOptions).synthetics_data_key"
       />
     </div>
   </QueryDataProvider>

--- a/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
@@ -8,10 +8,10 @@
   >
     <TopNTable
       :data="data"
-      :synthetics-data-key="chartOptions.syntheticsDataKey"
+      :synthetics-data-key="chartOptions.synthetics_data_key"
     >
       <template
-        v-if="props.chartOptions.entityLink"
+        v-if="props.chartOptions.entity_link"
         #name="{ record }"
       >
         <AsyncEntityLink
@@ -58,13 +58,13 @@ const AsyncEntityLink = defineAsyncComponent(async () => {
 })
 
 const parseLink = (record: TopNTableRecord) => {
-  if (props.chartOptions?.entityLink) {
+  if (props.chartOptions?.entity_link) {
     if (record.id.includes(':')) {
       const [cpId, entityId] = record.id.split(':')
 
-      return props.chartOptions.entityLink.replace(CP_ID_TOKEN, cpId).replace(ENTITY_ID_TOKEN, entityId)
+      return props.chartOptions.entity_link.replace(CP_ID_TOKEN, cpId).replace(ENTITY_ID_TOKEN, entityId)
     } else {
-      return props.chartOptions.entityLink.replace(ENTITY_ID_TOKEN, record.id)
+      return props.chartOptions.entity_link.replace(ENTITY_ID_TOKEN, record.id)
     }
   }
   return ''

--- a/packages/analytics/dashboard-renderer/src/components/layout/grid-utils.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/layout/grid-utils.spec.ts
@@ -3,7 +3,7 @@ import type { GridTile } from '../../types'
 import { describe, it, expect } from 'vitest'
 
 describe('calculateRowDefs', () => {
-  const getMockTile = (col: number, row: number, cols: number, rows: number, fitToContent?: boolean):GridTile<unknown> => ({
+  const getMockTile = (col: number, row: number, cols: number, rows: number, fit_to_content?: boolean): GridTile<unknown> => ({
     layout: {
       position: {
         col,
@@ -12,10 +12,10 @@ describe('calculateRowDefs', () => {
       size: {
         cols,
         rows,
-        ...(fitToContent !== undefined ? { fitToContent } : {}),
+        ...(fit_to_content !== undefined ? { fit_to_content } : {}),
       },
     },
-    id: `test-tile-${col}-${row}-${cols}-${rows}-${fitToContent}`,
+    id: `test-tile-${col}-${row}-${cols}-${rows}-${fit_to_content}`,
     meta: {},
   })
 

--- a/packages/analytics/dashboard-renderer/src/components/layout/grid-utils.ts
+++ b/packages/analytics/dashboard-renderer/src/components/layout/grid-utils.ts
@@ -7,7 +7,7 @@ export const calculateRowDefs = (tileHeight: number, tiles: Array<GridTile<unkno
   tiles.forEach(t => {
     const row = t.layout.position.row
     const existingVal = rowMap.get(row)
-    const eligibleForAutofit = t.layout.size.rows === 1 && !!t.layout.size.fitToContent
+    const eligibleForAutofit = t.layout.size.rows === 1 && !!t.layout.size.fit_to_content
 
     rowCount = Math.max(rowCount, row + t.layout.size.rows)
 


### PR DESCRIPTION
- Change the default export 
- Support v2 definitions in the renderer.
  - Requires changes to existing hardcoded dashboards.
  - Should support new custom dashboard API endpoint.
- Rename 'advanced' and 'ai' datasources to 'api_usage' and 'llm_usage'.
  - Requires changes to analytics bridges.

BREAKING CHANGE: dashboards only support v2 schemas; analytics-utilities exports v2 schema by default.

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
