### PR TITLE
feat(config-card-item): add iso date string rendering support

### DIFF
--- a/packages/entities/entities-shared/fixtures/mockData.ts
+++ b/packages/entities/entities-shared/fixtures/mockData.ts
@@ -117,7 +117,7 @@ export const gatewayServiceRecord = {
     '_KonnectService:a-good-one',
   ],
   tls_verify: true,
-  updated_at: 1686157266,
+  updated_at: '2023-06-07T17:01:06.000Z',
   write_timeout: 60000,
   extra: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 }

--- a/packages/entities/entities-shared/sandbox/pages/ConfigCardItemPage.vue
+++ b/packages/entities/entities-shared/sandbox/pages/ConfigCardItemPage.vue
@@ -60,6 +60,15 @@
       }"
     />
 
+    <ConfigCardItem
+      :item="{
+        type: ConfigurationSchemaType.Date,
+        key: 'updated_at',
+        label: 'Updated At',
+        value: '2023-06-07T17:01:06.000Z',
+      }"
+    />
+
     <h2>Status Badge</h2>
     <ConfigCardItem
       :item="{

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.cy.ts
@@ -5,7 +5,7 @@ import { ConfigurationSchemaType } from '../../types'
 import ConfigCardItem from './ConfigCardItem.vue'
 
 describe('<ConfigCardItem />', () => {
-  const { i18n: { formatUnixTimeStamp } } = composables.useI18n()
+  const { i18n: { formatUnixTimeStamp, formatIsoDate } } = composables.useI18n()
   describe('Labels & Tooltips', () => {
     it('renders a label and value correctly', () => {
       const label = 'Cool Name'
@@ -195,9 +195,30 @@ describe('<ConfigCardItem />', () => {
       })
     })
 
-    it('renders a Date correctly', () => {
+    it('renders a Date correctly when given a number', () => {
       const date = 1686245746
       const formattedVal = formatUnixTimeStamp(date)
+      const item: RecordItem = {
+        type: ConfigurationSchemaType.Date,
+        key: 'created_at',
+        label: 'Created At',
+        value: date,
+      }
+
+      cy.mount(ConfigCardItem, {
+        props: {
+          item,
+        },
+      })
+
+      cy.get('.config-card-details-row').should('be.visible')
+      cy.getTestId(`${item.key}-date`).should('be.visible')
+      cy.getTestId(`${item.key}-date`).should('contain.text', formattedVal)
+    })
+
+    it('renders a Date correctly when given a ISO date string', () => {
+      const date = '2023-06-08T15:22:26Z'
+      const formattedVal = formatIsoDate(date)
       const item: RecordItem = {
         type: ConfigurationSchemaType.Date,
         key: 'created_at',

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardItem.vue
@@ -165,7 +165,7 @@ const emit = defineEmits<{
 const uniqueId = useId()
 
 const slots = useSlots()
-const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
+const { i18n: { t, formatIsoDate, formatUnixTimeStamp } } = composables.useI18n()
 
 const itemHasValue = computed((): boolean => props.item.value !== undefined && props.item.value !== null && props.item.value !== '')
 const hasTooltip = computed((): boolean => !!(props.item.tooltip || slots['label-tooltip']))
@@ -230,7 +230,9 @@ const componentAttrsData = computed((): ComponentAttrsData => {
         attrs: {
           'data-testid': `${props.item.key}-date`,
         },
-        text: formatUnixTimeStamp(props.item.value),
+        text: isNaN(Number(props.item.value))
+          ? formatIsoDate(props.item.value)
+          : formatUnixTimeStamp(props.item.value),
       }
 
     case ConfigurationSchemaType.BadgeStatus:


### PR DESCRIPTION
Event gateway API endpoints return ISO format date string for `created_at` and `updated_at` fields

JIRA: KM-1726
