### PR TITLE
fix: dont generate links if no advanced analytics

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
@@ -2,6 +2,8 @@ import DashboardTile from './DashboardTile.vue'
 import { INJECT_QUERY_PROVIDER } from '../constants'
 import type { DashboardRendererContextInternal } from '../types'
 import { generateSingleMetricTimeSeriesData, type ExploreResultV4, type TileDefinition } from '@kong-ui-public/analytics-utilities'
+import { setupPiniaTestStore } from '../stores/tests/setupPiniaTestStore'
+import { useAnalyticsConfigStore } from '@kong-ui-public/analytics-config-store'
 
 const start = Date.now() - 6 * 60 * 60 * 1000
 const end = Date.now()
@@ -101,6 +103,13 @@ describe('<DashboardTile />', () => {
       },
     })
   }
+
+  beforeEach(() => {
+    setupPiniaTestStore({ createVueApp: true })
+    const analyticsConfigStore = useAnalyticsConfigStore()
+    // @ts-ignore - mocking just what we need for the test
+    analyticsConfigStore.analyticsConfig = { analytics: { percentiles: true } }
+  })
 
   it('should render tile with title', () => {
     mount()

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -1,5 +1,6 @@
 import { computed, onMounted, ref } from 'vue'
 import { getFieldDataSources, msToGranularity } from '@kong-ui-public/analytics-utilities'
+import { useAnalyticsConfigStore } from '@kong-ui-public/analytics-config-store'
 import type { DeepReadonly, Ref } from 'vue'
 import type { AiExploreAggregations, AiExploreQuery, AllFilters, ExploreAggregations, ExploreQuery, ExploreResultV4, FilterDatasource, QueryableAiExploreDimensions, QueryableExploreDimensions, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
 import type { AnalyticsBridge, TileDefinition } from '@kong-ui-public/analytics-utilities'
@@ -21,6 +22,7 @@ export default function useContextLinks(
 
   const exploreBaseUrl = ref('')
   const requestsBaseUrl = ref('')
+  const analyticsConfigStore = useAnalyticsConfigStore()
 
   onMounted(async () => {
     // Since this is async, it can't be in the `computed`.  Just check once, when the component mounts.
@@ -28,10 +30,11 @@ export default function useContextLinks(
     requestsBaseUrl.value = await queryBridge?.requestsBaseUrl?.() ?? ''
   })
 
+  const isAdvancedAnalytics = computed(() => analyticsConfigStore.analytics && analyticsConfigStore.percentiles)
   const canShowKebabMenu = computed(() => !['golden_signals', 'top_n', 'gauge'].includes(definition.value.chart.type))
 
-  const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && definition.value.query.datasource !== 'llm_usage')
-  const canGenerateExploreLink = computed(() => exploreBaseUrl.value && definition.value.query && ['basic', 'api_usage', 'llm_usage', undefined].includes(definition.value.query.datasource))
+  const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && definition.value.query.datasource !== 'llm_usage' && isAdvancedAnalytics.value)
+  const canGenerateExploreLink = computed(() => exploreBaseUrl.value && definition.value.query && ['basic', 'api_usage', 'llm_usage', undefined].includes(definition.value.query.datasource) && isAdvancedAnalytics.value)
 
   const chartDataGranularity = computed(() => {
     return chartData.value ? msToGranularity(chartData.value.meta.granularity_ms) : undefined

--- a/packages/analytics/dashboard-renderer/src/stores/tests/setupPiniaTestStore.ts
+++ b/packages/analytics/dashboard-renderer/src/stores/tests/setupPiniaTestStore.ts
@@ -1,0 +1,23 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { createApp } from 'vue'
+import type { App } from 'vue'
+
+interface SetupPiniaTestStoreOptions {
+  /** Should a Vue app be created and initialized? */
+  createVueApp?: boolean
+}
+
+/**
+ * Set up the Pinia test store instance for the given runner (Cypress or Vitest).
+ * @param {'cy.spy' | 'vi.fn} createSpy The test runner your spec file is using.
+ * @param {TestingOptions} config @pinia/testing options https://pinia.vuejs.org/api/@pinia/testing/interfaces/TestingOptions.html
+ */
+export const setupPiniaTestStore = (options?: SetupPiniaTestStoreOptions) => {
+  let app: App
+  const pinia = createPinia()
+  if (options?.createVueApp) {
+    app = createApp({})
+    app.use(pinia)
+  }
+  setActivePinia(pinia)
+}


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-4284

Do not show explore and view request options on dashboard/tile context menus if user does not have advanced analytics

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
