### PR TITLE
chore(codeowners): add team-km to core/expressions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,6 +35,7 @@
 /packages/core/documentation/ @Kong/team-core-ui @Kong/team-konnectx-platform-fe @Kong/team-devx
 /packages/core/tracing/ @Kong/team-km @Kong/team-core-ui
 /packages/core/entities-config-editor/ @Kong/team-km @Kong/team-core-ui
+/packages/core/expressions/ @Kong/team-km @Kong/team-core-ui
 
 # Portal packages
 /packages/portal/document-viewer/ @Kong/team-devx @Kong/team-core-ui


### PR DESCRIPTION
Add team-km as a codeowner to `/packages/core/expressions/`