### PR TITLE
fix(i18n): format timestamp of two decimal places

### DIFF
--- a/packages/core/i18n/src/i18n.spec.ts
+++ b/packages/core/i18n/src/i18n.spec.ts
@@ -132,6 +132,7 @@ describe('i18n', () => {
       const decimalTimestamp = formatUnixTimeStamp(1570111995.652561)
       const integerTimestamp = formatUnixTimeStamp(1570111995)
       const timestampInMs = formatUnixTimeStamp(1542068280000)
+      const timestampWithTwoDecimalPlaces = formatUnixTimeStamp(1570111995.65)
 
       expect(formattedDateAM).toBe('May 16, 2019, 11:42 AM')
       expect(formattedDatePM).toBe('May 17, 2019, 1:39 AM')
@@ -140,6 +141,7 @@ describe('i18n', () => {
       expect(november.substring(0, 7)).toBe('Nov 14,')
       expect(decimalTimestamp).toEqual(integerTimestamp)
       expect(timestampInMs).toBe('Nov 13, 2018, 12:18 AM')
+      expect(timestampWithTwoDecimalPlaces).toEqual(integerTimestamp)
     })
   })
 

--- a/packages/core/i18n/src/i18n.ts
+++ b/packages/core/i18n/src/i18n.ts
@@ -77,7 +77,7 @@ export const createI18n = <MessageSource extends Record<string, any>>
     }
 
     try {
-      const date = new Date(shamefullyNormalizeTimeStamp(timestamp) * 1000)
+      const date = new Date(shamefullyNormalizeTimeStamp(Math.round(timestamp)) * 1000)
 
       return intl.formatDate(date, datetimeFormat)
     } catch {


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

With a very special date and time `2025-08-16T04:15:05.220045Z`, which will be converted to `1755317705.22` as a Unix timestamp. Then, the `shamefullyNormalizeTimeStamp` function picks it up and checks its length, assuming it is a timestamp without decimals. However, `1755317705.22` coincidentally has a length of 13, causing it to be treated as a time in milliseconds, and it is then divided by 1000, which results in the date and time being formatted as 1970.

KM-1607
