### PR TITLE
feat(entities-plugins): datakit save and restore ui data

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -392,14 +392,23 @@ const fetchUrl = computed((): string => {
     return submitEndpoint
   }
 
+  let endpoint: string
+
   // plugin
   if (props.config.entityType && props.config.entityId) {
-    return endpoints.form[props.config.app].edit.forEntity
+    endpoint = endpoints.form[props.config.app].edit.forEntity
       .replace(/{entityType}/gi, props.config.entityType)
       .replace(/{entityId}/gi, props.config.entityId)
   } else {
-    return endpoints.form[props.config.app].edit.all
+    endpoint = endpoints.form[props.config.app].edit.all
   }
+
+  // UI data is currently only available on Konnect
+  if (props.config.app === 'konnect' && PLUGIN_METADATA[props.pluginType].useUIData) {
+    return `${endpoint}?__ui_data=true`
+  }
+
+  return endpoint
 })
 
 const toggle = (): void => {

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -404,7 +404,7 @@ const fetchUrl = computed((): string => {
   }
 
   // UI data is currently only available on Konnect
-  if (props.config.app === 'konnect' && PLUGIN_METADATA[props.pluginType].useUIData) {
+  if (props.config.app === 'konnect' && PLUGIN_METADATA[props.pluginType]?.useUIData) {
     return `${endpoint}?__ui_data=true`
   }
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/CodeEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/CodeEditor.vue
@@ -50,7 +50,7 @@ const {
 }>()
 
 const emit = defineEmits<{
-  change: [config: DatakitConfig]
+  change: [config: unknown]
   error: [msg: string]
 }>()
 
@@ -116,7 +116,7 @@ onMounted(() => {
       const config = yaml.load(value, {
         schema: JSON_SCHEMA,
         json: true,
-      }) as DatakitConfig
+      })
 
       monaco.editor.setModelMarkers(model!, LINT_SOURCE, [])
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/CodeEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/CodeEditor.vue
@@ -50,7 +50,7 @@ const {
 }>()
 
 const emit = defineEmits<{
-  change: [config: unknown]
+  change: [config: DatakitConfig]
   error: [msg: string]
 }>()
 
@@ -116,7 +116,7 @@ onMounted(() => {
       const config = yaml.load(value, {
         schema: JSON_SCHEMA,
         json: true,
-      })
+      }) as DatakitConfig
 
       monaco.editor.setModelMarkers(model!, LINT_SOURCE, [])
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
@@ -29,7 +29,7 @@
     <template #default="formProps">
       <Form
         v-bind="formProps"
-        :data="{ config }"
+        :data="{ config, __ui_data: uiData }"
         tag="div"
         @change="handleFormChange"
       >
@@ -38,7 +38,7 @@
           :config="config"
           :is-editing="props.isEditing"
           :ui-data="uiData"
-          @change="handleFlowConfigChange"
+          @change="handleConfigChange"
         />
         <CodeEditor
           v-else-if="finalEditorMode === 'code'"
@@ -64,7 +64,8 @@ import type { Component } from 'vue'
 // import type { ZodError } from 'zod'
 
 import type { Props } from '../shared/layout/StandardLayout.vue'
-import type { DatakitConfig, DatakitUIData, EditorMode } from './types'
+import type { DatakitConfig } from './types'
+import { type DatakitUIData, type EditorMode } from './types'
 
 import { createI18n } from '@kong-ui-public/i18n'
 import { CodeblockIcon, DesignIcon } from '@kong/icons'
@@ -135,8 +136,8 @@ const description = computed(() => {
 
 // Shared
 
-const config = ref({ ...props.model.config })
-const uiData = ref<DatakitUIData>()
+const config = ref<DatakitConfig>({ ...props.model.config })
+const uiData = ref<DatakitUIData | undefined>(props.model.__ui_data ? { ...props.model.__ui_data } : undefined)
 
 watch(realEditorMode, () => {
   props.onValidityChange?.({
@@ -145,10 +146,11 @@ watch(realEditorMode, () => {
   })
 })
 
-function handleConfigChange(newConfig: unknown) {
+function handleConfigChange(newConfig: DatakitConfig, newUIData?: DatakitUIData | null) {
   // update the external form state
   props.onFormChange({
     config: newConfig,
+    ...newUIData !== undefined ? { __ui_data: newUIData ?? undefined } : null,
   })
   props.onValidityChange?.({
     model: 'config',
@@ -158,11 +160,9 @@ function handleConfigChange(newConfig: unknown) {
   // update the local config as the external form state isn't
   // flowing back down to the component
   config.value = newConfig
-}
-
-function handleFlowConfigChange(newConfig: DatakitConfig, newUIData?: DatakitUIData) {
-  handleConfigChange(newConfig)
-  uiData.value = newUIData
+  if (newUIData !== undefined) {
+    uiData.value = newUIData ?? undefined
+  }
 }
 
 // Code editor

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
@@ -38,7 +38,7 @@
           :config="config"
           :is-editing="props.isEditing"
           :ui-data="uiData"
-          @change="handleConfigChange"
+          @change="handleFlowChange"
         />
         <CodeEditor
           v-else-if="finalEditorMode === 'code'"
@@ -64,8 +64,7 @@ import type { Component } from 'vue'
 // import type { ZodError } from 'zod'
 
 import type { Props } from '../shared/layout/StandardLayout.vue'
-import type { DatakitConfig } from './types'
-import { type DatakitUIData, type EditorMode } from './types'
+import type { DatakitConfig, DatakitUIData, EditorMode } from './types'
 
 import { createI18n } from '@kong-ui-public/i18n'
 import { CodeblockIcon, DesignIcon } from '@kong/icons'
@@ -136,7 +135,7 @@ const description = computed(() => {
 
 // Shared
 
-const config = ref<DatakitConfig>({ ...props.model.config })
+const config = ref({ ...props.model.config })
 const uiData = ref<DatakitUIData | undefined>(props.model.__ui_data ? { ...props.model.__ui_data } : undefined)
 
 watch(realEditorMode, () => {
@@ -146,7 +145,13 @@ watch(realEditorMode, () => {
   })
 })
 
-function handleConfigChange(newConfig: DatakitConfig, newUIData?: DatakitUIData | null) {
+/**
+ * Handle changes to the config and UI data.
+ *
+ * @param newConfig The new config to set.
+ * @param newUIData The new UI data to set. Use `null` to clear the existing UI data.
+ */
+function handleConfigChange(newConfig: unknown, newUIData?: DatakitUIData | null) {
   // update the external form state
   props.onFormChange({
     config: newConfig,
@@ -160,6 +165,17 @@ function handleConfigChange(newConfig: DatakitConfig, newUIData?: DatakitUIData 
   // update the local config as the external form state isn't
   // flowing back down to the component
   config.value = newConfig
+}
+
+/**
+ * Handle changes from the flow editor.
+ *
+ * @param newConfig The new config to set.
+ * @param newUIData The new UI data to set. Use `null` to clear the existing UI data.
+ */
+function handleFlowChange(newConfig: DatakitConfig, newUIData?: DatakitUIData | null) {
+  handleConfigChange(newConfig, newUIData)
+
   if (newUIData !== undefined) {
     uiData.value = newUIData ?? undefined
   }
@@ -191,7 +207,7 @@ function handleConfigChange(newConfig: DatakitConfig, newUIData?: DatakitUIData 
 //     .join('; ')
 // }
 
-function handleCodeChange(newConfig: DatakitConfig) {
+function handleCodeChange(newConfig: unknown) {
   handleConfigChange(newConfig)
 
   // TODO: use strict validation and map back to the exact location of schema validation errors
@@ -224,7 +240,7 @@ function handleFormChange(data: any) {
   for (const key in data.config) {
     // updating nodes can lead to re`load`ing the flow editor state
     if (key !== 'nodes') {
-      config.value[key as keyof DatakitConfig] = data.config[key]
+      config.value[key] = data.config[key]
     }
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
@@ -191,7 +191,7 @@ function handleConfigChange(newConfig: DatakitConfig, newUIData?: DatakitUIData 
 //     .join('; ')
 // }
 
-function handleCodeChange(newConfig: unknown) {
+function handleCodeChange(newConfig: DatakitConfig) {
   handleConfigChange(newConfig)
 
   // TODO: use strict validation and map back to the exact location of schema validation errors
@@ -224,7 +224,7 @@ function handleFormChange(data: any) {
   for (const key in data.config) {
     // updating nodes can lead to re`load`ing the flow editor state
     if (key !== 'nodes') {
-      config.value[key] = data.config[key]
+      config.value[key as keyof DatakitConfig] = data.config[key]
     }
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/init.ts
@@ -153,8 +153,6 @@ export function initEditorState(
   // Mark all nodes that should be in 'request' phase
   markRequestNodes(['request', 'service_request'])
 
-  // TODO(Makito): Should we clean up stale nodes from the UI data in case the name of a deleted node is reused in the future?
-
   return { nodes, edges, needLayout }
 }
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/types.ts
@@ -94,7 +94,7 @@ export interface DatakitUIData {
   /**
    * UI nodes that store data like input/output fields, positions, and other metadata.
    */
-  nodes: UINode[]
+  nodes?: UINode[]
 }
 /**
  * The phase of the node in the request/response cycle.

--- a/packages/entities/entities-plugins/src/definitions/metadata.ts
+++ b/packages/entities/entities-plugins/src/definitions/metadata.ts
@@ -708,6 +708,7 @@ export const PLUGIN_METADATA: Record<string, Omit<PluginMetaData<I18nMessageSour
     descriptionKey: 'plugins.meta.datakit.description',
     isEnterprise: false,
     nameKey: 'plugins.meta.datakit.name',
+    useUIData: true,
     ...PLUGIN_GROUP_AND_SCOPE_MAP['datakit'],
   },
   'ai-prompt-compressor': {

--- a/packages/entities/entities-plugins/src/types/plugin.ts
+++ b/packages/entities/entities-plugins/src/types/plugin.ts
@@ -119,6 +119,7 @@ export type PluginMetaData<I18nMessageSource = void> = {
   isEnterprise: boolean // The value will be True if the Plugin is enterprise only.
   useLegacyForm?: boolean // An optional field to use legacy form for the plugin. Default to false.
   fieldRules?: FieldRules
+  useUIData?: boolean // An optional field that indicates if the plugin may have associated UI data. (via `?__ui_data`)
 }
 
 export interface PluginType extends PluginMetaData {


### PR DESCRIPTION
* Utilise the `?__ui_data` endpoint to save and restore the UI data
* Add a `useUIData` field to plugin metadata for future usage
* Add more types

https://github.com/user-attachments/assets/98edfce7-9ddf-48c7-8d89-be9447468961

KM-1462

