### PR TITLE
refactor(entities-plugins): datakit rename and adjust file structure

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowCanvas.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowCanvas.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import type { DragPayload, NodeId, NodePhase } from '../../types'
+import type { DragPayload, NodeId, NodePhase } from '../types'
 
 import { SparklesIcon } from '@kong/icons'
 import { Background } from '@vue-flow/background'
@@ -61,10 +61,10 @@ import { VueFlow } from '@vue-flow/core'
 import { useElementBounding } from '@vueuse/core'
 import { nextTick, useTemplateRef } from 'vue'
 
-import { DK_DATA_TRANSFER_MIME_TYPE } from '../../constants'
-import { provideFlowStore } from '../composables/useFlow'
-import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from '../constants'
-import FlowNode from '../node/FlowNode.vue'
+import { DK_DATA_TRANSFER_MIME_TYPE } from '../constants'
+import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from './constants'
+import FlowNode from './node/FlowNode.vue'
+import { provideFlowStore } from './store/flow'
 
 import '@vue-flow/controls/dist/style.css'
 import '@vue-flow/core/dist/style.css'

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
@@ -39,7 +39,7 @@ import { useTemplateRef, watch } from 'vue'
 import english from '../../../../locales/en.json'
 import BooleanField from '../../shared/BooleanField.vue'
 import { provideEditorStore } from '../composables'
-import FlowPanels from './modal/EditorCanvas.vue'
+import FlowPanels from './FlowPanels.vue'
 import EditorModal from './modal/EditorModal.vue'
 
 const { t } = createI18n<typeof english>('en-us', english)

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowPanels.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowPanels.vue
@@ -81,8 +81,8 @@ import { useDraggable, useElementBounding } from '@vueuse/core'
 import { useVueFlow } from '@vue-flow/core'
 import { computed, nextTick, ref, useId, useTemplateRef, watch } from 'vue'
 
-import { useEditorStore } from '../../composables'
-import FlowCanvas from './EditorCanvasFlow.vue'
+import { useEditorStore } from '../composables'
+import FlowCanvas from './FlowCanvas.vue'
 
 const { readonly, resizable } = defineProps<{
   readonly?: boolean

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/constants.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/constants.ts
@@ -1,4 +1,4 @@
-import type { LayoutOptions } from './composables/useFlow'
+import type { LayoutOptions } from './store/flow'
 
 export const DEFAULT_LAYOUT_OPTIONS = {
   padding: 80,

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
@@ -31,7 +31,7 @@ import { ExternalLinkIcon } from '@kong/icons'
 import { KButton } from '@kong/kongponents'
 
 import english from '../../../../../locales/en.json'
-import FlowPanels from './EditorCanvas.vue'
+import FlowPanels from '../FlowPanels.vue'
 import { useEditorStore } from '../store/store'
 
 import '@vue-flow/controls/dist/style.css'

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -195,7 +195,7 @@ import { computed, watch } from 'vue'
 
 import english from '../../../../../locales/en.json'
 import { isReadableProperty, isWritableProperty } from '../node/property'
-import { useOptionalFlowStore } from '../composables/useFlow'
+import { useOptionalFlowStore } from '../store/flow'
 import { getNodeMeta } from '../store/helpers'
 import { useEditorStore } from '../store/store'
 import HandleTwig from './HandleTwig.vue'

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/flow.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/flow.ts
@@ -10,14 +10,14 @@ import { MarkerType, useVueFlow } from '@vue-flow/core'
 import { createInjectionState } from '@vueuse/core'
 import { computed, toRaw, toValue } from 'vue'
 
+import { KUI_COLOR_BORDER_NEUTRAL_WEAK, KUI_COLOR_BORDER_PRIMARY, KUI_COLOR_BORDER_PRIMARY_WEAK } from '@kong/design-tokens'
 import useI18n from '../../../../../composables/useI18n'
 import { useToaster } from '../../../../../composables/useToaster'
+import { createEdgeConnectionString, createNewConnectionString } from '../composables/helpers'
+import { useOptionalConfirm } from '../composables/useConflictConnectionConfirm'
 import { DEFAULT_LAYOUT_OPTIONS, DEFAULT_VIEWPORT_WIDTH } from '../constants'
 import { isImplicitNode } from '../node/node'
-import { useEditorStore } from '../store/store'
-import { createEdgeConnectionString, createNewConnectionString } from './helpers'
-import { useOptionalConfirm } from './useConflictConnectionConfirm'
-import { KUI_COLOR_BORDER_NEUTRAL_WEAK, KUI_COLOR_BORDER_PRIMARY, KUI_COLOR_BORDER_PRIMARY_WEAK } from '@kong/design-tokens'
+import { useEditorStore } from './store'
 
 /**
  * Parse a handle string in the format of "inputs@fieldId" or "outputs@fieldId".


### PR DESCRIPTION
Rename and move some files to let their names better indicate their usages. The dependency graph will look like this:

```mermaid
---
config:
  theme: redux
  look: neo
---
flowchart TD
    A["FlowCanvas (Request)"] --> C["FlowPanels"]
    B["FlowCanvas (Response)"] --> C
    C --> D["FlowEditor"] & n1["EditorMain"]
    F["EditorContent"] --> E["EditorModal"]
    n1 --> F
    D --> n2["DatakitForm"]
    E --> D
    n1@{ shape: rect}
    F@{ shape: rect}
    n2@{ shape: rect}

```

KM-1628