### PR TITLE
feat(entities-plugins): support ai-mcp

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/AIMcp/AIMcpForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/AIMcp/AIMcpForm.vue
@@ -1,0 +1,25 @@
+<template>
+  <PluginFormWrapper
+    v-slot="configFormProps"
+    v-bind="props"
+  >
+    <ConfigForm v-bind="configFormProps" />
+  </PluginFormWrapper>
+</template>
+
+<script setup lang="ts">
+import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
+import { provide } from 'vue'
+import ConfigForm from './ConfigForm.vue'
+import PluginFormWrapper from '../shared/PluginFormWrapper.vue'
+
+import type { PluginFormWrapperProps } from '../shared/PluginFormWrapper.vue'
+
+const props = defineProps<PluginFormWrapperProps>()
+
+const slots = defineSlots<{
+  [K in typeof AUTOFILL_SLOT_NAME]: () => any
+}>()
+
+provide(AUTOFILL_SLOT, slots?.[AUTOFILL_SLOT_NAME])
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/AIMcp/ConfigForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/AIMcp/ConfigForm.vue
@@ -1,0 +1,91 @@
+<template>
+  <Form
+    class="ai-mcp-config-form"
+    :config="formConfig"
+    :data="data"
+    :schema="schema"
+    tag="div"
+    @change="onChange"
+  >
+    <ObjectField
+      as-child
+      name="config"
+      reset-label-path="reset"
+    >
+      <template #tools="{ name }">
+        <ArrayField
+          appearance="tabs"
+          :item-label="(_, index) => t('plugins.free-form.ai-mcp.tool_item_label', { index: index + 1 })"
+          :name="name"
+          sticky-tabs
+        />
+      </template>
+    </ObjectField>
+    <AdvancedFields />
+  </Form>
+</template>
+
+<script setup lang="ts">
+import { cloneDeep } from 'lodash-es'
+import Form from '../shared/Form.vue'
+import ArrayField from '../shared/ArrayField.vue'
+import ObjectField from '../shared/ObjectField.vue'
+import AdvancedFields from '../shared/AdvancedFields.vue'
+import { splitMapValues, joinMapValues } from './utils'
+import composables from '../../../composables'
+
+import type { AIMcpPlugin } from './types'
+import type { FormConfig } from '../shared/types'
+import type { ConfigFormProps } from '../shared/PluginFormWrapper.vue'
+
+defineProps<ConfigFormProps<AIMcpPlugin>>()
+
+const emit = defineEmits<{
+  change: [value: AIMcpPlugin]
+}>()
+
+const { i18n: { t } } = composables.useI18n()
+
+const prepareFormData = (data: AIMcpPlugin): AIMcpPlugin => {
+  const pluginConfig = cloneDeep(data)
+
+  if (pluginConfig.config?.tools?.length) {
+    pluginConfig.config.tools.forEach(tool => {
+      joinMapValues(tool.headers)
+      joinMapValues(tool.query)
+    })
+  }
+
+  return pluginConfig
+}
+
+const hasValue = (data: AIMcpPlugin | undefined): boolean => {
+  return !!data?.config
+}
+
+const formConfig: FormConfig<AIMcpPlugin> = {
+  prepareFormData,
+  hasValue,
+}
+
+const onChange = (newVal: AIMcpPlugin) => {
+  const pluginConfig = cloneDeep(newVal)
+
+  if (pluginConfig.config?.tools?.length) {
+    pluginConfig.config.tools.forEach(tool => {
+      splitMapValues(tool.headers)
+      splitMapValues(tool.query)
+    })
+  }
+
+  emit('change', pluginConfig)
+}
+</script>
+
+<style lang="scss" scoped>
+.ai-mcp-config-form {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-100;
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/AIMcp/index.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/AIMcp/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AIMcpForm.vue'

--- a/packages/entities/entities-plugins/src/components/free-form/AIMcp/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/AIMcp/types.ts
@@ -1,0 +1,52 @@
+import type { FreeFormPluginData } from '../../../types/plugins/free-form'
+
+export type AIMcpPlugin = FreeFormPluginData<AIMcp>
+
+export interface AIMcp {
+  logging: Logging
+  server?: Server
+  tools?: Tool[]
+  max_request_body_size?: number | null
+}
+
+/************************************************
+ *                    Logging                   *
+ ************************************************/
+
+export interface Logging {
+  log_statistics: boolean
+  log_payloads: boolean
+}
+
+/************************************************
+ *                    Server                    *
+ ************************************************/
+
+export interface Server {
+  enabled?: boolean
+  tag?: string | null
+  timeout?: number | null
+}
+
+/************************************************
+ *                     Tool                     *
+ ************************************************/
+
+export interface Tool {
+  description: string
+  host?: string | null
+  path?: string | null
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | null
+  scheme?: 'http' | 'https' | null
+  parameters?: Record<string, any> | null
+  request_body?: Record<string, any> | null
+  headers?: Record<string, string[]> | null
+  query?: Record<string, string[]> | null
+  annotations?: {
+    title?: string | null
+    read_only_hint?: boolean
+    destructive_hint?: boolean
+    idempotent_hint?: boolean
+    open_world_hint?: boolean
+  }
+}

--- a/packages/entities/entities-plugins/src/components/free-form/AIMcp/utils.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/AIMcp/utils.ts
@@ -1,0 +1,25 @@
+//Splits comma-separated string values in an object into arrays, mutating the object in place.
+export const splitMapValues = (input?: Record<string, any> | null) => {
+  if (!input || typeof input !== 'object') {
+    return
+  }
+
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === 'string') {
+      input[key] = value.split(/\s*,\s*/).filter(Boolean)
+    }
+  }
+}
+
+// Joins array values in an object into a comma-separated string, mutating the object in place.
+export const joinMapValues = (input?: Record<string, any> | null) => {
+  if (!input || typeof input !== 'object') {
+    return
+  }
+
+  for (const [key, value] of Object.entries(input)) {
+    if (Array.isArray(value)) {
+      input[key] = value.join(', ')
+    }
+  }
+}

--- a/packages/entities/entities-plugins/src/components/free-form/AIMcp/utils.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/AIMcp/utils.ts
@@ -1,4 +1,4 @@
-//Splits comma-separated string values in an object into arrays, mutating the object in place.
+// Splits comma-separated string values in an object into arrays, mutating the object in place.
 export const splitMapValues = (input?: Record<string, any> | null) => {
   if (!input || typeof input !== 'object') {
     return

--- a/packages/entities/entities-plugins/src/components/free-form/index.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/index.ts
@@ -1,3 +1,4 @@
 export { default as RequestCalloutForm } from './RequestCallout'
 export { default as ServiceProtectionForm } from './ServiceProtection'
 export { default as DatakitForm } from './Datakit'
+export { default as AIMcpForm } from './AIMcp'

--- a/packages/entities/entities-plugins/src/components/free-form/shared/EnhancedInput.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/EnhancedInput.vue
@@ -2,6 +2,7 @@
   <InputComponent
     v-bind="$attrs"
     :model-value="modelValue"
+    :resizable="multiline ? true : undefined"
     @change="handleChange"
     @update:model-value="handleInput"
   >

--- a/packages/entities/entities-plugins/src/components/free-form/shared/Field.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/Field.vue
@@ -49,6 +49,7 @@ import NumberField from './NumberField.vue'
 import EnumField from './EnumField.vue'
 import KeyValueField from './KeyValueField.vue'
 import TagField from './TagField.vue'
+import JsonField from './JsonField.vue'
 import type { GlobalAction } from './types'
 
 defineOptions({ name: 'AutoField' })
@@ -91,6 +92,8 @@ const fieldRenderer = computed(() => {
       return ObjectField
     case 'map':
       return KeyValueField
+    case 'json':
+      return JsonField
     default:
       return undefined
   }

--- a/packages/entities/entities-plugins/src/components/free-form/shared/NumberField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/NumberField.vue
@@ -52,7 +52,7 @@ const fieldAttrs = useFieldAttrs(field.path!, props)
 
 const between = computed(() => {
   const schema = (field.schema?.value as NumberLikeFieldSchema)
-  if (schema.gt) {
+  if (typeof schema.gt === 'number') {
     return { min: schema.gt }
   }
   const [min, max] = schema.between ?? []

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -658,6 +658,9 @@
       }
     },
     "free-form": {
+      "ai-mcp": {
+        "tool_item_label": "Tool #{index}"
+      },
       "request-callout": {
         "entity_name": "Request Callout",
         "by_lua_placeholder": "Enter Lua script here..."

--- a/packages/entities/entities-plugins/src/utils/free-form.ts
+++ b/packages/entities/entities-plugins/src/utils/free-form.ts
@@ -5,6 +5,7 @@ const mapping = {
     component: 'ServiceProtectionForm',
   },
   'datakit': 'DatakitForm',
+  'ai-mcp': 'AIMcpForm',
 } as const
 
 export type FreeFormName = keyof typeof mapping


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Supporting the `ai-mcp` plugin, using free form:
1. Implements `JsonField` for `parameters` and `request_body`. It can be used for all future JSON-typed fields.
2. Adds logic for `headers` and `query` to handle array-typed map values.

Plugin schema: https://github.com/Kong/gateway-schema-watcher/blob/main/plugins/ai-mcp.json.

KM-1594
