### PR TITLE
fix(entities-plugins): improve datakit flow node styles, reduce warnings

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
@@ -33,7 +33,7 @@ export interface AutoLayoutOptions {
 }
 
 export default function useFlow(phase: NodePhase, flowId?: string) {
-  const vueFlowStore = useVueFlow({ id: flowId })
+  const vueFlowStore = useVueFlow(flowId)
   const editorStore = useEditorStore()
 
   const {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -41,22 +41,25 @@
                 class="handle-label"
                 :class="{
                   'has-fields': data.fields.input.length > 0,
-                  'not-collapsible': inputsNotCollapsible
+                  collapsible: inputsCollapsible
                 }"
               >
-                <div>inputs</div>
+                <div class="text">
+                  inputs
+                </div>
                 <div
                   v-if="data.fields.input.length > 0"
                   class="icon"
-                  @click.stop="inputsNotCollapsible || toggleExpanded('input')"
+                  @click.stop="!inputsCollapsible || toggleExpanded('input')"
                 >
                   <UnfoldMoreIcon
                     v-if="!inputsExpanded"
-                    :size="KUI_ICON_SIZE_30"
+                    :size="KUI_ICON_SIZE_20"
                   />
                   <UnfoldLessIcon
                     v-if="inputsExpanded"
-                    :size="KUI_ICON_SIZE_30"
+                    :color="inputsCollapsible ? undefined : KUI_COLOR_TEXT_DISABLED"
+                    :size="KUI_ICON_SIZE_20"
                   />
                 </div>
               </div>
@@ -81,7 +84,7 @@
                 type="target"
               />
               <div class="handle-label-wrapper">
-                <div class="handle-label">
+                <div class="handle-label text">
                   {{ field.name }}
                 </div>
                 <HandleTwig
@@ -100,25 +103,28 @@
           <div class="handle">
             <div class="handle-label-wrapper">
               <div
-                class="handle-label"
+                class="handle-label text"
                 :class="{
                   'has-fields': data.fields.output.length > 0,
-                  'not-collapsible': outputsNotCollapsible
+                  collapsible: outputsCollapsible
                 }"
               >
-                <div>outputs</div>
+                <div class="text">
+                  outputs
+                </div>
                 <div
                   v-if="data.fields.output.length > 0"
                   class="icon"
-                  @click.stop="outputsNotCollapsible || toggleExpanded('output')"
+                  @click.stop="!outputsCollapsible || toggleExpanded('output')"
                 >
                   <UnfoldMoreIcon
                     v-if="!outputsExpanded"
-                    :size="KUI_ICON_SIZE_30"
+                    :size="KUI_ICON_SIZE_20"
                   />
                   <UnfoldLessIcon
                     v-if="outputsExpanded"
-                    :size="KUI_ICON_SIZE_30"
+                    :color="outputsCollapsible ? undefined : KUI_COLOR_TEXT_DISABLED"
+                    :size="KUI_ICON_SIZE_20"
                   />
                 </div>
               </div>
@@ -170,7 +176,8 @@ import { createI18n } from '@kong-ui-public/i18n'
 import {
   KUI_COLOR_BACKGROUND_NEUTRAL_STRONG,
   KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER,
-  KUI_ICON_SIZE_30,
+  KUI_COLOR_TEXT_DISABLED,
+  KUI_ICON_SIZE_20,
 } from '@kong/design-tokens'
 import { UnfoldLessIcon, UnfoldMoreIcon } from '@kong/icons'
 import { Handle, Position } from '@vue-flow/core'
@@ -195,11 +202,11 @@ const { getInEdgesByNodeId, getOutEdgesByNodeId, toggleExpanded: storeToggleExpa
 
 const meta = computed(() => getNodeMeta(data.type))
 
-const inputsNotCollapsible = computed(() =>
-  getInEdgesByNodeId(data.id).some(edge => edge.targetField !== undefined),
+const inputsCollapsible = computed(() =>
+  getInEdgesByNodeId(data.id).every(edge => edge.targetField === undefined),
 )
-const outputsNotCollapsible = computed(() =>
-  getOutEdgesByNodeId(data.id).some(edge => edge.sourceField !== undefined),
+const outputsCollapsible = computed(() =>
+  getOutEdgesByNodeId(data.id).every(edge => edge.sourceField === undefined),
 )
 
 const inputsExpanded = computed(() => data.expanded.input ?? false)
@@ -251,14 +258,14 @@ function toggleExpanded(io: 'input' | 'output') {
   storeToggleExpanded(data.id, io)
 }
 
-watch(inputsNotCollapsible, (collapsible) => {
-  if (collapsible) {
+watch(inputsCollapsible, (collapsible) => {
+  if (!collapsible) {
     storeToggleExpanded(data.id, 'input', true)
   }
 }, { immediate: true })
 
-watch(outputsNotCollapsible, (collapsible) => {
-  if (collapsible) {
+watch(outputsCollapsible, (collapsible) => {
+  if (!collapsible) {
     storeToggleExpanded(data.id, 'output', true)
   }
 }, { immediate: true })
@@ -338,18 +345,20 @@ $handle-height: 10px;
           flex-direction: row;
           font-size: $kui-font-size-20;
           font-weight: $kui-font-weight-semibold;
-          gap: $kui-space-20;
-          padding: 0 $kui-space-10;
+          gap: $kui-space-40;
+          line-height: $kui-line-height-10;
+          padding: $kui-space-10;
 
-          &.has-fields {
-            padding: 0 $kui-space-10 0 $kui-space-20;
+          .text {
+            /* improve visual valign for our use case */
+            transform: translateY(-0.5px);
           }
 
           &.has-fields .icon {
             cursor: pointer;
           }
 
-          &.not-collapsible .icon {
+          &:not(.collapsible) .icon {
             cursor: not-allowed;
           }
         }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodeBadge.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodeBadge.vue
@@ -1,7 +1,7 @@
 <template>
   <KBadge
     :appearance="appearance"
-    :class="{ 'condensed': condensed }"
+    size="small"
   >
     <template #icon>
       <component :is="icon" />
@@ -47,10 +47,3 @@ const appearance = computed<BadgeAppearance>(() => {
   }
 })
 </script>
-
-<style lang="scss" scoped>
-.condensed {
-  font-size: $kui-font-size-20;
-  padding: $kui-space-10;
-}
-</style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
@@ -19,7 +19,11 @@
         @dragstart="(e: DragEvent) => handleDragStart(e, nodeType)"
       />
     </div>
-    <div class="preview">
+    <div
+      aria-hidden="true"
+      class="preview"
+      inert
+    >
       <VueFlow :nodes="previewNodes">
         <template #node-flow="node">
           <FlowNode
@@ -146,6 +150,13 @@ const handleDragStart = async (e: DragEvent, type: ConfigNodeType) => {
     flex-direction: column;
     gap: $kui-space-40;
     margin-top: $kui-space-40;
+  }
+
+  .preview {height: 1px;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    width: 1px;
   }
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
@@ -152,7 +152,8 @@ const handleDragStart = async (e: DragEvent, type: ConfigNodeType) => {
     margin-top: $kui-space-40;
   }
 
-  .preview {height: 1px;
+  .preview {
+    height: 1px;
     opacity: 0;
     pointer-events: none;
     position: absolute;

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePropertiesPanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePropertiesPanel.vue
@@ -93,7 +93,7 @@ const Form = computed(() => {
 
   :deep(.slideout-header),
   :deep(.slideout-content) {
-    padding-left: var(--kui-space-70, 20px);
+    padding-left: var(--kui-space-70, $kui-space-70);
   }
 
   &-desc {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePropertiesPanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePropertiesPanel.vue
@@ -21,9 +21,8 @@
       v-html="getNodeTypeDescription(selectedNode.type)"
     />
 
-    <component
-      :is="form"
-      v-if="form"
+    <Form
+      v-if="Form"
       class="dk-node-properties-panel-form"
     />
   </KSlideout>
@@ -62,7 +61,7 @@ defineEmits<{
   close: []
 }>()
 
-const form = computed(() => {
+const Form = computed(() => {
   switch (selectedNode.value?.type) {
     case 'call':
       return NodeFormCall
@@ -89,10 +88,12 @@ const form = computed(() => {
   :deep(.slideout-container) {
     box-shadow: none;
     gap: $kui-space-60;
+    padding-left: 0;
   }
 
-  :deep(.slideout-header) {
-    align-items: start;
+  :deep(.slideout-header),
+  :deep(.slideout-content) {
+    padding-left: var(--kui-space-70, 20px);
   }
 
   &-desc {


### PR DESCRIPTION
# Summary

[KM-1572](https://konghq.atlassian.net/browse/KM-1572)

- Refine styles for handle labels  
- Rename `inputNotCollapsible` / `outputNotCollapsible` → `inputCollapsible` / `outputCollapsible` for improved clarity  
- Resolve VueFlow warnings  
- Prevent slideout padding from clipping the left side of focus rings

[KM-1572]: https://konghq.atlassian.net/browse/KM-1572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ