### PR TITLE
fix(ma-4135): allow zooming on all tiles behind FF

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-plugins/DragSelectPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/DragSelectPlugin.ts
@@ -52,11 +52,11 @@ export class DragSelectPlugin implements Plugin {
   beforeInit(chart: Chart) {
     this._chart = chart
     const canvas = chart.canvas
-    const rect = canvas.getBoundingClientRect()
     let dragInitiated = false
 
     const onMouseDown = (event: MouseEvent) => {
       this._dragTimeout = window.setTimeout(() => {
+        const rect = canvas.getBoundingClientRect()
         this._isDragging = true
         this._clearSelectionArea = false
         dragInitiated = true
@@ -65,6 +65,7 @@ export class DragSelectPlugin implements Plugin {
     }
 
     const onMouseMove = (event: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect()
       if (dragInitiated && this._isDragging) {
         this._endX = event.clientX - rect.left
         dispatchEvent('dragSelectMove', chart, this)
@@ -73,6 +74,7 @@ export class DragSelectPlugin implements Plugin {
     }
 
     const onMouseUp = (event: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect()
       clearTimeout(this._dragTimeout)
       if (dragInitiated && this._isDragging) {
         this._endX = event.clientX - rect.left

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -31,7 +31,7 @@
         v-model="dashboardConfig"
         :context="context"
         @edit-tile="onEditTile"
-        @zoom-time-range="handleZoom"
+        @tile-time-range-zoom="handleZoom"
       >
         <template #slot-1>
           <div class="slot-container">
@@ -51,11 +51,10 @@
 </template>
 
 <script setup lang="ts">
-import type { DashboardRendererContext, GridTile } from '../../src'
+import type { DashboardRendererContext, GridTile, TileZoomEvent } from '../../src'
 import { DashboardRenderer } from '../../src'
 import { computed, inject, ref } from 'vue'
 import type {
-  AbsoluteTimeRangeV4,
   DashboardConfig,
   DashboardTileType,
   ExploreAggregations,
@@ -248,8 +247,8 @@ watchDebounced(() => dashboardConfig.value.tiles, (newValue) => {
   console.log('update tiles', newValue)
 }, { deep: true, debounce: 300 })
 
-const handleZoom = (newTimeRange: AbsoluteTimeRangeV4) => {
-  console.log('zoom-time-range', newTimeRange)
+const handleZoom = (zoomEvent: TileZoomEvent) => {
+  console.log('tile-time-range-zoom', zoomEvent)
 }
 
 </script>

--- a/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/BaseAnalyticsChartRenderer.vue
@@ -54,7 +54,7 @@ const emit = defineEmits<{
 }>()
 const { i18n } = composables.useI18n()
 const { evaluateFeatureFlag } = composables.useEvaluateFeatureFlag()
-const hasFinegrainedAbsoluteTimerangeAccess = evaluateFeatureFlag('explore-v4-fine-granularity', false)
+const hasZoomOnAllTiles = evaluateFeatureFlag('ma-4135-allow-zooming-all-dashboard-tiles', false)
 
 const options = computed((): AnalyticsChartOptions => ({
   type: props.chartOptions.type,
@@ -63,7 +63,12 @@ const options = computed((): AnalyticsChartOptions => ({
   threshold: props.chartOptions.threshold,
 }))
 
-const timeseriesZoom = computed(() => hasFinegrainedAbsoluteTimerangeAccess && props.context.zoomable && !props.query.time_range)
+const timeseriesZoom = computed(() => {
+  if (hasZoomOnAllTiles) {
+    return props.context.zoomable
+  }
+  return props.context.zoomable && !props.query.time_range
+})
 
 const editTile = () => {
   emit('edit-tile')

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -41,9 +41,8 @@
 </template>
 
 <script setup lang="ts">
-import type { DashboardRendererContext, DashboardRendererContextInternal, GridTile } from '../types'
+import type { DashboardRendererContext, DashboardRendererContextInternal, GridTile, TileZoomEvent } from '../types'
 import type {
-  AbsoluteTimeRangeV4,
   AllFilters,
   AnalyticsBridge,
   DashboardConfig,
@@ -74,7 +73,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'edit-tile', tile: GridTile<TileDefinition>): void
-  (e: 'zoom-time-range', newTimeRange: AbsoluteTimeRangeV4): void
+  (e: 'zoom-time-range', newTimeRange: TileZoomEvent): void
 }>()
 
 const model = defineModel<DashboardConfig>({ required: true })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -33,7 +33,7 @@
           @duplicate-tile="onDuplicateTile(tile)"
           @edit-tile="onEditTile(tile)"
           @remove-tile="onRemoveTile(tile)"
-          @zoom-time-range="emit('zoom-time-range', $event)"
+          @tile-time-range-zoom="emit('tile-time-range-zoom', $event)"
         />
       </template>
     </component>
@@ -73,7 +73,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'edit-tile', tile: GridTile<TileDefinition>): void
-  (e: 'zoom-time-range', newTimeRange: TileZoomEvent): void
+  (e: 'tile-time-range-zoom', newTimeRange: TileZoomEvent): void
 }>()
 
 const model = defineModel<DashboardConfig>({ required: true })
@@ -194,7 +194,7 @@ const mergedContext = computed<DashboardRendererContextInternal>(() => {
 
   // Check if the host app has provided an event handler for zooming.
   // If there's no handler, disable zooming -- it won't do anything.
-  const zoomable = !!getCurrentInstance()?.vnode?.props?.onZoomTimeRange
+  const zoomable = !!getCurrentInstance()?.vnode?.props?.onTileTimeRangeZoom
 
   return {
     filters,

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -128,13 +128,13 @@
         v-bind="componentData.rendererProps"
         @chart-data="onChartData"
         @select-chart-range="onSelectChartRange"
-        @zoom-time-range="emit('zoom-time-range', $event)"
+        @zoom-time-range="onZoom"
       />
     </div>
   </div>
 </template>
 <script setup lang="ts">
-import type { DashboardRendererContextInternal } from '../types'
+import type { DashboardRendererContextInternal, TileZoomEvent } from '../types'
 import {
   type DashboardTileType,
   formatTime,
@@ -179,7 +179,7 @@ const emit = defineEmits<{
   (e: 'edit-tile', tile: TileDefinition): void
   (e: 'duplicate-tile', tile: TileDefinition): void
   (e: 'remove-tile', tile: TileDefinition): void
-  (e: 'zoom-time-range', newTimeRange: AbsoluteTimeRangeV4): void
+  (e: 'zoom-time-range', newTimeRange: TileZoomEvent): void
 }>()
 
 const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
@@ -367,6 +367,14 @@ const setExportModalVisibility = (val: boolean) => {
 
 const exportCsv = () => {
   setExportModalVisibility(true)
+}
+
+const onZoom = (newTimeRange: AbsoluteTimeRangeV4) => {
+  const zoomEvent: TileZoomEvent = {
+    tileId: props.tileId.toString(),
+    timeRange: newTimeRange,
+  }
+  emit('zoom-time-range', zoomEvent)
 }
 
 const buildRequestsQuery = (timeRange: TimeRangeV4, filters: AllFilters[]) => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -179,7 +179,7 @@ const emit = defineEmits<{
   (e: 'edit-tile', tile: TileDefinition): void
   (e: 'duplicate-tile', tile: TileDefinition): void
   (e: 'remove-tile', tile: TileDefinition): void
-  (e: 'zoom-time-range', newTimeRange: TileZoomEvent): void
+  (e: 'tile-time-range-zoom', newTimeRange: TileZoomEvent): void
 }>()
 
 const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
@@ -374,7 +374,7 @@ const onZoom = (newTimeRange: AbsoluteTimeRangeV4) => {
     tileId: props.tileId.toString(),
     timeRange: newTimeRange,
   }
-  emit('zoom-time-range', zoomEvent)
+  emit('tile-time-range-zoom', zoomEvent)
 }
 
 const buildRequestsQuery = (timeRange: TimeRangeV4, filters: AllFilters[]) => {

--- a/packages/analytics/dashboard-renderer/src/types/index.ts
+++ b/packages/analytics/dashboard-renderer/src/types/index.ts
@@ -3,3 +3,4 @@
 
 export * from './grid-layout-types'
 export * from './renderer-types'
+export * from './tile-zoom-event'

--- a/packages/analytics/dashboard-renderer/src/types/tile-zoom-event.ts
+++ b/packages/analytics/dashboard-renderer/src/types/tile-zoom-event.ts
@@ -1,0 +1,6 @@
+import type { AbsoluteTimeRangeV4 } from '@kong-ui-public/analytics-utilities'
+
+export interface TileZoomEvent {
+  tileId: string
+  timeRange: AbsoluteTimeRangeV4
+}


### PR DESCRIPTION
# Summary

Part 1 of [ma-4135](https://konghq.atlassian.net/browse/MA-4135)

Behind new [FF](https://app.launchdarkly.com/projects/default/flags/ma-4135-allow-zooming-all-dashboard-tiles/targeting?env=local&env=dev&selected-env=local)

BREAKING CHANGE: zoom-time-range event signature changed
- Renamed dashboard renderer `zoom-time-range` emit to `tile-time-range-zoom` 

- Enable zooming on all tiles. When the feature flag is enabled, tiles with a pinned time range can now be zoomed, triggering a zoom event.
(Note: Host app must update handling for zoom events on pinned time range tiles.)
- Include tileId in the tile-time-range-zoom event payload:
```
interface TileZoomEvent {
  tileId: string
  timeRange: AbsoluteTimeRangeV4
}
```

Fixed a bug where the zoom area highlight no longer appeared after moving a chart in the dom
- Issue: The canvas' bounding rect was cached when the plugin was initialized causing the highlight to be drawn on coordinates that the chart no longer occupies when it is moved
- Fix: Recompute the canvas rect inside each event handler

## Bug
https://github.com/user-attachments/assets/1154ad8e-f291-4286-a158-b4faccc66a18


## FIx
https://github.com/user-attachments/assets/351d5d1f-0e14-44dd-89e9-abc88ff6f35d



<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
