### PR TITLE
feat(entities-plugins): datakit control icons/tooltips

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/icons/AutoLayoutIcon.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/icons/AutoLayoutIcon.vue
@@ -1,0 +1,11 @@
+<template>
+  <svg
+    fill="currentColor"
+    height="24px"
+    viewBox="0 -960 960 960"
+    width="24px"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M440-120H200q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h240v720Zm-80-80v-560H200v560h160Zm160-320v-320h240q33 0 56.5 23.5T840-760v240H520Zm80-80h160v-160H600v160Zm-80 480v-320h320v240q0 33-23.5 56.5T760-120H520Zm80-80h160v-160H600v160ZM360-480Zm240-120Zm0 240Z" />
+  </svg>
+</template>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/icons/FitIcon.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/icons/FitIcon.vue
@@ -1,0 +1,11 @@
+<template>
+  <svg
+    fill="currentColor"
+    height="24px"
+    viewBox="0 -960 960 960"
+    width="24px"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M120-120v-200h80v120h120v80H120Zm520 0v-80h120v-120h80v200H640ZM120-640v-200h200v80H200v120h-80Zm640 0v-120H640v-80h200v200h-80Z" />
+  </svg>
+</template>

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -727,6 +727,10 @@
             "description": "Drag a node onto the canvas to add it to your data flow."
           },
           "actions": {
+            "zoom_in": "Zoom in",
+            "zoom_out": "Zoom out",
+            "fit_view": "Fit view",
+            "auto_layout": "Auto layout",
             "undo": "Undo",
             "redo": "Redo",
             "delete": "Delete",


### PR DESCRIPTION
# Summary

[KM-1708](https://konghq.atlassian.net/browse/KM-1708)

<img width="181" height="155" alt="image" src="https://github.com/user-attachments/assets/6011ac89-5c0c-4040-8486-5a92f39fae15" />


[KM-1708]: https://konghq.atlassian.net/browse/KM-1708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ