### PR TITLE
fix(analytics): keep consistent metric formatting for geo maps [MA-4125]

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
@@ -197,7 +197,7 @@
               v-if="exportModalVisible"
               :export-state="exportState"
               filename="asdf.csv"
-              @toggle-modal="setModalVisibility"
+              @close-modal="setModalVisibility(false)"
             />
           </div>
         </div>

--- a/packages/analytics/analytics-geo-map/sandbox/App.vue
+++ b/packages/analytics/analytics-geo-map/sandbox/App.vue
@@ -36,10 +36,6 @@
       >
         Reset bounds
       </KButton>
-      <KInputSwitch
-        v-model="truncateMetrics"
-        label="Truncate metrics"
-      />
     </div>
 
 
@@ -50,7 +46,6 @@
         :fit-to-country="fitToCountry"
         :metric="'request_count'"
         :metric-unit="'requests'"
-        :truncated-metric="truncateMetrics"
         @bounds-change="console.log('bounds changed', $event)"
       />
     </div>
@@ -83,7 +78,6 @@ const bounds = ref<Array<[number, number]>>([
   [-180, -90],
   [180, 90],
 ])
-const truncateMetrics = ref(true)
 
 const countryMetrics = computed(() => {
   const metrics: Record<string, number> = {}

--- a/packages/analytics/analytics-geo-map/sandbox/App.vue
+++ b/packages/analytics/analytics-geo-map/sandbox/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="sandbox-container">
-    <div class="controls">
+    <div class="row">
       <div>
         <KLabel for="fit">
           Fit to country
@@ -22,7 +22,7 @@
       </div>
     </div>
 
-    <div class="generate-bounds">
+    <div class="row">
       <KButton
         size="medium"
         @click="genNewBounds()"
@@ -30,11 +30,16 @@
         Generate new bounds
       </KButton>
       <KButton
+        appearance="secondary"
         size="medium"
         @click="genNewBounds(true)"
       >
         Reset bounds
       </KButton>
+      <KInputSwitch
+        v-model="truncateMetrics"
+        label="Truncate metrics"
+      />
     </div>
 
 
@@ -45,6 +50,7 @@
         :fit-to-country="fitToCountry"
         :metric="'request_count'"
         :metric-unit="'requests'"
+        :truncated-metric="truncateMetrics"
         @bounds-change="console.log('bounds changed', $event)"
       />
     </div>
@@ -77,6 +83,7 @@ const bounds = ref<Array<[number, number]>>([
   [-180, -90],
   [180, 90],
 ])
+const truncateMetrics = ref(true)
 
 const countryMetrics = computed(() => {
   const metrics: Record<string, number> = {}
@@ -115,19 +122,14 @@ const genNewBounds = (reset = false) => {
 .sandbox-container {
   height: 900px;
 
-  .controls {
+  .row {
+    margin-top: 1em;
     display: flex;
     gap: 2em;
 
     .select-countries {
       width: 50%;
     }
-  }
-
-  .generate-bounds {
-    margin-top: 1em;
-    display: flex;
-    gap: 2em;
   }
 
   .map-container {

--- a/packages/analytics/analytics-geo-map/sandbox/App.vue
+++ b/packages/analytics/analytics-geo-map/sandbox/App.vue
@@ -1,15 +1,43 @@
 <template>
   <div class="sandbox-container">
-    <KLabel> Fit to country: </KLabel>
-    <KInput v-model="fitToCountry" />
-    <KMultiselect
-      v-model="selectedCountries"
-      :items="items"
-      label="Pick Something"
-    />
-    <KButton @click="genNewBounds()">
-      Generate new bounds
-    </KButton>
+    <div class="controls">
+      <div>
+        <KLabel for="fit">
+          Fit to country
+        </KLabel>
+        <KInput
+          id="fit"
+          v-model="fitToCountry"
+          help="Enter a country code to fit the map to that country"
+          placeholder="e.g. US, DE, JP"
+        />
+      </div>
+
+      <div class="select-countries">
+        <KMultiselect
+          v-model="selectedCountries"
+          :items="items"
+          label="Filter by country"
+        />
+      </div>
+    </div>
+
+    <div class="generate-bounds">
+      <KButton
+        size="medium"
+        @click="genNewBounds()"
+      >
+        Generate new bounds
+      </KButton>
+      <KButton
+        size="medium"
+        @click="genNewBounds(true)"
+      >
+        Reset bounds
+      </KButton>
+    </div>
+
+
     <div class="map-container">
       <AnalyticsGeoMap
         :bounds="bounds"
@@ -27,13 +55,6 @@
 import { computed, ref } from 'vue'
 import { AnalyticsGeoMap } from '../src'
 
-const fitToCountry = ref()
-const selectedCountries = ref<string[]>([])
-const bounds = ref<Array<[number, number]>>([
-  [-180, -90],
-  [180, 90],
-])
-
 const items = ref([
   { label: 'US', value: 'US' },
   { label: 'BR', value: 'BR' },
@@ -50,6 +71,12 @@ const items = ref([
   { label: 'SG', value: 'SG' },
   { label: 'MY', value: 'MY' },
 ])
+const fitToCountry = ref()
+const selectedCountries = ref<string[]>(items.value.map(i => i.value))
+const bounds = ref<Array<[number, number]>>([
+  [-180, -90],
+  [180, 90],
+])
 
 const countryMetrics = computed(() => {
   const metrics: Record<string, number> = {}
@@ -57,10 +84,18 @@ const countryMetrics = computed(() => {
     metrics[country] = Math.floor(Math.random() * 50000)
   })
   return metrics
-
 })
 
-const genNewBounds = () => {
+const genNewBounds = (reset = false) => {
+  if (reset) {
+    bounds.value = [
+      [-180, -90],
+      [180, 90],
+    ]
+
+    return
+  }
+
   const sw: [number, number] = [
     Math.random() * -180,
     Math.random() * -90,
@@ -77,12 +112,28 @@ const genNewBounds = () => {
 </script>
 
 <style lang="scss" scoped>
-  .sandbox-container {
-    height: 900px;
+.sandbox-container {
+  height: 900px;
 
-    .map-container {
-      height: 700px;
-      width: 900px;
+  .controls {
+    display: flex;
+    gap: 2em;
+
+    .select-countries {
+      width: 50%;
     }
   }
+
+  .generate-bounds {
+    margin-top: 1em;
+    display: flex;
+    gap: 2em;
+  }
+
+  .map-container {
+    margin-top: 1em;
+    height: 700px;
+    width: 900px;
+  }
+}
 </style>

--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.cy.ts
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.cy.ts
@@ -10,17 +10,19 @@ const mountComponent = ({
   metric = ref('request_count'),
   metricUnit = ref('requests'),
   onBoundsChange = cy.spy(),
+  truncatedMetric = ref(true),
 }: {
   countryMetrics: Record<string, number>
   fitToCountry?: Ref<string>
   metric?: Ref<ExploreAggregations>
   metricUnit?: Ref<MetricUnits>
   onBoundsChange?: (bounds: Array<[number, number]>) => void
+  truncatedMetric?: Ref<boolean>
 }) => {
 
   const WrapperComponent = defineComponent({
     setup() {
-      return { countryMetrics, fitToCountry, metric, metricUnit, onBoundsChange }
+      return { countryMetrics, fitToCountry, metric, metricUnit, onBoundsChange, truncatedMetric }
     },
     render() {
       return h('div', { style: 'height: 500px; width: 500px;' }, [
@@ -30,6 +32,7 @@ const mountComponent = ({
           metric: this.metric,
           metricUnit: this.metricUnit,
           onBoundsChange: this.onBoundsChange,
+          truncatedMetric: this.truncatedMetric,
         }),
       ])
     },
@@ -43,6 +46,13 @@ const romaniaBounds = [
   [29.6265429999994, 49.17185755292891],
 ]
 
+const COUNTRY_METRICS = {
+  US: 1,
+  CA: 12,
+  MX: 150,
+  BR: 3_100,
+  AR: 75_000,
+}
 
 describe('<AnalyticsGeoMap />', () => {
   beforeEach(() => {
@@ -81,5 +91,38 @@ describe('<AnalyticsGeoMap />', () => {
 
     cy.get('@boundsChangeSpy').should('have.been.calledOnce')
     cy.get('@boundsChangeSpy').should('have.been.calledWith', romaniaBounds)
+  })
+
+  it('renders legend ranges with compact formatting when truncatedMetric is true', () => {
+    mountComponent({ countryMetrics: COUNTRY_METRICS, truncatedMetric: ref(true) })
+
+    cy.get('.legend').should('exist')
+    cy.get('.legend-item').should('have.length', 5)
+
+    // Expect at least one item to use the truncated suffix and none to contain thousands separators
+    cy.get('.legend-item .legend-text').then((items) => {
+      const texts = items.toArray().map(el => el.textContent?.trim() || '')
+
+      // one or more items should include K
+      expect(texts).to.satisfy((arr: string[]) => arr.some(t => /K\b/.test(t)))
+
+      // ensure we didn't get comma-formatted numbers
+      expect(texts).to.satisfy((arr: string[]) => arr.every(t => !t.includes(',')))
+    })
+  })
+
+
+  it('renders legend ranges with comma formatting when truncatedMetric is false', () => {
+    mountComponent({ countryMetrics: COUNTRY_METRICS, truncatedMetric: ref(false) })
+
+    cy.get('.legend').should('exist')
+    cy.get('.legend-item').should('have.length', 5)
+
+    // Expect at least one item to contain thousands separator
+    cy.get('.legend-item .legend-text').then((items) => {
+      const texts = items.toArray().map(el => el.textContent?.trim() || '')
+
+      expect(texts).to.satisfy((arr: string[]) => arr.some(t => t.includes(',')))
+    })
   })
 })

--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.cy.ts
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.cy.ts
@@ -10,19 +10,17 @@ const mountComponent = ({
   metric = ref('request_count'),
   metricUnit = ref('requests'),
   onBoundsChange = cy.spy(),
-  truncatedMetric = ref(true),
 }: {
   countryMetrics: Record<string, number>
   fitToCountry?: Ref<string>
   metric?: Ref<ExploreAggregations>
   metricUnit?: Ref<MetricUnits>
   onBoundsChange?: (bounds: Array<[number, number]>) => void
-  truncatedMetric?: Ref<boolean>
 }) => {
 
   const WrapperComponent = defineComponent({
     setup() {
-      return { countryMetrics, fitToCountry, metric, metricUnit, onBoundsChange, truncatedMetric }
+      return { countryMetrics, fitToCountry, metric, metricUnit, onBoundsChange }
     },
     render() {
       return h('div', { style: 'height: 500px; width: 500px;' }, [
@@ -32,7 +30,6 @@ const mountComponent = ({
           metric: this.metric,
           metricUnit: this.metricUnit,
           onBoundsChange: this.onBoundsChange,
-          truncatedMetric: this.truncatedMetric,
         }),
       ])
     },
@@ -93,8 +90,8 @@ describe('<AnalyticsGeoMap />', () => {
     cy.get('@boundsChangeSpy').should('have.been.calledWith', romaniaBounds)
   })
 
-  it('renders legend ranges with compact formatting when truncatedMetric is true', () => {
-    mountComponent({ countryMetrics: COUNTRY_METRICS, truncatedMetric: ref(true) })
+  it('renders legend ranges with compact formatting when metric does not include latency', () => {
+    mountComponent({ countryMetrics: COUNTRY_METRICS })
 
     cy.get('.legend').should('exist')
     cy.get('.legend-item').should('have.length', 5)
@@ -112,8 +109,8 @@ describe('<AnalyticsGeoMap />', () => {
   })
 
 
-  it('renders legend ranges with comma formatting when truncatedMetric is false', () => {
-    mountComponent({ countryMetrics: COUNTRY_METRICS, truncatedMetric: ref(false) })
+  it('renders legend ranges with comma formatting when metric includes latency', () => {
+    mountComponent({ countryMetrics: COUNTRY_METRICS, metric: ref('response_latency_p99') })
 
     cy.get('.legend').should('exist')
     cy.get('.legend-item').should('have.length', 5)

--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
@@ -79,6 +79,7 @@ const {
   showTooltipValue = true,
   fitToCountry = undefined,
   bounds = undefined,
+  truncatedMetric = true,
 } = defineProps<{
   countryMetrics: Record<string, number>
   metricUnit: MetricUnits
@@ -87,6 +88,7 @@ const {
   showTooltipValue?: boolean
   fitToCountry?: CountryISOA2 | undefined
   bounds?: Array<[number, number]>
+  truncatedMetric?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -131,9 +133,8 @@ const showLegend = computed(() => {
 const logMinMetric = computed(() => Math.log(Math.min(...Object.values(countryMetrics))))
 const logMaxMetric = computed(() => Math.log(Math.max(...Object.values(countryMetrics))))
 
-
-const getColor = (metric: number) => {
-  const logMetric = Math.log(metric)
+const getColor = (linearMetric: number) => {
+  const logMetric = Math.log(linearMetric)
   const range = logMaxMetric.value - logMinMetric.value
   const step = range / 5
 
@@ -163,20 +164,31 @@ const legendData = computed(() => {
 
   return intervals.map((logBoundary, index) => {
     const nextLogBoundary = index === 0 ? logMaxMetric.value : intervals[index - 1]
+    const lowerLinear = Math.exp(logBoundary)
+    const upperLinear = Math.exp(nextLogBoundary)
+
     let rangeText = ''
     if (index === 0) {
-      rangeText = `> ${approxNum(Math.trunc(Math.exp(logBoundary)), { capital: true })}`
+      rangeText = `> ${formatMetric(lowerLinear)}`
     } else if (index === intervals.length - 1) {
-      rangeText = `< ${approxNum(Math.trunc(Math.exp(nextLogBoundary)), { capital: true })}`
+      rangeText = `< ${formatMetric(upperLinear)}`
     } else {
-      rangeText = `${approxNum(Math.trunc(Math.exp(logBoundary)), { capital: true })} - ${approxNum(Math.trunc(Math.exp(nextLogBoundary)), { capital: true })}`
+      rangeText = `${formatMetric(lowerLinear)} - ${formatMetric(upperLinear)}`
     }
+
     return {
-      color: getColor(Math.exp(logBoundary)),
+      color: getColor(lowerLinear),
       range: rangeText,
     }
   })
 })
+
+
+const formatMetric = (linearMetric: number) => {
+  const truncated = Math.trunc(linearMetric)
+
+  return truncatedMetric ? approxNum(truncated, { capital: true }) : new Intl.NumberFormat(document?.documentElement?.lang || 'en-US').format(truncated)
+}
 
 // Simplified coords may be 2 or 3 layers
 const flattenPositions = (position: any): number[][] => {
@@ -330,9 +342,16 @@ onMounted(async () => {
           const { iso_a2, iso_a2_eh, ISO_A2, admin } = feature.properties
           const lookup: CountryISOA2 = ISO_A2 ?? iso_a2 === '-99' ? iso_a2_eh : iso_a2
           const metric = countryMetrics[lookup]
+
           if (metric !== undefined) {
-          // @ts-ignore - dynamic i18n key
-            const popupHtml = showTooltipValue ? `<strong>${admin}</strong>: ${approxNum(metric, { capital: true })} ${i18n.t(`metricUnits.${metricUnit}`, { plural: metric > 1 ? 's' : '' })}` : `<strong>${admin}</strong>`
+            let popupHtml
+
+            if (showTooltipValue) {
+              popupHtml = `<strong data-testid="geo-map-tooltip">${admin}</strong>: ${formatMetric(metric)} ${i18n.t(`metricUnits.${metricUnit}`, { plural: metric > 1 ? 's' : '' })}`
+            } else {
+              popupHtml = `<strong data-testid="geo-map-tooltip">${admin}</strong>`
+            }
+
             popup.setLngLat(e.lngLat).setHTML(popupHtml).addTo(map.value as Map)
           } else {
             popup.remove()

--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
@@ -79,7 +79,6 @@ const {
   showTooltipValue = true,
   fitToCountry = undefined,
   bounds = undefined,
-  truncatedMetric = true,
 } = defineProps<{
   countryMetrics: Record<string, number>
   metricUnit: MetricUnits
@@ -88,7 +87,6 @@ const {
   showTooltipValue?: boolean
   fitToCountry?: CountryISOA2 | undefined
   bounds?: Array<[number, number]>
-  truncatedMetric?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -183,11 +181,18 @@ const legendData = computed(() => {
   })
 })
 
+const shouldTuncateMetric = computed(() => {
+  return !metric?.includes('latency')
+})
 
 const formatMetric = (linearMetric: number) => {
   const truncated = Math.trunc(linearMetric)
 
-  return truncatedMetric ? approxNum(truncated, { capital: true }) : new Intl.NumberFormat(document?.documentElement?.lang || 'en-US').format(truncated)
+  if (shouldTuncateMetric.value) {
+    return approxNum(truncated, { capital: true })
+  }
+
+  return new Intl.NumberFormat(document?.documentElement?.lang || 'en-US').format(truncated)
 }
 
 // Simplified coords may be 2 or 3 layers

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -59,7 +59,6 @@ import { computed, inject, ref } from 'vue'
 import type {
   DashboardConfig,
   DashboardTileType,
-  ExploreAggregations,
   TileConfig,
   TileDefinition,
 } from '@kong-ui-public/analytics-utilities'
@@ -117,8 +116,10 @@ const dashboardConfig = ref <DashboardConfig>({
           type: 'timeseries_line',
           chart_title: 'Timeseries line chart of mock data',
           threshold: {
-            'request_count': 3200,
-          } as Record<ExploreAggregations, number>,
+            request_count: [
+              { type: 'neutral', value: 3200, label: 'FOO' },
+            ],
+          },
         },
         query: {
           datasource: 'basic',
@@ -248,8 +249,10 @@ const addTile = () => {
         type: ['timeseries_line', 'timeseries_bar'][last] as any,
         chart_title: 'Timeseries line chart of mock data',
         threshold: {
-          'request_count': 3200,
-        } as Record<ExploreAggregations, number>,
+          request_count: [
+            { type: 'neutral', value: 3200, label: 'FOO' },
+          ],
+        },
       },
       query: {
         datasource: 'basic',


### PR DESCRIPTION
# Summary

Fix [MA-4125](https://konghq.atlassian.net/browse/MA-4125)
Contains chore from https://github.com/Kong/public-ui-components/pull/2532

This will add the ability to specify if a metric should be truncated within the GeoMap and also truncate them by default for non-latency type metrics in dashboards.

There are also a few updates to the sandbox to make things a bit cleaner, fix some typing, and add some functionality to the geo map sandbox.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

[sandbox.webm](https://github.com/user-attachments/assets/79a7a190-698b-46db-a6f3-d4612f9f7373)



[MA-4125]: https://konghq.atlassian.net/browse/MA-4125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ