### PR TITLE
fix: always show time in tooltip timestamp

### DIFF
--- a/packages/analytics/analytics-chart/src/utils/format-timestamps.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/format-timestamps.spec.ts
@@ -164,7 +164,7 @@ describe('formatChartTicksByGranularity', () => {
       ['hourly', 'Dec 10, 2024 3:30 PM'],
       ['twoHourly', 'Dec 10, 2024 3:30 PM'],
       ['twelveHourly', 'Dec 10, 2024 3:30 PM'],
-      ['daily', 'Dec 10, 2024'],
+      ['daily', 'Dec 10, 2024 3:30 PM'],
       ['weekly', '2024 W50'],
     ])('formats \'%s\' granularity in UTC', (granularity, expected) => {
       expect(formatTooltipTimestampByGranularity({
@@ -185,7 +185,7 @@ describe('formatChartTicksByGranularity', () => {
       ['hourly', 'Dec 10, 2024 10:30 AM'],
       ['twoHourly', 'Dec 10, 2024 10:30 AM'],
       ['twelveHourly', 'Dec 10, 2024 10:30 AM'],
-      ['daily', 'Dec 10, 2024'],
+      ['daily', 'Dec 10, 2024 10:30 AM'],
       ['weekly', '2024 W50'],
     ])('formats \'%s\' granularity in America/New_York', (granularity, expected) => {
       expect(formatTooltipTimestampByGranularity({

--- a/packages/analytics/analytics-chart/src/utils/format-timestamps.ts
+++ b/packages/analytics/analytics-chart/src/utils/format-timestamps.ts
@@ -15,7 +15,6 @@ const TICK_FMT_DATE = 'yyyy-MM-dd'
 
 const TOOLTIP_FMT_DATE_TIME_SECONDS = 'MMM dd, yyyy h:mm:ss a'
 const TOOLTIP_FMT_DATE_TIME_MINUTES = 'MMM dd, yyyy h:mm a'
-const TOOLTIP_FMT_DATE = 'MMM dd, yyyy'
 
 const tickResolvers: Partial<Record<GranularityValues, TickResolver>> = {
   secondly: (d) => (d ? TICK_FMT_DATE_TIME_SECONDS : TICK_FMT_TIME_SECONDS),
@@ -42,7 +41,7 @@ const tooltipResolvers: Partial<Record<GranularityValues, TooltipResolver>> = {
   hourly: () => TOOLTIP_FMT_DATE_TIME_MINUTES,
   twoHourly: () => TOOLTIP_FMT_DATE_TIME_MINUTES,
   twelveHourly: () => TOOLTIP_FMT_DATE_TIME_MINUTES,
-  daily: () => TOOLTIP_FMT_DATE,
+  daily: () => TOOLTIP_FMT_DATE_TIME_MINUTES,
 }
 
 function formatUsingResolver({


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-4312

Show time in tooltip timestamp when granularity is daily.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
