### PR TITLE
fix(entities-plugins): datakit do not handle pending autoLayout and fitView in multiple places

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowEditor.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="dk-flow-editor">
     <div class="flow-panels-container">
-      <FlowPanels readonly />
+      <FlowPanels
+        :inactive="modalOpen"
+        readonly
+      />
 
       <div class="overlay">
         <KButton
@@ -62,7 +65,7 @@ const { modalOpen, setPendingFitView } = provideEditorStore(formData.config?.nod
 watch(modalOpen, () => {
   // `fitView` when model is toggled.
   setPendingFitView(true)
-})
+}, { flush: 'post' }) // Safely schedule fitView after <FlowPanels /> receives the latest `inactive` prop
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowPanels.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/FlowPanels.vue
@@ -86,7 +86,11 @@ import FlowCanvas from './FlowCanvas.vue'
 
 import type { EdgeChange, NodeChange, VueFlowStore } from '@vue-flow/core'
 
-const { readonly, resizable } = defineProps<{
+const { inactive, readonly, resizable } = defineProps<{
+  /**
+   * Whether current component is inactive (e.g. covered by modal).
+   */
+  inactive?: boolean
   readonly?: boolean
   resizable?: boolean
 }>()
@@ -213,6 +217,10 @@ function fitView() {
 watch(
   [requestInitialized, responseInitialized, () => state.value.pendingLayout, () => state.value.pendingFitView],
   ([requestReady, responseReady, pendingLayout, pendingFitView]) => {
+    // If current component is inactive (e.g. covered by modal), do nothing
+    // Note: `inactive` does not trigger this watcher. Update this BEFORE updating sources that trigger this watcher.
+    if (inactive) return
+
     // Not ready
     if (!requestReady || !responseReady)
       return
@@ -239,9 +247,8 @@ watch(
           clear()
       }
 
-      if (pendingFitView) {
+      if (pendingFitView)
         fitView()
-      }
     }, 0)
   },
 )


### PR DESCRIPTION
Fix leftover issues from #2503, where `fitView` is called on the editor modal open: once in the direct `FlowPanels` and once in the deeply nested `FlowPanels` inside `EditorModal`.
