### PR TITLE
fix(entities-plugins): datakit - ui bugs

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/InputsField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/InputsField.vue
@@ -12,6 +12,7 @@
   <InputsField
     v-if="InputsField"
     :items="items"
+    :key-order="fieldNames"
     name="inputs"
     @add:field="handleAddField"
     @change:inputs="handleChangeInputs"
@@ -33,6 +34,7 @@ import type { FieldName, IdConnection } from '../../types'
 
 defineProps<{
   items: InputOption[]
+  fieldNames: FieldName[]
 }>()
 
 const emit = defineEmits<{

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormCall.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormCall.vue
@@ -36,6 +36,7 @@
     />
 
     <InputsField
+      :field-names="inputsFieldNames"
       :items="inputOptions"
       @change:input="setInput"
       @change:inputs="setInputs"
@@ -65,6 +66,7 @@ const {
   inputOptions,
   setInputs,
   setInput,
+  inputsFieldNames,
 } = useNodeForm(() => formRef.value!.getInnerData())
 </script>
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormJq.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormJq.vue
@@ -25,6 +25,7 @@
     />
 
     <InputsField
+      :field-names="inputsFieldNames"
       :items="inputOptions"
       @add:field="handleAddField"
       @change:input="setInput"
@@ -32,8 +33,6 @@
       @remove:field="handleRemoveField"
       @rename:field="handleRenameField"
     />
-
-    <!-- todo(zehao): outputs definition fields -->
   </Form>
 </template>
 
@@ -61,6 +60,7 @@ const {
   addField,
   removeFieldByName,
   renameFieldByName,
+  inputsFieldNames,
 } = useNodeForm(() => formRef.value!.getInnerData())
 
 function handleAddField(name: FieldName, value?: IdConnection | null) {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormProperty.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormProperty.vue
@@ -19,6 +19,7 @@
 
     <InputsField
       v-if="writable"
+      :field-names="inputsFieldNames"
       :items="inputOptions"
       @change:input="setInput"
       @change:inputs="setInputs"
@@ -53,6 +54,7 @@ const {
   inputOptions,
   setInputs,
   setInput,
+  inputsFieldNames,
 } = useNodeForm<PropertyFormData>(() => formRef.value!.getInnerData())
 
 const writable = computed(() => isWritableProperty(formData.value.property))

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormResponse.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormResponse.vue
@@ -6,6 +6,7 @@
     :schema="ResponseSchema"
   >
     <InputsField
+      :field-names="inputsFieldNames"
       :items="inputOptions"
       @change:input="setInput"
       @change:inputs="setInputs"
@@ -27,6 +28,7 @@ const {
   inputOptions,
   setInputs,
   setInput,
+  inputsFieldNames,
 } = useNodeForm(() => formRef.value!.getInnerData())
 </script>
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormServiceRequest.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormServiceRequest.vue
@@ -6,6 +6,7 @@
     :schema="ServiceRequestSchema"
   >
     <InputsField
+      :field-names="inputsFieldNames"
       :items="inputOptions"
       @change:input="setInput"
       @change:inputs="setInputs"
@@ -27,6 +28,7 @@ const {
   inputOptions,
   setInputs,
   setInput,
+  inputsFieldNames,
 } = useNodeForm(() => formRef.value!.getInnerData())
 </script>
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormStatic.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormStatic.vue
@@ -11,6 +11,7 @@
     />
 
     <OutputValueField
+      :key-order="outputsFieldNames"
       name="values"
       @add:field="handleAddField"
       @change:value="handleChangeValue"
@@ -40,6 +41,10 @@ const {
   removeField,
   replaceConfig,
 } = useEditorStore()
+
+const outputsFieldNames = computed<FieldName[]>(() => {
+  return selectedNode.value?.fields.output.map(f => f.name) || []
+})
 
 function setName(name: string | null) {
   if (!selectedNode.value) throw new Error('No selected node')

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/composables.ts
@@ -3,6 +3,7 @@ import { useEditorStore } from '../../composables'
 import { buildAdjacency, hasCycle } from '../store/validation'
 import type { EdgeInstance, FieldName, IdConnection, NameConnection, NodeId, NodeName } from '../../types'
 import { findFieldById, findFieldByName, getNodeMeta, parseIdConnection } from '../store/helpers'
+import { isReadableProperty } from '../node/property'
 
 export type InputOption = {
   value: IdConnection
@@ -226,11 +227,14 @@ export function useNodeForm<T extends BaseFormData = BaseFormData>(
       // skip no output nodes
       if (!meta.io?.output) continue
 
-      // skip the node that no output fields and can't be configured
-      if (!node.fields.output.length && !meta.io?.output?.configurable) continue
+      // skip nodes that are not output
+      if (!node.fields.output) continue
 
       // skip the selected node itself
       if (node.id === selectedNodeId.value) continue
+
+      // skip property nodes that are not readable
+      if (node.type === 'property' && !isReadableProperty(node.config?.property as string)) continue
 
       // skip the node that will create a cycle
       if (willCreateCycle(node.id)) continue

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/composables.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/composables.ts
@@ -251,12 +251,17 @@ export function useNodeForm<T extends BaseFormData = BaseFormData>(
     return options
   })
 
+  const inputsFieldNames = computed<FieldName[]>(() => {
+    return selectedNode.value?.fields.input.map(f => f.name) || []
+  })
+
   return {
     // states
     formData,
     inputOptions,
     inputEdge,
     inputsEdges,
+    inputsFieldNames,
 
     // form ops
     setName,

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePropertiesPanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePropertiesPanel.vue
@@ -24,6 +24,7 @@
     <component
       :is="form"
       v-if="form"
+      :key="selectedNode?.id"
       class="dk-node-properties-panel-form"
     />
   </KSlideout>


### PR DESCRIPTION
# Summary

* Fix the filtering logic of input options.
* Stabilizing the order of inputs/outputs when updating.
* Avoid rebuilding the IDs of entries on update, in order to allow users to switch to the next item by tab key.