### PR TITLE
feat(entities-plugins): add a before-custom-tab-content slot

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -90,6 +90,8 @@
 
         <template #custom>
           <div data-testid="custom-tab">
+            <slot name="before-custom-tab-content" />
+
             <p class="tab-description">
               {{ t('plugins.select.tabs.custom.description') }}
             </p>


### PR DESCRIPTION
Add a `before-custom-tab-content` slot before the content of the Custom Plugins tab.

KM-1713