### PR TITLE
chore(documenation, plugins): clean up l2 empty state flag

### DIFF
--- a/packages/core/documentation/src/components/DocumentationContent.vue
+++ b/packages/core/documentation/src/components/DocumentationContent.vue
@@ -3,7 +3,6 @@
     <div v-if="documentList && !documentList.length">
       <KCard v-if="emptyStateCard">
         <EntityEmptyState
-          v-if="enableV2EmptyStates"
           :action-button-text="t('documentation.show.empty_state_v2.cta')"
           appearance="secondary"
           :can-create="() => canEdit()"
@@ -21,14 +20,9 @@
             </div>
           </template>
         </EntityEmptyState>
-        <DocumentationPageEmptyState
-          v-else
-          :can-edit="canEdit"
-          @create-documentation="handleAddClick"
-        />
       </KCard>
       <EntityEmptyState
-        v-else-if="enableV2EmptyStates"
+        v-else
         :action-button-text="t('documentation.show.empty_state_v2.cta')"
         appearance="secondary"
         :can-create="() => canEdit()"
@@ -45,11 +39,6 @@
           </div>
         </template>
       </EntityEmptyState>
-      <DocumentationPageEmptyState
-        v-else
-        :can-edit="canEdit"
-        @create-documentation="handleAddClick"
-      />
     </div>
     <div
       v-else
@@ -96,7 +85,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import DocumentationDisplay from './DocumentationDisplay.vue'
-import DocumentationPageEmptyState from './DocumentationPageEmptyState.vue'
 import ProductDocumentModal from './ProductDocumentModal.vue'
 import type { PropType } from 'vue'
 import type { DocumentListItem, DocumentTree, FormData } from '../types'
@@ -186,14 +174,6 @@ const props = defineProps({
   selectedDocument: {
     type: Object as PropType<{ document: DocumentTree, ast: Record<string, any>, markdown?: string, status: 'published' | 'unpublished' }>,
     default: () => null,
-  },
-  /**
-   * Enables the new empty state design, this prop can be removed when
-   * the khcp-14756-empty-states-m2 FF is removed.
-   */
-  enableV2EmptyStates: {
-    type: Boolean,
-    default: false,
   },
 })
 

--- a/packages/entities/entities-plugins/docs/plugin-list.md
+++ b/packages/entities/entities-plugins/docs/plugin-list.md
@@ -206,11 +206,6 @@ The table is rendered inside a `KCard`. `title` text is displayed in the upper l
 
 HTML element you want title to be rendered as. Defaults to `h2`.
 
-#### `enableV2EmptyStates`
-- type: `boolean`
-- default: `false`
-
-Enables the new empty state design, this prop can be removed when the khcp-14756-empty-states-m2 FF is removed.
 
 ### Events
 

--- a/packages/entities/entities-plugins/src/components/PluginList.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginList.cy.ts
@@ -778,8 +778,8 @@ describe('<PluginList />', () => {
 
       cy.wait('@getRoutes')
       cy.get('.kong-ui-entities-plugins-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('be.visible')
+      cy.getTestId('plugins-entity-empty-state').should('be.visible')
+      cy.getTestId('entity-create-button').should('be.visible')
     })
 
     it('should hide empty state and create plugin cta if user can not create', () => {
@@ -798,8 +798,8 @@ describe('<PluginList />', () => {
 
       cy.wait('@getRoutes')
       cy.get('.kong-ui-entities-plugins-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.getTestId('empty-state-action').should('not.exist')
+      cy.getTestId('plugins-entity-empty-state').should('be.visible')
+      cy.getTestId('entity-create-button').should('not.exist')
     })
 
     it('should handle error state', () => {

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -59,29 +59,8 @@
         </Teleport>
       </template>
 
-      <!-- TODO: remove this slot when empty states M2 is cleaned up -->
       <template
-        v-if="!hasRecords && isLegacyLHButton"
-        #outside-actions
-      >
-        <Teleport
-          :disabled="!useActionOutside"
-          to="#kong-ui-app-page-header-action-button"
-        >
-          <KButton
-            appearance="secondary"
-            class="open-learning-hub"
-            data-testid="plugins-learn-more-button"
-            icon
-            @click="$emit('click:learn-more')"
-          >
-            <BookIcon decorative />
-          </KButton>
-        </Teleport>
-      </template>
-
-      <template
-        v-if="!filterQuery && enableV2EmptyStates && config.app === 'konnect'"
+        v-if="!filterQuery && config.app === 'konnect'"
         #empty-state
       >
         <EntityEmptyState
@@ -409,14 +388,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  /**
-   * Enables the new empty state design, this prop can be removed when
-   * the khcp-14756-empty-states-m2 FF is removed.
-   */
-  enableV2EmptyStates: {
-    type: Boolean,
-    default: false,
-  },
 })
 
 const { i18n: { t } } = composables.useI18n()
@@ -428,7 +399,6 @@ const { hasRecords, handleStateChange } = useTableState(() => filterQuery.value)
 // If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
 // If new empty states are not enabled, show the learning hub button (for Konnect)
 const showHeaderLHButton = computed((): boolean => hasRecords.value && props.config.app === 'konnect')
-const isLegacyLHButton = computed((): boolean => !props.enableV2EmptyStates && props.config.app === 'konnect')
 
 // if the Plugin list in nested in the plguns tab on a entity detail page
 const isEntityPage = computed<boolean>(() => !!props.config.entityId)


### PR DESCRIPTION
**Description:**
This PR is dedicated to cleaning up the feature flag `khcp-14756-empty-states-m2`.

**Entities Cleaned Up:**
* **Documentation Content**
* **Plugins List**