### PR TITLE
fix(analytics): remove duplicate error state when forbidden [MA-4332]

### DIFF
--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -44,6 +44,9 @@
     "timeout": {
       "message": "Data request timed out",
       "details": "We're sorry, the request timed out. Please consider using a shorter time period or try again later."
+    },
+    "other": {
+      "message": "Bad request"
     }
   },
   "legend": {

--- a/packages/analytics/analytics-chart/src/utils/queryError.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/queryError.spec.ts
@@ -44,17 +44,19 @@ describe('handleQueryError', () => {
     })
 
     expect(res).toMatchObject({ type: 'other', status: 400 })
-    expect(res.message).toBe('bar, baz')
+    expect(res.message).toBe('Bad request')
+    expect(res.details).toBe('bar, baz')
   })
 
   it('fallback to other (uses error.message)', () => {
     const res = handleQueryError({
       status: 500,
-      message: 'fallback message',
+      message: 'fallback details',
       response: { data: {} },
     })
 
     expect(res).toMatchObject({ type: 'other', status: 500 })
-    expect(res.message).toBe('fallback message')
+    expect(res.message).toBe('Bad request')
+    expect(res.details).toBe('fallback details')
   })
 })

--- a/packages/analytics/analytics-chart/src/utils/queryError.ts
+++ b/packages/analytics/analytics-chart/src/utils/queryError.ts
@@ -30,7 +30,8 @@ export const handleQueryError = (error: any): QueryError => {
     return {
       status: error.status,
       type: 'other',
-      message: error.response?.data?.invalid_parameters?.map((e: any) => e.reason).join(', ') || error?.message,
+      message: i18n.t('query_errors.other.message'),
+      details: error.response?.data?.invalid_parameters?.map((e: any) => e.reason).join(', ') || error?.message,
     }
   }
 }

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
@@ -5,23 +5,17 @@
     type="table"
   />
   <KEmptyState
-    v-else-if="hasError && queryError?.type === 'forbidden'"
-    :action-button-visible="false"
-    data-testid="chart-forbidden-state"
-  >
-    <template #default>
-      {{ queryError.message }}
-    </template>
-    <template #icon>
-      <VisibilityOffIcon />
-    </template>
-  </KEmptyState>
-  <KEmptyState
     v-else-if="hasError && queryError"
     :action-button-visible="false"
     data-testid="chart-empty-state"
-    icon-variant="error"
+    :icon-variant="queryError?.type !== 'forbidden' ? 'error' : undefined"
   >
+    <template
+      v-if="queryError.type === 'forbidden'"
+      #icon
+    >
+      <VisibilityOffIcon />
+    </template>
     <template #title>
       <p>{{ queryError.message }}</p>
     </template>

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
@@ -8,13 +8,10 @@
     v-else-if="hasError && queryError"
     :action-button-visible="false"
     data-testid="chart-empty-state"
-    :icon-variant="queryError?.type !== 'forbidden' ? 'error' : undefined"
   >
-    <template
-      v-if="queryError.type === 'forbidden'"
-      #icon
-    >
-      <VisibilityOffIcon />
+    <template #icon>
+      <VisibilityOffIcon v-if="queryError.type === 'forbidden'" />
+      <WarningOutlineIcon v-else />
     </template>
     <template #title>
       <p>{{ queryError.message }}</p>
@@ -56,7 +53,7 @@ import { handleQueryError } from '@kong-ui-public/analytics-chart'
 
 import composables from '../composables'
 import { INJECT_QUERY_PROVIDER } from '../constants'
-import { VisibilityOffIcon } from '@kong/icons'
+import { VisibilityOffIcon, WarningOutlineIcon } from '@kong/icons'
 
 const props = defineProps<{
   context: DashboardRendererContextInternal


### PR DESCRIPTION
# Summary

Related [MA-4332](https://konghq.atlassian.net/browse/MA-4332)

This will fix an issue with the "Forbidden" error state for dashboard tiles by removing a duplicate `KEmptyState` component that was specific to a forbidden state. Instead it will combine the two and conditionally load the correct icon for a forbidden state.
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-4332]: https://konghq.atlassian.net/browse/MA-4332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ