### PR TITLE
feat(entities-plugins): datakit remove nodes and edges upon deletion from canvas

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
@@ -40,7 +40,7 @@ export default function useFlow(phase: NodePhase, flowId?: string) {
     findNode,
     fitView,
     onNodeClick,
-    onNodeDrag,
+    onNodeDragStop,
     onEdgeClick,
     onConnect,
     onNodesChange,
@@ -140,7 +140,7 @@ export default function useFlow(phase: NodePhase, flowId?: string) {
     }
   })
 
-  onNodeDrag(({ node }) => {
+  onNodeDragStop(({ node }) => {
     if (!node) return
 
     // Update the node position in the store

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
@@ -13,8 +13,6 @@
       @dragover.prevent
       @drop="(e: DragEvent) => onDrop(e)"
       @node-click="onNodeClick"
-      @node-drag-stop="onNodeDragStop"
-      @nodes-change="onNodesChange"
       @nodes-initialized="onNodesInitializes"
     >
       <Background />
@@ -36,12 +34,12 @@
 </template>
 
 <script setup lang="ts">
-import type { DragPayload, NodeId, NodeInstance, NodePhase } from '../../types'
+import type { DragPayload, NodeInstance, NodePhase } from '../../types'
 
 import { SparklesIcon } from '@kong/icons'
 import { Background } from '@vue-flow/background'
 import { Controls } from '@vue-flow/controls'
-import { VueFlow, type NodeChange, type NodeMouseEvent } from '@vue-flow/core'
+import { VueFlow, type NodeMouseEvent } from '@vue-flow/core'
 import { ref, useId, useTemplateRef } from 'vue'
 
 import { DK_DATA_TRANSFER_MIME_TYPE } from '../../constants'
@@ -63,7 +61,7 @@ const uniqueId = useId()
 const flowId = `${uniqueId}-${props.phase}`
 
 const { vueFlowStore, editorStore, nodes, edges, autoLayout } = useFlow(props.phase, flowId)
-const { addNode, moveNode, removeNode } = editorStore
+const { addNode } = editorStore
 const { project, vueFlowRef } = vueFlowStore
 
 const emit = defineEmits<{
@@ -129,22 +127,6 @@ function onNodesInitializes() {
 function handleAutoLayout() {
   autoLayout({
     boundingRect: flowWrapper.value!.getBoundingClientRect(),
-  })
-}
-
-const onNodeDragStop = (event: NodeMouseEvent) => {
-  const { node } = event
-  if (!node) return
-
-  // Update the node position in the store
-  moveNode(node.id as NodeId, node.position)
-}
-
-const onNodesChange = (changes: NodeChange[]) => {
-  changes.forEach((change) => {
-    if (change.type === 'remove') {
-      removeNode(change.id as NodeId)
-    }
   })
 }
 </script>


### PR DESCRIPTION
# Summary

* Remove nodes or disconnect edges while deleting nodes or edges from the VueFlow canvas
* Move some listeners from the component to the `useFlow` composable

## TODO

* Move all event listeners (if possible) to the `useFlow` composable
