### PR TITLE
feat(entities-plugins): datakit show valid handles in property nodes and update edges

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/property.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/property.ts
@@ -217,6 +217,13 @@ export function resetPropertyIfHasKey(property?: string | null): string | null {
   return getPropertyWithoutKey(property) + PROPERTY_KEY_PATTERN
 }
 
+export function isReadableProperty(property?: string | null): boolean {
+  if (!property) return false
+  const rawProperty = resetPropertyIfHasKey(property)
+  if (!rawProperty) return false
+  return KONG_CLIENT_SUPPORTED_PROPERTIES[rawProperty]?.readable ?? false
+}
+
 export function isWritableProperty(property?: string | null): boolean {
   if (!property) return false
   const rawProperty = resetPropertyIfHasKey(property)

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -28,7 +28,7 @@
       :class="{ reversed: isReversed }"
     >
       <div class="input-handles">
-        <template v-if="meta.io?.input">
+        <template v-if="showInputHandles">
           <div class="handle">
             <Handle
               id="input"
@@ -96,7 +96,7 @@
       </div>
 
       <div class="output-handles">
-        <template v-if="meta.io?.output">
+        <template v-if="showOutputHandles">
           <div class="handle">
             <div class="handle-label-wrapper">
               <div
@@ -180,9 +180,10 @@ import HandleTwig from './HandleTwig.vue'
 import { isImplicitNode } from './node'
 
 import type { NodeInstance } from '../../types'
+import { isReadableProperty, isWritableProperty } from '../node-forms/property'
+import { getNodeMeta } from '../store/helpers'
 import { useEditorStore } from '../store/store'
 import NodeBadge from './NodeBadge.vue'
-import { getNodeMeta } from '../store/helpers'
 
 const { data } = defineProps<{
   data: NodeInstance
@@ -203,6 +204,26 @@ const outputsNotCollapsible = computed(() =>
 
 const inputsExpanded = computed(() => data.expanded.input ?? false)
 const outputsExpanded = computed(() => data.expanded.output ?? false)
+
+const showInputHandles = computed(() => {
+  if (data.type === 'property') {
+    // TODO: Should have a specific type for config in property nodes
+    const property = data.config?.['property'] as string | undefined
+    return isWritableProperty(property)
+  }
+
+  return meta.value.io?.input
+})
+
+const showOutputHandles = computed(() => {
+  if (data.type === 'property') {
+    // TODO: Should have a specific type for config in property nodes
+    const property = data.config?.['property'] as string | undefined
+    return isReadableProperty(property)
+  }
+
+  return meta.value.io?.output
+})
 
 const isImplicit = computed(() => isImplicitNode(data))
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -355,6 +355,22 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
       if (commitNow) history.commit()
     }
 
+    function disconnectInEdges(nodeId: NodeId, commitNow = true) {
+      const edges = getInEdgesByNodeId(nodeId)
+      for (const edge of edges) {
+        disconnectEdge(edge.id, false)
+      }
+      if (commitNow) history.commit()
+    }
+
+    function disconnectOutEdges(nodeId: NodeId, commitNow = true) {
+      const edges = getOutEdgesByNodeId(nodeId)
+      for (const edge of edges) {
+        disconnectEdge(edge.id, false)
+      }
+      if (commitNow) history.commit()
+    }
+
     /* ---------- serialization ---------- */
 
     function toConfigNodes(): ConfigNode[] {
@@ -492,6 +508,8 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
       connectEdge,
       replaceConnection,
       disconnectEdge,
+      disconnectInEdges,
+      disconnectOutEdges,
 
       // serialization
       toConfigNodes,


### PR DESCRIPTION
# Summary

* Show only valid (readable?/writable?) handles on property nodes
* Add `disconnectInEdges` and `disconnectOutEdges` helpers to disconnect all the in/out-edges associated with a node
* Add a `isReadableProperty` helper for property nodes

https://github.com/user-attachments/assets/f26f36a1-30c8-4930-b3e9-f5e8d57e03f1

KM-1562
