### PR TITLE
chore(entities-plugins): datakit rm nanoid

### DIFF
--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -99,7 +99,6 @@
     "focus-trap": "^7.6.5",
     "lodash-es": "^4.17.21",
     "marked": "^14.1.4",
-    "monaco-editor": "0.52.2",
-    "nanoid": "^5.1.5"
+    "monaco-editor": "0.52.2"
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/helpers.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/helpers.ts
@@ -15,8 +15,7 @@ import type {
   NameConnection,
   IdConnection,
 } from '../../types'
-import { cloneDeep } from 'lodash-es'
-import { nanoid } from 'nanoid'
+import { cloneDeep, uniqueId } from 'lodash-es'
 import {
   CONFIG_NODE_META_MAP,
   IMPLICIT_NODE_META_MAP,
@@ -32,7 +31,7 @@ export function clone<T>(value: T): T {
 export function createId<T extends 'node' | 'edge' | 'field'>(
   type: T,
 ): T extends 'node' ? NodeId : T extends 'edge' ? EdgeId : FieldId {
-  return `${type}:${nanoid()}` as unknown as T extends 'node'
+  return `${type}:${uniqueId()}` as unknown as T extends 'node'
     ? NodeId
     : T extends 'edge'
       ? EdgeId

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -991,9 +991,6 @@ importers:
       monaco-editor:
         specifier: 0.52.2
         version: 0.52.2
-      nanoid:
-        specifier: ^5.1.5
-        version: 5.1.5
     devDependencies:
       '@dagrejs/dagre':
         specifier: ^1.1.5


### PR DESCRIPTION
# Summary

[KM-1630](https://konghq.atlassian.net/browse/KM-1630)

`nanoid` isn't really needed. `lodash.uniqueId` should be enough.

[KM-1630]: https://konghq.atlassian.net/browse/KM-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ