### PR TITLE
feat(entities-plugins): improve datakit source selector copy

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/modal/EditorMain.vue
@@ -51,9 +51,7 @@
             :label="t('plugins.free-form.datakit.flow_editor.debug.label')"
             :label-attributes="{
               info: t('plugins.free-form.datakit.flow_editor.debug.description'),
-              tooltipAttributes: {
-                maxWidth: '300px',
-              },
+              tooltipAttributes,
             }"
             name="config.debug"
           />
@@ -111,7 +109,7 @@
 <script setup lang="ts">
 import { createI18n } from '@kong-ui-public/i18n'
 import { ExternalLinkIcon, RedoIcon, UndoIcon } from '@kong/icons'
-import { KButton } from '@kong/kongponents'
+import { KButton, KDropdown, KTooltip, KDropdownItem } from '@kong/kongponents'
 import yaml, { JSON_SCHEMA } from 'js-yaml'
 
 import english from '../../../../../locales/en.json'
@@ -127,6 +125,7 @@ import '@vue-flow/controls/dist/style.css'
 import '@vue-flow/core/dist/style.css'
 import '@vue-flow/core/dist/theme-default.css'
 
+import type { TooltipAttributes } from '@kong/kongponents'
 import type { DatakitConfig } from '../../types'
 
 const { t } = createI18n<typeof english>('en-us', english)
@@ -161,6 +160,12 @@ useHotkeys({
   undo,
   redo,
 })
+
+const tooltipAttributes = {
+  maxWidth: '300px',
+  // @ts-ignore-next-line Kongponents hasn't exposed zIndex in the type yet
+  zIndex: 10000,
+} satisfies TooltipAttributes
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/InputsField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/InputsField.vue
@@ -27,10 +27,7 @@
     </span>
   </div>
 
-  <KLabel
-    class="dk-inputs-field-h2 dk-margin-0"
-    :info="undefined"
-  >
+  <KLabel class="dk-inputs-field-h2 dk-margin-0">
     {{ t('plugins.free-form.datakit.flow_editor.node_properties.input.fields') }}
   </KLabel>
 

--- a/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/InputsField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Datakit/flow-editor/node-forms/InputsField.vue
@@ -1,7 +1,10 @@
 <template>
-  <div class="dk-inputs-field-h1">
-    {{ i18n.t('plugins.free-form.datakit.flow_editor.node_properties.input.label') }}
-  </div>
+  <KLabel
+    class="dk-inputs-field-h1"
+    :info="t('plugins.free-form.datakit.flow_editor.node_properties.input.tooltip')"
+  >
+    {{ t('plugins.free-form.datakit.flow_editor.node_properties.input.label') }}
+  </KLabel>
 
   <EnumField
     v-if="getSchema('input')"
@@ -9,26 +12,26 @@
     clearable
     enable-filtering
     :items="items"
-    :label="i18n.t('plugins.free-form.datakit.flow_editor.node_properties.input.whole_input')"
+    :label="t('plugins.free-form.datakit.flow_editor.node_properties.input.input')"
     :label-attributes="{
-      info: i18n.t('plugins.free-form.datakit.flow_editor.node_properties.input.whole_input_tooltip'),
+      info: undefined,
     }"
     name="input"
-    :placeholder="i18n.t('plugins.free-form.datakit.flow_editor.node_properties.input.placeholder')"
+    :placeholder="t('plugins.free-form.datakit.flow_editor.node_properties.input.placeholder')"
     @change="handleInputChange"
   />
 
   <div class="dk-inputs-field-or">
     <span>
-      {{ i18n.t('plugins.free-form.datakit.flow_editor.node_properties.input.or') }}
+      {{ t('plugins.free-form.datakit.flow_editor.node_properties.input.or') }}
     </span>
   </div>
 
   <KLabel
     class="dk-inputs-field-h2 dk-margin-0"
-    :info="i18n.t('plugins.free-form.datakit.flow_editor.node_properties.input.pre_field_tooltip')"
+    :info="undefined"
   >
-    {{ i18n.t('plugins.free-form.datakit.flow_editor.node_properties.input.pre_field') }}
+    {{ t('plugins.free-form.datakit.flow_editor.node_properties.input.fields') }}
   </KLabel>
 
   <InputsField
@@ -46,7 +49,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-
+import { KLabel } from '@kong/kongponents'
 import { useFormShared } from '../../../shared/composables'
 import EnumField from '../../../shared/EnumField.vue'
 import InputsRecordField from './InputsRecordField.vue'
@@ -70,7 +73,7 @@ const emit = defineEmits<{
 }>()
 
 const { getSchema } = useFormShared()
-const { i18n } = useI18n()
+const { i18n: { t } } = useI18n()
 
 const inputsSchema = computed(() => getSchema('inputs'))
 

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -804,11 +804,10 @@
               "placeholder": "Select a source",
               "add_button": "Add an input",
               "or": "or",
-              "whole_input": "Whole input",
-              "whole_input_tooltip": "Use one upstream output as this node's entire input value",
-              "pre_field": "Per field",
-              "pre_field_tooltip": "Bind individual fields to sources.",
-              "source": "Source"
+              "input": "Input",
+              "fields": "Fields",
+              "source": "Source",
+              "tooltip": "Fields are part of the node input. A source can connect to either the fields or the input, but not both."
             },
             "input_name": {
               "label": "Input name",


### PR DESCRIPTION
# Summary

[KM-1801](https://konghq.atlassian.net/browse/KM-1801)

<img width="650" height="501" alt="image" src="https://github.com/user-attachments/assets/b936efaa-85b4-4b85-bda6-674bff29d930" />

Also fixed an issue that the debug tooltip was covered by the node properties panel.

[KM-1801]: https://konghq.atlassian.net/browse/KM-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ