### PR TITLE
fix(entities-routes): update links to external in routelist [TDX-6793]"

### DIFF
--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -523,7 +523,7 @@ const rowClick = async (row: EntityRow): Promise<void> => {
     return
   }
 
-  router.push(props.config.getViewRoute(row.id as string))
+  router.push(props.config.getViewRoute(row.id))
 }
 
 // Render the view dropdown item as a router-link


### PR DESCRIPTION
# Summary

This PR
- passes the path to KButton to detect if a link is external or not
- removes the unnecessary typecast (as row.id is string by default)

ticket: https://konghq.atlassian.net/browse/TDX-6793