### PR TITLE
fix(entities-plugins): datakit clear all history after init

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
@@ -49,6 +49,7 @@ export default function useFlow(phase: NodePhase, flowId?: string) {
 
   const {
     state,
+    commit: historyCommit,
     moveNode,
     removeNode,
     getNodeById,
@@ -269,12 +270,12 @@ export default function useFlow(phase: NodePhase, flowId?: string) {
       moveNode(leftNode.data!.id, {
         x: padding,
         y: centerY - leftGraphNode.dimensions.height / 2,
-      })
+      }, false)
 
       moveNode(rightNode.data!.id, {
         x: boundingRect.width - padding - rightGraphNode.dimensions.width,
         y: centerY - rightGraphNode.dimensions.height / 2,
-      })
+      }, false)
 
       // No need to call dagre.layout()
     } else {
@@ -315,7 +316,7 @@ export default function useFlow(phase: NodePhase, flowId?: string) {
         const dagreNode = dagreGraph.node(node.id)
         const normalizedPosition = normalizePosition(dagreNode)
         updateConfigBoundingRect(normalizedPosition)
-        moveNode(node.data!.id, { x: normalizedPosition.x, y: normalizedPosition.y })
+        moveNode(node.data!.id, { x: normalizedPosition.x, y: normalizedPosition.y }, false)
       }
 
       const leftGraphNode = findNode(leftNode.id)
@@ -331,13 +332,15 @@ export default function useFlow(phase: NodePhase, flowId?: string) {
       moveNode(leftNode.data!.id, {
         x: configBoundingRect.x1 - (leftGraphNode.dimensions.width + nodeGap),
         y: centerY - leftGraphNode.dimensions.height / 2,
-      })
+      }, false)
 
       moveNode(rightNode.data!.id, {
         x: configBoundingRect.x2 + nodeGap,
         y: centerY - rightGraphNode.dimensions.height / 2,
-      })
+      }, false)
     }
+
+    historyCommit()
 
     nextTick(() => {
       fitView()

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorCanvasFlow.vue
@@ -61,7 +61,7 @@ const uniqueId = useId()
 const flowId = `${uniqueId}-${props.phase}`
 
 const { vueFlowStore, editorStore, nodes, edges, autoLayout } = useFlow(props.phase, flowId)
-const { addNode } = editorStore
+const { addNode, clear: historyClear } = editorStore
 const { project, vueFlowRef } = vueFlowStore
 
 const emit = defineEmits<{
@@ -119,6 +119,9 @@ function onNodesInitializes() {
   if (!initialLayoutTriggered.value) {
     initialLayoutTriggered.value = true
     handleAutoLayout()
+    // Clear all history post-initialization, as the state
+    // should be the 'origin' by this point.
+    historyClear()
   }
 
   // Reserved for future steps


### PR DESCRIPTION
# Summary

Clear all history after initialization, as the state by that point should be treated as the origin.

KM-1571