### PR TITLE
fix(entities-plugins): datakit disconnect before update edges

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useFlow.ts
@@ -431,7 +431,10 @@ const [provideFlowStore, useOptionalFlowStore] = createInjectionState(
       }))
     })
 
-    onEdgeUpdate(({ connection }) => handleConnect(connection))
+    onEdgeUpdate(({ edge, connection }) => {
+      disconnectEdge(edge.id as EdgeId, false)
+      handleConnect(connection)
+    })
 
     function autoLayout() {
       let leftNode: Node<NodeInstance> | undefined


### PR DESCRIPTION
Fix the issue where the old edge is left untouched in some conditions while updating the edge