### PR TITLE
fix(entities-plugins): hide __ui_data in config view while editing

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -117,18 +117,18 @@
         <template #json>
           <JsonCodeBlock
             :config="config"
-            :entity-record="getRequestBody"
+            :entity-record="viewConfigurationRecord"
             :fetcher-url="submitUrl"
             :request-method="props.pluginId ? 'put' : 'post'"
           />
         </template>
         <template #yaml>
-          <YamlCodeBlock :entity-record="getRequestBody" />
+          <YamlCodeBlock :entity-record="viewConfigurationRecord" />
         </template>
         <template #terraform>
           <TerraformCodeBlock
             :credential-type="credentialType"
-            :entity-record="getRequestBody"
+            :entity-record="viewConfigurationRecord"
             :entity-type="SupportedEntityType.Plugin"
           />
         </template>
@@ -1333,6 +1333,16 @@ const getRequestBody = computed((): Record<string, any> => {
   }
 
   return requestBody
+})
+
+// Read-only record for the View Configuration feature
+const viewConfigurationRecord = computed(() => {
+  const record = { ...getRequestBody.value }
+
+  // Don't show UI data in the configuration view
+  delete record['__ui_data']
+
+  return record
 })
 
 // make the actual API request to save on create/edit

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -1337,11 +1337,9 @@ const getRequestBody = computed((): Record<string, any> => {
 
 // Read-only record for the View Configuration feature
 const viewConfigurationRecord = computed(() => {
-  const record = { ...getRequestBody.value }
-
-  // Don't show UI data in the configuration view
-  delete record['__ui_data']
-
+  // __ui_data: Don't show UI data in the configuration view
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { __ui_data, ...record } = { ...getRequestBody.value }
   return record
 })
 


### PR DESCRIPTION
Strip the `__ui_data` field (it will still be submitted via the UI) from the config displayed in the View Configuration slideout while editing the plugin. This applies to all plugins, as `__ui_data` should be considered a special field that should not be displayed for any plugin.

<img width="764" height="922" alt="Screenshot 2025-09-16 at 14 21 03" src="https://github.com/user-attachments/assets/cc476a50-39d6-4eb5-a174-8844f1c38956" />

KM-1759