### PR TITLE
fix: add back no-select css when dragging

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
@@ -128,6 +128,14 @@ watch(() => [props.absoluteLeft, props.absoluteTop], ([left, top]) => {
   }
 })
 
+watch(isDragging, (dragging) => {
+  if (dragging) {
+    document.body.classList.add('no-select')
+  } else {
+    document.body.classList.remove('no-select')
+  }
+})
+
 watch(tooltipEl, value => {
   if (value) {
     const { width, height } = value.getBoundingClientRect()


### PR DESCRIPTION
# Summary

https://github.com/Kong/public-ui-components/pull/2362 accidentally removed this

Specifically here: https://github.com/Kong/public-ui-components/pull/2362/files#diff-71dc2a490a433c8ae400ff6c7d0a5f36ddae8f1868c1eea59c7eff249feda218L138 

This PR adds back the `no-select` css to the document body when dragging the tooltip to prevent text selection on the page.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
