### PR TITLE
fix(entities-plugins): free-form scope is not correctly initialized

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -205,15 +205,16 @@ const prunedData = computed(() => {
   return pick(props.model, ffDataKeys)
 })
 
-const scoped = ref(false)
-const moreCollapsed = ref(true)
-
 const scopeIds: Record<string, string | null> = pick(props.formModel, [
   'service-id',
   'route-id',
   'consumer-id',
   'consumer_group-id',
 ])
+
+// `scopeIds` is not reactive. Initialize `scoped` in one shot.
+const scoped = ref(Object.values(scopeIds).some(id => Boolean(id)))
+const moreCollapsed = ref(true)
 
 function handleScopeUpdate(value: any, model: string) {
   scopeIds[model] = value


### PR DESCRIPTION
Initialize the `scoped` ref in `<StandardLayout />` with `scopeIds` to fix an issue where a scoped plugin was displayed as a global plugin.

### Possible issue

* `scoped` is not reactive to `scopeIds` (so does `scopeId`), so it may be out of sync with `formModel`

KM-1701