### PR TITLE
fix(entity-form-block): fix layout for step badge

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-form-block/EntityFormBlock.vue
+++ b/packages/entities/entities-shared/src/components/entity-form-block/EntityFormBlock.vue
@@ -64,6 +64,7 @@ const slots = defineSlots<{
     border: 1px solid $kui-color-border-neutral-weak;
     border-radius: $kui-border-radius-round;
     display: flex;
+    flex: 0 0 auto;
     height: 32px;
     justify-content: center;
     padding: $kui-space-20;


### PR DESCRIPTION
A `flex: 0 0 auto;` is added to step badge to prevent it from shrinking, ensuring it maintains its size.

JIRA: KM-1434

