### PR TITLE
fix(dashboardrenderer): clear error message value after await [MA-4181]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
@@ -139,7 +139,10 @@ const { data: v4Data, error, isValidating } = useSWRV(queryKey, async () => {
     }
 
     // Note that queryBridge is guaranteed to be set here because SWRV won't execute the query if the key is null.
-    return await queryBridge?.queryFn(mergedQuery, abortController)
+    const result = await queryBridge?.queryFn(mergedQuery, abortController)
+    errorMessage.value = null
+
+    return result
   } catch (e: any) {
     // Note: The error object will contain a response status property at the root when the analytics bridge
     // detects a 403 or 408 status code. This allows us to provide proper error messages for impacted tiles.


### PR DESCRIPTION
# Summary

Fix [MA-4181](https://konghq.atlassian.net/browse/MA-4181)
Fix [MA-4182](https://konghq.atlassian.net/browse/MA-4182)

Whenever the query data provider would return an error message, the message would subsequently never be cleared even when a new set of data should remove it. This will clear the `errorMessage` after the fetch to the queryBridge has resolved.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-4181]: https://konghq.atlassian.net/browse/MA-4181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MA-4182]: https://konghq.atlassian.net/browse/MA-4182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ