### PR TITLE
fix(entities-routes): source and destination port

### DIFF
--- a/packages/entities/entities-routes/src/components/RouteForm.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteForm.cy.ts
@@ -451,7 +451,8 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
 
           cy.getTestId('route-form-sources-ip-input-1').clear()
           cy.getTestId('route-form-sources-port-input-1').type('8080')
-          cy.getTestId('route-create-form-submit').should('be.disabled')
+          cy.getTestId('route-create-form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
           // destinations
           cy.getTestId('route-form-destinations-ip-input-1').type('127.0.0.2')
@@ -460,7 +461,8 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
 
           cy.getTestId('route-form-destinations-ip-input-1').clear()
           cy.getTestId('route-form-destinations-port-input-1').type('8000')
-          cy.getTestId('route-create-form-submit').should('be.disabled')
+          cy.getTestId('route-create-form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
         })
       } // if !routeFlavors || routeFlavors?.traditional
 
@@ -1407,7 +1409,8 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
 
           cy.getTestId('route-form-sources-ip-input-1').clear()
           cy.getTestId('route-form-sources-port-input-1').type('8080')
-          cy.getTestId('route-create-form-submit').should('be.disabled')
+          cy.getTestId('route-create-form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
 
           // destinations
           cy.getTestId('route-form-destinations-ip-input-1').type('127.0.0.2')
@@ -1416,7 +1419,8 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
 
           cy.getTestId('route-form-destinations-ip-input-1').clear()
           cy.getTestId('route-form-destinations-port-input-1').type('8000')
-          cy.getTestId('route-create-form-submit').should('be.disabled')
+          cy.getTestId('route-create-form-submit').should('be.enabled').click()
+          cy.wait('@createRoute').then((res) => res.response?.body?.kind).should('eq', 'trad')
         })
       } // if !routeFlavors || routeFlavors?.traditional
 

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -455,8 +455,8 @@ const isFormValid = computed((): boolean => {
         const paths = state.fields.paths ? !!state.fields.paths.filter(Boolean).length : null
         const headers = state.fields.headers ? state.fields.headers.some(({ header }) => !!header) : null
         const snis = state.fields.snis ? !!state.fields.snis.filter(Boolean).length : null
-        const destinations = state.fields.destinations ? state.fields.destinations.some(({ ip }) => !!ip) : null
-        const sources = state.fields.sources ? state.fields.sources.some(({ ip }) => !!ip) : null
+        const destinations = state.fields.destinations ? state.fields.destinations.some(({ ip, port }) => !!ip || !!port) : null
+        const sources = state.fields.sources ? state.fields.sources.some(({ ip, port }) => !!ip || !!port) : null
         const methods = state.fields.methods ? !!state.fields.methods.filter(Boolean).length : null
 
         return !!state.fields.protocols && ((isProtocolSelected(['http']) && !!(hosts || methods || paths || headers)) ||

--- a/packages/entities/entities-routes/src/components/RouteFormRulesComposer.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormRulesComposer.vue
@@ -235,7 +235,7 @@ const cleanDataArr = (entity: RoutingRulesEntities, originalData: any) => {
     return [...originalData]
       .filter((item: Sources | Destinations) => !!item.ip || !!item.port)
       .map((item: Sources | Destinations) => ({
-        ...item,
+        ip: item.ip || undefined,
         port: !item.port && item.port !== 0 ? undefined : item.port,
       }))
   } else if (entity === RoutingRulesEntities.HEADERS) {

--- a/packages/entities/entities-routes/src/components/RouteFormRulesComposer.vue
+++ b/packages/entities/entities-routes/src/components/RouteFormRulesComposer.vue
@@ -233,10 +233,10 @@ const cleanDataArr = (entity: RoutingRulesEntities, originalData: any) => {
     return [...originalData].filter((item: string) => !!item)
   } else if (entity === RoutingRulesEntities.SOURCES || entity === RoutingRulesEntities.DESTINATIONS) {
     return [...originalData]
-      .filter((item: Sources | Destinations) => !!item.ip)
+      .filter((item: Sources | Destinations) => !!item.ip || !!item.port)
       .map((item: Sources | Destinations) => ({
         ...item,
-        port: !item.port && item.port !== 0 ? null : item.port,
+        port: !item.port && item.port !== 0 ? undefined : item.port,
       }))
   } else if (entity === RoutingRulesEntities.HEADERS) {
     return [...originalData].filter((item: Headers) => !!item.header)


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

1. The route form now allows submission when only the `port` field is filled (and `ip` is empty) for both Sources and Destinations.
2. Fixed an issue in Konnect Gateway Manager where the form couldn’t be submitted if only the `ip` field was filled and `port` was left empty.

KM-1482
