### PR TITLE
fix(dashboard-renderer): allow csv export by default [MA-4289]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
@@ -136,6 +136,20 @@ describe('<DashboardTile />', () => {
     cy.getTestId('csv-export-modal').should('exist')
   })
 
+  it('should show CSV export by default', () => {
+    mount({
+      definition: {
+        query: mockTileDefinition.query,
+        chart: {
+          type: 'vertical_bar',
+        },
+      },
+    })
+
+    cy.getTestId('kebab-action-menu-1').click()
+    cy.getTestId('chart-csv-export-1').should('exist')
+  })
+
   it('should not show CSV export if disabled for chart', () => {
     mount({
       definition: {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -225,7 +225,7 @@ const csvFilename = computed<string>(() => i18n.t('csvExport.defaultFilename'))
 
 const canShowTitleActions = computed((): boolean => (canShowKebabMenu.value && (kebabMenuHasItems.value || props.context.editable)) || !!badgeData.value)
 
-const kebabMenuHasItems = computed((): boolean => !!exploreLinkKebabMenu.value || ('allow_csv_export' in props.definition.chart && props.definition.chart.allow_csv_export) || props.context.editable)
+const kebabMenuHasItems = computed((): boolean => !!exploreLinkKebabMenu.value || ('allow_csv_export' in props.definition.chart ? props.definition.chart.allow_csv_export : true) || props.context.editable)
 
 const rendererLookup: Record<DashboardTileType, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,


### PR DESCRIPTION
# Summary

Fix [MA-4289](https://konghq.atlassian.net/browse/MA-4289)


This will ensure that the `allow_csv_export` property defaults to `true` when the `chart.definition` does not include the prop.
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-4289]: https://konghq.atlassian.net/browse/MA-4289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ