### PR TITLE
fix: initialize zoom action links

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -160,7 +160,6 @@ import type { AiExploreQuery, AnalyticsBridge, ExploreQuery, ExploreResultV4, Fi
 import { CsvExportModal } from '@kong-ui-public/analytics-chart'
 import { TIMEFRAME_LOOKUP } from '@kong-ui-public/analytics-utilities'
 import DonutChartRenderer from './DonutChartRenderer.vue'
-import type { ExternalLink } from '@kong-ui-public/analytics-chart'
 
 const PADDING_SIZE = parseInt(KUI_SPACE_70, 10)
 
@@ -191,8 +190,6 @@ const chartData = ref<ExploreResultV4>()
 const exportModalVisible = ref<boolean>(false)
 const titleRef = ref<HTMLElement>()
 const isTitleTruncated = ref(false)
-const requestsLinkZoomActions = ref<ExternalLink | undefined>(undefined)
-const exploreLinkZoomActions = ref<ExternalLink | undefined>(undefined)
 const loadingChartData = ref(true)
 const {
   exploreLinkKebabMenu,
@@ -200,6 +197,8 @@ const {
   canShowKebabMenu,
   canGenerateRequestsLink,
   canGenerateExploreLink,
+  requestsLinkZoomActions,
+  exploreLinkZoomActions,
   buildExploreQuery,
   buildExploreLink,
   buildRequestLink,

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
@@ -123,6 +123,8 @@ describe('useContextLinks', () => {
   beforeEach(() => {
     setupPiniaTestStore({ createVueApp: true })
     vi.clearAllMocks()
+    analyticsConfig.analytics = true
+    analyticsConfig.percentiles = true
   })
 
   it('builds explore link with datasource-scoped filters and explicit granularity', async () => {
@@ -285,6 +287,23 @@ describe('useContextLinks', () => {
     expect(wrapper2.vm.canGenerateRequestsLink).toBe(false)
     expect(wrapper2.vm.exploreLinkKebabMenu).toBe('')
     expect(wrapper2.vm.requestsLinkKebabMenu).toBe('')
+  })
 
+  it('initializes exploreLinkZoomActions and requestsLinkZoomActions with empty href', async () => {
+    const { wrapper } = mountComposable({})
+    await flushPromises()
+
+    expect(wrapper.vm.canGenerateExploreLink).toBe(true)
+    expect(wrapper.vm.canGenerateRequestsLink).toBe(true)
+    expect(wrapper.vm.exploreLinkZoomActions).toEqual({ href: '' })
+    expect(wrapper.vm.requestsLinkZoomActions).toEqual({ href: '' })
+
+    analyticsConfig.analytics = false
+    analyticsConfig.percentiles = false
+
+    const { wrapper: wrapper2 } = mountComposable({})
+    await flushPromises()
+    expect(wrapper2.vm.exploreLinkZoomActions).toBe(undefined)
+    expect(wrapper2.vm.requestsLinkZoomActions).toBe(undefined)
   })
 })

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -1,10 +1,11 @@
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { getFieldDataSources, msToGranularity } from '@kong-ui-public/analytics-utilities'
 import { useAnalyticsConfigStore } from '@kong-ui-public/analytics-config-store'
 import type { DeepReadonly, Ref } from 'vue'
 import type { AiExploreAggregations, AiExploreQuery, AllFilters, ExploreAggregations, ExploreQuery, ExploreResultV4, FilterDatasource, QueryableAiExploreDimensions, QueryableExploreDimensions, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
 import type { AnalyticsBridge, TileDefinition } from '@kong-ui-public/analytics-utilities'
 import type { DashboardRendererContextInternal } from '../types'
+import type { ExternalLink } from '@kong-ui-public/analytics-chart'
 
 export default function useContextLinks(
   {
@@ -22,6 +23,9 @@ export default function useContextLinks(
 
   const exploreBaseUrl = ref('')
   const requestsBaseUrl = ref('')
+  const requestsLinkZoomActions = ref<ExternalLink | undefined>(undefined)
+  const exploreLinkZoomActions = ref<ExternalLink | undefined>(undefined)
+
   const analyticsConfigStore = useAnalyticsConfigStore()
 
   onMounted(async () => {
@@ -134,12 +138,27 @@ export default function useContextLinks(
     return `${exploreBaseUrl.value}?q=${JSON.stringify(exploreQuery)}&d=${datasource}&c=${definition.value.chart.type}`
   }
 
+
+  // Need to initialize zoom-action links when they become available.
+  // If we leave them as `undefined` AnalyticsChart will never be able to
+  // register the dragSelect plugin.
+  watch([canGenerateRequestsLink, canGenerateExploreLink], ([canGenerateRequestsLink, canGenerateExploreLink]) => {
+    if (canGenerateRequestsLink) {
+      requestsLinkZoomActions.value = { href: '' }
+    }
+    if (canGenerateExploreLink) {
+      exploreLinkZoomActions.value = { href: '' }
+    }
+  })
+
   return {
     exploreLinkKebabMenu,
     requestsLinkKebabMenu,
     canShowKebabMenu,
     canGenerateRequestsLink,
     canGenerateExploreLink,
+    requestsLinkZoomActions,
+    exploreLinkZoomActions,
     buildExploreQuery,
     buildRequestsQueryZoomActions,
     buildExploreLink,


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-4288

One more fix needed for this. 

### Issue
`exploreLinkZoomActions` and `requestsLinkZoomActions` were initialized as undefined and only set after an event from the dragSelect plugin (onSelectChartRange).
When `timeseries-zoom` was disabled, the dragSelect plugin could not register with the chart because it required either the explore link or requests link to be defined.

### Fix
Initialize `exploreLinkZoomActions` and `requestsLinkZoomActions` with an empty href as soon as the `canGenerate`... composables become true.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
