### PR TITLE
chore(redis, routes): clean up l2 empty state flag

### DIFF
--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.cy.ts
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.cy.ts
@@ -174,8 +174,8 @@ describe('<RedisConfigurationList />', () => {
         })
 
         cy.wait('@getRedisConfigurations')
-        cy.get('.table-empty-state').should('be.visible')
-        cy.get('.table-empty-state .empty-state-action .k-button').should('be.visible')
+        cy.getTestId('redis-entity-empty-state').should('be.visible')
+        cy.getTestId('entity-create-button').should('be.visible')
       })
 
       it('should hide create redis configuration cta if user can not create', () => {
@@ -191,7 +191,7 @@ describe('<RedisConfigurationList />', () => {
         })
 
         cy.wait('@getRedisConfigurations')
-        cy.get('.table-empty-state .empty-state-action .k-button').should('not.exist')
+        cy.getTestId('entity-create-button').should('not.exist')
       })
 
       it('should show redis configuration items', () => {

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.vue
@@ -97,7 +97,6 @@
       </template>
 
       <template
-        v-if="enableV2EmptyStates"
         #empty-state
       >
         <EntityEmptyState
@@ -263,14 +262,6 @@ const props = defineProps({
   },
   /** default to false, setting to true will teleport the toolbar button to the destination in the consuming app */
   useActionOutside: {
-    type: Boolean,
-    default: false,
-  },
-  /**
-   * Enables the new empty state design, this prop can be removed when
-   * the khcp-14756-empty-states-m2 FF is removed.
-   */
-  enableV2EmptyStates: {
     type: Boolean,
     default: false,
   },

--- a/packages/entities/entities-routes/docs/route-list.md
+++ b/packages/entities/entities-routes/docs/route-list.md
@@ -166,12 +166,6 @@ HTML element you want title to be rendered as. Defaults to `h2`.
 
 Whether to show the "Expression" column. Defaults to `false`.
 
-#### `enableV2EmptyStates`
-- type: `boolean`
-- default: `false`
-
-Enables the new empty state design, this prop can be removed when the khcp-14756-empty-states-m2 FF is removed.
-
 ### Events
 
 #### error

--- a/packages/entities/entities-routes/src/components/RouteList.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteList.cy.ts
@@ -609,8 +609,8 @@ describe('<RouteList />', () => {
 
       cy.wait('@getRoutes')
       cy.get('.kong-ui-entities-routes-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.get('.table-empty-state .empty-state-action .k-button').should('be.visible')
+      cy.getTestId('routes-entity-empty-state').should('be.visible')
+      cy.getTestId('entity-create-button').should('be.visible')
     })
 
     it('should hide empty state and create route cta if user can not create', () => {
@@ -629,8 +629,8 @@ describe('<RouteList />', () => {
 
       cy.wait('@getRoutes')
       cy.get('.kong-ui-entities-routes-list').should('be.visible')
-      cy.get('.table-empty-state').should('be.visible')
-      cy.get('.table-empty-state .empty-state-action .k-button').should('not.exist')
+      cy.getTestId('routes-entity-empty-state').should('be.visible')
+      cy.getTestId('entity-create-button').should('not.exist')
     })
 
     it('should handle error state', () => {

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -61,29 +61,8 @@
         </Teleport>
       </template>
 
-      <!-- TODO: remove this slot when empty states M2 is cleaned up -->
       <template
-        v-if="!hasRecords && isLegacyLHButton"
-        #outside-actions
-      >
-        <Teleport
-          :disabled="!useActionOutside"
-          to="#kong-ui-app-page-header-action-button"
-        >
-          <KButton
-            appearance="secondary"
-            class="open-learning-hub"
-            data-testid="routes-learn-more-button"
-            icon
-            @click="$emit('click:learn-more')"
-          >
-            <BookIcon decorative />
-          </KButton>
-        </Teleport>
-      </template>
-
-      <template
-        v-if="!filterQuery && enableV2EmptyStates && config.app === 'konnect'"
+        v-if="!filterQuery && config.app === 'konnect'"
         #empty-state
       >
         <EntityEmptyState
@@ -361,14 +340,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  /**
-   * Enables the new empty state design, this prop can be removed when
-   * the khcp-14756-empty-states-m2 FF is removed.
-   */
-  enableV2EmptyStates: {
-    type: Boolean,
-    default: false,
-  },
 })
 
 const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
@@ -380,7 +351,6 @@ const { handleStateChange, hasRecords } = useTableState(() => filterQuery.value)
 // If new empty states are enabled, show the learning hub button when the empty state is hidden (for Konnect)
 // If new empty states are not enabled, show the learning hub button (for Konnect)
 const showHeaderLHButton = computed((): boolean => hasRecords.value && props.config.app === 'konnect')
-const isLegacyLHButton = computed((): boolean => !props.enableV2EmptyStates && props.config.app === 'konnect')
 
 // if the RouteList in nested in the routes tab on a service detail page
 const isServicePage = computed<boolean>(() => !!props.config.serviceId)


### PR DESCRIPTION
**Description:**
This PR is dedicated to cleaning up the feature flag `khcp-14756-empty-states-m2`.

**Entities Cleaned Up:**
* **redis configuration**
* **routes list**