### PR TITLE
fix(entities-plugins): datakit expand handles on i/o fields update

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/OutputValueField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/OutputValueField.vue
@@ -205,12 +205,14 @@ watchEffect(() => {
       position: absolute;
       right: 8px;
       top: 8px;
+      z-index: 10;
     }
 
     :deep(.card-content) {
       display: flex;
       flex-direction: column;
       gap: $kui-space-40;
+      z-index: 1;
     }
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -288,6 +288,14 @@ watch(outputsCollapsible, (collapsible) => {
     storeToggleExpanded(data.id, 'output', true, false)
   }
 }, { immediate: true })
+
+watch(() => data.fields.input, (input) => {
+  storeToggleExpanded(data.id, 'input', input.length > 0, false)
+}, { deep: true })
+
+watch(() => data.fields.output, (output) => {
+  storeToggleExpanded(data.id, 'output', output.length > 0, false)
+}, { deep: true })
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
* Expand handles on I/O fields update (add, rename)
* Collapse handles when all I/O fields are removed
* Fix a `z-index` issue (the removal button is hard to interact with)


https://github.com/user-attachments/assets/86ee3311-50a9-471d-afef-0b04e51014eb



KM-1655