### PR TITLE
refactor(entities-plugins): datakit - data flow

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/CodeEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/CodeEditor.vue
@@ -37,16 +37,15 @@ import yaml, { JSON_SCHEMA } from 'js-yaml'
 import * as examples from './examples'
 
 import type { YAMLException } from 'js-yaml'
-import type { DatakitConfig } from './types'
+import type { DatakitConfig, DatakitFormData } from './types'
+import { useFormShared } from '../shared/composables'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
-const {
-  // editing,
-  config,
-} = defineProps<{
+const { formData } = useFormShared<DatakitFormData>()
+
+defineProps<{
   editing: boolean
-  config?: DatakitConfig
 }>()
 
 const emit = defineEmits<{
@@ -100,9 +99,9 @@ onMounted(() => {
   })
   editorRef.value = editor
 
-  if (config && Object.keys(config).length > 0) {
+  if (formData.config && Object.keys(formData.config).length > 0) {
     editor.setValue(
-      yaml.dump(toRaw(config), {
+      yaml.dump(toRaw(formData.config), {
         schema: JSON_SCHEMA,
         noArrayIndent: true,
       }),
@@ -119,7 +118,7 @@ onMounted(() => {
       })
 
       monaco.editor.setModelMarkers(model!, LINT_SOURCE, [])
-
+      formData.config = config as DatakitConfig
       emit('change', config)
     } catch (error: unknown) {
       const { message, mark } = error as YAMLException

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/DatakitForm.vue
@@ -29,21 +29,16 @@
     <template #default="formProps">
       <Form
         v-bind="formProps"
-        :data="{ config, __ui_data: uiData }"
         tag="div"
-        @change="handleFormChange"
       >
         <FlowEditor
           v-if="finalEditorMode === 'flow'"
-          :config="config"
           :is-editing="props.isEditing"
-          :ui-data="uiData"
           @change="handleFlowChange"
         />
         <CodeEditor
           v-else-if="finalEditorMode === 'code'"
           class="code-editor"
-          :config="config"
           :editing="props.isEditing"
           @change="handleCodeChange"
           @error="handleCodeError"
@@ -64,7 +59,7 @@ import type { Component } from 'vue'
 // import type { ZodError } from 'zod'
 
 import type { Props } from '../shared/layout/StandardLayout.vue'
-import type { DatakitConfig, DatakitUIData, EditorMode } from './types'
+import type { EditorMode } from './types'
 
 import { createI18n } from '@kong-ui-public/i18n'
 import { CodeblockIcon, DesignIcon } from '@kong/icons'
@@ -133,11 +128,6 @@ const description = computed(() => {
   }
 })
 
-// Shared
-
-const config = ref({ ...props.model.config })
-const uiData = ref<DatakitUIData | undefined>(props.model.__ui_data ? { ...props.model.__ui_data } : undefined)
-
 watch(realEditorMode, () => {
   props.onValidityChange?.({
     model: 'config',
@@ -151,20 +141,11 @@ watch(realEditorMode, () => {
  * @param newConfig The new config to set.
  * @param newUIData The new UI data to set.
  */
-function handleConfigChange(newConfig: unknown, newUIData?: DatakitUIData) {
-  // update the external form state
-  props.onFormChange({
-    config: newConfig,
-    ...newUIData ? { __ui_data: newUIData } : undefined,
-  })
+function handleConfigChange() {
   props.onValidityChange?.({
     model: 'config',
     valid: true,
   })
-
-  // update the local config as the external form state isn't
-  // flowing back down to the component
-  config.value = newConfig
 }
 
 /**
@@ -173,10 +154,8 @@ function handleConfigChange(newConfig: unknown, newUIData?: DatakitUIData) {
  * @param newConfig The new config to set.
  * @param newUIData The new UI data to set.
  */
-function handleFlowChange(newConfig: DatakitConfig, newUIData: DatakitUIData) {
-  handleConfigChange(newConfig, newUIData)
-
-  uiData.value = newUIData
+function handleFlowChange() {
+  handleConfigChange()
 }
 
 // Code editor
@@ -206,7 +185,7 @@ function handleFlowChange(newConfig: DatakitConfig, newUIData: DatakitUIData) {
 // }
 
 function handleCodeChange(newConfig: unknown) {
-  handleConfigChange(newConfig)
+  handleConfigChange()
 
   // TODO: use strict validation and map back to the exact location of schema validation errors
   // const { success, error } = DatakitConfigSchema.safeParse(newConfig)
@@ -232,16 +211,6 @@ function handleCodeError(msg: string) {
 }
 
 // Flow editor
-
-// This change comes from freeform fields
-function handleFormChange(data: any) {
-  for (const key in data.config) {
-    // updating nodes can lead to re`load`ing the flow editor state
-    if (key !== 'nodes') {
-      config.value[key] = data.config[key]
-    }
-  }
-}
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ConfigNode, DatakitConfig, DatakitUIData, UINode } from '../types'
+import type { ConfigNode, DatakitConfig, DatakitFormData, DatakitUIData, UINode } from '../types'
 
 import { createI18n } from '@kong-ui-public/i18n'
 import { ExpandIcon } from '@kong/icons'
@@ -41,12 +41,13 @@ import BooleanField from '../../shared/BooleanField.vue'
 import { provideEditorStore } from '../composables'
 import FlowPanels from './FlowPanels.vue'
 import EditorModal from './modal/EditorModal.vue'
+import { useFormShared } from '../../shared/composables'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
-const { config, uiData, isEditing } = defineProps<{
-  config?: DatakitConfig
-  uiData?: DatakitUIData
+const { formData } = useFormShared<DatakitFormData>()
+
+const { isEditing } = defineProps<{
   isEditing?: boolean
 }>()
 
@@ -58,13 +59,14 @@ const emit = defineEmits<{
 const flowPanels = useTemplateRef('flowPanels')
 
 function onChange(configNodes: ConfigNode[], uiNodes: UINode[]) {
-  emit('change',
-    { ...config, nodes: configNodes },
-    { ...uiData, nodes: uiNodes },
-  )
+  const nextConfig = { ...formData.config, nodes: configNodes }
+  const nextUIData = { ...formData.__ui_data, nodes: uiNodes }
+  formData.config = nextConfig
+  formData.__ui_data = nextUIData
+  emit('change', nextConfig, nextUIData)
 }
 
-const { modalOpen } = provideEditorStore(config?.nodes ?? [], uiData?.nodes ?? [], {
+const { modalOpen } = provideEditorStore(formData.config?.nodes ?? [], formData.__ui_data?.nodes ?? [], {
   onChange,
   isEditing,
 })

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/types.ts
@@ -191,3 +191,8 @@ export interface DragPayload {
     }
   }
 }
+
+export type DatakitFormData = {
+  config: DatakitConfig
+  __ui_data: DatakitUIData
+}

--- a/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/PluginFormWrapper.vue
@@ -22,7 +22,7 @@
     <div class="ff-form-config-form">
       <slot
         class="ff-form"
-        :data="pruneData(model)"
+        :data="prunedData"
         :schema="freeFormSchema"
         @change="onFormChange"
       />
@@ -118,16 +118,17 @@ const configCollapse = ref(false)
  * Avoid passing freeform data that it can't handle. e.g. `scope`, `update_time`
  * freeform will pass these unknown values back through the update method, resulting in the data being overwritten when it is eventually merged with the vfg's data
  */
-function pruneData(data: PluginFormWrapperProps<T>['model']) {
+const prunedData = computed(() => {
   const ffDataKeys: Array<keyof PluginFormWrapperProps<T>['model']> = [
     'config',
     'instance_name',
     'partials',
     'protocols',
     'tags',
+    '__ui_data',
   ]
-  return pick(data, ffDataKeys)
-}
+  return pick(props.model, ffDataKeys)
+})
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -79,7 +79,7 @@
       :title="pluginConfigTitle ?? t('plugins.form.sections.plugin_config.title')"
     >
       <slot
-        :data="pruneData(model)"
+        :data="prunedData"
         :schema="freeFormSchema"
         @change="onFormChange"
       />
@@ -196,13 +196,14 @@ const freeFormSchema = computed(() => {
  * Avoid passing freeform data that it can't handle. e.g. `scope`, `update_time`
  * freeform will pass these unknown values back through the update method, resulting in the data being overwritten when it is eventually merged with the vfg's data
  */
-function pruneData(data: Props<T>['model']) {
+const prunedData = computed(() => {
   const ffDataKeys: Array<keyof Props<T>['model']> = [
     'config',
     'partials',
+    '__ui_data',
   ]
-  return pick(data, ffDataKeys)
-}
+  return pick(props.model, ffDataKeys)
+})
 
 const scoped = ref(false)
 const moreCollapsed = ref(true)

--- a/packages/entities/entities-plugins/src/types/plugins/free-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/free-form.ts
@@ -4,4 +4,5 @@ export type FreeFormPluginData<T extends Record<string, any> = any> = {
   partials?: Array<{ id: string }>
   protocols?: string[]
   tags?: string[]
+  __ui_data?: Record<string, any>
 }


### PR DESCRIPTION
# Summary

### Before
The `flowEditor` and the `codeEditor` shared the local states from `DatakitForm`, then sync the local states to freeform, then freeform will send the data to the outside.
<img width="2090" height="1174" alt="image" src="https://github.com/user-attachments/assets/e746bf96-224b-4d9d-bef6-87718d0fe5c3" />



### After
The `flowEditor` and the `codeEditor` shared form data from freeform directly
<img width="1934" height="1176" alt="image" src="https://github.com/user-attachments/assets/0b4db2dd-10fd-4613-8562-1514e5ee9502" />

