### PR TITLE
feat(analytics): add country name lookup and swap for labels [MA-4083]

### DIFF
--- a/packages/analytics/analytics-utilities/src/utils/GeoLookup.ts
+++ b/packages/analytics/analytics-utilities/src/utils/GeoLookup.ts
@@ -1,0 +1,9 @@
+import type { CountryIsoMap, CountryISOA2 } from '../types'
+
+import { COUNTRIES } from '../types'
+
+export const countries: Map<string, CountryIsoMap> = new Map(COUNTRIES.map(country => [country.code, { code: country.code, name: country.name }]))
+
+export const getCountryName = (country_code: CountryISOA2) => {
+  return countries.get(country_code)?.name || country_code
+}

--- a/packages/analytics/analytics-utilities/src/utils/index.ts
+++ b/packages/analytics/analytics-utilities/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './chartDataGenerator'
 export * from './helpers'
 export * from './SeedRandom'
+export * from './GeoLookup'


### PR DESCRIPTION
# Summary

Fix [MA-4083](https://konghq.atlassian.net/browse/MA-4082)

This will add the `GeoLookup` utility which includes a `getCountryName` method to retrieve the country name from a given `country_code`.

Using this new utility, country names will now appear within tooltip and chart legends.
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
