### PR TITLE
fix(dashboards): preserve tile type field

### DIFF
--- a/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
@@ -541,6 +541,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
   tileHeight: 167,
   tiles: [
     {
+      type: 'chart',
       definition: {
         chart: {
           type: 'timeseries_line',
@@ -562,6 +563,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
       id: 'tile-1',
     },
     {
+      type: 'chart',
       definition: {
         chart: {
           type: 'timeseries_line',
@@ -583,6 +585,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
       id: 'tile-2',
     },
     {
+      type: 'chart',
       definition: {
         chart: {
           type: 'timeseries_line',
@@ -604,6 +607,7 @@ export const fourByFourDashboardConfigJustCharts: DashboardConfig = {
       id: 'tile-3',
     },
     {
+      type: 'chart',
       definition: {
         chart: {
           type: 'timeseries_line',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -947,6 +947,9 @@ describe('<DashboardRenderer />', () => {
     cy.wrap(configRef).should((ref: Ref<DashboardConfig>) => {
       const currentOrder = ref.value.tiles.map((tile: TileConfig) => tile.id)
       expect(currentOrder).to.deep.equal(updatedTileIDOrder)
+
+      const tileTypes = ref.value.tiles.map((tile) => tile.type)
+      expect(tileTypes).to.deep.equal(Array(4).fill('chart'))
     })
   })
 })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -120,7 +120,7 @@ const tileSortFn = (a: TileConfig, b: TileConfig) => {
   return a.layout.position.col - b.layout.position.col
 }
 
-const gridTiles = computed(() => {
+const gridTiles = computed<Array<GridTile<TileDefinition>>>(() => {
   return model.value.tiles.map((tile: TileConfig) => {
     let tileMeta = tile.definition
 
@@ -161,9 +161,10 @@ const gridTiles = computed(() => {
     return {
       layout: tile.layout,
       meta: tileMeta,
+      type: tile.type,
       // Add a unique key to each tile internally.
       id: tile.id ?? crypto.randomUUID(),
-    } as GridTile<TileDefinition>
+    }
   })
 })
 
@@ -245,6 +246,7 @@ const handleUpdateTiles = (tiles: Array<GridTile<TileDefinition>>) => {
   const updatedTiles = tiles.map(tile => {
     return {
       id: tile.id,
+      type: tile.type,
       layout: tile.layout,
       definition: tile.meta,
     } as TileConfig

--- a/packages/analytics/dashboard-renderer/src/types/grid-layout-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/grid-layout-types.ts
@@ -12,6 +12,7 @@ export interface TileSize {
 
 export interface GridTile<T> {
   id: string | number
+  type: 'chart' // Right now we only support one type of tile.
   layout: TileLayout
   meta: T
 }


### PR DESCRIPTION
The object being passed to GridStack wasn't preserving the new top-level 'type' field on tiles, which caused the field to be lost when tiles were sorted.

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
