### PR TITLE
fix: explore link fall back to `api_usage` if query datasource is not provided

### DIFF
--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
@@ -176,6 +176,14 @@ describe('useContextLinks', () => {
     expect(params.get('d')).toBe('api_usage')
   })
 
+  it('falls back to api_usage when query datasource is not provided', async () => {
+    const { wrapper } = mountComposable({ datasource: undefined })
+    await flushPromises()
+
+    const params = new URLSearchParams((wrapper.vm.exploreLinkKebabMenu as string).split('?')[1])
+    expect(params.get('d')).toBe('api_usage')
+  })
+
   it('does not build explore link if base URL missing', async () => {
     const { wrapper } = mountComposable({
       exploreBase: '',

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -31,7 +31,7 @@ export default function useContextLinks(
   const canShowKebabMenu = computed(() => !['golden_signals', 'top_n', 'gauge'].includes(definition.value.chart.type))
 
   const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && definition.value.query.datasource !== 'llm_usage')
-  const canGenerateExploreLink = computed(() => exploreBaseUrl.value && definition.value.query && ['api_usage', 'llm_usage', 'basic'].includes(definition.value.query.datasource))
+  const canGenerateExploreLink = computed(() => exploreBaseUrl.value && definition.value.query && ['basic', 'api_usage', 'llm_usage', undefined].includes(definition.value.query.datasource))
 
   const chartDataGranularity = computed(() => {
     return chartData.value ? msToGranularity(chartData.value.meta.granularity_ms) : undefined
@@ -124,8 +124,8 @@ export default function useContextLinks(
       return ''
     }
 
-    // If the datasource is 'basic', we need to map it to 'api_usage' for the explore URL.
-    const datasource = definition.value.query?.datasource === 'basic' ? 'api_usage' : definition.value.query?.datasource
+    // If the datasource is 'basic' or not provided, fallback to api_usage
+    const datasource = ['api_usage', 'llm_usage'].includes(definition.value.query.datasource) ? definition.value.query.datasource : 'api_usage'
 
     return `${exploreBaseUrl.value}?q=${JSON.stringify(exploreQuery)}&d=${datasource}&c=${definition.value.chart.type}`
   }


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
