### PR TITLE
feat: draw threshold intersection brush

### DIFF
--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -85,7 +85,7 @@
     "vue-chartjs": "^5.3.2"
   },
   "distSizeChecker": {
-    "warningLimit": "1.35MB",
-    "errorLimit": "1.5MB"
+    "warningLimit": "1.6MB",
+    "errorLimit": "1.7MB"
   }
 }

--- a/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
@@ -303,7 +303,7 @@ const serviceDimensionValues = ref(new Set([
 const threshold = {
   'request_count': [
     { type: 'warning', value: 700 },
-    { type: 'error', value: 900 },
+    { type: 'error', value: 900, highlightIntersections: true },
   ],
 } as Record<ExploreAggregations, Threshold[]>
 

--- a/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
@@ -125,6 +125,13 @@
             :label="timeSeriesZoomToggle ? 'Zoom enabled' : 'Zoom disabled'"
           />
         </div>
+        <div>
+          <KInput
+            v-model="thresholdValue"
+            label="Eror threshold"
+            type="number"
+          />
+        </div>
         <br>
 
         <div class="config-container">
@@ -273,6 +280,7 @@ const selectedMetric = ref<MetricSelection>({
   name: Metrics.TotalRequests,
   unit: 'count',
 })
+const thresholdValue = ref(500)
 
 const metricItems = [{
   label: 'Total Requests',
@@ -300,12 +308,11 @@ const serviceDimensionValues = ref(new Set([
   'service1', 'service2', 'service3', 'service4', 'service5',
 ]))
 
-const threshold = {
+const threshold = computed(() => ({
   'request_count': [
-    { type: 'warning', value: 700 },
-    { type: 'error', value: 900, highlightIntersections: true },
+    { type: 'error', value: thresholdValue.value, highlightIntersections: true },
   ],
-} as Record<ExploreAggregations, Threshold[]>
+} as Record<ExploreAggregations, Threshold[]>))
 
 const exportModalVisible = ref(false)
 const exportState = ref<ExploreExportState>({ status: 'loading' })
@@ -385,7 +392,7 @@ const analyticsChartOptions = computed<AnalyticsChartOptions>(() => {
   return {
     type: chartType.value,
     stacked: stackToggle.value,
-    threshold,
+    threshold: threshold.value,
     // chartDatasetColors: colorPalette.value,
   }
 })

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.cy.ts
@@ -47,7 +47,7 @@ describe('ThresholdPlugin', () => {
   it('calls afterDatasetDraw with appropriate plugin options', () => {
 
     const thresholdPlugin = new ThresholdPlugin(i18nMock)
-    cy.spy(thresholdPlugin, 'afterDatasetDraw').as('afterDatasetDrawSpy')
+    cy.spy(thresholdPlugin, 'afterDatasetsDraw').as('afterDatasetDrawSpy')
 
     mount({
       plugins: [thresholdPlugin],

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.ts
@@ -121,8 +121,7 @@ export class ThresholdPlugin implements Plugin {
 
   constructor(private i18n: ReturnType<typeof createI18n<typeof english>>) {}
 
-  beforeInit(chart: Chart, _: any, pluginOptions: ThresholdOptions): void {
-    const canvas = chart.canvas
+  private _syncThresholds(pluginOptions: ThresholdOptions) {
     for (const key of Object.keys(pluginOptions.threshold || {})) {
       const threshold = pluginOptions.threshold?.[key as ExploreAggregations]
       if (threshold) {
@@ -132,6 +131,17 @@ export class ThresholdPlugin implements Plugin {
         } as Record<ExploreAggregations, ThresholdExtra[]>
       }
     }
+  }
+
+  // Gets called when chart options are updated
+  beforeUpdate(chart: Chart, _: any, pluginOptions: ThresholdOptions): void {
+    this._syncThresholds(pluginOptions)
+  }
+
+
+  beforeInit(chart: Chart, _: any, pluginOptions: ThresholdOptions): void {
+    const canvas = chart.canvas
+    this._syncThresholds(pluginOptions)
 
     const onMouseMove = (event: MouseEvent) => {
       if (chart) {
@@ -157,8 +167,9 @@ export class ThresholdPlugin implements Plugin {
     this._mouseMoveHandler = onMouseMove
   }
 
-  afterDatasetsDraw(chart: Chart): void {
+  afterDatasetsDraw(chart: Chart, _: any): void {
     const context = chart.ctx
+
     for (const key of Object.keys(this._thresholds || {})) {
       const threshold = this._thresholds?.[key as ExploreAggregations]
 

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.ts
@@ -18,7 +18,7 @@ type ThresholdExtra = Threshold & {
   hovered?: boolean
 }
 
-type ThresholdIntersection = {
+export type ThresholdIntersection = {
   start: number
   end: number
   type: ThresholdType
@@ -36,7 +36,7 @@ const getExactIntersection = (p0: Point, p1: Point, targetY: number): number => 
   return p0.x + f * (p1.x - p0.x)
 }
 
-const getThresholdIntersections = (chart: Chart, thresholds: ThresholdExtra[]): ThresholdIntersection[] => {
+export const getThresholdIntersections = (chart: Chart, thresholds: Threshold[]): ThresholdIntersection[] => {
   const intersections: ThresholdIntersection[] = []
   chart.data.datasets.forEach((dataset) => {
     const meta = chart.getDatasetMeta(chart.data.datasets.indexOf(dataset))
@@ -49,7 +49,7 @@ const getThresholdIntersections = (chart: Chart, thresholds: ThresholdExtra[]): 
       return
     }
 
-    thresholds.forEach((t) => {
+    thresholds.filter(t => t.highlightIntersections).forEach((t) => {
       const intersectionTrack = dataPoints.map((d) => ({
         ts: d.x,
         aboveThreshold: d.y >= t.value,
@@ -93,7 +93,7 @@ const getThresholdIntersections = (chart: Chart, thresholds: ThresholdExtra[]): 
   return intersections
 }
 
-const mergeThresholdIntersections = (intersections: ThresholdIntersection[]): ThresholdIntersection[] => {
+export const mergeThresholdIntersections = (intersections: ThresholdIntersection[]): ThresholdIntersection[] => {
   if (!intersections.length) {
     return []
   }

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.ts
@@ -39,7 +39,8 @@ const getExactIntersection = (p0: Point, p1: Point, targetY: number): number => 
 const getThresholdIntersections = (chart: Chart, thresholds: ThresholdExtra[]): ThresholdIntersection[] => {
   const intersections: ThresholdIntersection[] = []
   chart.data.datasets.forEach((dataset) => {
-    if (dataset.hidden) {
+    const meta = chart.getDatasetMeta(chart.data.datasets.indexOf(dataset))
+    if (!meta.visible) {
       return
     }
 
@@ -102,8 +103,8 @@ const mergeThresholdIntersections = (intersections: ThresholdIntersection[]): Th
   const merged: ThresholdIntersection[] = []
 
   for (const curr of intersections) {
-    const last = merged[merged.length - 1]
-    if (last && last.type === curr.type && curr.start <= last.end) {
+    const last = merged.findLast(({ type }) => type === curr.type)
+    if (last && curr.start <= last.end) {
       last.end = Math.max(last.end, curr.end)
     } else {
       merged.push({ ...curr })

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/thresholdPlugin.spec.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/thresholdPlugin.spec.ts
@@ -1,0 +1,50 @@
+import { it, expect, describe } from 'vitest'
+import { getThresholdIntersections, mergeThresholdIntersections, type ThresholdIntersection } from './ThresholdPlugin'
+import type { Threshold } from 'src/types'
+
+describe('getThresholdIntersections', () => {
+  it('returns empty array when no datasets are visible', () => {
+    const chart = {
+      data: {
+        datasets: [
+          { data: [{ x: 1, y: 10 }, { x: 2, y: 20 }] },
+        ],
+      },
+      getDatasetMeta: () => ({ visible: false }),
+    } as any
+
+    const thresholds: Threshold[] = [{ type: 'error', value: 15, highlightIntersections: true }]
+    const result = getThresholdIntersections(chart, thresholds)
+    expect(result).toEqual([])
+  })
+  it('detects intersections correctly', () => {
+    const chart = {
+      data: {
+        datasets: [
+          { data: [{ x: 1, y: 10 }, { x: 2, y: 20 }, { x: 3, y: 10 }] },
+        ],
+      },
+      getDatasetMeta: () => ({ visible: true }),
+    } as any
+
+    const thresholds: Threshold[] = [{ type: 'error', value: 15, highlightIntersections: true }]
+    const result = getThresholdIntersections(chart, thresholds)
+    expect(result).toEqual([
+      { start: 1.5, end: 2.5, type: 'error' },
+    ])
+  })
+
+  it('merges overlapping intersections of the same type', () => {
+    const intersections: ThresholdIntersection[] = [
+      { start: 1, end: 3, type: 'error' },
+      { start: 2, end: 4, type: 'error' },
+      { start: 5, end: 6, type: 'warning' },
+      { start: 6, end: 7, type: 'warning' },
+    ]
+    const result = mergeThresholdIntersections(intersections)
+    expect(result).toEqual([
+      { start: 1, end: 4, type: 'error' },
+      { start: 5, end: 7, type: 'warning' },
+    ])
+  })
+})

--- a/packages/analytics/analytics-chart/src/types/chart-data.ts
+++ b/packages/analytics/analytics-chart/src/types/chart-data.ts
@@ -64,6 +64,7 @@ export interface Threshold {
   type: ThresholdType
   value: number
   label?: string
+  highlightIntersections?: boolean
 }
 
 /**

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -109,6 +109,10 @@ export const thresholdSchema = {
     label: {
       type: 'string',
     },
+    highlightIntersections: {
+      type: 'boolean',
+      default: false,
+    },
   },
   required: ['type', 'value'],
   additionalProperties: false,


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-4302

Detect when data crosses thresholds and brush the area

figure out where each datasource intersects the threshold, merge overlapping "intersections" so we don't draw overlapping brushes

<img width="894" height="175" alt="image" src="https://github.com/user-attachments/assets/d796b047-8187-42c3-9782-366cc74d5469" />

<img width="1355" height="567" alt="image" src="https://github.com/user-attachments/assets/29924229-a2dd-440c-ab71-86b9cc532bb3" />


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
