### PR TITLE
fix(entities-plugins): datakit incorrect fitView calls on DND and duplicate

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="dk-flow-editor">
     <div class="flow-panels-container">
-      <FlowPanels
-        ref="flowPanels"
-        readonly
-      />
+      <FlowPanels readonly />
 
       <div class="overlay">
         <KButton
@@ -24,17 +21,17 @@
 </template>
 
 <script setup lang="ts">
-import type { ConfigNode, DatakitConfig, DatakitFormData, DatakitUIData, UINode } from '../types'
-
 import { createI18n } from '@kong-ui-public/i18n'
 import { ExpandIcon } from '@kong/icons'
-import { useTemplateRef, watch } from 'vue'
+import { watch } from 'vue'
 
 import english from '../../../../locales/en.json'
+import { useFormShared } from '../../shared/composables'
 import { provideEditorStore } from '../composables'
 import FlowPanels from './FlowPanels.vue'
 import EditorModal from './modal/EditorModal.vue'
-import { useFormShared } from '../../shared/composables'
+
+import type { ConfigNode, DatakitConfig, DatakitFormData, DatakitUIData, UINode } from '../types'
 
 const { t } = createI18n<typeof english>('en-us', english)
 
@@ -48,8 +45,6 @@ const emit = defineEmits<{
   change: [config: DatakitConfig, uiData: DatakitUIData]
   error: [msg: string]
 }>()
-
-const flowPanels = useTemplateRef('flowPanels')
 
 function onChange(configNodes: ConfigNode[], uiNodes: UINode[]) {
   const nextConfig = { ...formData.config, nodes: configNodes }
@@ -65,13 +60,8 @@ const { modalOpen, setPendingFitView } = provideEditorStore(formData.config?.nod
 })
 
 watch(modalOpen, () => {
-  if (modalOpen.value) {
-    // Schedule a `fitView` for the opened modal.
-    setPendingFitView(true)
-  } else {
-    // Perform another `fitView` on modal close.
-    flowPanels.value?.fitView()
-  }
+  // `fitView` when model is toggled.
+  setPendingFitView(true)
 })
 </script>
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
@@ -59,13 +59,17 @@ function onChange(configNodes: ConfigNode[], uiNodes: UINode[]) {
   emit('change', nextConfig, nextUIData)
 }
 
-const { modalOpen } = provideEditorStore(formData.config?.nodes ?? [], formData.__ui_data?.nodes ?? [], {
+const { modalOpen, setPendingFitView } = provideEditorStore(formData.config?.nodes ?? [], formData.__ui_data?.nodes ?? [], {
   onChange,
   isEditing,
 })
 
 watch(modalOpen, () => {
-  if (!modalOpen.value) {
+  if (modalOpen.value) {
+    // Schedule a `fitView` for the opened modal.
+    setPendingFitView(true)
+  } else {
+    // Perform another `fitView` on modal close.
     flowPanels.value?.fitView()
   }
 })

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowPanels.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowPanels.vue
@@ -238,8 +238,6 @@ watch(
     }, 0)
   },
 )
-
-defineExpose({ fitView })
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowPanels.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowPanels.vue
@@ -211,14 +211,22 @@ function fitView() {
 }
 
 watch(
-  [requestInitialized, responseInitialized, () => state.value.pendingLayout],
-  ([request, response, pendingLayout]) => {
-    if (!request || !response)
+  [requestInitialized, responseInitialized, () => state.value.pendingLayout, () => state.value.pendingFitView],
+  ([requestReady, responseReady, pendingLayout, pendingFitView]) => {
+    // Not ready
+    if (!requestReady || !responseReady)
       return
 
-    // Dismiss the flag to avoid reentering
+    // Nothing to do here
+    if (!pendingLayout && !pendingFitView)
+      return
+
+    // Clear the pending states to avoid reentrance
     if (pendingLayout)
       clearPendingLayout()
+
+    if (pendingFitView)
+      setPendingFitView(false)
 
     // Wait for VueFlow internal layout measurements. nextTick does not work here.
     setTimeout(() => {
@@ -231,9 +239,8 @@ watch(
           clear()
       }
 
-      if (state.value.pendingFitView) {
+      if (pendingFitView) {
         fitView()
-        setPendingFitView(false)
       }
     }, 0)
   },

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/store/store.ts
@@ -58,9 +58,18 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
     const skipValidation = ref(false)
     const invalidConfigNodeIds = ref<Set<NodeId>>(new Set())
 
-    // Should only be called by internal actions instead of user ones.
-    function markAsLayoutCompleted() {
-      state.value.needLayout = false
+    // This is one way because `pendingLayout` should only be set to `true` on init.
+    function clearPendingLayout() {
+      state.value.pendingLayout = false
+      history.commit('*')
+    }
+
+    // Mark the current state as needing a `fitView`. Does not guarantee the immediate execution.
+    function setPendingFitView(isPending = true) {
+      if (state.value.pendingFitView === isPending)
+        return
+
+      state.value.pendingFitView = isPending
       history.commit('*')
     }
 
@@ -621,8 +630,9 @@ const [provideEditorStore, useOptionalEditorStore] = createInjectionState(
       isValidVueFlowConnection,
       validateGraph: () => validateGraph(),
 
-      // layout helpers
-      markAsLayoutCompleted,
+      // layout & viewport helpers
+      clearPendingLayout,
+      setPendingFitView,
     }
   },
 )

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/types.ts
@@ -159,21 +159,16 @@ export interface EdgeInstance extends EdgeData {
 export interface EditorState {
   nodes: NodeInstance[]
   edges: EdgeInstance[]
+
   /**
-   * A hint to indicate if a layout should be scheduled after the state is loaded.
-   *
-   * If set to `false`, no layout will be scheduled.
-   * If set to `true`, an auto-layout will be scheduled and the history will be cleared after layout.
-   * Set to an object to schedule an auto-layout and customize the behavior.
+   * Whether to schedule an `autoLayout` after the current state is rendered.
    */
-  needLayout?: boolean | {
-    /**
-     * Whether to keep the history after the auto-layout.
-     *
-     * @default false
-     */
-    keepHistory?: boolean
-  }
+  pendingLayout?: false | 'clearHistory' | 'keepHistory'
+
+  /**
+   * Whether to schedule a `fitView` after the current state is rendered.
+   */
+  pendingFitView?: boolean
 }
 
 export interface MakeNodeInstancePayload {


### PR DESCRIPTION
Introduce a `pendingFitView` (like `needLayout` which was renamed to `pendingLayout` for more clarity) in the editor state to prevent unexpected `fitView` calls on nodes/edges change, especially while adding nodes via drag and drop or duplicating nodes.

KM-1783