### PR TITLE
feat(query-bridge): allow passing axios config [khcp-17216]

### DIFF
--- a/packages/analytics/analytics-utilities/package.json
+++ b/packages/analytics/analytics-utilities/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.17.4",
+    "axios": "^1.7.7",
     "json-schema-to-ts": "^3.1.1",
     "vue": "^3.5.13"
   }

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -1,3 +1,4 @@
+import type { AxiosRequestConfig } from 'axios'
 import type { BasicExploreQuery, ExploreQuery, AiExploreQuery, ExploreResultV4 } from './explore'
 import type { AnalyticsConfigV2 } from './analytics-config'
 import type { Component } from 'vue'
@@ -21,7 +22,7 @@ export type DatasourceAwareQuery = BasicDatasourceQuery | AdvancedDatasourceQuer
 
 export interface AnalyticsBridge {
   // Issue queries to the KAnalytics API
-  queryFn: (query: DatasourceAwareQuery, abortController: AbortController) => Promise<ExploreResultV4>
+  queryFn: (query: DatasourceAwareQuery, abortController: AbortController, config?: AxiosRequestConfig<any>) => Promise<ExploreResultV4>
 
   // Determine the current org's analytics config
   configFn: () => Promise<AnalyticsConfigV2>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       '@kong/design-tokens':
         specifier: 1.17.4
         version: 1.17.4
+      axios:
+        specifier: ^1.7.7
+        version: 1.7.7
       json-schema-to-ts:
         specifier: ^3.1.1
         version: 3.1.1


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
Modify analytics bridge to allow passing axios config options into `queryFn`. The docker extension uses headers on all axios requests for authentication, without the ability to pass `headers` in, the `axios.post()` in `queryFn` will always fail with a `401`. Part of [KHCP-17216](https://konghq.atlassian.net/browse/KHCP-17216).
