### PR TITLE
refactor(free-form): wrap string field with a div

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
@@ -6,7 +6,10 @@
     :message="field.error.message"
   />
 
-  <template v-else>
+  <div
+    v-else
+    v-bind="$attrs"
+  >
     <InputComponent
       v-bind="{
         ...fieldAttrs,
@@ -43,7 +46,7 @@
       :data-testid="`ff-vault-secret-picker-warning-${field.path.value}`"
       :message="i18n.t('plugins.free-form.vault_picker.component_error')"
     />
-  </template>
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
# Summary
Group the `<Input />` and `<VaultPicker />` of the `<StringField />` by wrapping them in a single `<div>` container.