### PR TITLE
feat(entities-plugins): datakit auto-layout and store improvements

### DIFF
--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -37,6 +37,7 @@
     "vue-router": "catalog:"
   },
   "devDependencies": {
+    "@dagrejs/dagre": "^1.1.5",
     "@kong-ui-public/entities-plugins-icon": "workspace:^",
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/entities-vaults": "workspace:^",

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
@@ -12,12 +12,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
 import { createI18n } from '@kong-ui-public/i18n'
+import { ref } from 'vue'
 import english from '../../../../locales/en.json'
-import EditorModal from './modal/EditorModal.vue'
 import { provideEditorStore } from '../composables'
-import { MockData } from './node/mock'
+import type { ConfigNodeName, FieldName, NameConnection } from '../types'
+import EditorModal from './modal/EditorModal.vue'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
@@ -29,5 +29,47 @@ defineProps<{
 const modalOpen = ref(false)
 
 // todo(zehao): mock data, remove later
-provideEditorStore(MockData.configNodes, MockData.uiNodes)
+// provideEditorStore(MockData.configNodes, MockData.uiNodes)
+
+provideEditorStore([
+  {
+    name: 'CAT_FACT' as ConfigNodeName ,
+    type: 'call',
+    url: 'https://catfact.ninja/fact',
+    input: 'request.body' as NameConnection,
+  },
+  {
+    name: 'DOG_FACT' as ConfigNodeName,
+    type: 'call',
+    url: 'https://dogapi.dog/api/v1/facts',
+  },
+  {
+    name: 'JOIN' as ConfigNodeName,
+    type: 'jq',
+    inputs: {
+      cat: 'CAT_FACT.body',
+      dog: 'DOG_FACT.body',
+    } as Record<FieldName, NameConnection>,
+    jq: '{\n  cat_fact: .cat.fact,\n  dog_fact: .dog.facts[0],\n}\n',
+  },
+  {
+    name: 'EXIT' as ConfigNodeName,
+    type: 'exit',
+    inputs: {
+      body: 'JOIN',
+    } as Record<FieldName, NameConnection>,
+    status: 200,
+  },
+  {
+    name: 'DANGLING_CALL' as ConfigNodeName,
+    type: 'call',
+    url: 'https://dogapi.dog/api/v1/facts',
+  },
+  {
+    name: 'READ_UPSTREAM' as ConfigNodeName,
+    type: 'jq',
+    input: 'service_response',
+    jq: '.',
+  },
+], [])
 </script>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
@@ -1,8 +1,12 @@
 import type { Node as DagreNode } from '@dagrejs/dagre'
+
+import type { EdgeData, EdgeInstance, NodeInstance, NodePhase } from '../../types'
+
 import dagre from '@dagrejs/dagre'
 import { MarkerType, useVueFlow, type Edge, type Node } from '@vue-flow/core'
 import { computed, nextTick, toRaw } from 'vue'
-import type { EdgeData, EdgeInstance, NodeInstance, NodePhase } from '../../types'
+
+import { AUTO_LAYOUT_DEFAULT_OPTIONS } from '../constants'
 import { useEditorStore } from '../store/store'
 
 export interface AutoLayoutOptions {
@@ -79,11 +83,12 @@ export default function useFlow(phase: NodePhase, flowId?: string) {
   function autoLayout(options: AutoLayoutOptions) {
     const {
       boundingRect,
-      padding = 80,
-      nodeGap = 80,
-      edgeGap = 80,
-      rankGap = 80,
+      padding = AUTO_LAYOUT_DEFAULT_OPTIONS.padding,
+      nodeGap = AUTO_LAYOUT_DEFAULT_OPTIONS.nodeGap,
+      edgeGap = AUTO_LAYOUT_DEFAULT_OPTIONS.edgeGap,
+      rankGap = AUTO_LAYOUT_DEFAULT_OPTIONS.rankGap,
     } = options
+
     let leftNode: Node<NodeInstance> | undefined
     let rightNode: Node<NodeInstance> | undefined
     const configNodes: Array<Node<NodeInstance>> = []

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
@@ -1,0 +1,273 @@
+import type { Node as DagreNode } from '@dagrejs/dagre'
+import dagre from '@dagrejs/dagre'
+import { MarkerType, useVueFlow, type Edge, type Node } from '@vue-flow/core'
+import { computed, nextTick, toRaw } from 'vue'
+import type { EdgeData, EdgeInstance, NodeInstance, NodePhase } from '../../types'
+import { useEditorStore } from '../store/store'
+
+export interface AutoLayoutOptions {
+  boundingRect: DOMRect
+  padding?: number
+  nodeGap?: number
+  edgeGap?: number
+  rankGap?: number
+}
+
+export default function useFlow(phase: NodePhase, flowId?: string) {
+  const vueFlowStore = useVueFlow({ id: flowId })
+  const editorStore = useEditorStore()
+
+  const { findNode, fitView, onNodeClick, onEdgeClick } = vueFlowStore
+  const { state, moveNode, getNodeById } = editorStore
+
+  // TODO(Makito): Remove these in the future
+  onNodeClick(({ node }) => {
+    console.debug('[useFlow] onNodeClick', toRaw(node))
+  })
+
+  // TODO(Makito): Remove these in the future
+  onEdgeClick(({ edge }) => {
+    console.debug('[useFlow] onEdgeClick', toRaw(edge))
+  })
+
+  function edgeInPhase(edge: EdgeInstance, phase: NodePhase) {
+    const sourceNode = getNodeById(edge.source)
+    const targetNode = getNodeById(edge.target)
+    return !!(
+      sourceNode &&
+        targetNode &&
+        sourceNode.phase === phase &&
+        targetNode.phase === phase
+    )
+  }
+
+  const nodes = computed(() =>
+    state.value.nodes
+      .filter((node) => node.phase === phase)
+      .map<Node<NodeInstance>>((node) => ({
+        id: node.id,
+        type: 'flow',
+        position: node.position,
+        data: node,
+      })),
+  )
+
+  const edges = computed(() =>
+    state.value.edges
+      .filter((edge) => edgeInPhase(edge, phase))
+      .map<Edge<EdgeData>>((edge) => {
+        const sourceNode = getNodeById(edge.source)
+        const targetNode = getNodeById(edge.target)
+        if (!sourceNode) {
+          throw new Error(`Missing source node "${edge.source}" for edge "${edge.id}" in phase "${phase}"`)
+        } else if (!targetNode) {
+          throw new Error(`Missing target node "${edge.target}" for edge "${edge.id}" in phase "${phase}"`)
+        }
+
+        return {
+          id: edge.id,
+          source: edge.source,
+          target: edge.target,
+          sourceHandle: edge.sourceField ? `outputs:${edge.sourceField}` : 'output',
+          targetHandle: edge.targetField ? `inputs:${edge.targetField}` : 'input',
+          markerEnd: MarkerType.ArrowClosed,
+          data: edge,
+        }
+      }),
+  )
+
+  function autoLayout(options: AutoLayoutOptions) {
+    const {
+      boundingRect,
+      padding = 80,
+      nodeGap = 80,
+      edgeGap = 80,
+      rankGap = 80,
+    } = options
+    let leftNode: Node<NodeInstance> | undefined
+    let rightNode: Node<NodeInstance> | undefined
+    const configNodes: Array<Node<NodeInstance>> = []
+
+    /**
+     * Check for implicit nodes in the current phase. If the node is an implicit node,
+     * it will be assigned to either leftNode or rightNode based on its type.
+     *
+     * @param node Node to check
+     * @return Whether the node is an implicit node or not
+     */
+    const checkImplicitNode = (node: Node<NodeInstance>): boolean => {
+      switch (node.data!.name) {
+        case 'request': {
+          if (phase !== 'request') {
+            throw new Error(`Unexpected request node in ${phase} phase`)
+          }
+          if (leftNode) {
+            throw new Error('Duplicated request node in request phase')
+          }
+          leftNode = node
+          return true
+        }
+        case 'service_request': {
+          if (phase !== 'request') {
+            throw new Error(`Unexpected service_request node in ${phase} phase`)
+          }
+          if (rightNode) {
+            throw new Error('Duplicated service_request node in request phase')
+          }
+          rightNode = node
+          return true
+        }
+        case 'service_response': {
+          if (phase !== 'response') {
+            throw new Error(`Unexpected service_response node in ${phase} phase`)
+          }
+          if (rightNode) {
+            throw new Error('Duplicated service_response node in response phase')
+          }
+          rightNode = node
+          return true
+        }
+        case 'response': {
+          if (phase !== 'response') {
+            throw new Error(`Unexpected response node in ${phase} phase`)
+          }
+          if (leftNode) {
+            throw new Error('Duplicated response node in response phase')
+          }
+          leftNode = node
+          return true
+        }
+        default: {
+          configNodes.push(node)
+          return false
+        }
+      }
+    }
+
+    const dagreGraph = new dagre.graphlib.Graph({ multigraph: true })
+    dagreGraph.setGraph({
+      rankdir: phase === 'request' ? 'LR' : 'RL',
+      nodesep: nodeGap,
+      edgesep: edgeGap,
+      ranksep: rankGap,
+    })
+
+    for (const node of nodes.value) {
+      if (checkImplicitNode(node)) {
+        // Skip auto-layout by Dagre for implicit nodes
+        continue
+      }
+
+      // Only run for config nodes
+      const graphNode = findNode(node.id)
+      if (!graphNode) {
+        throw new Error(`Node ${node.id} is missing from the graph in ${phase} phase`)
+      }
+
+      dagreGraph.setNode(node.id, {
+        width: graphNode.dimensions.width,
+        height: graphNode.dimensions.height,
+      })
+    }
+
+    if (!leftNode || !rightNode) {
+      throw new Error(`One or more implicit nodes are missing from ${phase} phase`)
+    }
+
+    const leftGraphNode = findNode(leftNode.id)
+    const rightGraphNode = findNode(rightNode.id)
+    if (!leftGraphNode || !rightGraphNode) {
+      throw new Error(`One or more implicit nodes are missing from the graph in ${phase} phase`)
+    }
+
+    if (configNodes.length === 0) {
+      const centerY = boundingRect.height / 2
+
+      moveNode(leftNode.data!.id, {
+        x: padding,
+        y: centerY - leftGraphNode.dimensions.height / 2,
+      })
+
+      moveNode(rightNode.data!.id, {
+        x: boundingRect.width - padding - rightGraphNode.dimensions.width,
+        y: centerY - rightGraphNode.dimensions.height / 2,
+      })
+
+      // No need to call dagre.layout()
+    } else {
+      const implicitIds = new Set([leftNode.id, rightNode.id])
+      for (const edge of edges.value) {
+        if (!implicitIds.has(edge.source) && !implicitIds.has(edge.target)) {
+          dagreGraph.setEdge(edge.source, edge.target, { points: [] })
+        }
+      }
+
+      // Layout
+      dagre.layout(dagreGraph)
+
+      const configBoundingRect = {
+        x1: Number.POSITIVE_INFINITY,
+        y1: Number.POSITIVE_INFINITY,
+        x2: Number.NEGATIVE_INFINITY,
+        y2: Number.NEGATIVE_INFINITY,
+      }
+      const updateConfigBoundingRect = (node: { x: number, y: number, width: number, height: number }) => {
+        configBoundingRect.x1 = Math.min(configBoundingRect.x1, node.x)
+        configBoundingRect.y1 = Math.min(configBoundingRect.y1, node.y)
+        configBoundingRect.x2 = Math.max(configBoundingRect.x2, node.x + node.width)
+        configBoundingRect.y2 = Math.max(configBoundingRect.y2, node.y + node.height)
+      }
+
+      // Positions returned by Dagre are centered
+      const normalizePosition = (node: DagreNode) => {
+        return {
+          x: node.x - node.width / 2,
+          y: node.y - node.height / 2,
+          width: node.width,
+          height: node.height,
+        }
+      }
+
+      for (const node of configNodes) {
+        const dagreNode = dagreGraph.node(node.id)
+        const normalizedPosition = normalizePosition(dagreNode)
+        updateConfigBoundingRect(normalizedPosition)
+        moveNode(node.data!.id, { x: normalizedPosition.x, y: normalizedPosition.y })
+      }
+
+      const leftGraphNode = findNode(leftNode.id)
+      const rightGraphNode = findNode(rightNode.id)
+      if (!leftGraphNode || !rightGraphNode) {
+        throw new Error(`One or more implicit nodes are missing from the graph in ${phase} phase`)
+      }
+
+      // TODO(Makito): Better positioning for implicit nodes
+
+      const centerY = configBoundingRect.y1 + (configBoundingRect.y2 - configBoundingRect.y1) / 2
+
+      moveNode(leftNode.data!.id, {
+        x: configBoundingRect.x1 - (leftGraphNode.dimensions.width + nodeGap),
+        y: centerY - leftGraphNode.dimensions.height / 2,
+      })
+
+      moveNode(rightNode.data!.id, {
+        x: configBoundingRect.x2 + nodeGap,
+        y: centerY - rightGraphNode.dimensions.height / 2,
+      })
+    }
+
+    nextTick(() => {
+      fitView()
+    })
+  }
+
+  return {
+    vueFlowStore,
+    editorStore,
+
+    nodes,
+    edges,
+
+    autoLayout,
+  }
+}

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/constants.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/constants.ts
@@ -1,0 +1,8 @@
+import type { AutoLayoutOptions } from './composables/useFlow'
+
+export const AUTO_LAYOUT_DEFAULT_OPTIONS = {
+  padding: 80,
+  nodeGap: 80,
+  edgeGap: 80,
+  rankGap: 80,
+} as const satisfies Pick<AutoLayoutOptions, 'padding' | 'nodeGap' | 'edgeGap' | 'rankGap'>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
@@ -4,7 +4,7 @@
     class="flow-wrapper"
   >
     <VueFlow
-      :id="phase"
+      :id="flowId"
       class="flow"
       :edges="edges"
       fit-view-on-init
@@ -15,7 +15,7 @@
       @node-click="onNodeClick"
       @node-drag-stop="onNodeDragStop"
       @nodes-change="onNodesChange"
-      @nodes-initialized="handleAutoLayout"
+      @nodes-initialized="onNodesInitializes"
     >
       <Background />
       <Controls position="bottom-left">
@@ -42,9 +42,9 @@ import { SparklesIcon } from '@kong/icons'
 import { Background } from '@vue-flow/background'
 import { Controls } from '@vue-flow/controls'
 import { VueFlow, type NodeChange, type NodeMouseEvent } from '@vue-flow/core'
-import { useId, useTemplateRef } from 'vue'
-import { DK_DATA_TRANSFER_MIME_TYPE } from '../../constants'
+import { ref, useId, useTemplateRef } from 'vue'
 
+import { DK_DATA_TRANSFER_MIME_TYPE } from '../../constants'
 import useFlow from '../composables/useFlow'
 import FlowNode from '../node/FlowNode.vue'
 
@@ -57,6 +57,7 @@ const props = defineProps<{
 }>()
 
 const flowWrapper = useTemplateRef('flow-wrapper')
+const initialLayoutTriggered = ref(false)
 
 const uniqueId = useId()
 const flowId = `${uniqueId}-${props.phase}`
@@ -114,6 +115,15 @@ function onMaybeBackdropClick(event: MouseEvent) {
     }
   }
   emit('click:backdrop')
+}
+
+function onNodesInitializes() {
+  if (!initialLayoutTriggered.value) {
+    initialLayoutTriggered.value = true
+    handleAutoLayout()
+  }
+
+  // Reserved for future steps
 }
 
 function handleAutoLayout() {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
@@ -174,18 +174,23 @@ const onNodesChange = (changes: NodeChange[]) => {
       }
     }
 
-    // TODO(Makito): Make markers have the same color as paths
-    // :deep(.vue-flow__edge) {
-    //   &:hover .vue-flow__edge-path {
-    //     marker: $kui-color-border-primary-weak;
-    //     stroke: $kui-color-border-primary-weak;
-    //   }
 
-    //   &.selected .vue-flow__edge-path {
-    //     marker: $kui-color-border-primary;
-    //     stroke: $kui-color-border-primary;
-    //   }
-    // }
+    :deep(.vue-flow__edge) {
+      .vue-flow__edge-path {
+        stroke-dasharray: 5;
+      }
+
+      // TODO(Makito): Make markers have the same color as paths
+      // &:hover .vue-flow__edge-path {
+      //   marker: $kui-color-border-primary-weak;
+      //   stroke: $kui-color-border-primary-weak;
+      // }
+
+      // &.selected .vue-flow__edge-path {
+      //   marker: $kui-color-border-primary;
+      //   stroke: $kui-color-border-primary;
+      // }
+    }
   }
 }
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
@@ -15,7 +15,7 @@
       @node-click="onNodeClick"
       @node-drag-stop="onNodeDragStop"
       @nodes-change="onNodesChange"
-      @nodes-initialized="onNodeInitialized"
+      @nodes-initialized="handleAutoLayout"
     >
       <Background />
       <Controls position="bottom-left">
@@ -114,12 +114,6 @@ function onMaybeBackdropClick(event: MouseEvent) {
     }
   }
   emit('click:backdrop')
-}
-
-function onNodeInitialized() {
-  autoLayout({
-    boundingRect: flowWrapper.value!.getBoundingClientRect(),
-  })
 }
 
 function handleAutoLayout() {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
@@ -1,0 +1,192 @@
+<template>
+  <div
+    ref="flow-wrapper"
+    class="flow-wrapper"
+  >
+    <VueFlow
+      :id="phase"
+      class="flow"
+      :edges="edges"
+      fit-view-on-init
+      :nodes="nodes"
+      @click.capture="onMaybeBackdropClick"
+      @dragover.prevent
+      @drop="(e: DragEvent) => onDrop(e)"
+      @node-click="onNodeClick"
+      @node-drag-stop="onNodeDragStop"
+      @nodes-change="onNodesChange"
+      @nodes-initialized="onNodeInitialized"
+    >
+      <Background />
+      <Controls position="bottom-left">
+        <button
+          class="vue-flow__controls-button vue-flow__controls-interactive custom"
+          @click="handleAutoLayout"
+        >
+          <SparklesIcon :size="18" /> <!-- TODO: Replace with a better icon for "auto layout" -->
+        </button>
+      </Controls>
+
+      <!-- To not use the default node style -->
+      <template #node-flow="node">
+        <FlowNode :data="node.data" />
+      </template>
+    </VueFlow>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { DragPayload, NodeId, NodeInstance, NodePhase } from '../../types'
+
+import { SparklesIcon } from '@kong/icons'
+import { Background } from '@vue-flow/background'
+import { Controls } from '@vue-flow/controls'
+import { VueFlow, type NodeChange, type NodeMouseEvent } from '@vue-flow/core'
+import { useId, useTemplateRef } from 'vue'
+import { DK_DATA_TRANSFER_MIME_TYPE } from '../../constants'
+
+import useFlow from '../composables/useFlow'
+import FlowNode from '../node/FlowNode.vue'
+
+import '@vue-flow/controls/dist/style.css'
+import '@vue-flow/core/dist/style.css'
+import '@vue-flow/core/dist/theme-default.css'
+
+const props = defineProps<{
+  phase: NodePhase
+}>()
+
+const flowWrapper = useTemplateRef('flow-wrapper')
+
+const uniqueId = useId()
+const flowId = `${uniqueId}-${props.phase}`
+
+const { vueFlowStore, editorStore, nodes, edges, autoLayout } = useFlow(props.phase, flowId)
+const { addNode, moveNode, removeNode } = editorStore
+const { project, vueFlowRef } = vueFlowStore
+
+const emit = defineEmits<{
+  'click:node': [node: NodeInstance]
+  'click:backdrop': []
+}>()
+
+const onDrop = (e: DragEvent) => {
+  const data = e.dataTransfer?.getData(DK_DATA_TRANSFER_MIME_TYPE)
+  if (!data) return
+
+  e.preventDefault()
+
+  const payload = JSON.parse(data) as DragPayload
+  if (payload.action !== 'create-node') return
+
+  // VueFlow has a bug where it fails to take the top/left offset of the flow canvas into account
+  // when projecting the coordinates from mouse event to viewport coordinates.
+  const { top = 0, left = 0 } = vueFlowRef.value?.getBoundingClientRect() || {}
+
+  const projected = project({
+    x: e.clientX - left,
+    y: e.clientY - top,
+  })
+
+  const { type, anchor } = payload.data
+  const newNode = {
+    type,
+    phase: props.phase,
+    position: {
+      x: projected.x - anchor.offsetX,
+      y: projected.y - anchor.offsetY,
+    },
+  }
+
+  addNode(newNode)
+}
+
+function onNodeClick({ event, node }: NodeMouseEvent) {
+  event.stopPropagation()
+  emit('click:node', node.data)
+}
+
+function onMaybeBackdropClick(event: MouseEvent) {
+  if (event.target instanceof Element) {
+    // Ignore clicks on controls
+    if (event.target.closest('.vue-flow__controls')) {
+      return
+    }
+  }
+  emit('click:backdrop')
+}
+
+function onNodeInitialized() {
+  autoLayout({
+    boundingRect: flowWrapper.value!.getBoundingClientRect(),
+  })
+}
+
+function handleAutoLayout() {
+  autoLayout({
+    boundingRect: flowWrapper.value!.getBoundingClientRect(),
+  })
+}
+
+const onNodeDragStop = (event: NodeMouseEvent) => {
+  const { node } = event
+  if (!node) return
+
+  // Update the node position in the store
+  moveNode(node.id as NodeId, node.position)
+}
+
+const onNodesChange = (changes: NodeChange[]) => {
+  changes.forEach((change) => {
+    if (change.type === 'remove') {
+      removeNode(change.id as NodeId)
+    }
+  })
+}
+</script>
+
+<style lang="scss" scoped>
+.flow-wrapper {
+  height: 100%;
+  width: 100%;
+
+  .flow {
+    :deep(.vue-flow__controls-button) {
+      // Ensure it works in both the sandbox and host apps
+      box-sizing: content-box;
+
+      // TODO(Makito): Maybe remove this as soon as we find a better icon
+      &.custom {
+        svg {
+          max-height: unset;
+          max-width: unset;
+        }
+      }
+    }
+
+    :deep(.vue-flow__node) {
+      &:hover .flow-node {
+        border-color: $kui-color-border-primary-weak;
+      }
+
+      &.selected .flow-node {
+        border-color: $kui-color-border-primary;
+      }
+    }
+
+    // TODO(Makito): Make markers have the same color as paths
+    // :deep(.vue-flow__edge) {
+    //   &:hover .vue-flow__edge-path {
+    //     marker: $kui-color-border-primary-weak;
+    //     stroke: $kui-color-border-primary-weak;
+    //   }
+
+    //   &.selected .vue-flow__edge-path {
+    //     marker: $kui-color-border-primary;
+    //     stroke: $kui-color-border-primary;
+    //   }
+    // }
+  }
+}
+
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
@@ -1,16 +1,17 @@
 import type {
+  ConfigEdge,
   ConfigNode,
-  EditorState,
   EdgeInstance,
+  EditorState,
+  FieldName,
   ImplicitNodeName,
+  MakeNodeInstancePayload,
   NodeInstance,
   NodeName,
   NodeType,
   UINode,
-  FieldName,
-  ConfigEdge,
-  MakeNodeInstancePayload,
 } from '../../types'
+import { isImplicitName } from '../node/node'
 import {
   createId,
   deepClone,
@@ -33,6 +34,38 @@ export function initEditorState(
   const edges: EdgeInstance[] = []
   const nodesMap = new Map<NodeName, NodeInstance>()
   const connections: ConfigEdge[] = []
+  const adjacencies = new Map<NodeName, Set<NodeName>>() // Undirected adjacency list
+
+  /**
+   * [SIDE EFFECT]
+   *
+   * Walk the graph with the undirected adjacency list to find all nodes that are
+   * ultimately connected to the start nodes.
+   *
+   * Time complexity (upper): O(n) (n = nodes + edges)
+   *
+   * @param starts - The starting nodes to begin the search from
+   */
+  const markRequestNodes = (starts: NodeName[]) => {
+    const visited = new Set<NodeName>()
+    const queue = [...starts]
+
+    while (queue.length > 0) {
+      const current = queue.shift()!
+      if (visited.has(current)) continue
+      visited.add(current)
+
+      if (!isImplicitName(current)) {
+        nodesMap.get(current)!.phase = 'request'
+      }
+
+      if (!adjacencies.has(current)) continue
+      for (const next of adjacencies.get(current)!) {
+        if (visited.has(next)) continue
+        queue.push(next)
+      }
+    }
+  }
 
   // config nodes
   for (const configNode of configNodes) {
@@ -73,6 +106,17 @@ export function initEditorState(
         )
       continue
     }
+
+    if (!adjacencies.has(connection.source)) {
+      adjacencies.set(connection.source, new Set())
+    }
+    adjacencies.get(connection.source)!.add(connection.target)
+
+    if (!adjacencies.has(connection.target)) {
+      adjacencies.set(connection.target, new Set())
+    }
+    adjacencies.get(connection.target)!.add(connection.source)
+
     edges.push({
       id: createId('edge'),
       source: sourceNode.id,
@@ -83,6 +127,9 @@ export function initEditorState(
         ?.id,
     })
   }
+
+  // Mark all nodes that should be in 'request' phase
+  markRequestNodes(['request', 'service_request'])
 
   return { nodes, edges }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -55,7 +55,7 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
         const edgeMapById = new Map<EdgeId, EdgeInstance>()
         const edgeIdMapByNodeId = new Map<NodeId, Set<EdgeId>>()
 
-        state.value.edges.map((edge) => {
+        for (const edge of state.value.edges) {
           edgeMapById.set(edge.id, edge)
 
           if (!edgeIdMapByNodeId.has(edge.source)) {
@@ -67,7 +67,7 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
             edgeIdMapByNodeId.set(edge.target, new Set())
           }
           edgeIdMapByNodeId.get(edge.target)!.add(edge.id)
-        })
+        }
 
         return {
           edgeMapById,

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -2,19 +2,18 @@ import { createInjectionState } from '@vueuse/core'
 import { computed, ref } from 'vue'
 import type {
   ConfigNode,
+  CreateNodePayload,
   EdgeData,
   EdgeId,
   EdgeInstance,
   EditorState,
   FieldId,
   FieldName,
+  NameConnection,
   NodeId,
   NodeInstance,
   NodeName,
-  NodePhase,
   UINode,
-  NameConnection,
-  CreateNodePayload,
 } from '../../types'
 import { isImplicitName, isImplicitType } from '../node/node'
 import {
@@ -26,7 +25,6 @@ import {
 import { useTaggedHistory } from './history'
 import { initEditorState, makeNodeInstance } from './init'
 import { useValidators } from './validation'
-import type { Edge, Node } from '@vue-flow/core'
 
 const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
   function createState(configNodes: ConfigNode[], uiNodes: UINode[]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1001,6 +1001,9 @@ importers:
         specifier: 0.52.2
         version: 0.52.2
     devDependencies:
+      '@dagrejs/dagre':
+        specifier: ^1.1.5
+        version: 1.1.5
       '@kong-ui-public/entities-plugins-icon':
         specifier: workspace:^
         version: link:../entities-plugins-icon
@@ -1673,6 +1676,13 @@ packages:
 
   '@cypress/xvfb@1.2.4':
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
+
+  '@dagrejs/dagre@1.1.5':
+    resolution: {integrity: sha512-Ghgrh08s12DCL5SeiR6AoyE80mQELTWhJBRmXfFoqDiFkR458vPEdgTbbjA0T+9ETNxUblnD0QW55tfdvi5pjQ==}
+
+  '@dagrejs/graphlib@2.2.4':
+    resolution: {integrity: sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==}
+    engines: {node: '>17.0.0'}
 
   '@digitalroute/cz-conventional-changelog-for-jira@8.0.1':
     resolution: {integrity: sha512-I7uNQ2R5LnDYVhQ01sfNvaxqe1PutXyDl8Kltj4L8uDa1LTYqQgWWp3yEj3XYDNjhUjsAheHW0lsmF1oiAjWVg==}
@@ -8143,7 +8153,7 @@ packages:
   right-pad@1.0.1:
     resolution: {integrity: sha512-bYBjgxmkvTAfgIYy328fmkwhp39v8lwVgWhhrzxPV3yHtcSqyYKe9/XOhvW48UFjATg3VuJbpsp5822ACNvkmw==}
     engines: {node: '>= 0.10'}
-    deprecated: Use String.prototype.padEnd() instead
+    deprecated: Please use String.prototype.padEnd() over this package.
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
@@ -10309,6 +10319,12 @@ snapshots:
       lodash.once: 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@dagrejs/dagre@1.1.5':
+    dependencies:
+      '@dagrejs/graphlib': 2.2.4
+
+  '@dagrejs/graphlib@2.2.4': {}
 
   '@digitalroute/cz-conventional-changelog-for-jira@8.0.1(@types/node@18.19.64)(typescript@5.6.3)':
     dependencies:


### PR DESCRIPTION
# Summary

* (Initial) Auto-layout with Dagre + Implicit nodes placement
* Move eligible nodes (ultimately connected to `request` or `service_request`) to the request phase on editor init
* Populate VueFlow nodes and edges inside a new composable
* No collapse for handles with field-level connections
* Hovered/Selected state on nodes

|Hovered/Selected|Node-level I/O handle vs. Field-level I/O handle|
|:-:|:-:|
|![Kapture 2025-08-05 at 17 54 41](https://github.com/user-attachments/assets/9d042d07-9405-483a-8517-ae33e5b0fe59)|![Kapture 2025-08-05 at 17 58 31](https://github.com/user-attachments/assets/12eafee4-c79e-4c87-858d-4a3ea653bc4c)|

<img width="4012" height="2656" alt="localhost_5173_plugin_create_datakit (4)" src="https://github.com/user-attachments/assets/358a4882-1cb1-4290-b5b4-2ea795d1b87b" />

## Known issues

* VueFlow didn't provide built-in dashed edges
* Hovered/Selected states for edges are not implemented, as it takes more effort to change the markers (arrows) on the end of edge paths

## TODOs

* Better auto-layout
* Fields are not showing on JQ nodes
