### PR TITLE
fix: require ctrl/cmnd + scroll to zoom the map by default

### DIFF
--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
@@ -230,6 +230,12 @@ const mapOptions = computed(() => {
       [-179, -75], // -75 south tip of south america
       [179, 90],
     ],
+    cooperativeGestures: true,
+    locale: {
+      'CooperativeGesturesHandler.WindowsHelpText': i18n.t('cooperative_gestures.windows_zoom_help_text'),
+      'CooperativeGesturesHandler.MacHelpText': i18n.t('cooperative_gestures.mac_zoom_help_text'),
+      'CooperativeGesturesHandler.MobileHelpText': i18n.t('cooperative_gestures.mobile_zoom_help_text'),
+    },
   }
 
   if (bounds) {

--- a/packages/analytics/analytics-geo-map/src/locales/en.json
+++ b/packages/analytics/analytics-geo-map/src/locales/en.json
@@ -31,5 +31,10 @@
     "request_size_p95": "Request size (p95)",
     "request_size_p50": "Request size (p50)",
     "request_size_sum": "Request size (sum)"
+  },
+  "cooperative_gestures": {
+    "windows_zoom_help_text": "Use Ctrl + Scroll to zoom the map",
+    "mac_zoom_help_text": "Use ⌘ + Scroll to zoom the map",
+    "mobile_zoom_help_text": "Use two fingers to zoom the map"
   }
 }


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-4276

Require ctrl/cmd + scroll to zoom analytics geo map
See [maplibre cooperative gestures](https://maplibre.org/maplibre-gl-js/docs/examples/cooperative-gestures/)

<img width="1766" height="1372" alt="image" src="https://github.com/user-attachments/assets/dd3fa638-7c7e-46af-bfab-58d48b0f36c5" />


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
