### PR TITLE
feat(entities-plugins): datakit multiple fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@evilmartians/lefthook": "^1.12.2",
     "@kong/design-tokens": "1.18.0",
     "@kong/eslint-config-kong-ui": "^1.5.1",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@stylistic/stylelint-plugin": "^3.1.3",
     "@types/flat": "^5.0.5",
     "@types/js-yaml": "^4.0.9",

--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -29,7 +29,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@types/uuid": "^10.0.0",
     "file-saver": "^2.0.5",
     "lodash.mapkeys": "^4.6.0",

--- a/packages/analytics/analytics-geo-map/package.json
+++ b/packages/analytics/analytics-geo-map/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@types/geobuf": "^3.0.4",
     "@types/geojson": "^7946.0.16",
     "maplibre-gl": "^4.7.1",

--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -67,7 +67,7 @@
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "pinia": ">= 2.1.7 < 3"
   }
 }

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -49,7 +49,7 @@
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "ajv": "^8.17.1",
     "cypress-real-events": "^1.14.0",
     "pinia": ">= 2.1.7 < 3",

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/core/documentation/package.json
+++ b/packages/core/documentation/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13"
   },

--- a/packages/core/entities-config-editor/package.json
+++ b/packages/core/entities-config-editor/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "vue": "^3.5.13"
   },
   "repository": {

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@kong/atc-router": "1.6.0-rc.1",
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@types/uuid": "^10.0.0",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vite-plugin-top-level-await": "^1.4.4",

--- a/packages/core/forms/package.json
+++ b/packages/core/forms/package.json
@@ -66,7 +66,7 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@types/lodash-es": "^4.17.12",
     "pug": "^3.0.3"
   },

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "vue": "^3.5.13"
   },
   "repository": {

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"
   },

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-data-plane-nodes/package.json
+++ b/packages/entities/entities-data-plane-nodes/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -33,7 +33,7 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -43,7 +43,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.2",
     "@vue-flow/core": "^1.45.0",

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowCanvas.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowCanvas.vue
@@ -7,6 +7,7 @@
       :id="flowId"
       class="flow"
       :class="{ readonly }"
+      :connect-on-click="false"
       :edges="edges"
       :elements-selectable="!readonly"
       :max-zoom="MAX_ZOOM_LEVEL"

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
@@ -23,6 +23,11 @@
 
     <div class="field">
       <BooleanField
+        :description="t('plugins.free-form.datakit.flow_editor.debug.help')"
+        :label="t('plugins.free-form.datakit.flow_editor.debug.label')"
+        :label-attributes="{
+          info: t('plugins.free-form.datakit.flow_editor.debug.description'),
+        }"
         name="config.debug"
       />
     </div>
@@ -83,37 +88,37 @@ watch(modalOpen, () => {
   .field {
     margin-top: $kui-space-80;
   }
-}
 
-.flow-panels-container {
-  border: $kui-border-width-10 solid $kui-color-border;
-  border-radius: $kui-border-radius-30;
-  height: 560px;
-  overflow: hidden;
-  position: relative;
+  .flow-panels-container {
+    border: $kui-border-width-10 solid $kui-color-border;
+    border-radius: $kui-border-radius-30;
+    height: 560px;
+    overflow: hidden;
+    position: relative;
 
-  .overlay {
-    align-items: center;
-    backdrop-filter: blur(6px);
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    justify-content: center;
-    left: 0;
-    opacity: 0;
-    position: absolute;
-    top: 0;
-    transition: opacity $kui-animation-duration-20 ease-out;
-    width: 100%;
-    z-index: 200;
+    .overlay {
+      align-items: center;
+      backdrop-filter: blur(6px);
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      justify-content: center;
+      left: 0;
+      opacity: 0;
+      position: absolute;
+      top: 0;
+      transition: opacity $kui-animation-duration-20 ease-out;
+      width: 100%;
+      z-index: 200;
 
-    &:hover {
-      opacity: 1;
+      &:hover {
+        opacity: 1;
+      }
     }
   }
-}
 
-.button-open-editor {
-  margin-top: $kui-space-70;
+  .button-open-editor {
+    margin-top: $kui-space-70;
+  }
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormCall.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormCall.vue
@@ -11,7 +11,7 @@
     />
 
     <KLabel class="dk-node-configuration-label">
-      {{ t('plugins.free-form.datakit.flow_editor.node_properties.Configuration') }}
+      {{ t('plugins.free-form.datakit.flow_editor.node_properties.configuration') }}
     </KLabel>
 
     <StringField

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormJq.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/NodeFormJq.vue
@@ -11,13 +11,13 @@
     />
 
     <KLabel class="dk-node-configuration-label">
-      {{ t('plugins.free-form.datakit.flow_editor.node_properties.Configuration') }}
+      {{ t('plugins.free-form.datakit.flow_editor.node_properties.configuration') }}
     </KLabel>
 
     <!-- todo(zehao): replace to monaco editor -->
     <StringField
       :error="jqHandler.error.value"
-      :help="jqHandler.errorMessage.value"
+      :error-message="jqHandler.errorMessage.value"
       :label="jqFieldName"
       multiline
       name="jq"

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node/FlowNode.vue
@@ -5,6 +5,7 @@
       reversed: isReversed,
       implicit: isImplicit,
     }"
+    @mousedown="closeMenu"
   >
     <div class="body">
       <KTooltip
@@ -30,11 +31,15 @@
       />
       <KDropdown
         v-if="!isImplicit"
+        ref="menu"
         class="menu"
         :kpop-attributes="{
           offset: '4px',
+          target: 'body',
+          popoverClasses: 'dk-flow-node-menu',
         }"
         width="160"
+        @click.stop
       >
         <KButton
           appearance="tertiary"
@@ -213,7 +218,7 @@
 <script setup lang="ts">
 import type { NodeInstance } from '../../types'
 
-import { computed, watch } from 'vue'
+import { computed, useTemplateRef, watch } from 'vue'
 import { KTooltip, KButton, KDropdown, KDropdownItem } from '@kong/kongponents'
 import { createI18n } from '@kong-ui-public/i18n'
 import {
@@ -357,6 +362,12 @@ watch(() => data.fields.output, (output, oldOutput) => {
     storeToggleExpanded(data.id, 'output', output.length > 0, true, '*')
   }
 }, { deep: true })
+
+
+const menuRef = useTemplateRef('menu')
+function closeMenu() {
+  menuRef.value?.closeDropdown()
+}
 </script>
 
 <style lang="scss" scoped>
@@ -420,9 +431,9 @@ $io-column-min-width-no-fields: 70px;
         display: flex;
       }
 
-      :deep(.dropdown-item-trigger) {
-        font-size: $kui-font-size-20;
-        padding: $kui-space-30 $kui-space-40;
+      :global(.dk-flow-node-menu .dropdown-item-trigger) {
+        font-size: $kui-font-size-20 !important;
+        padding: $kui-space-30 $kui-space-40 !important;
       }
     }
   }
@@ -602,10 +613,8 @@ $io-column-min-width-no-fields: 70px;
     }
   }
 }
-</style>
 
-<style>
-.vue-flow__node:has(.vue-flow__handle.connecting) {
+:global(.vue-flow__node:has(.vue-flow__handle.connecting)) {
   z-index: 10000 !important;
 }
 </style>

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -726,10 +726,15 @@
             "title": "Node types",
             "description": "Drag a node onto the canvas to add it to your data flow."
           },
+          "debug": {
+            "label": "Enable debugging",
+            "description": "Enables detailed error messages in client responses for easier debugging.",
+            "help": "Enabling the debug option in Datakit is considered unsafe for production environments, as it can cause arbitrary information to leak into client responses."
+          },
           "actions": {
             "zoom_in": "Zoom in",
             "zoom_out": "Zoom out",
-            "fit_view": "Fit view",
+            "fit_view": "Zoom to fit",
             "auto_layout": "Auto layout",
             "undo": "Undo",
             "redo": "Redo",
@@ -783,7 +788,7 @@
           },
           "node_properties": {
             "name": "Name",
-            "Configuration": "Configuration",
+            "configuration": "Configuration",
             "input": {
               "placeholder": "Select output(s)",
               "add_button": "Add an input"

--- a/packages/entities/entities-redis-configurations/package.json
+++ b/packages/entities/entities-redis-configurations/package.json
@@ -44,7 +44,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@types/uuid": "^10.0.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@types/lodash.isequal": "^4.5.8",
     "axios": "^1.7.7",
     "vite-plugin-monaco-editor": "^1.1.0",

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -32,7 +32,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
     "@kong/icons": "^1.36.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -33,7 +33,7 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "axios": "^1.7.7",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/packages/portal/document-viewer/package.json
+++ b/packages/portal/document-viewer/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@types/prismjs": "^1.26.5",
     "@vitejs/plugin-vue-jsx": "^4.2.0",
     "vue": "^3.5.13"

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.18.0",
-    "@kong/kongponents": "9.39.0",
+    "@kong/kongponents": "9.40.0",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/uuid": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@stylistic/stylelint-plugin':
         specifier: ^3.1.3
         version: 3.1.3(stylelint@16.10.0(typescript@5.9.2))
@@ -232,8 +232,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -287,8 +287,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@types/geobuf':
         specifier: ^3.0.4
         version: 3.0.4
@@ -333,8 +333,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       pinia:
         specifier: '>= 2.1.7 < 3'
         version: 2.1.7(typescript@5.9.2)(vue@3.5.18(typescript@5.9.2))
@@ -404,8 +404,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -456,8 +456,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -524,8 +524,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -539,8 +539,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       vue:
         specifier: ^3.5.13
         version: 3.5.18(typescript@5.9.2)
@@ -585,8 +585,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -631,8 +631,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -661,8 +661,8 @@ importers:
         specifier: workspace:^
         version: link:../i18n
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       vue:
         specifier: ^3.5.13
         version: 3.5.18(typescript@5.9.2)
@@ -677,8 +677,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       vue:
         specifier: ^3.5.13
         version: 3.5.18(typescript@5.9.2)
@@ -705,8 +705,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -732,8 +732,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -759,8 +759,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -786,8 +786,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -813,8 +813,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -840,8 +840,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -864,8 +864,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -891,8 +891,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -958,8 +958,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@vue-flow/background':
         specifier: ^1.3.2
         version: 1.3.2(@vue-flow/core@1.45.0(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
@@ -1024,8 +1024,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -1061,8 +1061,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@types/lodash.isequal':
         specifier: ^4.5.8
         version: 4.5.8
@@ -1098,8 +1098,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -1125,8 +1125,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -1152,8 +1152,8 @@ importers:
         specifier: ^1.36.0
         version: 1.36.0(vue@3.5.18(typescript@5.9.2))
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -1180,8 +1180,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       axios:
         specifier: ^1.7.7
         version: 1.11.0
@@ -1205,8 +1205,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@types/prismjs':
         specifier: ^1.26.5
         version: 1.26.5
@@ -1239,8 +1239,8 @@ importers:
         specifier: 1.18.0
         version: 1.18.0
       '@kong/kongponents':
-        specifier: 9.39.0
-        version: 9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+        specifier: 9.40.0
+        version: 9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.1
         version: 1.1.1(rollup@4.46.2)(vite@5.4.19(@types/node@24.1.0)(sass-embedded@1.80.3)(sass@1.89.2)(terser@5.43.1))
@@ -1450,6 +1450,10 @@ packages:
 
   '@babel/runtime@7.28.3':
     resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -2005,8 +2009,8 @@ packages:
       vue: '>= 3.3.4 < 4'
       vue-router: ^4.2.4
 
-  '@kong/kongponents@9.39.0':
-    resolution: {integrity: sha512-5qTqiKm1JpERn2fdmeQOBQwQGbR0tkigfax/TAF6/Z1eC9q9fIGrPF7qjX0BjRz7wEsTRPU9yEjFLo6oMxFqSA==}
+  '@kong/kongponents@9.40.0':
+    resolution: {integrity: sha512-djSz1s6bfOxuAMWIkmRZUl4mP0/W9uEIXnYh6LCa/VD2196IS9sieaMB8J3kQK59wDhmxY5ZOcSa+3SfxdQBmg==}
     engines: {node: '>=v16.20.2 || >=18.12.1 || >=20.14.0 || >=22.14.0', pnpm: '>=9.11.0 || >=10.10.0'}
     peerDependencies:
       vue: '>= 3.5.0 < 4'
@@ -10065,6 +10069,8 @@ snapshots:
 
   '@babel/runtime@7.28.3': {}
 
+  '@babel/runtime@7.28.4': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -10681,7 +10687,7 @@ snapshots:
       vue-draggable-next: 2.3.0(sortablejs@1.15.6)(vue@3.5.18(typescript@5.9.2))
       vue-router: 4.5.1(vue@3.5.18(typescript@5.9.2))
 
-  '@kong/kongponents@9.39.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))':
+  '@kong/kongponents@9.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))':
     dependencies:
       '@floating-ui/vue': 1.1.9(vue@3.5.18(typescript@5.9.2))
       '@kong/icons': 1.36.0(vue@3.5.18(typescript@5.9.2))
@@ -14033,7 +14039,7 @@ snapshots:
 
   date-fns@2.30.0:
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
 
   date-fns@4.1.0: {}
 


### PR DESCRIPTION
# Summary

[KM-1722](https://konghq.atlassian.net/browse/KM-1722)

This PR includes the following changes:

- Bumped `@kong/kongponents` version and set `kpopAttributes.target` to `body` for `<KDropdown>`.
- Improved tooltip and description for the `debug` field.
- Updated tooltip for the `fitView` control.
- Disabled `connect-on-click` to prevent handles from remaining in a connecting state.

<img width="466" height="234" alt="image" src="https://github.com/user-attachments/assets/3649c3e8-41d6-4af4-9bd3-2d929b4ba4a9" />

<img width="925" height="66" alt="image" src="https://github.com/user-attachments/assets/43061878-7474-4056-9f85-ebbba0e2f94f" />

<img width="159" height="128" alt="image" src="https://github.com/user-attachments/assets/5a9e290a-be46-4988-8ee3-f0a0ac203f89" />


[KM-1722]: https://konghq.atlassian.net/browse/KM-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ