### PR TITLE
fix(entities-plugins): fix toggle node expanded

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -263,7 +263,11 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
     ) {
       const node = getNodeById(nodeId)
       if (!node) return
-      node.expanded[io] = value ?? !node.expanded[io]
+
+      const newValue = value ?? !node.expanded[io]
+      if (newValue === !!node.expanded[io]) return
+
+      node.expanded[io] = newValue
       if (commitNow) history.commit(tag ?? `toggle:${nodeId}:${io}`)
     }
 


### PR DESCRIPTION
# Summary

[KM-1737](https://konghq.atlassian.net/browse/KM-1737)

Only commit when `expanded` does change. Otherwise this will contaminate the history records especially when tagged with `*`.

[KM-1737]: https://konghq.atlassian.net/browse/KM-1737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ