### PR TITLE
feat(documentation): show discard changes warning and allow revert [TDX-6534]

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
       bundler: 'vite',
       viteConfig: {
         ...sharedViteConfig,
+        define: {
+          'process.env.VSCODE_TEXTMATE_DEBUG': false,
+        },
       },
     },
     supportFile: 'cypress/support/index.ts',

--- a/packages/core/documentation/src/components/DiscardChangesPrompt.vue
+++ b/packages/core/documentation/src/components/DiscardChangesPrompt.vue
@@ -1,0 +1,49 @@
+<template>
+  <Teleport to="body">
+    <KPrompt
+      action-button-appearance="danger"
+      :action-button-text="i18n.t('documentation.form_modal.discard_changes')"
+      cancel-button-appearance="secondary"
+      :cancel-button-text="i18n.t('documentation.form_modal.continue_editing')"
+      :confirmation-text="confirmationText"
+      data-testid="discard-changes-prompt"
+      :message="i18n.t('documentation.form_modal.discard_changes_message')"
+      :modal-attributes="{ maxWidth: '640' }"
+      :title="i18n.t('documentation.form_modal.discard_changes_title')"
+      :visible="modalVisible"
+      @cancel="emit('cancel')"
+      @proceed="emit('discard-changes')"
+    />
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import composables from '../composables'
+import { ref, watch } from 'vue'
+
+
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'discard-changes'): void
+}>()
+
+const props = defineProps({
+  /** If the modal is visible. */
+  visible: {
+    type: Boolean,
+    default: false,
+  },
+  /** To require the user to type text before confirming, provide the confirmationText as a prop */
+  confirmationText: {
+    type: String,
+    default: undefined,
+  },
+})
+
+const { i18n } = composables.useI18n()
+
+const modalVisible = ref<boolean>(props.visible)
+watch(() => props.visible, (visible) => {
+  modalVisible.value = visible
+}, { immediate: true })
+</script>

--- a/packages/core/documentation/src/components/DocumentationDisplay.cy.ts
+++ b/packages/core/documentation/src/components/DocumentationDisplay.cy.ts
@@ -33,6 +33,7 @@ describe('<DocumentationDisplay />', () => {
 
     cy.get('.document-title').should('contain', 'Test Document')
   })
+
   it('renders document title when revision', () => {
     cy.mount(DocumentationDisplay as any, {
       props: {
@@ -50,6 +51,7 @@ describe('<DocumentationDisplay />', () => {
 
     cy.get('.document-title').should('contain', 'Test Document - Revision 1')
   })
+
   it('respects hidePublishToggle', () => {
     cy.mount(DocumentationDisplay as any, {
       props: {
@@ -60,6 +62,7 @@ describe('<DocumentationDisplay />', () => {
 
     cy.get('.document-status').should('not.exist')
   })
+
   it('shows publish status', () => {
     cy.mount(DocumentationDisplay as any, {
       props: {
@@ -76,6 +79,7 @@ describe('<DocumentationDisplay />', () => {
 
     cy.get('.document-status').should('exist')
   })
+
   it('can toggle published status', () => {
     cy.mount(DocumentationDisplay as any, {
       props: {
@@ -96,6 +100,7 @@ describe('<DocumentationDisplay />', () => {
     cy.get('.document-publish-toggle .switch-control').click()
     cy.get('.document-status').should('contain', 'Unpublished')
   })
+
   it('shows discard when changes detected and publish state changes', () => {
     cy.mount(DocumentationDisplay as any, {
       props: {
@@ -120,6 +125,7 @@ describe('<DocumentationDisplay />', () => {
     cy.get('.document-status').should('not.contain', 'Unpublished')
     cy.getTestId('discard-changes-prompt').should('exist')
   })
+
   it('does not show created date when createdAt is empty', () => {
     cy.mount(DocumentationDisplay as any, {
       props: { ...baseProps },
@@ -127,6 +133,7 @@ describe('<DocumentationDisplay />', () => {
 
     cy.get('.document-create').should('not.exist')
   })
+
   it('document title shows the .md extension', () => {
     cy.mount(DocumentationDisplay as any, {
       props: { ...baseProps },
@@ -135,6 +142,7 @@ describe('<DocumentationDisplay />', () => {
     cy.get('.document-title .document-title-extension').should('contain', 'md')
     cy.get('.document-title').should('contain', 'Test Document')
   })
+
   it('typing in the editor updates the textarea value', () => {
     cy.mount(DocumentationDisplay as any, {
       props: {

--- a/packages/core/documentation/src/components/DocumentationDisplay.cy.ts
+++ b/packages/core/documentation/src/components/DocumentationDisplay.cy.ts
@@ -1,0 +1,159 @@
+import DocumentationDisplay from './DocumentationDisplay.vue'
+
+
+describe('<DocumentationDisplay />', () => {
+
+  const baseProps = {
+    canEdit: () => true,
+    card: false,
+    hidePublishToggle: false,
+    selectedDocument: {
+      document: {
+        id: '1',
+        parent_document_id: null,
+        title: 'Test Document',
+        slug: 'test-document',
+        metadata: {},
+        status: 'unpublished',
+        children: [],
+        revision: undefined,
+      },
+      ast: {
+        'ok': 'bud',
+      },
+      markdown: '# TEST',
+      status: 'unpublished',
+    },
+  }
+
+  it('renders document title when no revision', () => {
+    cy.mount(DocumentationDisplay as any, {
+      props: { ...baseProps },
+    })
+
+    cy.get('.document-title').should('contain', 'Test Document')
+  })
+  it('renders document title when revision', () => {
+    cy.mount(DocumentationDisplay as any, {
+      props: {
+        ...baseProps,
+        selectedDocument: {
+          ...baseProps.selectedDocument,
+          document: {
+            ...baseProps.selectedDocument.document,
+            title: '',
+            revision: { id: '1', title: 'Test Document - Revision 1' },
+          },
+        },
+      },
+    })
+
+    cy.get('.document-title').should('contain', 'Test Document - Revision 1')
+  })
+  it('respects hidePublishToggle', () => {
+    cy.mount(DocumentationDisplay as any, {
+      props: {
+        ...baseProps,
+        hidePublishToggle: true,
+      },
+    })
+
+    cy.get('.document-status').should('not.exist')
+  })
+  it('shows publish status', () => {
+    cy.mount(DocumentationDisplay as any, {
+      props: {
+        ...baseProps,
+        selectedDocument: {
+          ...baseProps.selectedDocument,
+          document: {
+            ...baseProps.selectedDocument.document,
+            status: 'published',
+          },
+        },
+      },
+    })
+
+    cy.get('.document-status').should('exist')
+  })
+  it('can toggle published status', () => {
+    cy.mount(DocumentationDisplay as any, {
+      props: {
+        ...baseProps,
+        card: false,
+        hidePublishToggle: false,
+        selectedDocument: {
+          ...baseProps.selectedDocument,
+          document: {
+            ...baseProps.selectedDocument.document,
+            status: 'published',
+          },
+        },
+      },
+    })
+
+    cy.get('.document-status').should('contain', 'Published')
+    cy.get('.document-publish-toggle .switch-control').click()
+    cy.get('.document-status').should('contain', 'Unpublished')
+  })
+  it('shows discard when changes detected and publish state changes', () => {
+    cy.mount(DocumentationDisplay as any, {
+      props: {
+        ...baseProps,
+        selectedDocument: {
+          ...baseProps.selectedDocument,
+          document: {
+            ...baseProps.selectedDocument.document,
+            status: 'published',
+          },
+        },
+      },
+    })
+
+    cy.get('.document-status').should('contain', 'Published')
+    cy.getTestId('edit').click({ timeout: 1000 })
+    cy.getTestId('markdown-editor').get('textarea').type('New content')
+    cy.getTestId('markdown-editor').get('textarea')
+      .invoke('val')
+      .should('contain', 'New content')
+    cy.get('.document-publish-toggle .switch-control').click()
+    cy.get('.document-status').should('not.contain', 'Unpublished')
+    cy.getTestId('discard-changes-prompt').should('exist')
+  })
+  it('does not show created date when createdAt is empty', () => {
+    cy.mount(DocumentationDisplay as any, {
+      props: { ...baseProps },
+    })
+
+    cy.get('.document-create').should('not.exist')
+  })
+  it('document title shows the .md extension', () => {
+    cy.mount(DocumentationDisplay as any, {
+      props: { ...baseProps },
+    })
+
+    cy.get('.document-title .document-title-extension').should('contain', 'md')
+    cy.get('.document-title').should('contain', 'Test Document')
+  })
+  it('typing in the editor updates the textarea value', () => {
+    cy.mount(DocumentationDisplay as any, {
+      props: {
+        ...baseProps,
+        selectedDocument: {
+          ...baseProps.selectedDocument,
+          document: {
+            ...baseProps.selectedDocument.document,
+            status: 'published',
+          },
+        },
+      },
+    })
+
+    cy.getTestId('edit').click({ timeout: 1000 })
+    cy.getTestId('markdown-editor').get('textarea').clear()
+    cy.getTestId('markdown-editor').get('textarea').type('Hello World')
+    cy.getTestId('markdown-editor').get('textarea')
+      .invoke('val')
+      .should('contain', 'Hello World')
+  })
+})

--- a/packages/core/documentation/src/components/DocumentationDisplay.vue
+++ b/packages/core/documentation/src/components/DocumentationDisplay.vue
@@ -79,7 +79,7 @@
           @mode="(mode: MarkdownMode) => handleMarkdownUiModeChange(mode)"
           @save="(payload: EmitUpdatePayload) => {
             emit('save-markdown', payload.content)
-            originalMarkdownContent = payload.content // <- add this line
+            originalMarkdownContent = payload.content
           }"
         />
       </div>
@@ -204,7 +204,7 @@ const handleMarkdownUiModeChange = (mode: MarkdownMode): void => {
 
 const _handlePublishToggle = (): void => {
   // check for unsaved changes
-  if ( ['edit', 'split'].includes( currentMode.value) && (markdownContent.value !== originalMarkdownContent.value) ) {
+  if (['edit', 'split'].includes(currentMode.value) && (markdownContent.value !== originalMarkdownContent.value)) {
     showDiscardChangesMessage.value = true
   } else {
     handlePublishToggle()

--- a/packages/core/documentation/src/locales/en.json
+++ b/packages/core/documentation/src/locales/en.json
@@ -39,7 +39,11 @@
       "subtitle": "Provide guides, examples and other useful information about this service to developers.",
       "edit_markdown": "To edit the document's markdown content rather than replacing the file, close this modal and click the 'Document Actions' icon button at the top right of the document.",
       "title_label": "Page Name",
-      "title_placeholder": "Enter a page name"
+      "title_placeholder": "Enter a page name",
+      "discard_changes_message": "There are unsaved changes on this page. Would you like to discard changes or continue editing?",
+      "discard_changes_title": "You have unsaved changes",
+      "continue_editing": "Continue Editing",
+      "discard_changes": "Discard Changes"
     },
     "show": {
       "actions": "Actions",


### PR DESCRIPTION
# Summary

This introduces a user-friendly prompt for handling unsaved changes when toggling the publish state of documentation pages. The main improvement is the addition of a modal dialog that asks users to confirm discarding unsaved changes, helping prevent accidental data loss. 

**Notable Changes: **

* Added a new `DiscardChangesPrompt.vue` component that displays a modal dialog when the user attempts to publish/unpublish with unsaved changes. The modal provides options to discard changes or continue editing.
* Integrated the discard changes prompt into `DocumentationDisplay.vue`, showing it when unsaved changes are detected during publish/unpublish actions.
* Added helper to attach/detach a native input listener on the editor textarea to better-detect changes. There was a bug where you could go fast and it wouldn't update appropriately.
* Updates cypress config to account for `VSCODE_TEXTMATE_DEBUG` bug.

