### PR TITLE
fix(entities-plugins): datakit - editorstate->editorstore, fix node type

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
@@ -19,7 +19,7 @@
     <div class="body">
       <VueFlow
         class="flow"
-        :nodes="nodes"
+        :nodes="requestNodes"
         @click="emit('click:backdrop')"
         @nodes-initialized="fitView"
       >
@@ -41,15 +41,17 @@ import { ExternalLinkIcon } from '@kong/icons'
 import { KButton } from '@kong/kongponents'
 import { Background } from '@vue-flow/background'
 import { Controls } from '@vue-flow/controls'
-import { useVueFlow, VueFlow, type Node } from '@vue-flow/core'
-import { ref } from 'vue'
+import { useVueFlow, VueFlow } from '@vue-flow/core'
 import english from '../../../../../locales/en.json'
-import type { NodeInstance } from '../../types'
 import FlowNode from '../node/FlowNode.vue'
+import { useEditorStore } from '../store/store'
+
 
 import '@vue-flow/controls/dist/style.css'
 import '@vue-flow/core/dist/style.css'
 import '@vue-flow/core/dist/theme-default.css'
+
+import type { NodeInstance } from '../../types'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
@@ -62,7 +64,13 @@ const emit = defineEmits<{
   'click:backdrop': []
 }>()
 
-const nodes = ref<Array<Node<NodeInstance>>>([])
+const editorState = useEditorStore()
+
+if (!editorState) {
+  throw new Error('Editor state is not provided. Ensure you are using provideEditorStore in a parent component.')
+}
+
+const { requestNodes } = editorState
 
 const { fitView, onNodeClick } = useVueFlow()
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -62,18 +62,18 @@
 
           <template v-if="inputHandlesExpanded">
             <div
-              v-for="(fieldName, i) in data.fields.input"
-              :key="`input-${fieldName}`"
+              v-for="(field, i) in data.fields.input"
+              :key="`input-${field.id}`"
               class="handle indented"
             >
               <Handle
-                :id="`input-${fieldName}`"
+                :id="`input-${field.id}`"
                 :position="inputPosition"
                 type="target"
               />
               <div class="handle-label-wrapper">
                 <div class="handle-label">
-                  {{ fieldName }}
+                  {{ field.name }}
                 </div>
                 <HandleTwig
                   :color="handleTwigColor"
@@ -120,13 +120,13 @@
 
           <template v-if="outputHandlesExpanded">
             <div
-              v-for="(fieldName, i) in data.fields.output"
-              :key="`output-${fieldName}`"
+              v-for="(field, i) in data.fields.output"
+              :key="`output-${field.id}`"
               class="handle indented"
             >
               <div class="handle-label-wrapper">
                 <div class="handle-label">
-                  {{ fieldName }}
+                  {{ field.name }}
                 </div>
                 <HandleTwig
                   :color="handleTwigColor"
@@ -135,7 +135,7 @@
                 />
               </div>
               <Handle
-                :id="`output-${fieldName}`"
+                :id="`output-${field.id}`"
                 :position="outputPosition"
                 type="source"
               />

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -26,7 +26,7 @@ import { initEditorState, makeNodeInstance } from './init'
 import { useValidators } from './validation'
 import { useTaggedHistory } from './history'
 
-export const [provideEditorState, useEditorState] = createInjectionState(
+export const [provideEditorStore, useEditorStore] = createInjectionState(
   function createState(configNodes: ConfigNode[], uiNodes: UINode[]) {
     const state = ref<EditorState>(initEditorState(configNodes, uiNodes))
     const selection = ref<NodeId>()
@@ -432,7 +432,7 @@ export const [provideEditorState, useEditorState] = createInjectionState(
         .filter((node) => node.phase === 'request')
         .map((node) => ({
           id: node.id,
-          type: node.type,
+          type: 'flow',
           position: node.position,
           data: node,
         })),
@@ -456,7 +456,7 @@ export const [provideEditorState, useEditorState] = createInjectionState(
         .filter((node) => node.phase === 'response')
         .map((node) => ({
           id: node.id,
-          type: node.type,
+          type: 'flow',
           position: node.position,
           data: node,
         })),


### PR DESCRIPTION
# Summary

[KM-1518](https://konghq.atlassian.net/browse/KM-1518)

- `editorState` -> `editorStore` as it includes things other than states
- Fix fields display as they are now objects
- The node `type` for VueFlow should be fixed as `flow`.

Maybe we should probably move the VueFlow adaptors into a separate composable in the future (or define that inline into the flow editor component). /cc @sumimakito