### PR TITLE
fix: add data-testid to zoom-timerange from - to

### DIFF
--- a/packages/analytics/analytics-chart/src/components/ZoomTimerange.vue
+++ b/packages/analytics/analytics-chart/src/components/ZoomTimerange.vue
@@ -1,13 +1,19 @@
 <template>
   <div class="zoom-timerange-container">
     <div class="zoom-timerange-details">
-      <div class="label">
+      <div
+        class="label"
+        data-testid="zoom-timerange-from"
+      >
         {{ i18n.t('zoom_time_range.from') }}
       </div>
       <div>
         {{ throttledStartTime }}
       </div>
-      <div class="label">
+      <div
+        class="label"
+        data-testid="zoom-timerange-to"
+      >
         {{ i18n.t('zoom_time_range.to') }}
       </div>
       <div>


### PR DESCRIPTION
# Summary

- Add data-testid to zoom timerange labels

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
