### PR TITLE
chore(entities-plugins): externalize plugin-icons

### DIFF
--- a/packages/entities/entities-plugins/vite.config.ts
+++ b/packages/entities/entities-plugins/vite.config.ts
@@ -28,6 +28,7 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
         '@vueuse/integrations',
         'marked',
         'monaco-editor',
+        '@kong-ui-public/entities-plugins-icon',
       ],
     },
   },


### PR DESCRIPTION
# Summary
Externalize the plugin-icons from the bundle of entities-plugins.

**Before**
```
dist/entities-plugins.umd.js  703.05 kB │ gzip: 359.03 kB │ map: 1,609.54 kB
```
**After**
```
dist/entities-plugins.umd.js  326.59 kB │ gzip: 90.52 kB │ map: 1,227.16 kB
```

-269 kB after gzip