### PR TITLE
fix: remove widgets if tiles are removed externally

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -133,6 +133,12 @@ watch(() => props.tiles.length, async (newLen, oldLen) => {
         h: tile.layout.size.rows,
       })
     }
+  } else if (newLen < oldLen && grid) {
+    const currentIds = new Set(props.tiles.map(t => t.id))
+    const tileIDsToRemove = new Set(tilesRef.value.keys()).symmetricDifference(currentIds)
+    for (const id of tileIDsToRemove) {
+      removeWidget(id)
+    }
   }
 })
 


### PR DESCRIPTION
# Summary

### Changes
- If tiles are removed externally need to actually remove the tiles from the gridstack grid.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
