### PR TITLE
fix(entities-consumers): consumers list empty state toolbar slot

### DIFF
--- a/packages/entities/entities-consumers/docs/consumer-list.md
+++ b/packages/entities/entities-consumers/docs/consumer-list.md
@@ -6,6 +6,7 @@ A table component for consumers.
 - [Usage](#usage)
   - [Install](#install)
   - [Props](#props)
+  - [Slots](#slots)
   - [Events](#events)
   - [Usage example](#usage-example)
 - [TypeScript interfaces](#typescript-interfaces)
@@ -165,6 +166,17 @@ A synchronous or asynchronous function, that returns a boolean, that evaluates i
 - default: `async () => true`
 
 A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can retrieve (view details) a given entity.
+
+### Slots
+
+#### `toolbar-filter`
+
+This slot displays content left-aligned directly above the table. Typically a Search input is placed here.
+Note: This slot is automatically hidden while the table is loading for the first time.
+
+#### `empty-state-toolbar`
+
+This slot renders directly above the empty state view when table has no data. Since consumers is an entity that can be control plane-scoped or global, often a switch control is used to toggle the view between scoped and global consumers -- which is what this slot is useful for.
 
 ### Events
 

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -688,6 +688,8 @@ onBeforeMount(async () => {
     display: flex;
     flex-direction: column;
     gap: $kui-space-20;
+    padding: $kui-space-20;
+    padding-bottom: $kui-space-0;
   }
 
   .message {

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -67,33 +67,37 @@
         v-if="!filterQuery && config.app === 'konnect'"
         #empty-state
       >
-        <EntityEmptyState
-          :action-button-text="t('consumers.list.toolbar_actions.new_consumer')"
-          appearance="secondary"
-          :can-create="() => canCreate()"
-          :data-testid="config.consumerGroupId ? 'nested-consumers-entity-empty-state' : 'consumers-entity-empty-state'"
-          :description="t('consumers.list.empty_state_v2.description')"
-          :learn-more="config.app === 'konnect'"
-          :title="t('consumers.list.empty_state_v2.title')"
-          @click:create="handleCreateClick"
-          @click:learn-more="$emit('click:learn-more')"
-        >
-          <template #image>
-            <div class="empty-state-icon-gateway">
-              <TeamIcon
-                :color="KUI_COLOR_TEXT_DECORATIVE_AQUA"
-                :size="KUI_ICON_SIZE_50"
-              />
-            </div>
-          </template>
+        <div class="empty-state-wrapper">
+          <slot name="empty-state-toolbar" />
 
-          <template
-            v-if="config?.isControlPlaneGroup"
-            #message
+          <EntityEmptyState
+            :action-button-text="t('consumers.list.toolbar_actions.new_consumer')"
+            appearance="secondary"
+            :can-create="() => canCreate()"
+            :data-testid="config.consumerGroupId ? 'nested-consumers-entity-empty-state' : 'consumers-entity-empty-state'"
+            :description="t('consumers.list.empty_state_v2.description')"
+            :learn-more="config.app === 'konnect'"
+            :title="t('consumers.list.empty_state_v2.title')"
+            @click:create="handleCreateClick"
+            @click:learn-more="$emit('click:learn-more')"
           >
-            {{ t('consumers.list.empty_state_v2.group') }}
-          </template>
-        </EntityEmptyState>
+            <template #image>
+              <div class="empty-state-icon-gateway">
+                <TeamIcon
+                  :color="KUI_COLOR_TEXT_DECORATIVE_AQUA"
+                  :size="KUI_ICON_SIZE_50"
+                />
+              </div>
+            </template>
+
+            <template
+              v-if="config?.isControlPlaneGroup"
+              #message
+            >
+              {{ t('consumers.list.empty_state_v2.group') }}
+            </template>
+          </EntityEmptyState>
+        </div>
       </template>
 
       <!-- Column Formatting -->
@@ -679,6 +683,12 @@ onBeforeMount(async () => {
 
 .kong-ui-entities-consumers-list {
   width: 100%;
+
+  .empty-state-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: $kui-space-20;
+  }
 
   .message {
     margin-top: 0;


### PR DESCRIPTION
# Summary

Add `empty-state-toolbar` slot for displaying switch control for toggling the view between scoped and global consumers in empty state.

<img width="1466" height="433" alt="Screenshot 2025-07-22 at 12 35 03 PM" src="https://github.com/user-attachments/assets/ee460086-3362-44e7-a7af-7820465ad336" />

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
