### PR TITLE
feat: new flow node layout, truncate text when overflow

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/constants.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/constants.ts
@@ -1,3 +1,5 @@
+import type { KeySpec } from './flow-editor/utils'
+
 export const DK_HEADER_HEIGHT = '44px'
 export const DK_SIDE_PANEL_WIDTH = '220px'
 export const DK_NODE_PROPERTIES_PANEL_WIDTH = '366px'
@@ -26,3 +28,16 @@ export const HTTP_METHODS = [
 ] as const
 
 export const DK_DATA_TRANSFER_MIME_TYPE = 'application/x-datakit+json'
+
+export const HOTKEYS = {
+  delete: ['Delete'],
+  undo: ['Mod', 'Z'],
+  redo: {
+    mac: ['Mod', 'Shift', 'Z'],
+    windows: ['Mod', 'Y'],
+    linux: ['Mod', 'Shift', 'Z'],
+  },
+  copy: ['Mod', 'C'],
+  paste: ['Mod', 'V'],
+  duplicate: ['Mod', 'D'],
+} as const satisfies Record<string, KeySpec>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/HotkeyLabel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/HotkeyLabel.vue
@@ -1,0 +1,48 @@
+<template>
+  <span
+    class="dk-hotkey-label"
+    :class="{ reverse }"
+  >
+    <span
+      v-if="label"
+      class="label"
+    >
+      {{ label }}
+    </span>
+    <kbd class="keys">{{ formattedKeys }}</kbd>
+  </span>
+</template>
+
+<script setup lang="ts">
+import type { KeySpec } from './utils'
+
+import { formatKeys } from './utils'
+
+const { keys, reverse } = defineProps<{
+  label?: string
+  keys: KeySpec
+  reverse?: boolean
+}>()
+
+const formattedKeys = formatKeys(keys)
+</script>
+
+<style lang="scss" scoped>
+.dk-hotkey-label {
+  display: flex;
+  flex-grow: 1;
+  gap: $kui-space-30;
+  justify-content: space-between;
+  white-space: nowrap;
+
+  .keys {
+    color: $kui-color-text-neutral;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, Inter, sans-serif;
+    font-size: $kui-font-size-20;
+  }
+
+  &.reverse .keys {
+    color: $kui-color-text-neutral-weak;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
@@ -3,7 +3,6 @@
     <header class="header">
       <div class="actions">
         <KTooltip
-          :text="t('plugins.free-form.datakit.flow_editor.actions.undo')"
           :z-index="10000"
         >
           <KButton
@@ -15,9 +14,16 @@
             <!-- TODO: switch to <UndoIcon /> when available -->
             <RedoIcon class="flip" />
           </KButton>
+
+          <template #content>
+            <HotkeyLabel
+              :keys="HOTKEYS.undo"
+              :label="t('plugins.free-form.datakit.flow_editor.actions.undo')"
+              reverse
+            />
+          </template>
         </KTooltip>
         <KTooltip
-          :text="t('plugins.free-form.datakit.flow_editor.actions.redo')"
           :z-index="10000"
         >
           <KButton
@@ -28,6 +34,14 @@
           >
             <RedoIcon />
           </KButton>
+
+          <template #content>
+            <HotkeyLabel
+              :keys="HOTKEYS.redo"
+              :label="t('plugins.free-form.datakit.flow_editor.actions.redo')"
+              reverse
+            />
+          </template>
         </KTooltip>
         <div class="divider" />
         <KButton
@@ -66,6 +80,8 @@ import '@vue-flow/controls/dist/style.css'
 import '@vue-flow/core/dist/style.css'
 import '@vue-flow/core/dist/theme-default.css'
 import { useHotkeys } from '../composables/useHotkeys'
+import HotkeyLabel from '../HotkeyLabel.vue'
+import { HOTKEYS } from '../../constants'
 
 const { t } = createI18n<typeof english>('en-us', english)
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -296,6 +296,8 @@ watch(() => data.fields.output, (output) => {
 @use "sass:math";
 
 $node-border-width: 1px;
+$node-max-width: 246px;
+$node-min-width: 168px;
 $handle-width: 3px;
 $handle-height: 10px;
 
@@ -303,14 +305,15 @@ $handle-height: 10px;
   background-color: $kui-color-background;
   border: 1px solid $kui-color-border-neutral-weak;
   border-radius: $kui-border-radius-20;
-  min-width: 120px;
+  max-width: $node-max-width;
+  min-width: $node-min-width;
   padding: $kui-space-40 0;
 
   .body {
     padding: 0 $kui-space-40;
 
     .info-line {
-      align-items: center;
+      align-items: flex-start;
       display: flex;
       flex-direction: row;
       gap: $kui-space-40;
@@ -321,13 +324,26 @@ $handle-height: 10px;
       .name-and-error {
         align-items: center;
         display: flex;
+        flex: 1 1 auto;
         gap: $kui-space-10;
       }
 
+      .error-icon {
+        align-self: flex-start;
+      }
+
       .name {
+        -webkit-box-orient: vertical;
+        display: -webkit-box;
         font-size: $kui-font-size-20;
         font-weight: $kui-font-weight-semibold;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
         line-height: $kui-line-height-20;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        word-break: break-all;
+        word-wrap: break-word;
       }
     }
   }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -7,27 +7,52 @@
     }"
   >
     <div class="body">
-      <div class="info-line">
-        <div class="name-and-error">
-          <WarningIcon
-            v-if="error"
-            class="error-icon"
-            :color="KUI_COLOR_TEXT_DANGER"
-            :size="16"
-          />
-          <div class="name">
-            {{ name }}
-          </div>
-        </div>
-
+      <KTooltip
+        v-if="!isImplicit"
+        class="badge"
+        placement="top"
+        :text="data.type"
+      >
         <NodeBadge
-          v-if="!isImplicit"
+          icon-only
           size="small"
           :type="data.type"
         />
+      </KTooltip>
+      <div class="name">
+        {{ name }}
       </div>
-
-      <slot />
+      <WarningIcon
+        v-if="error"
+        class="error-icon"
+        :color="KUI_COLOR_TEXT_DANGER"
+        :size="16"
+      />
+      <KDropdown
+        v-if="!isImplicit"
+        class="menu"
+        :kpop-attributes="{
+          offset: '4px',
+        }"
+        width="120"
+      >
+        <KButton
+          appearance="tertiary"
+          class="trigger"
+          icon
+          size="small"
+        >
+          <MoreIcon :color="KUI_COLOR_TEXT" />
+        </KButton>
+        <template #items>
+          <KDropdownItem danger>
+            <div class="item">
+              Delete
+              <kbd class="key">⌫</kbd>
+            </div>
+          </KDropdownItem>
+        </template>
+      </KDropdown>
     </div>
 
     <div
@@ -179,11 +204,12 @@ import { createI18n } from '@kong-ui-public/i18n'
 import {
   KUI_COLOR_BACKGROUND_NEUTRAL_STRONG,
   KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER,
+  KUI_COLOR_TEXT,
   KUI_COLOR_TEXT_DANGER,
   KUI_COLOR_TEXT_DISABLED,
   KUI_ICON_SIZE_20,
 } from '@kong/design-tokens'
-import { UnfoldLessIcon, UnfoldMoreIcon, WarningIcon } from '@kong/icons'
+import { MoreIcon, UnfoldLessIcon, UnfoldMoreIcon, WarningIcon } from '@kong/icons'
 import { Handle, Position } from '@vue-flow/core'
 import { computed, watch } from 'vue'
 
@@ -310,40 +336,60 @@ $handle-height: 10px;
   padding: $kui-space-40 0;
 
   .body {
+    align-items: flex-start;
+    display: flex;
+    gap: $kui-space-40;
+    margin-bottom: $kui-space-40;
     padding: 0 $kui-space-40;
 
-    .info-line {
-      align-items: flex-start;
-      display: flex;
-      flex-direction: row;
-      gap: $kui-space-40;
-      justify-content: space-between;
-      margin-bottom: $kui-space-40;
-      width: 100%;
+    .error-icon {
+      align-self: flex-start;
+    }
 
-      .name-and-error {
-        align-items: center;
+    .name {
+      -webkit-box-orient: vertical;
+      display: -webkit-box;
+      flex: 1 1 auto;
+      font-size: $kui-font-size-20;
+      font-weight: $kui-font-weight-semibold;
+      -webkit-line-clamp: 2;
+      line-clamp: 2;
+      line-height: $kui-line-height-20;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      word-break: break-all;
+      word-wrap: break-word;
+    }
+
+    .trigger {
+      height: 16px;
+      width: 16px;
+
+      :deep(.kui-icon) {
+        height: 12px !important;
+        width: 12px !important;
+      }
+    }
+
+    .menu {
+      .item {
         display: flex;
-        flex: 1 1 auto;
-        gap: $kui-space-10;
+        flex-grow: 1;
+        justify-content: space-between;
       }
 
-      .error-icon {
-        align-self: flex-start;
+      .key {
+        color: $kui-color-text-neutral;
+        font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
       }
 
-      .name {
-        -webkit-box-orient: vertical;
-        display: -webkit-box;
+      :deep(.dropdown-trigger) {
+        display: flex;
+      }
+
+      :deep(.dropdown-item-trigger) {
         font-size: $kui-font-size-20;
-        font-weight: $kui-font-weight-semibold;
-        -webkit-line-clamp: 2;
-        line-clamp: 2;
-        line-height: $kui-line-height-20;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        word-break: break-all;
-        word-wrap: break-word;
+        padding: $kui-space-30 $kui-space-40;
       }
     }
   }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -226,6 +226,7 @@ import { isImplicitNode } from './node'
 import NodeBadge from './NodeBadge.vue'
 import HotkeyLabel from '../HotkeyLabel.vue'
 import { HOTKEYS } from '../../constants'
+import { isEqual } from 'lodash-es'
 
 const { data } = defineProps<{
   data: NodeInstance
@@ -314,12 +315,16 @@ watch(outputsCollapsible, (collapsible) => {
   }
 }, { immediate: true })
 
-watch(() => data.fields.input, (input) => {
-  storeToggleExpanded(data.id, 'input', input.length > 0, false)
+watch(() => data.fields.input, (input, oldInput) => {
+  if (!isEqual(input, oldInput)) {
+    storeToggleExpanded(data.id, 'input', input.length > 0, false)
+  }
 }, { deep: true })
 
-watch(() => data.fields.output, (output) => {
-  storeToggleExpanded(data.id, 'output', output.length > 0, false)
+watch(() => data.fields.output, (output, oldOutput) => {
+  if (!isEqual(output, oldOutput)) {
+    storeToggleExpanded(data.id, 'output', output.length > 0, false)
+  }
 }, { deep: true })
 </script>
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -75,7 +75,7 @@
               <div
                 class="handle-label trigger"
                 :class="{
-                  'has-fields': data.fields.input.length > 0,
+                  'has-fields': hasInputFields,
                   collapsible: inputsCollapsible,
                 }"
                 @click.stop="toggleExpanded('input')"
@@ -83,7 +83,7 @@
                 <div class="text">
                   inputs
                 </div>
-                <template v-if="data.fields.input.length > 0">
+                <template v-if="hasInputFields">
                   <UnfoldMoreIcon
                     v-if="!inputsExpanded"
                     :size="KUI_ICON_SIZE_20"
@@ -96,7 +96,7 @@
                 </template>
               </div>
               <HandleTwig
-                v-if="inputsExpanded"
+                v-if="hasInputFields && inputsExpanded"
                 :color="handleTwigColor"
                 :position="inputPosition"
                 type="bar"
@@ -104,7 +104,7 @@
             </div>
           </div>
 
-          <template v-if="inputsExpanded">
+          <template v-if="hasInputFields && inputsExpanded">
             <div
               v-for="(field, i) in data.fields.input"
               :key="`inputs-${field.id}`"
@@ -137,7 +137,7 @@
               <div
                 class="handle-label trigger"
                 :class="{
-                  'has-fields': data.fields.output.length > 0,
+                  'has-fields': hasOutputFields,
                   collapsible: outputsCollapsible,
                 }"
                 @click.stop="toggleExpanded('output')"
@@ -145,7 +145,7 @@
                 <div class="text">
                   outputs
                 </div>
-                <template v-if="data.fields.output.length > 0">
+                <template v-if="hasOutputFields">
                   <UnfoldMoreIcon
                     v-if="!outputsExpanded"
                     :size="KUI_ICON_SIZE_20"
@@ -158,7 +158,7 @@
                 </template>
               </div>
               <HandleTwig
-                v-if="outputsExpanded"
+                v-if="hasOutputFields && outputsExpanded"
                 :color="handleTwigColor"
                 :position="outputPosition"
                 type="bar"
@@ -171,7 +171,7 @@
             />
           </div>
 
-          <template v-if="outputsExpanded">
+          <template v-if="hasOutputFields && outputsExpanded">
             <div
               v-for="(field, i) in data.fields.output"
               :key="`outputs-${field.id}`"
@@ -242,11 +242,14 @@ const { getInEdgesByNodeId, getOutEdgesByNodeId, toggleExpanded: storeToggleExpa
 
 const meta = computed(() => getNodeMeta(data.type))
 
+const hasInputFields = computed(() => data.fields.input.length > 0)
+const hasOutputFields = computed(() => data.fields.output.length > 0)
+
 const inputsCollapsible = computed(() =>
-  getInEdgesByNodeId(data.id).every(edge => edge.targetField === undefined),
+  hasInputFields.value && getInEdgesByNodeId(data.id).every(edge => edge.targetField === undefined),
 )
 const outputsCollapsible = computed(() =>
-  getOutEdgesByNodeId(data.id).every(edge => edge.sourceField === undefined),
+  hasOutputFields.value && getOutEdgesByNodeId(data.id).every(edge => edge.sourceField === undefined),
 )
 
 const inputsExpanded = computed(() => data.expanded.input ?? false)
@@ -438,12 +441,12 @@ $handle-height: 10px;
           line-height: $kui-line-height-10;
           padding: $kui-space-10;
 
-          &.has-fields.trigger {
+          &.trigger.has-fields {
             cursor: pointer;
-          }
 
-          &:not(.collapsible).trigger {
-            cursor: not-allowed;
+            &:not(.collapsible) {
+              cursor: not-allowed;
+            }
           }
 
           &.text {

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodeBadge.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodeBadge.vue
@@ -1,6 +1,9 @@
 <template>
   <KBadge
     :appearance="appearance"
+    :class="{
+      'icon-only': iconOnly,
+    }"
     :size="size"
   >
     <template #icon>
@@ -19,6 +22,7 @@ import type { BadgeAppearance, BadgeSize } from '@kong/kongponents'
 const { type } = defineProps<{
   type: NodeType
   size?: BadgeSize
+  iconOnly?: boolean
 }>()
 
 const icon = computed(() => {
@@ -47,3 +51,11 @@ const appearance = computed<BadgeAppearance>(() => {
   }
 })
 </script>
+
+<style lang="scss" scoped>
+.icon-only {
+  :deep(.badge-content-wrapper) {
+    display: none;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/NodePanel.vue
@@ -86,6 +86,7 @@ const handleDragStart = async (e: DragEvent, type: ConfigNodeType) => {
 
   // Create temporary clone for drag image
   const clone = preview.cloneNode(true) as HTMLElement
+  clone.classList.add('dk-drag-snapshot')
   const { offsetWidth: previewWidth, offsetHeight: previewHeight } = preview
 
   Object.assign(clone.style, {
@@ -94,7 +95,6 @@ const handleDragStart = async (e: DragEvent, type: ConfigNodeType) => {
     left: '-9999px',
     width: `${previewWidth}px`,
     height: `${previewHeight}px`,
-    boxSizing: 'border-box',
   })
 
   document.body.appendChild(clone)
@@ -158,6 +158,16 @@ const handleDragStart = async (e: DragEvent, type: ConfigNodeType) => {
     pointer-events: none;
     position: absolute;
     width: 1px;
+  }
+}
+</style>
+
+<style lang="scss">
+.dk-drag-snapshot, .dk-drag-snapshot * {
+  &,
+  &::before,
+  &::after {
+    box-sizing: border-box;
   }
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/flow.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/flow.ts
@@ -10,7 +10,7 @@ import { MarkerType, useVueFlow } from '@vue-flow/core'
 import { createInjectionState } from '@vueuse/core'
 import { computed, toRaw, toValue } from 'vue'
 
-import { KUI_COLOR_BORDER_NEUTRAL_WEAK, KUI_COLOR_BORDER_PRIMARY, KUI_COLOR_BORDER_PRIMARY_WEAK } from '@kong/design-tokens'
+import { KUI_COLOR_BORDER_NEUTRAL, KUI_COLOR_BORDER_PRIMARY, KUI_COLOR_BORDER_PRIMARY_WEAK } from '@kong/design-tokens'
 import useI18n from '../../../../../composables/useI18n'
 import { useToaster } from '../../../../../composables/useToaster'
 import { createEdgeConnectionString, createNewConnectionString } from '../composables/helpers'
@@ -66,7 +66,7 @@ function createWrapper(): [typeof wrap, typeof copy] {
 }
 
 const BORDER_COLORS: Record<EdgeState, string> = {
-  default: KUI_COLOR_BORDER_NEUTRAL_WEAK,
+  default: KUI_COLOR_BORDER_NEUTRAL,
   hover: KUI_COLOR_BORDER_PRIMARY_WEAK,
   selected: KUI_COLOR_BORDER_PRIMARY,
 }
@@ -90,6 +90,7 @@ function updateEdgeStyle(edge: Edge<EdgeData>): Edge<EdgeData> {
     style: {
       ...edge.style,
       stroke: color,
+      strokeWidth: state === 'selected' ? 1.5 : undefined,
     },
     markerEnd: marker,
     zIndex: state === 'default' ? undefined : 1,

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/utils.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/utils.ts
@@ -1,0 +1,123 @@
+type Platform = 'mac' | 'windows' | 'linux'
+
+let _platform: Platform | null = null
+
+export function detectPlatform(): Platform {
+  if (_platform) return _platform
+
+  if (typeof navigator === 'undefined') {
+    return (_platform = 'windows')
+  }
+
+  const p =
+    (navigator as any).userAgentData?.platform ||
+    navigator.platform ||
+    navigator.userAgent
+
+  if (/Mac|iPhone|iPad|iPod/i.test(p)) return (_platform = 'mac')
+  if (/Linux/i.test(p) && !/Android/i.test(p)) return (_platform = 'linux')
+  // unknown, assume windows
+  return (_platform = 'windows')
+}
+
+export type SpecialKey =
+  | 'Shift'
+  | 'Alt'
+  | 'Ctrl'
+  | 'Meta'
+  | 'Mod'
+  | 'Enter'
+  | 'ArrowUp'
+  | 'ArrowDown'
+  | 'ArrowLeft'
+  | 'ArrowRight'
+  | 'Tab'
+  | 'Esc'
+  | 'Space'
+  | 'Delete'
+
+export type Key = SpecialKey | string & {}
+
+const MAC_KEY_MAP: Record<SpecialKey, string> = {
+  Shift: '⇧',
+  Alt: '⌥',
+  Ctrl: '⌃',
+  Meta: '⌘',
+  Mod: '⌘',
+  Enter: '↩',
+  ArrowUp: '↑',
+  ArrowDown: '↓',
+  ArrowLeft: '←',
+  ArrowRight: '→',
+  Tab: '⇥',
+  Esc: '⎋',
+  Space: 'Space',
+  Delete: '⌫',
+}
+
+const WIN_KEY_MAP: Record<SpecialKey, string> = {
+  Shift: 'Shift',
+  Alt: 'Alt',
+  Ctrl: 'Ctrl',
+  Meta: 'Win',
+  Mod: 'Ctrl',
+  Enter: 'Enter',
+  ArrowUp: 'Up',
+  ArrowDown: 'Down',
+  ArrowLeft: 'Left',
+  ArrowRight: 'Right',
+  Tab: 'Tab',
+  Esc: 'Esc',
+  Space: 'Spacebar',
+  Delete: 'Delete',
+}
+
+export const LINUX_KEY_MAP: Record<SpecialKey, string> = {
+  Shift: 'Shift',
+  Alt: 'Alt',
+  Ctrl: 'Ctrl',
+  Meta: 'Super',
+  Mod: 'Ctrl',
+  Enter: 'Enter',
+  ArrowUp: 'Up',
+  ArrowDown: 'Down',
+  ArrowLeft: 'Left',
+  ArrowRight: 'Right',
+  Tab: 'Tab',
+  Esc: 'Esc',
+  Space: 'Space',
+  Delete: 'Delete',
+}
+
+export type FormatOptions = {
+  platform?: Platform
+  joiner?: string
+}
+
+export type KeySpec = Key[] | { [K in Platform]: Key[] }
+
+export function formatKeys(spec: KeySpec, opts: FormatOptions = {}): string {
+  const platform = opts.platform ?? detectPlatform()
+  const joiner = opts.joiner ?? (platform === 'mac' ? '' : ' + ')
+
+  const map =
+    platform === 'mac'
+      ? MAC_KEY_MAP
+      : platform === 'linux'
+        ? LINUX_KEY_MAP
+        : WIN_KEY_MAP
+
+  let combination = null
+
+  if (Array.isArray(spec)) {
+    combination = spec
+  } else {
+    combination = platform === 'mac'
+      ? spec.mac
+      : spec[platform]
+  }
+
+  return combination
+    .map((key) => (key in map ? map[key as SpecialKey] : key))
+    .join(joiner)
+}

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -741,8 +741,8 @@
             },
             "jq": {
               "name": "jq",
-              "summary": "Transform data and cast variables with jq",
-              "description": "The jq node executes a jq script for processing JSON. See the official <a href=\"https://jqlang.org\" target=\"_blank\">jq docs</a> for more details."
+              "summary": "Transform data and cast variables with jq",
+              "description": "The jq node executes a jq script for processing JSON. See the official <a href=\"https://jqlang.org\" target=\"_blank\">jq docs</a> for more details."
             },
             "exit": {
               "name": "exit",
@@ -751,13 +751,13 @@
             },
             "property": {
               "name": "property",
-              "summary": "Get and set Kong Gateway configuration data",
-              "description": "Get and set Kong Gateway host and request properties."
+              "summary": "Get and set gateway configuration data",
+              "description": "Get and set gateway host and request properties."
             },
             "static": {
               "name": "static",
               "summary": "Define static values to use for call nodes",
-              "description": "Emits static values to be used as inputs for other nodes. The static node can help you with hardcoding some known value for an input."
+              "description": "Emits static values to be used as inputs for other nodes. The static node can help you with hardcoding some known value for an input."
             },
             "request": {
               "name": "request",

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -729,6 +729,7 @@
           "actions": {
             "undo": "Undo",
             "redo": "Redo",
+            "delete": "Delete",
             "view_docs": "View docs",
             "done": "Done"
           },


### PR DESCRIPTION
# Summary

[KM-1682](https://konghq.atlassian.net/browse/KM-1682)

[KM-1683](https://konghq.atlassian.net/browse/KM-1683)

This PR:

- Introduces `<HotkeyLabel>` for rendering platform-specific shortcut labels
- Adds a `formatKeys()` utility to format shortcuts per platform
- Adds a node dropdown menu with a Delete action
- Fixes a regression where changing inputs/outputs expanded all fields on every node
- Updates the flow-node layout with min/max widths and text-overflow handling
- Fixes drag preview snapshot styles