### PR TITLE
feat(dashboards): disable zoom if event handler not present [MA-4159]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -15,7 +15,7 @@
         legend-position="bottom"
         :show-menu="context.editable"
         :synthetics-data-key="chartOptions.synthetics_data_key"
-        :timeseries-zoom="hasFinegrainedAbsoluteTimerangeAccess && !query.time_range"
+        :timeseries-zoom="timeseriesZoom"
         tooltip-title=""
         v-bind="extraProps"
         @zoom-time-range="emit('zoom-time-range', $event)"
@@ -58,6 +58,8 @@ const options = computed((): AnalyticsChartOptions => ({
   chartDatasetColors: props.chartOptions.chart_dataset_colors,
   threshold: props.chartOptions.threshold,
 }))
+
+const timeseriesZoom = computed(() => hasFinegrainedAbsoluteTimerangeAccess && props.context.zoomable && !props.query.time_range)
 
 const editTile = () => {
   emit('edit-tile')

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -42,15 +42,23 @@
 
 <script setup lang="ts">
 import type { DashboardRendererContext, DashboardRendererContextInternal, GridTile } from '../types'
-import type { AbsoluteTimeRangeV4, DashboardConfig, TileConfig, SlottableOptions, TileDefinition, AllFilters } from '@kong-ui-public/analytics-utilities'
+import type {
+  AbsoluteTimeRangeV4,
+  AllFilters,
+  AnalyticsBridge,
+  DashboardConfig,
+  SlottableOptions,
+  TileConfig,
+  TileDefinition,
+  TimeRangeV4,
+} from '@kong-ui-public/analytics-utilities'
 import DashboardTile from './DashboardTile.vue'
-import { computed, inject, ref } from 'vue'
 import type { ComponentPublicInstance } from 'vue'
+import { computed, getCurrentInstance, inject, ref } from 'vue'
 import composables from '../composables'
 import GridLayout from './layout/GridLayout.vue'
-import DraggableGridLayout from './layout/DraggableGridLayout.vue'
 import type { DraggableGridLayoutExpose } from './layout/DraggableGridLayout.vue'
-import type { AnalyticsBridge, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
+import DraggableGridLayout from './layout/DraggableGridLayout.vue'
 import {
   DEFAULT_TILE_HEIGHT,
   DEFAULT_TILE_REFRESH_INTERVAL_MS,
@@ -185,12 +193,17 @@ const mergedContext = computed<DashboardRendererContextInternal>(() => {
     editable = false
   }
 
+  // Check if the host app has provided an event handler for zooming.
+  // If there's no handler, disable zooming -- it won't do anything.
+  const zoomable = !!getCurrentInstance()?.vnode?.props?.onZoomTimeRange
+
   return {
     filters,
     tz,
     timeSpec: timeSpec.value,
     refreshInterval,
     editable,
+    zoomable,
   }
 })
 

--- a/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
@@ -13,7 +13,9 @@ export interface DashboardRendererContext {
 }
 
 // The DashboardRenderer component fills in optional values before passing them down to the tile renderers.
-export type DashboardRendererContextInternal = Required<DashboardRendererContext>
+export interface DashboardRendererContextInternal extends Required<DashboardRendererContext> {
+  zoomable: boolean
+}
 
 export interface RendererProps<T> {
   query: ValidDashboardQuery


### PR DESCRIPTION
Dashboards aren't in charge of the time period they're querying, so unless the host app provides a zoom event handler, there's no point in allowing zoom.

# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
