### PR TITLE
fix(entities-plugins): remove unsupported scoping fields in detail view

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
@@ -144,30 +144,35 @@
 </template>
 
 <script setup lang="ts">
-import type { PropType } from 'vue'
-import { computed, ref, onBeforeMount } from 'vue'
-import type { AxiosError } from 'axios'
+import { PluginIcon } from '@kong-ui-public/entities-plugins-icon'
+import {
+  ConfigurationSchemaSection,
+  ConfigurationSchemaType,
+  EntityBaseConfigCard,
+  InternalLinkItem,
+  SupportedEntityType,
+  useAxios,
+  useErrors,
+  useHelpers,
+  useSchemaProvider,
+} from '@kong-ui-public/entities-shared'
+import { computed, onBeforeMount, ref } from 'vue'
+
+import composables from '../composables'
+import endpoints from '../plugins-endpoints'
 import { PluginScope } from '../types'
-import { type KongManagerPluginEntityConfig, type KonnectPluginEntityConfig, type PluginMetaData } from '../types'
+
+import '@kong-ui-public/entities-shared/dist/style.css'
+
 import type {
   ConfigurationSchema,
   PluginConfigurationSchema,
 } from '@kong-ui-public/entities-shared'
-import {
-  EntityBaseConfigCard,
-  ConfigurationSchemaType,
-  ConfigurationSchemaSection,
-  InternalLinkItem,
-  useAxios,
-  useErrors,
-  useHelpers,
-  SupportedEntityType,
-} from '@kong-ui-public/entities-shared'
-import composables from '../composables'
-import { useSchemaProvider } from '@kong-ui-public/entities-shared'
-import endpoints from '../plugins-endpoints'
-import { PluginIcon } from '@kong-ui-public/entities-plugins-icon'
-import '@kong-ui-public/entities-shared/dist/style.css'
+import type { AxiosError } from 'axios'
+import type { PropType } from 'vue'
+
+import type { KongManagerPluginEntityConfig, KonnectPluginEntityConfig } from '../types'
+
 
 const PLUGIN_CONFIG_KEY = 'config'
 

--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
@@ -344,17 +344,18 @@ const resolveRecord = (data: Record<string, any>): Record<string, any> => {
   return Object.fromEntries(Object.entries(data).filter(([key, value]) => {
     // If a scoped field is falsy (e.g., empty), and the plugin doesn't support that scope, remove it.
     // Keeping non-empty scoping fields in case, in the very rare case, we made a mistake in the metadata.
+    if (value) return true
 
-    if (key === 'service' && !value && !scopes.includes(PluginScope.SERVICE))
+    if (key === 'service' && !scopes.includes(PluginScope.SERVICE))
       return false
 
-    if (key === 'route' && !value && !scopes.includes(PluginScope.ROUTE))
+    if (key === 'route' && !scopes.includes(PluginScope.ROUTE))
       return false
 
-    if (key === 'consumer' && !value && !scopes.includes(PluginScope.CONSUMER))
+    if (key === 'consumer' && !scopes.includes(PluginScope.CONSUMER))
       return false
 
-    if (key === 'consumer_group' && !value && !scopes.includes(PluginScope.CONSUMER_GROUP))
+    if (key === 'consumer_group' && !scopes.includes(PluginScope.CONSUMER_GROUP))
       return false
 
     return true

--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
@@ -30,6 +30,7 @@
       :hide-title="hideTitle"
       :plugin-config-key="PLUGIN_CONFIG_KEY"
       :plugin-config-schema="pluginConfigSchema"
+      :record-resolver="resolveRecord"
       @fetch:error="(err: any) => $emit('fetch:error', err)"
       @fetch:success="(entity: any) => $emit('fetch:success', entity)"
       @loading="(val: boolean) => $emit('loading', val)"
@@ -146,7 +147,8 @@
 import type { PropType } from 'vue'
 import { computed, ref, onBeforeMount } from 'vue'
 import type { AxiosError } from 'axios'
-import type { KongManagerPluginEntityConfig, KonnectPluginEntityConfig } from '../types'
+import { PluginScope } from '../types'
+import { type KongManagerPluginEntityConfig, type KonnectPluginEntityConfig, type PluginMetaData } from '../types'
 import type {
   ConfigurationSchema,
   PluginConfigurationSchema,
@@ -326,6 +328,33 @@ const pluginConfigSchema = computed((): PluginConfigurationSchema => {
 
   return customSchema
 })
+
+const resolveRecord = (data: Record<string, any>): Record<string, any> => {
+  const scopes: PluginScope[] | undefined = pluginMetaData.pluginMetaData[props.config.pluginType]?.scope
+
+  // Missing `scope` indicates an unknown plugin. We'd better not touch the data.
+  if (!scopes)
+    return data
+
+  return Object.fromEntries(Object.entries(data).filter(([key, value]) => {
+    // If a scoped field is falsy (e.g., empty), and the plugin doesn't support that scope, remove it.
+    // Keeping non-empty scoping fields in case, in the very rare case, we made a mistake in the metadata.
+
+    if (key === 'service' && !value && !scopes.includes(PluginScope.SERVICE))
+      return false
+
+    if (key === 'route' && !value && !scopes.includes(PluginScope.ROUTE))
+      return false
+
+    if (key === 'consumer' && !value && !scopes.includes(PluginScope.CONSUMER))
+      return false
+
+    if (key === 'consumer_group' && !value && !scopes.includes(PluginScope.CONSUMER_GROUP))
+      return false
+
+    return true
+  }))
+}
 
 const { getMessageFromError } = useErrors()
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)


### PR DESCRIPTION
Remove unsupported scoping fields in the plugin detail view according to the plugin metadata. This does not affect Konnect, as their API does not return the unsupported fields in the first place.

1. If the scope definition is missing for a plugin, keep it as is, as it could be a new bundled plugin or a custom plugin with an incorrect schema.
2. If a scoping field is not empty, but the plugin metadata does not have that scope (unsupported if telling from the metadata), keep the scoping field in case we have incorrect metadata.

|Structured|JSON|
|:-|:-|
|<img width="732" height="698" alt="Screenshot 2025-09-18 at 16 16 37" src="https://github.com/user-attachments/assets/34c04c96-42f2-44bc-9e06-500c67cadddc" />|<img width="704" height="747" alt="Screenshot 2025-09-18 at 16 16 22" src="https://github.com/user-attachments/assets/f07bb922-5837-47f2-bd25-647d80dc341c" />|

KM-1789