### PR TITLE
fix(dashboardrenderer): disable jump to request for llm datasource [MA-4246]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -120,6 +120,7 @@ interface ChartProps {
   showAnnotations?: boolean
   timeseriesZoom?: boolean
   requestsLink?: ExternalLink
+  queryDatasource?: string
 }
 
 const emit = defineEmits<{
@@ -138,6 +139,7 @@ const props = withDefaults(defineProps<ChartProps>(), {
   showAnnotations: true,
   timeseriesZoom: false,
   requestsLink: undefined,
+  queryDatasource: undefined,
 })
 
 const { i18n } = composables.useI18n()
@@ -333,7 +335,7 @@ const chartTooltipSortFn = computed(() => {
 const zoomActionItems = computed<ZoomActionItem[]>(() => {
   return [
     { label: i18n.t('zoom_action_items.zoom'), action: (newTimeRange: AbsoluteTimeRangeV4) => emit('zoom-time-range', newTimeRange) },
-    ...(props.requestsLink ? [{
+    ...(props.queryDatasource !== 'llm_usage' && props.requestsLink ? [{
       label: i18n.t('zoom_action_items.view_requests'),
       href: props.requestsLink.href,
     }] : []),

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -120,7 +120,6 @@ interface ChartProps {
   showAnnotations?: boolean
   timeseriesZoom?: boolean
   requestsLink?: ExternalLink
-  queryDatasource?: string
 }
 
 const emit = defineEmits<{
@@ -139,7 +138,6 @@ const props = withDefaults(defineProps<ChartProps>(), {
   showAnnotations: true,
   timeseriesZoom: false,
   requestsLink: undefined,
-  queryDatasource: undefined,
 })
 
 const { i18n } = composables.useI18n()
@@ -335,7 +333,7 @@ const chartTooltipSortFn = computed(() => {
 const zoomActionItems = computed<ZoomActionItem[]>(() => {
   return [
     { label: i18n.t('zoom_action_items.zoom'), action: (newTimeRange: AbsoluteTimeRangeV4) => emit('zoom-time-range', newTimeRange) },
-    ...(props.queryDatasource !== 'llm_usage' && props.requestsLink ? [{
+    ...(props.requestsLink ? [{
       label: i18n.t('zoom_action_items.view_requests'),
       href: props.requestsLink.href,
     }] : []),

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
@@ -230,4 +230,20 @@ describe('<DashboardTile />', () => {
     cy.getTestId('kebab-action-menu-1').click()
     cy.getTestId('chart-jump-to-requests-1').should('not.exist')
   })
+
+  it('should not show jump to requests link if datasource is llm_usage', () => {
+    mount({
+      definition: {
+        chart: mockTileDefinition.chart,
+        query: {
+          datasource: 'llm_usage',
+          metrics: [],
+          filters: [],
+        },
+      },
+    })
+
+    cy.getTestId('kebab-action-menu-1').click()
+    cy.getTestId('chart-jump-to-requests-1').should('not.exist')
+  })
 })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -230,8 +230,10 @@ const exploreLink = computed(() => {
   return `${exploreBaseUrl.value}?q=${JSON.stringify(exploreQuery)}&d=${datasource}&c=${props.definition.chart.type}`
 })
 
+const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && props.definition.query && props.definition.query?.datasource !== 'llm_usage')
+
 const requestsLink = computed(() => {
-  if (!requestsBaseUrl.value || !props.definition.query || !canShowKebabMenu.value) {
+  if (!canGenerateRequestsLink.value || !canShowKebabMenu.value) {
     return ''
   }
   const filters = [...props.context.filters, ...props.definition.query.filters ?? []]
@@ -403,12 +405,16 @@ const buildRequestsQuery = (timeRange: TimeRangeV4, filters: AllFilters[]) => {
 }
 
 const onSelectChartRange = (newTimeRange: AbsoluteTimeRangeV4) => {
+  if (!canGenerateRequestsLink.value) {
+    requestsLinkZoomActions.value = undefined
+
+    return
+  }
+
   const filters = [...props.context.filters, ...props.definition.query.filters ?? []]
   const query = buildRequestsQuery(newTimeRange, filters)
 
-  requestsLinkZoomActions.value = requestsBaseUrl.value ? {
-    href: `${requestsBaseUrl.value}?q=${JSON.stringify(query)}`,
-  } : undefined
+  requestsLinkZoomActions.value = { href: `${requestsBaseUrl.value}?q=${JSON.stringify(query)}` }
 }
 </script>
 


### PR DESCRIPTION
# Summary

Fix [MA-4246](https://konghq.atlassian.net/browse/MA-4246)
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

This will disable the Jump to Requests action when zooming or selecting the action dropdown menu for a DashboardTile when the datasource is `llm_usage`. 

Added a computed property to clean up other sections of the component that use the same conditions.


[MA-4246]: https://konghq.atlassian.net/browse/MA-4246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ