### PR TITLE
fix(entities-plugins): datakit handles, adopt types, add helpers

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
@@ -44,8 +44,9 @@ import { Controls } from '@vue-flow/controls'
 import { useVueFlow, VueFlow, type Node } from '@vue-flow/core'
 import { ref } from 'vue'
 import english from '../../../../../locales/en.json'
+import type { NodeData } from '../../types'
 import FlowNode from '../node/FlowNode.vue'
-import { IMPLICIT_NODE_META_MAP } from '../node/node'
+import { createImplicitNode } from '../node/node'
 
 import '@vue-flow/controls/dist/style.css'
 import '@vue-flow/core/dist/style.css'
@@ -62,31 +63,19 @@ const emit = defineEmits<{
   'click:backdrop': []
 }>()
 
-const nodes = ref<Node[]>([
-  {
-    id: 'implicit:request',
-    type: 'flow', // To not use the default node style
+const nodes = ref<Array<Node<NodeData>>>([
+  createImplicitNode('request', {
     position: { x: 0, y: 0 },
-    data: IMPLICIT_NODE_META_MAP.request,
-  },
-  {
-    id: 'implicit:service-request',
-    type: 'flow', // To not use the default node style
-    position: { x: 400, y: 0 },
-    data: IMPLICIT_NODE_META_MAP.service_request,
-  },
-  {
-    id: 'implicit:service-response',
-    type: 'flow', // To not use the default node style
-    position: { x: 400, y: 300 },
-    data: IMPLICIT_NODE_META_MAP.service_response,
-  },
-  {
-    id: 'implicit:response',
-    type: 'flow', // To not use the default node style
-    position: { x: 0, y: 300 },
-    data: IMPLICIT_NODE_META_MAP.response,
-  },
+  }),
+  createImplicitNode('service_request', {
+    position: { x: 300, y: 0 },
+  }),
+  createImplicitNode('service_response', {
+    position: { x: 300, y: 200 },
+  }),
+  createImplicitNode('response', {
+    position: { x: 0, y: 200 },
+  }),
 ])
 
 const { fitView, onNodeClick } = useVueFlow()

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -2,7 +2,7 @@
   <div
     class="flow-node"
     :class="{
-      reverse: ioDirection === 'rl',
+      reversed: isReversed,
       implicit: isImplicit(data)
     }"
   >
@@ -21,7 +21,7 @@
       <div class="handle">
         <Handle
           id="inputs"
-          :position="ioDirection === 'rl' ? Position.Right : Position.Left"
+          :position="inputPosition"
           type="target"
         />
 
@@ -36,7 +36,7 @@
           <HandleTwig
             v-if="inputHandlesExpanded"
             :color="KUI_COLOR_BACKGROUND_NEUTRAL_STRONG"
-            :direction="ioDirection === 'rl' ? 'right' : 'left'"
+            :position="inputPosition"
             type="bar"
           />
         </div>
@@ -50,7 +50,7 @@
         >
           <Handle
             :id="`input-${fieldName}`"
-            :position="ioDirection === 'rl' ? Position.Right : Position.Left"
+            :position="inputPosition"
             type="target"
           />
           <div class="handle-label-wrapper">
@@ -59,7 +59,7 @@
             </div>
             <HandleTwig
               :color="KUI_COLOR_BACKGROUND_NEUTRAL_STRONG"
-              :direction="ioDirection === 'rl' ? 'right' : 'left'"
+              :position="inputPosition"
               :type="i < data.fields.input.length - 1 ? 'trident' : 'corner'"
             />
           </div>
@@ -83,13 +83,13 @@
           <HandleTwig
             v-if="outputHandlesExpanded"
             :color="KUI_COLOR_BACKGROUND_NEUTRAL_STRONG"
-            :direction="ioDirection === 'rl' ? 'left' : 'right'"
+            :position="outputPosition"
             type="bar"
           />
         </div>
         <Handle
           id="outputs"
-          :position="ioDirection === 'rl' ? Position.Left : Position.Right"
+          :position="outputPosition"
           type="target"
         />
       </div>
@@ -106,13 +106,13 @@
             </div>
             <HandleTwig
               :color="KUI_COLOR_BACKGROUND_NEUTRAL_STRONG"
-              :direction="ioDirection === 'rl' ? 'left' : 'right'"
+              :position="outputPosition"
               :type="i < data.fields.output.length - 1 ? 'trident' : 'corner'"
             />
           </div>
           <Handle
             :id="`output-${fieldName}`"
-            :position="ioDirection === 'rl' ? Position.Left : Position.Right"
+            :position="outputPosition"
             type="source"
           />
         </div>
@@ -133,15 +133,26 @@ import HandleTwig from './HandleTwig.vue'
 
 import type { NodeData } from '../../types'
 
-const { data, ioDirection = 'lr' } = defineProps<{
+const { data } = defineProps<{
   data: NodeData
-  ioDirection?: 'lr' | 'rl'
 }>()
 
 const { t } = createI18n<typeof english>('en-us', english)
 
 const inputHandlesExpanded = ref(false)
 const outputHandlesExpanded = ref(false)
+
+const isReversed = computed(() => {
+  return data.phase === 'response'
+})
+
+const inputPosition = computed(() => {
+  return data.phase === 'request' ? Position.Left : Position.Right
+})
+
+const outputPosition = computed(() => {
+  return data.phase === 'request' ? Position.Right : Position.Left
+})
 
 const name = computed(() => {
   if (isImplicit(data)) {
@@ -245,7 +256,7 @@ $handle-height: 10px;
     }
   }
 
-  &.reverse {
+  &.reversed {
     .input-handles,
     .output-handles {
       .handle {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/HandleTwig.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/HandleTwig.vue
@@ -1,23 +1,24 @@
 <template>
   <div
     class="handle-twig"
-    :class="[type, direction]"
+    :class="[type, position === Position.Left ? 'left' : 'right']"
     :style="twigStyle"
   />
 </template>
 
 <script setup lang="ts">
 import { KUI_SPACE_40 } from '@kong/design-tokens'
+import { Position } from '@vue-flow/core'
 import { computed } from 'vue'
 
 const {
   color,
-  direction = 'left',
+  position = Position.Left,
   size = Number.parseFloat(KUI_SPACE_40),
   type,
 } = defineProps<{
   color?: string
-  direction?: 'left' | 'right'
+  position?: Position.Left | Position.Right
   size?: number
   type: 'bar' | 'trident' | 'corner'
 }>()

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/node.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/node.ts
@@ -6,13 +6,14 @@ import {
   StackIcon,
   VitalsIcon,
 } from '@kong/icons'
+import type { Node } from '@vue-flow/core'
 import english from '../../../../../locales/en.json'
 import type {
-  NodeMeta,
   ImplicitNodeType,
-  UserNodeType,
   NodeData,
+  NodeMeta,
   NodeType,
+  UserNodeType,
 } from '../../types'
 
 const { t } = createI18n<typeof english>('en-us', english)
@@ -102,3 +103,21 @@ export const isImplicit = (
   node: NodeMeta | NodeData,
 ): node is (NodeMeta | NodeData) & { type: ImplicitNodeType } =>
   (IMPLICIT_NODE_TYPES as readonly string[]).includes(node.type)
+
+export const createNode = (data: NodeData): Node<NodeData> => ({
+  id: isImplicit(data) ? `implicit:${data.type}` : `user:${data.type}:${data.name}`,
+  type: 'flow', // Hardcoded
+  position: data.position,
+  data,
+})
+
+export const createImplicitNode = (type: ImplicitNodeType, dataOverrides?: Partial<NodeData>): Node<NodeData> => {
+  return createNode({
+    ...IMPLICIT_NODE_META_MAP[type],
+    name: type,
+    phase: type === 'request' || type === 'service_request' ? 'request' : 'response',
+    expanded: {},
+    position: { x: 0, y: 0 },
+    ...dataOverrides,
+  })
+}


### PR DESCRIPTION
# Summary

This pull request fixes the issues with the node handle placements in the "reversed" phases. 

Meanwhile, it also cleans up the codebase a bit to use the freshly added types, adds some node helpers, and unifies the position properties to use VueFlow's `Position`.