### PR TITLE
feat(entities-plugins): datakit store, improve types

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
@@ -20,13 +20,10 @@
 
     <template #default="formProps">
       <div v-if="finalEditorMode === 'flow'">
-        <KButton
-          appearance="secondary"
-          @click="modalOpen = true"
-        >
-          {{ t('plugins.free-form.datakit.flow_editor.cta') }}
-        </KButton>
-        <EditorModal v-model:open="modalOpen" />
+        <FlowEditor
+          :config="props.model.config"
+          :editing="props.isEditing"
+        />
       </div>
 
       <Form
@@ -56,7 +53,7 @@
 
         <CodeEditor
           ref="code-editor"
-          class="editor"
+          class="code-editor"
           :config="props.model.config"
           :editing="props.isEditing"
           @change="handleCodeChange"
@@ -73,22 +70,23 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, useTemplateRef, inject, type Component } from 'vue'
+import { computed, useTemplateRef, inject } from 'vue'
 import { KAlert, KSegmentedControl } from '@kong/kongponents'
 import { SparklesIcon, DesignIcon, CodeblockIcon } from '@kong/icons'
 import { createI18n } from '@kong-ui-public/i18n'
 import english from '../../../locales/en.json'
 import StandardLayout from '../shared/layout/StandardLayout.vue'
 import Form from '../shared/Form.vue'
-import EditorModal from './flow-editor/modal/EditorModal.vue'
+import FlowEditor from './flow-editor/FlowEditor.vue'
 import CodeEditor from './CodeEditor.vue'
 import { usePreferences } from './composables'
 import * as examples from './examples'
+import { FEATURE_FLAGS } from '../../../constants'
 
+import type { Component } from 'vue'
 import type { SegmentedControlOption } from '@kong/kongponents'
 import type { Props } from '../shared/layout/StandardLayout.vue'
 import type { EditorMode } from './types'
-import { FEATURE_FLAGS } from '../../../constants'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
@@ -133,10 +131,6 @@ const description = computed(() => {
   }
 })
 
-// Flow editor
-
-const modalOpen = ref(false)
-
 // Code editor
 
 const codeEditor = useTemplateRef('code-editor')
@@ -166,7 +160,7 @@ function handleCodeError(msg: string) {
 
 <style lang="scss" scoped>
 .dk-form {
-  .editor {
+  .code-editor {
     height: 684px;
   }
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/composables.ts
@@ -1,26 +1,12 @@
-import { createGlobalState, createInjectionState, useLocalStorage } from '@vueuse/core'
-
+import { createGlobalState, useLocalStorage } from '@vueuse/core'
 import type { EditorMode } from './types'
+export { provideEditorState, useEditorState } from './flow-editor/store/store'
 
 export const usePreferences = createGlobalState(() => {
-  const editorMode = useLocalStorage<EditorMode>(
-    'datakit-editor-mode',
-    'flow',
-  )
+  const editorMode = useLocalStorage<EditorMode>('datakit-editor-mode', 'flow')
   const sidePanelExpanded = useLocalStorage<boolean>(
     'datakit-editor-sidebar-expanded',
     true,
   )
   return { editorMode, sidePanelExpanded }
-})
-
-export const [provideEditorState, useEditorState] = createInjectionState(() => {
-  // TODO: define editor store
-  // const layoutData = reactive<any>(initialConfig)
-  // const pluginConfig = reactive<any>(null)
-
-  return {
-    // layoutData,
-    // pluginConfig,
-  }
 })

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="dk-flow-editor">
+    <div>Nothing here yet.</div>
+    <KButton
+      appearance="secondary"
+      @click="modalOpen = true"
+    >
+      {{ t('plugins.free-form.datakit.flow_editor.cta') }}
+    </KButton>
+    <EditorModal v-model:open="modalOpen" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { createI18n } from '@kong-ui-public/i18n'
+import english from '../../../../locales/en.json'
+import EditorModal from './modal/EditorModal.vue'
+import { provideEditorState } from '../composables'
+
+const { t } = createI18n<typeof english>('en-us', english)
+
+defineProps<{
+  editing: boolean
+  config: any
+}>()
+
+const modalOpen = ref(false)
+
+provideEditorState([], [])
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorContent.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorContent.vue
@@ -38,16 +38,16 @@ import EditorMain from './EditorMain.vue'
 import NodePanel from '../node/NodePanel.vue'
 import NodePropertiesPanel from '../node/NodePropertiesPanel.vue'
 import { ref } from 'vue'
-import type { NodeData } from '../../types'
+import type { NodeInstance } from '../../types'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
 const { sidePanelExpanded } = usePreferences()
 
 const propertiesPanelVisible = ref(false)
-const selectedNode = ref<NodeData | null>(null)
+const selectedNode = ref<NodeInstance | null>(null)
 
-const handleNodeClick = (node: NodeData) => {
+const handleNodeClick = (node: NodeInstance) => {
   propertiesPanelVisible.value = true
   selectedNode.value = node
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
@@ -44,9 +44,8 @@ import { Controls } from '@vue-flow/controls'
 import { useVueFlow, VueFlow, type Node } from '@vue-flow/core'
 import { ref } from 'vue'
 import english from '../../../../../locales/en.json'
-import type { NodeData } from '../../types'
+import type { NodeInstance } from '../../types'
 import FlowNode from '../node/FlowNode.vue'
-import { createImplicitNode, createUserNode } from '../node/node'
 
 import '@vue-flow/controls/dist/style.css'
 import '@vue-flow/core/dist/style.css'
@@ -59,60 +58,11 @@ defineSlots<{
 }>()
 
 const emit = defineEmits<{
-  'click:node': [nodeData: NodeData]
+  'click:node': [nodeData: NodeInstance]
   'click:backdrop': []
 }>()
 
-const nodes = ref<Array<Node<NodeData>>>([
-  createImplicitNode('request', {
-    position: { x: 0, y: 0 },
-  }),
-  createImplicitNode('service_request', {
-    position: { x: 800, y: 0 },
-  }),
-  createImplicitNode('service_response', {
-    position: { x: 800, y: 200 },
-  }),
-  createImplicitNode('response', {
-    position: { x: 0, y: 200 },
-  }),
-  createUserNode('call', {
-    name: 'fetch_data',
-    phase: 'request',
-    position: { x: 200, y: 0 },
-  }),
-  createUserNode('jq', {
-    name: 'process_data',
-    phase: 'request',
-    position: { x: 400, y: 0 },
-    fields: {
-      input: ['foo', 'bar'],
-      output: ['baz'],
-    },
-  }),
-  createUserNode('exit', {
-    name: 'exit',
-    phase: 'request',
-    position: { x: 200, y: 200 },
-  }),
-  createUserNode('property', {
-    name: 'get_properties',
-    phase: 'request',
-    position: { x: 400, y: 200 },
-    fields: {
-      output: ['authenticated_user'],
-    },
-  }),
-  createUserNode('static', {
-    name: 'predefined_data',
-    phase: 'request',
-    position: { x: 200, y: 400 },
-    fields: {
-      output: ['foo', 'bar'],
-    },
-  }),
-
-])
+const nodes = ref<Array<Node<NodeInstance>>>([])
 
 const { fitView, onNodeClick } = useVueFlow()
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
@@ -58,7 +58,7 @@ defineSlots<{
 }>()
 
 const emit = defineEmits<{
-  'click:node': [nodeData: NodeInstance]
+  'click:node': [node: NodeInstance]
   'click:backdrop': []
 }>()
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -3,7 +3,7 @@
     class="flow-node"
     :class="{
       reversed: isReversed,
-      implicit: isImplicit,
+      implicit: isImplicitNode,
     }"
   >
     <div class="body">
@@ -14,7 +14,7 @@
 
         <!-- TODO: Use small variant when available -->
         <NodeBadge
-          v-if="!isImplicit"
+          v-if="!isImplicitNode"
           condensed
           :type="data.type"
         />
@@ -161,11 +161,11 @@ import english from '../../../../../locales/en.json'
 import HandleTwig from './HandleTwig.vue'
 import { isImplicitNode } from './node'
 
-import type { NodeData } from '../../types'
 import NodeBadge from './NodeBadge.vue'
+import type { NodeInstance } from '../../types'
 
 const { data } = defineProps<{
-  data: NodeData
+  data: NodeInstance
 }>()
 
 const { t } = createI18n<typeof english>('en-us', english)

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -3,7 +3,7 @@
     class="flow-node"
     :class="{
       reversed: isReversed,
-      implicit: isImplicitNode,
+      implicit: isImplicit,
     }"
   >
     <div class="body">
@@ -14,7 +14,7 @@
 
         <!-- TODO: Use small variant when available -->
         <NodeBadge
-          v-if="!isImplicitNode"
+          v-if="!isImplicit"
           condensed
           :type="data.type"
         />

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodeBadge.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodeBadge.vue
@@ -13,7 +13,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { NodeType } from '../../types'
-import { USER_NODE_META_MAP, getNodeTypeName, isImplicitNodeType } from './node'
+import { CONFIG_NODE_META_MAP, getNodeTypeName, isImplicitType } from './node'
 import type { BadgeAppearance } from '@kong/kongponents'
 
 const { type } = defineProps<{
@@ -22,8 +22,8 @@ const { type } = defineProps<{
 }>()
 
 const icon = computed(() => {
-  if (!isImplicitNodeType(type)) {
-    return USER_NODE_META_MAP[type]?.icon ?? undefined
+  if (!isImplicitType(type)) {
+    return CONFIG_NODE_META_MAP[type]?.icon ?? undefined
   }
   return undefined
 })
@@ -50,6 +50,7 @@ const appearance = computed<BadgeAppearance>(() => {
 
 <style lang="scss" scoped>
 .condensed {
+  font-size: $kui-font-size-20;
   padding: $kui-space-10;
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
@@ -10,7 +10,7 @@
     </h3>
     <div class="node-list">
       <NodePanelItem
-        v-for="nodeType in (Object.keys(USER_NODE_META_MAP) as Array<UserNodeType>)"
+        v-for="nodeType in (Object.keys(CONFIG_NODE_META_MAP) as Array<ConfigNodeType>)"
         :key="nodeType"
         :type="nodeType"
       />
@@ -21,10 +21,10 @@
 <script setup lang="ts">
 import { createI18n } from '@kong-ui-public/i18n'
 import english from '../../../../../locales/en.json'
-import { USER_NODE_META_MAP } from './node'
+import { CONFIG_NODE_META_MAP } from './node'
 import NodePanelItem from './NodePanelItem.vue'
 
-import type { UserNodeType } from '../../types'
+import type { ConfigNodeType } from '../../types'
 
 const { t } = createI18n<typeof english>('en-us', english)
 </script>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanelItem.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanelItem.vue
@@ -20,15 +20,15 @@
 </template>
 
 <script setup lang="ts">
-import { USER_NODE_META_MAP } from './node'
+import { CONFIG_NODE_META_MAP } from './node'
 
-import type { UserNodeType } from '../../types'
+import type { ConfigNodeType } from '../../types'
 
-const { type } = defineProps<{ type: UserNodeType }>()
+const { type } = defineProps<{ type: ConfigNodeType }>()
 const {
   summary,
   icon: Icon,
-} = USER_NODE_META_MAP[type]
+} = CONFIG_NODE_META_MAP[type]
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePropertiesPanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePropertiesPanel.vue
@@ -40,7 +40,7 @@ import NodeFormJq from './NodeFormJq.vue'
 
 import { KSlideout } from '@kong/kongponents'
 import { getNodeTypeDescription } from './node'
-import type { NodeData } from '../../types'
+import type { NodeInstance } from '../../types'
 import { computed } from 'vue'
 
 const {
@@ -52,7 +52,7 @@ const {
   maxWidth?: string
   offsetTop?: string
   visible?: boolean
-  node?: NodeData | null
+  node?: NodeInstance | null
 }>()
 
 defineEmits<{

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/node.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/node.ts
@@ -118,8 +118,8 @@ export const isImplicitNode = (
 ): node is (NodeMeta | NodeInstance) & { type: ImplicitNodeType } =>
   isImplicitType(node.type)
 
-export const isNodeId = (id: string): id is NodeId =>
-  id.startsWith('node:')
+export const isNodeId = (id?: string): id is NodeId =>
+  !!id?.startsWith('node:')
 
-export const isFieldId = (id: string): id is FieldId =>
-  id.startsWith('field:')
+export const isFieldId = (id?: string): id is FieldId =>
+  !!id?.startsWith('field:')

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/helpers.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/helpers.ts
@@ -2,7 +2,7 @@ import type {
   EdgeId,
   FieldId,
   FieldName,
-  FlowPhase,
+  NodePhase,
   ImplicitNodeName,
   NodeInstance,
   NodeField,
@@ -103,7 +103,7 @@ export const IMPLICIT_NODE_NAMES: ImplicitNodeName[] = [
 
 /** Default UI blob for an implicit node. */
 export function makeDefaultImplicitUINode(name: ImplicitNodeName): UINode {
-  const phase: FlowPhase =
+  const phase: NodePhase =
     name === 'request' || name === 'service_request' ? 'request' : 'response'
   const meta = IMPLICIT_NODE_META_MAP[name]
   return {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/helpers.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/helpers.ts
@@ -10,6 +10,8 @@ import type {
   NodeName,
   NodeType,
   UINode,
+  ConfigNodeType,
+  ConfigNodeName,
 } from '../../types'
 import {
   CONFIG_NODE_META_MAP,
@@ -21,7 +23,8 @@ let idCounter = 0
 
 /** Deep clone for snapshots and immutable returns. */
 export function deepClone<T>(value: T): T {
-  return structuredClone(value)
+  // TODO: move to lodash or similar utility library
+  return JSON.parse(JSON.stringify(value))
 }
 
 /** Generate a unique runtime id. */
@@ -116,4 +119,20 @@ export function makeDefaultImplicitUINode(name: ImplicitNodeName): UINode {
     },
     expanded: {},
   }
+}
+
+/** Generate a unique node name when user doesn’t supply one. */
+export function generateNodeName(
+  type: ConfigNodeType,
+  nodeNames: Set<NodeName>,
+): ConfigNodeName {
+  const prefix = type.toUpperCase()
+
+  let next = 1
+  while (true) {
+    if (!nodeNames.has(`${prefix}_${next}` as ConfigNodeName)) break
+    next++
+  }
+
+  return `${prefix}_${next}` as ConfigNodeName
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/helpers.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/helpers.ts
@@ -1,0 +1,119 @@
+import type {
+  EdgeId,
+  FieldId,
+  FieldName,
+  FlowPhase,
+  ImplicitNodeName,
+  NodeInstance,
+  NodeField,
+  NodeId,
+  NodeName,
+  NodeType,
+  UINode,
+} from '../../types'
+import {
+  CONFIG_NODE_META_MAP,
+  IMPLICIT_NODE_META_MAP,
+  isImplicitType,
+} from '../node/node'
+
+let idCounter = 0
+
+/** Deep clone for snapshots and immutable returns. */
+export function deepClone<T>(value: T): T {
+  return structuredClone(value)
+}
+
+/** Generate a unique runtime id. */
+export function createId<T extends 'node' | 'edge' | 'field'>(
+  type: T,
+): T extends 'node' ? NodeId : T extends 'edge' ? EdgeId : FieldId {
+  return `${type}:${idCounter++}` as unknown as T extends 'node'
+    ? NodeId
+    : T extends 'edge'
+      ? EdgeId
+      : FieldId
+}
+
+/** Parse "NODE" or "NODE.FIELD". */
+export function parseConnection(connection: string): {
+  nodeName: NodeName
+  fieldName?: FieldName
+} {
+  const [nodeName, fieldName] = connection.split('.') as [
+    NodeName,
+    FieldName | undefined,
+  ]
+  return { nodeName, fieldName }
+}
+
+/** Default field names from node meta. */
+export function getFieldsFromMeta(type: NodeType): {
+  input: FieldName[]
+  output: FieldName[]
+} {
+  const meta = isImplicitType(type)
+    ? IMPLICIT_NODE_META_MAP[type]
+    : CONFIG_NODE_META_MAP[type]
+  return { input: meta.fields?.input ?? [], output: meta.fields?.output ?? [] }
+}
+
+/** Build NodeField array from names. */
+export function toFieldArray(names?: FieldName[]): NodeField[] {
+  return (names ?? []).map((name) => ({ id: createId('field'), name }))
+}
+
+/** Find a field by visible name. */
+export function findFieldByName(
+  node: NodeInstance,
+  io: 'input' | 'output',
+  name?: FieldName,
+): NodeField | undefined {
+  if (!name) return undefined
+  return node.fields[io].find((field) => field.name === name)
+}
+
+/** Find a field by id. */
+export function findFieldById(
+  node: NodeInstance,
+  io: 'input' | 'output',
+  id?: FieldId,
+): NodeField | undefined {
+  if (!id) return undefined
+  return node.fields[io].find((field) => field.id === id)
+}
+
+/** Quick checks for handle type. */
+export function hasOutputField(node: NodeInstance, fieldId?: FieldId): boolean {
+  if (!fieldId) return true
+  return node.fields.output.some((field) => field.id === fieldId)
+}
+export function hasInputField(node: NodeInstance, fieldId?: FieldId): boolean {
+  if (!fieldId) return true
+  return node.fields.input.some((field) => field.id === fieldId)
+}
+
+/** The 4 implicit nodes always present. */
+export const IMPLICIT_NODE_NAMES: ImplicitNodeName[] = [
+  'request',
+  'service_request',
+  'service_response',
+  'response',
+]
+
+/** Default UI blob for an implicit node. */
+export function makeDefaultImplicitUINode(name: ImplicitNodeName): UINode {
+  const phase: FlowPhase =
+    name === 'request' || name === 'service_request' ? 'request' : 'response'
+  const meta = IMPLICIT_NODE_META_MAP[name]
+  return {
+    name,
+    phase,
+    position: { x: 0, y: 0 },
+    fields: {
+      input: meta.fields?.input ?? [],
+      output: meta.fields?.output ?? [],
+    },
+    expanded: {},
+  }
+}

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/history.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/history.ts
@@ -1,0 +1,60 @@
+import { useManualRefHistory } from '@vueuse/core'
+import type { Ref } from 'vue'
+
+/** Minimal tagged history. Same tag + replace drops previous snapshot. */
+export function useTaggedHistory<T>(
+  stateRef: Ref<T>,
+  options?: { capacity?: number, clone?: (v: T) => T },
+) {
+  const {
+    commit: baseCommit,
+    undo: baseUndo,
+    redo: baseRedo,
+    canUndo,
+    canRedo,
+    clear: baseClear,
+    reset: baseReset,
+    undoStack,
+  } = useManualRefHistory(stateRef, {
+    capacity: options?.capacity ?? 200,
+    clone: options?.clone,
+  })
+
+  let lastTag: string | undefined
+
+  function commit(tag?: string, opts?: { replace?: boolean }) {
+    const replace = !!opts?.replace
+    if (replace && tag && lastTag === tag && undoStack.value.length > 0) {
+      undoStack.value.pop()
+    }
+    baseCommit()
+    lastTag = tag
+  }
+
+  function undo() {
+    baseUndo()
+    lastTag = undefined
+  }
+  function redo() {
+    baseRedo()
+    lastTag = undefined
+  }
+  function clear() {
+    baseClear()
+    lastTag = undefined
+  }
+  function reset() {
+    baseReset()
+    lastTag = undefined
+  }
+
+  return {
+    canUndo,
+    canRedo,
+    commit,
+    undo,
+    redo,
+    clear,
+    reset,
+  }
+}

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
@@ -87,7 +87,7 @@ export function initEditorState(
   return { nodes, edges }
 }
 
-export function makeNodeInstance(params: {
+export function makeNodeInstance(payload: {
   type: NodeType
   name?: NodeName
   phase?: NodePhase
@@ -95,7 +95,7 @@ export function makeNodeInstance(params: {
   uiFieldNames?: { input?: FieldName[], output?: FieldName[] }
   config?: Record<string, unknown>
 }): NodeInstance {
-  const { type, name, phase, position, uiFieldNames, config } = params
+  const { type, name, phase, position, uiFieldNames, config } = payload
   const defaults = getFieldsFromMeta(type)
 
   return {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
@@ -2,7 +2,7 @@ import type {
   ConfigNode,
   EditorState,
   EdgeInstance,
-  FlowPhase,
+  NodePhase,
   ImplicitNodeName,
   NodeInstance,
   NodeName,
@@ -90,7 +90,7 @@ export function initEditorState(
 export function makeNodeInstance(params: {
   type: NodeType
   name?: NodeName
-  phase?: FlowPhase
+  phase?: NodePhase
   position?: { x: number, y: number }
   uiFieldNames?: { input?: FieldName[], output?: FieldName[] }
   config?: Record<string, unknown>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
@@ -1,0 +1,193 @@
+import type {
+  ConfigNode,
+  EditorState,
+  EdgeInstance,
+  FlowPhase,
+  ImplicitNodeName,
+  NodeInstance,
+  NodeName,
+  NodeType,
+  UINode,
+  FieldName,
+  ConfigEdge,
+} from '../../types'
+import {
+  createId,
+  deepClone,
+  findFieldByName,
+  getFieldsFromMeta,
+  IMPLICIT_NODE_NAMES,
+  makeDefaultImplicitUINode,
+  parseConnection,
+  toFieldArray,
+} from './helpers'
+
+export function initEditorState(
+  configNodes: ConfigNode[],
+  uiNodes: UINode[],
+): EditorState {
+  const uiNodesMap = new Map<NodeName, UINode>(
+    uiNodes.map((uiNode) => [uiNode.name, uiNode]),
+  )
+  const nodes: NodeInstance[] = []
+  const edges: EdgeInstance[] = []
+  const nodesMap = new Map<NodeName, NodeInstance>()
+  const connections: ConfigEdge[] = []
+
+  // config nodes
+  for (const configNode of configNodes) {
+    const uiNode = uiNodesMap.get(configNode.name)
+    const node = buildNodeInstance(configNode.type, configNode, uiNode)
+    nodes.push(node)
+    nodesMap.set(node.name, node)
+  }
+
+  // ensure implicit nodes
+  for (const implicitName of IMPLICIT_NODE_NAMES) {
+    if (!nodesMap.has(implicitName)) {
+      const uiNode =
+        uiNodesMap.get(implicitName) ?? makeDefaultImplicitUINode(implicitName)
+      const node = buildNodeInstance(implicitName, undefined, uiNode)
+      nodes.push(node)
+      nodesMap.set(node.name, node)
+    }
+  }
+
+  // collect connections
+  for (const configNode of configNodes) {
+    collectConnectionsFromConfigNode(configNode, connections)
+  }
+
+  // materialize edges
+  for (const connection of connections) {
+    const sourceNode = nodesMap.get(connection.source)
+    const targetNode = nodesMap.get(connection.target)
+    if (!sourceNode || !targetNode) {
+      if (!sourceNode)
+        console.warn(
+          `[initEditorState] skip: source "${connection.source}" not found`,
+        )
+      if (!targetNode)
+        console.warn(
+          `[initEditorState] skip: target "${connection.target}" not found`,
+        )
+      continue
+    }
+    edges.push({
+      id: createId('edge'),
+      source: sourceNode.id,
+      sourceField: findFieldByName(sourceNode, 'output', connection.sourceField)
+        ?.id,
+      target: targetNode.id,
+      targetField: findFieldByName(targetNode, 'input', connection.targetField)
+        ?.id,
+    })
+  }
+
+  return { nodes, edges }
+}
+
+export function makeNodeInstance(params: {
+  type: NodeType
+  name?: NodeName
+  phase?: FlowPhase
+  position?: { x: number, y: number }
+  uiFieldNames?: { input?: FieldName[], output?: FieldName[] }
+  config?: Record<string, unknown>
+}): NodeInstance {
+  const { type, name, phase, position, uiFieldNames, config } = params
+  const defaults = getFieldsFromMeta(type)
+
+  return {
+    id: createId('node'),
+    type,
+    name: name ?? (type as ImplicitNodeName),
+    phase:
+      phase ??
+      (type === 'request' || type === 'service_request'
+        ? 'request'
+        : 'response'),
+    position: position ?? { x: 0, y: 0 },
+    expanded: {},
+    fields: {
+      input: toFieldArray(uiFieldNames?.input ?? defaults.input),
+      output: toFieldArray(uiFieldNames?.output ?? defaults.output),
+    },
+    config: config ? deepClone(config) : {},
+  }
+}
+
+export function buildNodeInstance(
+  type: NodeType,
+  configNode?: ConfigNode,
+  uiNode?: UINode,
+): NodeInstance {
+  return makeNodeInstance({
+    type,
+    name: configNode?.name,
+    phase:
+      uiNode?.phase ??
+      (type === 'request' || type === 'service_request'
+        ? 'request'
+        : 'response'),
+    position: uiNode?.position,
+    uiFieldNames: uiNode?.fields,
+    config: configNode ? extractConfig(configNode) : undefined,
+  })
+}
+
+/** Strip identity and IO fields. */
+export function extractConfig(configNode: ConfigNode): Record<string, unknown> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { type, name, input, inputs, output, outputs, ...rest } = configNode
+  return deepClone(rest)
+}
+
+export function collectConnectionsFromConfigNode(
+  configNode: ConfigNode,
+  out: ConfigEdge[],
+): void {
+  const self = configNode.name
+
+  if (configNode.input) {
+    const { nodeName, fieldName } = parseConnection(configNode.input)
+    if (nodeName)
+      out.push({ source: nodeName, sourceField: fieldName, target: self })
+  }
+
+  if (configNode.inputs) {
+    for (const [toFieldName, connection] of Object.entries(configNode.inputs)) {
+      const { nodeName, fieldName } = parseConnection(connection)
+      if (nodeName) {
+        out.push({
+          source: nodeName,
+          sourceField: fieldName,
+          target: self,
+          targetField: toFieldName as FieldName,
+        })
+      }
+    }
+  }
+
+  if (configNode.output) {
+    const { nodeName, fieldName } = parseConnection(configNode.output)
+    if (nodeName)
+      out.push({ source: self, target: nodeName, targetField: fieldName })
+  }
+
+  if (configNode.outputs) {
+    for (const [fromFieldName, connection] of Object.entries(
+      configNode.outputs,
+    )) {
+      const { nodeName, fieldName } = parseConnection(connection)
+      if (nodeName) {
+        out.push({
+          source: self,
+          sourceField: fromFieldName as FieldName,
+          target: nodeName,
+          targetField: fieldName,
+        })
+      }
+    }
+  }
+}

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -1,0 +1,545 @@
+import { computed, ref } from 'vue'
+import { createInjectionState } from '@vueuse/core'
+import type {
+  ConfigNode,
+  ConfigNodeType,
+  EdgeData,
+  EdgeInstance,
+  EdgeId,
+  EditorState,
+  FieldId,
+  FieldName,
+  FlowPhase,
+  NodeInstance,
+  NodeId,
+  NodeName,
+  UINode,
+} from '../../types'
+import { createId, deepClone, findFieldById } from './helpers'
+import { isImplicitName, isImplicitType } from '../node/node'
+import { initEditorState, makeNodeInstance } from './init'
+import { useValidators } from './validation'
+import { useTaggedHistory } from './history'
+
+export const [provideEditorState, useEditorState] = createInjectionState(
+  function(configNodes: ConfigNode[], uiNodes: UINode[]) {
+    const state = ref<EditorState>(initEditorState(configNodes, uiNodes))
+    const selection = ref<NodeId>()
+    const history = useTaggedHistory(state, {
+      capacity: 200,
+      clone: deepClone,
+    })
+
+    // maps
+    const nodeMapById = computed(
+      () =>
+        new Map<NodeId, NodeInstance>(
+          state.value.nodes.map((node) => [node.id, node]),
+        ),
+    )
+    const nodeMapByName = computed(
+      () =>
+        new Map<NodeName, NodeInstance>(
+          state.value.nodes.map((node) => [node.name, node]),
+        ),
+    )
+    const edgeMapById = computed(
+      () =>
+        new Map<EdgeId, EdgeInstance>(
+          state.value.edges.map((edge) => [edge.id, edge]),
+        ),
+    )
+
+    // validators bound to current maps
+    const {
+      canonicalizeConnection,
+      validateConnection,
+      validateGraph,
+      isValidConnection,
+      isValidVueFlowConnection,
+    } = useValidators(state)
+
+    // O(1) getters
+    function getNodeById(id: NodeId) {
+      return nodeMapById.value.get(id)
+    }
+    function getNodeByName(name: NodeName) {
+      return nodeMapByName.value.get(name)
+    }
+    function getEdgeById(id: EdgeId) {
+      return edgeMapById.value.get(id)
+    }
+
+    const selectedNode = computed(() =>
+      selection.value ? getNodeById(selection.value) : undefined,
+    )
+    function selectNode(id?: NodeId) {
+      selection.value = id
+    }
+
+    /* ---------- node ops ---------- */
+
+    function addNode(
+      payload: {
+        type: ConfigNodeType
+        name?: NodeName
+        phase?: FlowPhase
+        position?: { x: number, y: number }
+        fields?: { input?: FieldName[], output?: FieldName[] }
+        config?: Record<string, unknown>
+      },
+      commitNow = true,
+    ) {
+      if (isImplicitType(payload.type)) {
+        console.warn('[addNode] implicit nodes are fixed.')
+        return
+      }
+      const node = makeNodeInstance({
+        type: payload.type,
+        name: payload.name,
+        phase: payload.phase,
+        position: payload.position,
+        uiFieldNames: payload.fields,
+        config: payload.config,
+      })
+      state.value.nodes.push(node)
+      if (commitNow) history.commit()
+      return node.id
+    }
+
+    function removeNode(nodeId: NodeId, commitNow = true) {
+      state.value.edges = state.value.edges.filter(
+        (edge) => edge.source !== nodeId && edge.target !== nodeId,
+      )
+      state.value.nodes = state.value.nodes.filter(
+        (node) => node.id !== nodeId,
+      )
+      if (selection.value === nodeId) selection.value = undefined
+
+      const topo = validateGraph()
+      if (!topo.ok) {
+        console.warn('[removeNode] topology invalid:', topo.errors.join('; '))
+      }
+
+      if (commitNow) history.commit()
+    }
+
+    function renameNode(nodeId: NodeId, newName: NodeName, commitNow = true) {
+      const node = getNodeById(nodeId)
+      if (!node) return
+      if (isImplicitName(node.name)) {
+        console.warn('[renameNode] implicit node name is reserved.')
+        return
+      }
+      node.name = newName
+      if (commitNow) history.commit()
+    }
+
+    function moveNode(
+      nodeId: NodeId,
+      position: { x: number, y: number },
+      commitNow = true,
+    ) {
+      const node = getNodeById(nodeId)
+      if (!node) return
+      node.position = { ...position }
+      if (commitNow) history.commit(`move:${nodeId}`, { replace: true })
+    }
+
+    function toggleExpanded(
+      nodeId: NodeId,
+      io: 'input' | 'output',
+      value?: boolean,
+      commitNow = true,
+    ) {
+      const node = getNodeById(nodeId)
+      if (!node) return
+      node.expanded[io] = value ?? !node.expanded[io]
+      if (commitNow)
+        history.commit(`toggle:${nodeId}:${io}`, { replace: true })
+    }
+
+    function replaceConfig(
+      nodeId: NodeId,
+      next: Record<string, unknown>,
+      commitNow = true,
+    ) {
+      const node = getNodeById(nodeId)
+      if (!node) return
+      node.config = deepClone(next)
+      if (commitNow) history.commit()
+    }
+
+    /* ---------- field ops ---------- */
+
+    function addField(
+      nodeId: NodeId,
+      io: 'input' | 'output',
+      name: FieldName,
+      commitNow = true,
+    ) {
+      const node = getNodeById(nodeId)
+      if (!node) return
+      const fields = node.fields[io]
+      if (fields.some((field) => field.name === name)) {
+        console.warn(`[addField] field "${name}" already exists on ${io}.`)
+        return
+      }
+      fields.push({ id: createId('field'), name })
+      if (io === 'input') node.fields.input = fields
+      else node.fields.output = fields
+      if (commitNow) history.commit()
+    }
+
+    function renameField(
+      nodeId: NodeId,
+      fieldId: FieldId,
+      newName: FieldName,
+      commitNow = true,
+    ) {
+      const node = getNodeById(nodeId)
+      if (!node) return
+      const inputFields = node.fields.input
+      const outputFields = node.fields.output
+      const field =
+        inputFields.find((field) => field.id === fieldId) ??
+        outputFields.find((field) => field.id === fieldId)
+      if (!field) return
+      field.name = newName
+      if (commitNow) history.commit()
+    }
+
+    function removeField(
+      nodeId: NodeId,
+      fieldId: FieldId,
+      cascade = true,
+      commitNow = true,
+    ) {
+      const node = getNodeById(nodeId)
+      if (!node) return
+      const inputFields = node.fields.input
+      const outputFields = node.fields.output
+
+      const inputIndex = inputFields.findIndex((field) => field.id === fieldId)
+      if (inputIndex >= 0) inputFields.splice(inputIndex, 1)
+
+      const outputIndex = outputFields.findIndex(
+        (field) => field.id === fieldId,
+      )
+      if (outputIndex >= 0) outputFields.splice(outputIndex, 1)
+
+      node.fields.input = inputFields
+      node.fields.output = outputFields
+
+      if (cascade) {
+        state.value.edges = state.value.edges.filter(
+          (edge) => edge.sourceField !== fieldId && edge.targetField !== fieldId,
+        )
+      }
+
+      const topo = validateGraph()
+      if (!topo.ok) {
+        console.warn('[removeField] topology invalid:', topo.errors.join('; '))
+      }
+
+      if (commitNow) history.commit()
+    }
+
+    /* ---------- edge ops (two-step validation) ---------- */
+
+    function connectEdge(payload: EdgeData, commitNow = true) {
+      const canonical = canonicalizeConnection(payload)
+      const local = validateConnection(canonical)
+      if (!local.ok) {
+        console.warn(
+          '[connectEdge] invalid connection:',
+          local.errors.join('; '),
+        )
+        return
+      }
+      const edge: EdgeInstance = { id: createId('edge'), ...canonical }
+      state.value.edges.push(edge)
+
+      const topo = validateGraph()
+      if (!topo.ok) {
+        state.value.edges.pop()
+        console.warn('[connectEdge] topology invalid:', topo.errors.join('; '))
+        return
+      }
+      if (commitNow) history.commit()
+      return edge.id
+    }
+
+    function replaceConnection(
+      edgeId: EdgeId,
+      patch: Partial<Omit<EdgeInstance, 'id'>>,
+      commitNow = true,
+    ) {
+      const edge = getEdgeById(edgeId)
+      if (!edge) return
+      const candidate = canonicalizeConnection({ ...edge, ...patch })
+
+      const local = validateConnection(candidate)
+      if (!local.ok) {
+        console.warn(
+          '[replaceConnection] invalid connection:',
+          local.errors.join('; '),
+        )
+        return
+      }
+
+      const backup = { ...edge }
+      Object.assign(edge, candidate)
+
+      const topo = validateGraph()
+      if (!topo.ok) {
+        Object.assign(edge, backup)
+        console.warn(
+          '[replaceConnection] topology invalid:',
+          topo.errors.join('; '),
+        )
+        return
+      }
+      if (commitNow) history.commit()
+    }
+
+    function disconnectEdge(edgeId: EdgeId, commitNow = true) {
+      const index = state.value.edges.findIndex((edge) => edge.id === edgeId)
+      if (index < 0) return
+      const backup = state.value.edges[index]
+      state.value.edges.splice(index, 1)
+
+      const topo = validateGraph()
+      if (!topo.ok) {
+        state.value.edges.splice(index, 0, backup)
+        console.warn(
+          '[disconnectEdge] topology invalid:',
+          topo.errors.join('; '),
+        )
+        return
+      }
+
+      if (commitNow) history.commit()
+    }
+
+    /* ---------- serialization ---------- */
+
+    function toConfigNodes(): ConfigNode[] {
+      const output: ConfigNode[] = []
+
+      for (const node of state.value.nodes) {
+        if (isImplicitType(node.type)) continue
+
+        const inputs: Record<string, string> = {}
+        const outputs: Record<string, string> = {}
+
+        // incoming -> inputs
+        for (const edge of state.value.edges.filter(
+          (edge) => edge.target === node.id,
+        )) {
+          const sourceNode = getNodeById(edge.source)
+          if (!sourceNode) continue
+          const sourceFieldName = findFieldById(
+            sourceNode,
+            'output',
+            edge.sourceField,
+          )?.name
+          const value = sourceFieldName
+            ? `${sourceNode.name}.${sourceFieldName}`
+            : sourceNode.name
+          const targetFieldName = findFieldById(
+            node,
+            'input',
+            edge.targetField,
+          )?.name
+          if (targetFieldName) inputs[targetFieldName] = value
+          else if (!('input' in inputs)) inputs.input = value
+        }
+
+        // outgoing -> outputs
+        for (const edge of state.value.edges.filter(
+          (edge) => edge.source === node.id,
+        )) {
+          const targetNode = getNodeById(edge.target)
+          if (!targetNode) continue
+          const targetFieldName = findFieldById(
+            targetNode,
+            'input',
+            edge.targetField,
+          )?.name
+          const value = targetFieldName
+            ? `${targetNode.name}.${targetFieldName}`
+            : targetNode.name
+          const sourceFieldName = findFieldById(
+            node,
+            'output',
+            edge.sourceField,
+          )?.name
+          if (sourceFieldName) outputs[sourceFieldName] = value
+          else if (!('output' in outputs)) outputs.output = value
+        }
+
+        const configNode: ConfigNode = {
+          ...deepClone(node.config),
+          name: node.name,
+          type: node.type,
+        } as ConfigNode
+
+        const inputKeys = Object.keys(inputs)
+        const outputKeys = Object.keys(outputs)
+
+        if (inputKeys.length === 1 && inputKeys[0] === 'input')
+          configNode.input = inputs.input
+        else if (inputKeys.length) configNode.inputs = inputs
+
+        if (outputKeys.length === 1 && outputKeys[0] === 'output')
+          configNode.output = outputs.output
+        else if (outputKeys.length) configNode.outputs = outputs
+
+        output.push(configNode)
+      }
+
+      return output
+    }
+
+    function toUINodes(): UINode[] {
+      return state.value.nodes.map((node) =>
+        deepClone({
+          name: node.name,
+          phase: node.phase,
+          position: { ...node.position },
+          expanded: { ...node.expanded },
+          fields: {
+            input: node.fields.input.map((field) => field.name),
+            output: node.fields.output.map((field) => field.name),
+          },
+        }),
+      )
+    }
+
+    function load(nextConfig: ConfigNode[], nextUI: UINode[]) {
+      state.value = initEditorState(nextConfig, nextUI)
+      history.reset()
+    }
+
+    /* ---------- Vue Flow adapters ---------- */
+
+    function edgeInPhase(edge: EdgeInstance, phase: FlowPhase) {
+      const sourceNode = getNodeById(edge.source)
+      const targetNode = getNodeById(edge.target)
+      return !!(
+        sourceNode &&
+        targetNode &&
+        sourceNode.phase === phase &&
+        targetNode.phase === phase
+      )
+    }
+
+    const requestNodes = computed(() =>
+      state.value.nodes
+        .filter((node) => node.phase === 'request')
+        .map((node) => ({
+          id: node.id,
+          type: node.type,
+          position: node.position,
+          data: node,
+        })),
+    )
+
+    const requestEdges = computed(() =>
+      state.value.edges
+        .filter((edge) => edgeInPhase(edge, 'request'))
+        .map((edge) => ({
+          id: edge.id,
+          source: edge.source,
+          target: edge.target,
+          sourceHandle: edge.sourceField,
+          targetHandle: edge.targetField,
+          data: edge,
+        })),
+    )
+
+    const responseNodes = computed(() =>
+      state.value.nodes
+        .filter((node) => node.phase === 'response')
+        .map((node) => ({
+          id: node.id,
+          type: node.type,
+          position: node.position,
+          data: node,
+        })),
+    )
+
+    const responseEdges = computed(() =>
+      state.value.edges
+        .filter((edge) => edgeInPhase(edge, 'response'))
+        .map((edge) => ({
+          id: edge.id,
+          source: edge.source,
+          target: edge.target,
+          sourceHandle: edge.sourceField,
+          targetHandle: edge.targetField,
+          data: edge,
+        })),
+    )
+
+    return {
+      // state
+      state,
+      selection,
+
+      // maps & getters
+      nodeMapById,
+      nodeMapByName,
+      edgeMapById,
+      getNodeById,
+      getNodeByName,
+      getEdgeById,
+      selectedNode,
+      selectNode,
+
+      // node ops
+      addNode,
+      removeNode,
+      renameNode,
+      moveNode,
+      toggleExpanded,
+      replaceConfig,
+
+      // field ops
+      addField,
+      renameField,
+      removeField,
+
+      // edge ops
+      connectEdge,
+      replaceConnection,
+      disconnectEdge,
+
+      // serialization
+      toConfigNodes,
+      toUINodes,
+      load,
+
+      // history
+      commit: history.commit,
+      undo: history.undo,
+      redo: history.redo,
+      canUndo: history.canUndo,
+      canRedo: history.canRedo,
+      clear: history.clear,
+      reset: history.reset,
+
+      // Vue Flow views
+      requestNodes,
+      requestEdges,
+      responseNodes,
+      responseEdges,
+
+      // validation helpers for UI
+      isValidConnection,
+      isValidVueFlowConnection,
+      validateGraph: () => validateGraph(),
+    }
+  },
+)

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -9,7 +9,7 @@ import type {
   EditorState,
   FieldId,
   FieldName,
-  FlowPhase,
+  NodePhase,
   NodeInstance,
   NodeId,
   NodeName,
@@ -83,7 +83,7 @@ export const [provideEditorState, useEditorState] = createInjectionState(
       payload: {
         type: ConfigNodeType
         name?: NodeName
-        phase?: FlowPhase
+        phase?: NodePhase
         position?: { x: number, y: number }
         fields?: { input?: FieldName[], output?: FieldName[] }
         config?: Record<string, unknown>
@@ -424,7 +424,7 @@ export const [provideEditorState, useEditorState] = createInjectionState(
 
     /* ---------- Vue Flow adapters ---------- */
 
-    function edgeInPhase(edge: EdgeInstance, phase: FlowPhase) {
+    function edgeInPhase(edge: EdgeInstance, phase: NodePhase) {
       const sourceNode = getNodeById(edge.source)
       const targetNode = getNodeById(edge.target)
       return !!(

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/validation.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/validation.ts
@@ -1,0 +1,214 @@
+import type { Ref } from 'vue'
+import { computed } from 'vue'
+import type {
+  EditorState,
+  EdgeInstance,
+  EdgeData,
+  FieldId,
+  NodeInstance,
+  NodeId,
+} from '../../types'
+import { hasInputField, hasOutputField } from './helpers'
+
+export type ValidationResult = { ok: true } | { ok: false, errors: string[] }
+
+/**
+ * Validators bound to a reactive EditorState.
+ * Always reads the latest state through computed getters.
+ */
+export function useValidators(stateRef: Ref<EditorState>) {
+  /** reactive maps for O(1) look-up */
+  const nodesById = computed(() => {
+    const m = new Map<NodeId, NodeInstance>()
+    stateRef.value.nodes.forEach((n) => m.set(n.id, n))
+    return m
+  })
+  const edges = computed<readonly EdgeInstance[]>(
+    () => stateRef.value.edges,
+  )
+
+  /* ---------- helpers ---------- */
+
+  /** Swap ends when drag starts at an input handle. */
+  function canonicalizeConnection(edge: EdgeData): EdgeData {
+    const sourceNode = nodesById.value.get(edge.source)
+    const targetNode = nodesById.value.get(edge.target)
+    if (!sourceNode || !targetNode) return edge
+
+    const fromIsInput =
+      hasInputField(sourceNode, edge.sourceField) &&
+      !hasOutputField(sourceNode, edge.sourceField)
+    const toIsOutput = hasOutputField(targetNode, edge.targetField)
+
+    return fromIsInput && toIsOutput
+      ? {
+        source: edge.target,
+        sourceField: edge.targetField,
+        target: edge.source,
+        targetField: edge.sourceField,
+      }
+      : edge
+  }
+
+  function buildAdjacency(extra?: { source: NodeId, target: NodeId } | null) {
+    const map = new Map<NodeId, NodeId[]>()
+    for (const e of edges.value) {
+      if (!map.has(e.source)) map.set(e.source, [])
+      map.get(e.source)!.push(e.target)
+      if (!map.has(e.target)) map.set(e.target, [])
+    }
+    if (extra) {
+      if (!map.has(extra.source)) map.set(extra.source, [])
+      map.get(extra.source)!.push(extra.target)
+      if (!map.has(extra.target)) map.set(extra.target, [])
+    }
+    return map
+  }
+
+  function hasCycle(graph: ReadonlyMap<NodeId, readonly NodeId[]>): boolean {
+    const seen = new Set<NodeId>()
+    const stack = new Set<NodeId>()
+
+    function dfs(n: NodeId): boolean {
+      if (stack.has(n)) return true
+      if (seen.has(n)) return false
+      seen.add(n)
+      stack.add(n)
+      for (const next of graph.get(n) ?? []) if (dfs(next)) return true
+      stack.delete(n)
+      return false
+    }
+
+    for (const id of graph.keys()) if (dfs(id)) return true
+    return false
+  }
+
+  /* ---------- edge-level validation ---------- */
+
+  function validateConnection(raw: EdgeData): ValidationResult {
+    const edge = canonicalizeConnection(raw)
+    const errors: string[] = []
+
+    const sourceNode = nodesById.value.get(edge.source)
+    const targetNode = nodesById.value.get(edge.target)
+
+    if (!sourceNode) errors.push('source node not found')
+    if (!targetNode) errors.push('target node not found')
+    if (!sourceNode || !targetNode) return { ok: false, errors }
+
+    if (!hasOutputField(sourceNode, edge.sourceField))
+      errors.push('source handle is not an output field')
+    if (!hasInputField(targetNode, edge.targetField))
+      errors.push('target handle is not an input field')
+
+    // phase / implicit rules
+    if (sourceNode.phase === 'response' && targetNode.phase === 'request')
+      errors.push('cannot connect from response phase to request phase')
+    if (targetNode.name === 'request') errors.push('cannot target "request"')
+    if (sourceNode.name === 'response')
+      errors.push('cannot source from "response"')
+    if (sourceNode.phase === 'response' && targetNode.phase !== 'response')
+      errors.push('response-phase output must go to response-phase nodes')
+
+    // fan-in rules
+    const hasWholeOnTarget = edges.value.some(
+      (e) => e.target === edge.target && !e.targetField,
+    )
+    const hasFieldOnTarget = edges.value.some(
+      (e) => e.target === edge.target && !!e.targetField,
+    )
+    if (
+      (hasWholeOnTarget && edge.targetField) ||
+      (hasFieldOnTarget && !edge.targetField)
+    )
+      errors.push(
+        'cannot mix whole-node and field-level inputs on same target',
+      )
+
+    if (
+      edge.sourceField &&
+      edges.value.some(
+        (e) => e.source === edge.source && e.sourceField === edge.sourceField,
+      )
+    )
+      errors.push('source field already connected')
+    if (
+      edge.targetField &&
+      edges.value.some(
+        (e) => e.target === edge.target && e.targetField === edge.targetField,
+      )
+    )
+      errors.push('target field already connected')
+    if (
+      !edge.targetField &&
+      edges.value.some((e) => e.target === edge.target && !e.targetField)
+    )
+      errors.push('target input already taken')
+
+    if (edge.source === edge.target) errors.push('self-loop not allowed')
+
+    if (hasCycle(buildAdjacency({ source: edge.source, target: edge.target })))
+      errors.push('connection introduces a cycle')
+
+    return errors.length ? { ok: false, errors } : { ok: true }
+  }
+
+  /* ---------- graph-level validation ---------- */
+
+  function validateGraph(): ValidationResult {
+    const errors: string[] = []
+    const implicit = [
+      'request',
+      'service_request',
+      'service_response',
+      'response',
+    ]
+    for (const n of implicit)
+      if (![...nodesById.value.values()].some((node) => node.name === n))
+        errors.push(`missing implicit node "${n}"`)
+
+    for (const e of edges.value) {
+      const s = nodesById.value.get(e.source)!
+      const t = nodesById.value.get(e.target)!
+      if (s.phase === 'response' && t.phase === 'request')
+        errors.push(`edge "${e.id}" crosses phases (response → request)`)
+      if (t.name === 'request') errors.push(`edge "${e.id}" targets "request"`)
+      if (s.name === 'response')
+        errors.push(`edge "${e.id}" sources from "response"`)
+      if (s.phase === 'response' && t.phase !== 'response')
+        errors.push(`edge "${e.id}" violates response-phase rule`)
+    }
+
+    if (hasCycle(buildAdjacency())) errors.push('graph contains cycle')
+    return errors.length ? { ok: false, errors } : { ok: true }
+  }
+
+  /* ---------- UI helpers ---------- */
+
+  function isValidConnection(edge: EdgeData): boolean {
+    return validateConnection(edge).ok
+  }
+
+  function isValidVueFlowConnection(conn: {
+    source?: string | null
+    sourceHandle?: string | null
+    target?: string | null
+    targetHandle?: string | null
+  }) {
+    if (!conn.source || !conn.target) return false
+    return isValidConnection({
+      source: conn.source as NodeId,
+      sourceField: conn.sourceHandle as FieldId | undefined,
+      target: conn.target as NodeId,
+      targetField: conn.targetHandle as FieldId | undefined,
+    })
+  }
+
+  return {
+    canonicalizeConnection,
+    validateConnection,
+    validateGraph,
+    isValidConnection,
+    isValidVueFlowConnection,
+  }
+}


### PR DESCRIPTION
# Summary

[KM-1518](https://konghq.atlassian.net/browse/KM-1518)

### Add global editor store for Datakit

- Type updates: `UserNode` → `ConfigNode`, `NodeData` → `NodeInstance`
- Added edge-related types and state
- Provide global store via `provideEditorState` / `useEditorState`
- Expose core state: `nodes`, `edges`, lookup maps
- Support node/field/edge operations
- Undo/redo with tagged history
- Built-in validation: structure, cycles, phase rules
- VueFlow adapters and connection validation

[KM-1518]: https://konghq.atlassian.net/browse/KM-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ