### PR TITLE
fix: update golden signals trend text for fine grain absolute time

### DIFF
--- a/packages/analytics/analytics-metric-provider/sandbox/App.vue
+++ b/packages/analytics/analytics-metric-provider/sandbox/App.vue
@@ -19,9 +19,7 @@
   <div>
     <SandboxBridgeInjector :query-bridge="globalBridge">
       <MetricsProvider v-bind="globalProviderProps">
-        <MetricsConsumer
-          :card-size="MetricCardSize.Large"
-        />
+        <MetricsConsumer :card-size="MetricCardSize.Large" />
       </MetricsProvider>
     </SandboxBridgeInjector>
   </div>
@@ -30,9 +28,7 @@
   <div style="width: 330px">
     <SandboxBridgeInjector :query-bridge="globalBridge">
       <MetricsProvider v-bind="globalProviderProps">
-        <MetricsConsumer
-          :card-size="MetricCardSize.Small"
-        />
+        <MetricsConsumer :card-size="MetricCardSize.Small" />
       </MetricsProvider>
     </SandboxBridgeInjector>
   </div>
@@ -41,9 +37,7 @@
   <div v-if="!USE_REAL_DATA">
     <SandboxBridgeInjector :query-bridge="globalBridge">
       <MetricsProvider v-bind="filteredProviderProps">
-        <MetricsConsumer
-          :card-size="MetricCardSize.Medium"
-        />
+        <MetricsConsumer :card-size="MetricCardSize.Medium" />
       </MetricsProvider>
     </SandboxBridgeInjector>
   </div>
@@ -123,6 +117,15 @@
       </MetricsProvider>
     </SandboxBridgeInjector>
   </div>
+
+  <h4>Custom timeframe</h4>
+  <div>
+    <SandboxBridgeInjector :query-bridge="oneHourBridge">
+      <MetricsProvider v-bind="globalProviderPropsCustomTimeframe">
+        <MetricsConsumer :card-size="MetricCardSize.Large" />
+      </MetricsProvider>
+    </SandboxBridgeInjector>
+  </div>
 </template>
 <script setup lang="ts">
 import { ref, computed } from 'vue'
@@ -137,7 +140,7 @@ import type {
   ExploreFilter,
   ExploreQuery,
 } from '@kong-ui-public/analytics-utilities'
-import { TimePeriods } from '@kong-ui-public/analytics-utilities'
+import { Timeframe, TimePeriods } from '@kong-ui-public/analytics-utilities'
 import { MetricCardSize } from '../src/enums'
 import SandboxBridgeInjector from './SandboxBridgeInjector.vue'
 
@@ -147,6 +150,18 @@ const refreshInterval = 60 * 1000
 const USE_REAL_DATA = false
 
 const timeframeSelection = ref('15m')
+const custom1hourTimeframe = new Timeframe({
+  key: 'custom',
+  timeframeText: 'Custom Timeframe',
+  display: 'Custom Timeframe',
+  startCustom: new Date('2023-01-01T00:00:00Z'),
+  endCustom: new Date('2023-01-01T01:00:00Z'),
+  isRelative: false,
+  timeframeLength: () => 3600000, // 1 hour in milliseconds,
+  defaultResponseGranularity: 'minutely',
+  dataGranularity: 'minutely',
+  allowedTiers: ['free', 'pro', 'enterprise'],
+})
 
 const makeQueryBridge = (opts?: MockOptions): AnalyticsBridge => {
 
@@ -203,6 +218,17 @@ const globalProviderProps = computed(() => ({
 }))
 
 const globalBridge = makeQueryBridge()
+
+
+const globalProviderPropsCustomTimeframe = computed(() => ({
+  ...globalProviderProps.value,
+  // 1 hour timeframe
+  overrideTimeframe: custom1hourTimeframe,
+}))
+
+const oneHourBridge = makeQueryBridge({
+  timeFrame: custom1hourTimeframe,
+})
 
 // Query stats for an entire org, but also apply a filter.
 const filteredProviderProps = computed(() => ({

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsProvider.cy.ts
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsProvider.cy.ts
@@ -1,5 +1,6 @@
 import MetricsTestHarness from './MetricsTestHarness.vue'
 import { ref } from 'vue'
+import { Timeframe } from '@kong-ui-public/analytics-utilities'
 import type {
   AdvancedDatasourceQuery,
   AnalyticsBridge,
@@ -12,6 +13,45 @@ import type { MockOptions } from '../mockExploreResponse'
 import { mockExploreResponse } from '../mockExploreResponse'
 import { INJECT_QUERY_PROVIDER } from '../constants'
 import { createPinia, setActivePinia } from 'pinia'
+
+
+const custom1DayTimeframe = new Timeframe({
+  key: 'custom',
+  timeframeText: 'Custom Timeframe',
+  display: 'Custom Timeframe',
+  startCustom: new Date('2023-01-01T00:00:00Z'),
+  endCustom: new Date('2023-01-02T00:00:00Z'),
+  isRelative: false,
+  timeframeLength: () => 86400000, // 1 day in milliseconds
+  defaultResponseGranularity: 'minutely',
+  dataGranularity: 'minutely',
+  allowedTiers: ['free', 'pro', 'enterprise'],
+})
+const custom10Minuteframe = new Timeframe({
+  key: 'custom',
+  timeframeText: 'Custom Timeframe',
+  display: 'Custom Timeframe',
+  startCustom: new Date('2023-01-01T00:00:00Z'),
+  endCustom: new Date('2023-01-01T00:10:00Z'),
+  isRelative: false,
+  timeframeLength: () => 600000, // 10 minutes in milliseconds
+  defaultResponseGranularity: 'minutely',
+  dataGranularity: 'minutely',
+  allowedTiers: ['free', 'pro', 'enterprise'],
+})
+const custom1hourTimeframe = new Timeframe({
+  key: 'custom',
+  timeframeText: 'Custom Timeframe',
+  display: 'Custom Timeframe',
+  startCustom: new Date('2023-01-01T00:00:00Z'),
+  endCustom: new Date('2023-01-01T01:00:00Z'),
+  isRelative: false,
+  timeframeLength: () => 3600000, // 1 hour in milliseconds,
+  defaultResponseGranularity: 'minutely',
+  dataGranularity: 'minutely',
+  allowedTiers: ['free', 'pro', 'enterprise'],
+})
+
 
 describe('<AnalyticsMetricProvider />', () => {
 
@@ -503,5 +543,66 @@ describe('<AnalyticsMetricProvider />', () => {
       cy.get('.metricscard').eq(1).get('.metricscard-error').should('exist')
       cy.getTestId('metric-value').eq(0).should('have.text', '1001ms')
     })
+  })
+
+  it('1 day custom time frame', () => {
+    const queryBridge = makeQueryBridge({
+      timeFrame: custom1DayTimeframe,
+    })
+
+    cy.mount(MetricsTestHarness, {
+      props: {
+        render: 'global',
+        overrideTimeframe: custom1DayTimeframe,
+      },
+      global: {
+        provide: {
+          [INJECT_QUERY_PROVIDER]: queryBridge,
+        },
+      },
+    })
+
+    cy.get('.metricscard-trend-range').first().should('contain', 'vs previous day')
+  })
+
+
+  it('1 hour custom time frame', () => {
+    const queryBridge = makeQueryBridge({
+      timeFrame: custom1hourTimeframe,
+    })
+
+    cy.mount(MetricsTestHarness, {
+      props: {
+        render: 'global',
+        overrideTimeframe: custom1hourTimeframe,
+      },
+      global: {
+        provide: {
+          [INJECT_QUERY_PROVIDER]: queryBridge,
+        },
+      },
+    })
+
+    cy.get('.metricscard-trend-range').first().should('contain', 'vs previous hour')
+  })
+
+  it('10 min custom time frame', () => {
+    const queryBridge = makeQueryBridge({
+      timeFrame: custom10Minuteframe,
+    })
+
+    cy.mount(MetricsTestHarness, {
+      props: {
+        render: 'global',
+        overrideTimeframe: custom10Minuteframe,
+      },
+      global: {
+        provide: {
+          [INJECT_QUERY_PROVIDER]: queryBridge,
+        },
+      },
+    })
+
+    cy.get('.metricscard-trend-range').first().should('contain', 'vs previous 10 minutes')
   })
 })

--- a/packages/analytics/analytics-metric-provider/src/components/MetricsTestHarness.vue
+++ b/packages/analytics/analytics-metric-provider/src/components/MetricsTestHarness.vue
@@ -47,7 +47,7 @@
 import MetricsConsumer from './MetricsConsumer.vue'
 import MetricsProvider from './MetricsProvider.vue'
 import { MetricCardSize } from '../enums'
-import type { ExploreFilterAll, FilterableExploreDimensions, QueryDatasource } from '@kong-ui-public/analytics-utilities'
+import type { ExploreFilterAll, FilterableExploreDimensions, QueryDatasource, Timeframe } from '@kong-ui-public/analytics-utilities'
 import { computed } from 'vue'
 
 const props = withDefaults(defineProps<{
@@ -60,6 +60,7 @@ const props = withDefaults(defineProps<{
   containerTitle?: string
   description?: string
   percentileLatency?: boolean
+  overrideTimeframe?: Timeframe
 }>(), {
   refreshInterval: 60 * 1000,
   queryReady: true,
@@ -69,6 +70,7 @@ const props = withDefaults(defineProps<{
   containerTitle: undefined,
   description: undefined,
   percentileLatency: undefined,
+  overrideTimeframe: undefined,
 })
 
 // Query stats for an entire org, no grouping or filtering.

--- a/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
+++ b/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
@@ -155,14 +155,26 @@ export default function useMetricFetcher(opts: MetricFetcherOptions): FetcherRes
       const { start_ms: startMs, end_ms: endMs } = raw.value.meta
 
       let numDays = (endMs - startMs) / (1000 * 60 * 60 * 24)
+      let numHours = (endMs - startMs) / (1000 * 60 * 60)
+      let numMinutes = (endMs - startMs) / (1000 * 60)
 
       if (opts.withTrend.value) {
         // If we're querying a trend, then the time range queried is doubled.
         numDays /= 2
+        numHours /= 2
+        numMinutes /= 2
+      }
+
+      if (numDays >= 1) {
+        return i18n.t('trendRange.custom_days', { numDays: Math.round(numDays) })
+      } else if (numHours >= 1) {
+        return i18n.t('trendRange.custom_hours', { numHours: Math.round(numHours) })
+      } else if (numMinutes >= 1) {
+        return i18n.t('trendRange.custom_minutes', { numMinutes: Math.round(numMinutes) })
       }
 
       // Avoid weirdness around daylight savings time by rounding up or down to the nearest day.
-      return i18n.t('trendRange.custom', { numDays: Math.round(numDays) })
+      return i18n.t('trendRange.custom_days', { numDays: Math.round(numDays) })
     } else {
       return opts.withTrend.value
         // @ts-ignore - dynamic i18n key

--- a/packages/analytics/analytics-metric-provider/src/locales/en.json
+++ b/packages/analytics/analytics-metric-provider/src/locales/en.json
@@ -23,7 +23,9 @@
     }
   },
   "trendRange": {
-    "custom": "vs previous {numDays, plural, =1 {day} other {# days}}",
+    "custom_days": "vs previous {numDays, plural, =1 {day} other {# days}}",
+    "custom_hours": "vs previous {numHours, plural, =1 {hour} other {# hours}}",
+    "custom_minutes": "vs previous {numMinutes, plural, =1 {minute} other {# minutes}}",
     "15m": "vs previous 15 minutes",
     "1h": "vs previous hour",
     "6h": "vs previous 6 hours",

--- a/packages/analytics/analytics-metric-provider/src/mockExploreResponse.ts
+++ b/packages/analytics/analytics-metric-provider/src/mockExploreResponse.ts
@@ -6,6 +6,7 @@ import type {
   ExploreResultV4,
   GroupByResult,
   QueryResponseMeta,
+  Timeframe,
 } from '@kong-ui-public/analytics-utilities'
 import { DeltaQueryTime, TimeframeKeys, TimePeriods, UnaryQueryTime } from '@kong-ui-public/analytics-utilities'
 
@@ -16,6 +17,7 @@ export interface MockOptions {
   dimensionNames?: string[]
   injectErrors?: 'latency' | 'traffic' | 'all'
   deterministic?: boolean
+  timeFrame?: Timeframe
 }
 
 export const mockExploreResponseFromCypress = (
@@ -40,7 +42,7 @@ export const mockExploreResponse = (
   body: ExploreQuery,
   opts?: MockOptions,
 ) => {
-  const timeframe = TimePeriods.get(TimeframeKeys.ONE_DAY)!
+  const timeframe = opts?.timeFrame || TimePeriods.get(TimeframeKeys.ONE_DAY)!
   const defaultQueryTime = body.granularity === 'trend' ? new DeltaQueryTime(timeframe) : new UnaryQueryTime(timeframe)
   const end = defaultQueryTime.endMs()
   const start = defaultQueryTime.startMs()


### PR DESCRIPTION
# Summary
https://konghq.atlassian.net/browse/MA-4160

This fixes the golden signals trend text so it correctly describes trends for absolute time ranges. The trend wording will no longer be "vs previous 0 days" for any sub-day time range.

## Changes

- Adjusted trend text logic for absolute time ranges.
- Added hour and minute trend text handling for sub-day absolute time ranges.
- Added/updated unit tests to cover absolute/fine-grain scenarios.

## Testing

- Component tests added/updated.
- Manually verified trend text for relative ranges and multiple absolute, fine-grain ranges.

## Before
Any sub-day absolute time range would display as `vs previous 0 days`
<img width="1459" height="273" alt="image" src="https://github.com/user-attachments/assets/e8de8c18-89ee-415b-8510-9da0d7309a13" />

## After
<img width="1448" height="267" alt="image" src="https://github.com/user-attachments/assets/5e8e63a4-4c90-4932-875e-ec23b8319a32" />


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
