### PR TITLE
refactor(entities-plugins): datakit - simplify skip validation logic

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowCanvas.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowCanvas.vue
@@ -111,7 +111,7 @@ const {
   },
   readonly,
 })
-const { addNode, selectNode: selectStoreNode, propertiesPanelOpen, newCreatedNodeId, invalidConfigNodeIds } = editorStore
+const { addNode, selectNode: selectStoreNode, propertiesPanelOpen, skipValidation, invalidConfigNodeIds } = editorStore
 const { project, vueFlowRef, addSelectedNodes, getNodes } = vueFlowStore
 const disableDrop = ref(false)
 
@@ -167,7 +167,7 @@ function onDrop(e: DragEvent) {
   selectNode(nodeId)
 
   if (nodeId) {
-    newCreatedNodeId.value = nodeId
+    skipValidation.value = true
     propertiesPanelOpen.value = true
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useNodeForm.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/composables/useNodeForm.ts
@@ -41,7 +41,6 @@ export function useNodeForm<T extends BaseFormData = BaseFormData>(
     replaceConfig,
     disconnectEdge,
     connectEdge,
-    newCreatedNodeId,
     invalidConfigNodeIds,
     undo,
     commit,
@@ -353,8 +352,6 @@ export function useNodeForm<T extends BaseFormData = BaseFormData>(
     return currentNode.value.fields.input.map(f => f.name) || []
   })
 
-  const skipValidationOnMount = computed(() => newCreatedNodeId.value === nodeId)
-
   function toggleNodeValid(isValid: boolean) {
     invalidConfigNodeIds.value.delete(nodeId)
     if (!isValid) {
@@ -382,7 +379,6 @@ export function useNodeForm<T extends BaseFormData = BaseFormData>(
     inputEdge,
     inputsEdges,
     inputsFieldNames,
-    skipValidationOnMount,
     currentNode,
 
     // form ops

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorContent.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorContent.vue
@@ -39,20 +39,15 @@ import NodePropertiesPanel from '../node/NodePropertiesPanel.vue'
 const { t } = createI18n<typeof english>('en-us', english)
 
 const { sidePanelExpanded } = usePreferences()
-const { propertiesPanelOpen, selectedNode, newCreatedNodeId } = useEditorStore()
+const { propertiesPanelOpen, selectedNode } = useEditorStore()
 
 function handleClose() {
   propertiesPanelOpen.value = false
-  newCreatedNodeId.value = null
 }
 
 watch(selectedNode, (node) => {
   if (!node) {
     handleClose()
-  }
-
-  if (!node || node.id !== newCreatedNodeId.value) {
-    newCreatedNodeId.value = null
   }
 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormCall.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormCall.vue
@@ -91,7 +91,6 @@ const {
   setInput,
   inputsFieldNames,
   nameValidator,
-  skipValidationOnMount,
   toggleNodeValid,
   fieldNameValidator,
 } = useNodeForm<CallFormData>(nodeId, () => formRef.value!.getInnerData())
@@ -113,7 +112,6 @@ const {
     url: formData.value.url,
     timeout: formData.value.timeout,
   }),
-  skipValidationOnMount,
   toggleNodeValid,
 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormExit.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormExit.vue
@@ -68,7 +68,6 @@ const {
   inputsFieldNames,
   nameValidator,
   toggleNodeValid,
-  skipValidationOnMount,
   fieldNameValidator,
 } = useNodeForm<ExitFormData>(nodeId, () => formRef.value!.getInnerData())
 
@@ -84,7 +83,6 @@ const {
   getValidationData: () => ({
     status: formData.value.status,
   }),
-  skipValidationOnMount,
   toggleNodeValid,
 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormJq.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormJq.vue
@@ -79,7 +79,6 @@ const {
   renameFieldByName,
   inputsFieldNames,
   nameValidator,
-  skipValidationOnMount,
   toggleNodeValid,
   fieldNameValidator,
 } = useNodeForm<JqFormData>(nodeId, () => formRef.value!.getInnerData())
@@ -110,7 +109,6 @@ const {
   getValidationData: () => ({
     jq: formData.value.jq,
   }),
-  skipValidationOnMount,
   toggleNodeValid,
 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormProperty.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormProperty.vue
@@ -70,7 +70,6 @@ const {
   inputsFieldNames,
   nameValidator,
   toggleNodeValid,
-  skipValidationOnMount,
   fieldNameValidator,
 } = useNodeForm<PropertyFormData>(nodeId, () => formRef.value!.getInnerData())
 
@@ -113,7 +112,6 @@ const {
     property: formData.value.property,
     key: extractKeyFromProperty(formData.value.property),
   }),
-  skipValidationOnMount,
   toggleNodeValid,
 })
 </script>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -53,7 +53,7 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
         options.onChange?.(toConfigNodes(), toUINodes())
       },
     })
-    const newCreatedNodeId = ref<NodeId | null>(null)
+    const skipValidation = ref(false)
     const invalidConfigNodeIds = ref<Set<NodeId>>(new Set())
 
     function markAsLayoutCompleted() {
@@ -516,7 +516,7 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
       state,
       selection,
       modalOpen,
-      newCreatedNodeId,
+      skipValidation,
       invalidConfigNodeIds,
       propertiesPanelOpen,
 


### PR DESCRIPTION
# Summary
Replaced `newCreatedNodeId` with a boolean state `skipValidation` to make the logic for skipping validation on newly created nodes simpler.
