### PR TITLE
feat(entities-plugins): datakit - avoid call and exit in response

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useNodeForm.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useNodeForm.ts
@@ -334,6 +334,9 @@ export function useNodeForm<T extends BaseFormData = BaseFormData>(
       // skip the node that will create a cycle
       if (willCreateCycle(node.id)) continue
 
+      // the nodes in request phase can not connect to response phase
+      if (currentNode.value.phase === 'request' && node.phase === 'response') continue
+
       options.push({ value: node.id, label: node.name })
 
       for (const field of node.fields.output) {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
@@ -41,7 +41,6 @@ import { computed, nextTick, shallowRef, useId } from 'vue'
 import { VueFlow } from '@vue-flow/core'
 import { createI18n } from '@kong-ui-public/i18n'
 import english from '../../../../../locales/en.json'
-import { DK_DATA_TRANSFER_MIME_TYPE } from '../../constants'
 import { useEditorStore } from '../store/store'
 import { CONFIG_NODE_META_MAP } from './node'
 import NodePanelItem from './NodePanelItem.vue'
@@ -51,7 +50,7 @@ import type { ConfigNodeType, NodeInstance, DragPayload } from '../../types'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
-const { createNode } = useEditorStore()
+const { createNode, draggingNodePayload } = useEditorStore()
 
 const previewId = `dk-drag-preview-${useId()}`
 
@@ -112,7 +111,7 @@ const handleDragStart = async (e: DragEvent, type: ConfigNodeType) => {
       anchor,
     },
   }
-  e.dataTransfer?.setData(DK_DATA_TRANSFER_MIME_TYPE, JSON.stringify(payload))
+  draggingNodePayload.value = payload
   e.dataTransfer?.setDragImage(
     clone,
     anchor.offsetX,

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import type {
   ConfigNode,
   CreateNodePayload,
+  DragPayload,
   EdgeData,
   EdgeId,
   EdgeInstance,
@@ -40,6 +41,7 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
     const selection = ref<NodeId>()
     const modalOpen = ref(false)
     const propertiesPanelOpen = ref(false)
+    const draggingNodePayload = ref<DragPayload | null>(null)
 
     const history = useTaggedHistory(state, {
       capacity: 200,
@@ -518,6 +520,7 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
       newCreatedNodeId,
       invalidConfigNodeIds,
       propertiesPanelOpen,
+      draggingNodePayload,
 
       // maps & getters
       nodeMapById,


### PR DESCRIPTION
# Summary

1. Avoid any nodes in the request phase to select a node from the response phase
2. Avoid the `call` node and the `exit` node to be added to the response phase