### PR TITLE
fix(entities-plugins): move the icons package to dependencies

### DIFF
--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -25,7 +25,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@kong-ui-public/entities-plugins-icon": "workspace:^",
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.31.0",
@@ -39,7 +38,6 @@
   },
   "devDependencies": {
     "@dagrejs/dagre": "^1.1.5",
-    "@kong-ui-public/entities-plugins-icon": "workspace:^",
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/entities-vaults": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
@@ -93,6 +91,7 @@
     "@kong-ui-public/entities-consumer-groups": "workspace:^",
     "@kong-ui-public/entities-consumers": "workspace:^",
     "@kong-ui-public/entities-gateway-services": "workspace:^",
+    "@kong-ui-public/entities-plugins-icon": "workspace:^",
     "@kong-ui-public/entities-plugins-metadata": "workspace:^",
     "@kong-ui-public/entities-redis-configurations": "workspace:^",
     "@kong-ui-public/entities-routes": "workspace:^",

--- a/packages/entities/entities-redis-configurations/package.json
+++ b/packages/entities/entities-redis-configurations/package.json
@@ -39,7 +39,6 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
   },
   "devDependencies": {
-    "@kong-ui-public/entities-plugins-icon": "workspace:^",
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/entities-vaults": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
@@ -69,7 +68,6 @@
     "errorLimit": "400KB"
   },
   "peerDependencies": {
-    "@kong-ui-public/entities-plugins-icon": "workspace:^",
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/entities-vaults": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
@@ -80,6 +78,7 @@
     "vue-router": "^4.4.5"
   },
   "dependencies": {
+    "@kong-ui-public/entities-plugins-icon": "workspace:^",
     "uuid": "^11.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1035,13 +1035,13 @@ importers:
 
   packages/entities/entities-redis-configurations:
     dependencies:
+      '@kong-ui-public/entities-plugins-icon':
+        specifier: workspace:^
+        version: link:../entities-plugins-icon
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
     devDependencies:
-      '@kong-ui-public/entities-plugins-icon':
-        specifier: workspace:^
-        version: link:../entities-plugins-icon
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -948,6 +948,9 @@ importers:
       '@kong-ui-public/entities-gateway-services':
         specifier: workspace:^
         version: link:../entities-gateway-services
+      '@kong-ui-public/entities-plugins-icon':
+        specifier: workspace:^
+        version: link:../entities-plugins-icon
       '@kong-ui-public/entities-plugins-metadata':
         specifier: workspace:^
         version: link:../entities-plugins-metadata
@@ -976,9 +979,6 @@ importers:
       '@dagrejs/dagre':
         specifier: ^1.1.5
         version: 1.1.5
-      '@kong-ui-public/entities-plugins-icon':
-        specifier: workspace:^
-        version: link:../entities-plugins-icon
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

KM and Konnect do not list the `@kong-ui-public/entities-plugins-icon` package as their dependency. So, for `@kong-ui-public/entities-plugins`, the icons package should not be a peer dependency.
