### PR TITLE
fix(service-form): clear tag error when tag input changes

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -408,6 +408,7 @@
               :placeholder="t('gateway_services.form.fields.tags.placeholder')"
               :readonly="form.isReadonly"
               type="text"
+              @input="resetFormFieldErrors('tags')"
             />
           </div>
         </KCollapse>


### PR DESCRIPTION
# Summary

KM-1514
The tag error is not cleared after tag input change so the user is not able to re-submit, this PR fix this.

https://github.com/user-attachments/assets/f665db49-3878-40f4-9f82-a0e6f9f7a9ab



