### PR TITLE
fix(plugins): remove the size limit against exit transformer plugin

### DIFF
--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -9,6 +9,7 @@ import { aiLlmAsJudgeSchema } from '../definitions/schemas/AILLMAsJudge'
 import { applicationRegistrationSchema } from '../definitions/schemas/ApplicationRegistration'
 import { ArrayInputFieldSchema } from '../definitions/schemas/ArrayInputFieldSchema'
 import { dataDogSchema } from '../definitions/schemas/Datadog'
+import { exitTransformerSchema } from '../definitions/schemas/ExitTransformer'
 import { graphqlRateLimitingAdvancedSchema } from '../definitions/schemas/GraphQLRateLimitingAdvanced'
 import { injectionProtectionSchema } from '../definitions/schemas/InjectionProtection'
 import { mockingSchema } from '../definitions/schemas/Mocking'
@@ -123,6 +124,10 @@ export const useSchemas = (options?: UseSchemasOptions) => {
 
     datadog: {
       ...dataDogSchema,
+    },
+
+    'exit-transformer': {
+      ...exitTransformerSchema,
     },
 
     'upstream-tls': {

--- a/packages/entities/entities-plugins/src/definitions/schemas/ExitTransformer.ts
+++ b/packages/entities/entities-plugins/src/definitions/schemas/ExitTransformer.ts
@@ -1,0 +1,13 @@
+import type { ExitTransformerSchema } from '../../types/plugins/exit-transformer'
+import { ArrayInputFieldSchema } from './ArrayInputFieldSchema'
+
+export const exitTransformerSchema: ExitTransformerSchema = {
+  'config-functions': {
+    ...ArrayInputFieldSchema,
+    inputAttributes: {
+      ...ArrayInputFieldSchema.inputAttributes,
+      type: 'textarea',
+      max: false,
+    },
+  },
+}

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -6,6 +6,7 @@ import type { ApplicationRegistrationSchema } from './plugins/application-regist
 import type { StatsDSchema } from './plugins/stats-d'
 import type { MockingSchema } from './plugins/mocking'
 import type { DatadogSchema } from './plugins/datadog-schema'
+import type { ExitTransformerSchema } from './plugins/exit-transformer'
 import type { StatsDAdvancedSchema } from './plugins/stats-d-advanced'
 import type { UpstreamTlsSchema } from './plugins/upstream-tls'
 import type { RateLimitingSchema } from './plugins/rate-limiting'
@@ -205,6 +206,7 @@ export type ReturnArrayItem = ArrayItem & Item
 export interface CustomSchemas {
   'application-registration': ApplicationRegistrationSchema
   datadog: DatadogSchema
+  'exit-transformer': ExitTransformerSchema
   'upstream-tls': UpstreamTlsSchema
   statsd: StatsDSchema
   'statsd-advanced': StatsDAdvancedSchema

--- a/packages/entities/entities-plugins/src/types/plugins/exit-transformer.d.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/exit-transformer.d.ts
@@ -1,0 +1,6 @@
+import type { ReturnArrayItem } from '../../types/plugins/typedefs'
+import type { CommonSchemaFields } from './shared'
+
+export interface ExitTransformerSchema extends CommonSchemaFields {
+  'config-functions': ReturnArrayItem
+}


### PR DESCRIPTION
# Summary

<img width="2964" height="1124" alt="image" src="https://github.com/user-attachments/assets/8e2ae675-1d4d-4f49-ba0c-ffda9bd2b481" />

Tested with big function, not seeing the size limitation warning.

JIRA:KM-1800

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
