### PR TITLE
fix(analytics): improve fallback axes titles [MA-4286]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -226,6 +226,10 @@ const tooltipMetricDisplay = computed<string | undefined>(() => {
 })
 
 const metricAxesTitle = computed<string | undefined>(() => {
+  if (props.chartOptions?.metricAxesTitle) {
+    return props.chartOptions?.metricAxesTitle
+  }
+
   if (!props.chartData?.meta.metric_names || !props.chartData?.meta.metric_units) {
     return undefined
   }
@@ -242,10 +246,6 @@ const metricAxesTitle = computed<string | undefined>(() => {
       // @ts-ignore - dynamic i18n key
       return i18n.t('metricAxisTitles.size_in', { unit: i18n.t(`chartUnits.${metricUnit}`, { plural: 's' }) })
     }
-  }
-
-  if (props.chartOptions?.metricAxesTitle) {
-    return props.chartOptions?.metricAxesTitle
   }
 
   // @ts-ignore - dynamic i18n key

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -217,9 +217,12 @@ const tooltipMetricDisplay = computed<string | undefined>(() => {
     }
   }
 
-  // @ts-ignore - dynamic i18n key
-  return i18n.t(`chartLabels.${metricName}`)
+  if (!metricName) {
+    return undefined
+  }
 
+  // @ts-ignore - dynamic i18n key
+  return i18n.te(`chartLabels.${metricName}`) ? i18n.t(`chartLabels.${metricName}`) : metricName
 })
 
 const metricAxesTitle = computed<string | undefined>(() => {
@@ -240,26 +243,44 @@ const metricAxesTitle = computed<string | undefined>(() => {
       return i18n.t('metricAxisTitles.size_in', { unit: i18n.t(`chartUnits.${metricUnit}`, { plural: 's' }) })
     }
   }
+
+  if (props.chartOptions?.metricAxesTitle) {
+    return props.chartOptions?.metricAxesTitle
+  }
+
   // @ts-ignore - dynamic i18n key
-  return props.chartOptions?.metricAxesTitle || (i18n.te(`metricAxisTitles.${metricName}`) && i18n.te(`chartUnits.${metricUnit}`) &&
+  if (i18n.te(`metricAxisTitles.${metricName}`) && i18n.te(`chartUnits.${metricUnit}`)) {
     // @ts-ignore - dynamic i18n key
-    // Metric units are always pluralized on the axis.
-    i18n.t(`metricAxisTitles.${metricName}`, { unit: i18n.t(`chartUnits.${metricUnit}`, { plural: 's' }) })) || undefined
+    return i18n.t(`metricAxisTitles.${metricName}`, { unit: i18n.t(`chartUnits.${metricUnit}`, { plural: 's' }) }) || undefined
+  }
+
+  return metricName || undefined
 })
 
 const dimensionAxesTitle = computed<string | undefined>(() => {
+  if (props.chartOptions?.dimensionAxesTitle) {
+    return props.chartOptions.dimensionAxesTitle
+  }
+
   const dimension = isTimeSeriesChart.value ? 'Time' : Object.keys(props.chartData.meta.display || props.chartData.meta.metric_names as Record<string, any>)[0]
-  const key = `chartLabels.${dimension}`
+
+  if (!dimension) {
+    return undefined
+  }
 
   // @ts-ignore - dynamic i18n key
-  return props.chartOptions.dimensionAxesTitle || (i18n.te(key) && i18n.t(key)) || undefined
+  return i18n.te(`chartLabels.${dimension}`) ? i18n.t(`chartLabels.${dimension}`) : dimension
 })
 
 const timestampAxisTitle = computed(() => {
   const granularity = msToGranularity(Number(props.chartData.meta.granularity_ms))
 
+  if (!granularity) {
+    return undefined
+  }
+
   // @ts-ignore - dynamic i18n key
-  return i18n.t(`granularityAxisTitles.${granularity}`)
+  return i18n.te(`granularityAxisTitles.${granularity}`) ? i18n.t(`granularityAxisTitles.${granularity}`) : granularity
 })
 
 const emptyStateTitle = computed(() => props.emptyStateTitle || i18n.t('noDataAvailableTitle'))


### PR DESCRIPTION
# Summary

Fix [MA-4286](https://konghq.atlassian.net/browse/MA-4286)

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

The returns for each analytics chart axis title type had a few inconsistencies. Namely:

- Returning localized strings that may not exist
- Returning `boolean`'s when a string is expected
- Not having proper fallbacks in place if a localized string didn't exist

This will add a few fallbacks to return a metric/dimension/granularity property when a localized string is not found; If neither is found, only then will `undefined` be returned.

[MA-4286]: https://konghq.atlassian.net/browse/MA-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ