### PR TITLE
feat (analytics): threshold highlighting highlights things that begin over the threshold [MA-4362]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ThresholdPlugin.ts
@@ -55,16 +55,21 @@ export const getThresholdIntersections = (chart: Chart, thresholds: Threshold[])
         aboveThreshold: d.y >= t.value,
       }))
 
-      let intersectionStart: number | undefined = undefined
+      // the intersectionStart begins with a value if the initial datapoint is above the threshold
+      let intersectionStart: number | undefined = intersectionTrack[0].aboveThreshold
+        ? dataPoints[0].x
+        : undefined
+
       for (let i = 1; i < intersectionTrack.length; i++) {
         if (!intersectionTrack[i - 1].aboveThreshold && intersectionTrack[i].aboveThreshold) {
-          // If we have a start of an intersection, record it
+          // If the series was under the threshold line and goes to above the threshold line
           intersectionStart = getExactIntersection(
             dataPoints[i - 1],
             dataPoints[i],
             t.value,
           )
         } else if (intersectionTrack[i - 1].aboveThreshold && !intersectionTrack[i].aboveThreshold) {
+          // if the series was above the threshold line and goes to below the threshold line
           if (intersectionStart !== undefined) {
             intersections.push({
               start: intersectionStart,

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/thresholdPlugin.spec.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/thresholdPlugin.spec.ts
@@ -2,49 +2,101 @@ import { it, expect, describe } from 'vitest'
 import { getThresholdIntersections, mergeThresholdIntersections, type ThresholdIntersection } from './ThresholdPlugin'
 import type { Threshold } from 'src/types'
 
-describe('getThresholdIntersections', () => {
-  it('returns empty array when no datasets are visible', () => {
-    const chart = {
-      data: {
-        datasets: [
-          { data: [{ x: 1, y: 10 }, { x: 2, y: 20 }] },
-        ],
-      },
-      getDatasetMeta: () => ({ visible: false }),
-    } as any
+describe('thresholdPlugin', () => {
+  describe('getThresholdIntersections', () => {
+    const getResult = ({
+      datasets,
+      thresholds = [],
+      hiddenDatasetIndices = [],
+    }: {
+      datasets: Array<{
+        data: Array<{ x: number, y: number }>
+      }>
+      thresholds?: Threshold[]
+      hiddenDatasetIndices?: number[]
+    }) => {
+      const chart = {
+        data: {
+          datasets,
+        },
+        getDatasetMeta: (index: number) => {
+          return {
+            visible: !hiddenDatasetIndices.includes(index),
+          }
+        },
+      } as any
 
-    const thresholds: Threshold[] = [{ type: 'error', value: 15, highlightIntersections: true }]
-    const result = getThresholdIntersections(chart, thresholds)
-    expect(result).toEqual([])
+      return getThresholdIntersections(chart, thresholds)
+    }
+
+    it('returns an empty array when no datasets are visible', () => {
+      const result = getResult({
+        datasets: [{ data: [{ x: 1, y: 10 }, { x: 2, y: 20 }] }],
+        thresholds: [{ type: 'error', value: 15, highlightIntersections: true }],
+        hiddenDatasetIndices: [0],
+      })
+      expect(result).toEqual([])
+    })
+
+    it('returns an empty array when all datapoints are below the threshold', () => {
+      const result = getResult({
+        datasets: [{ data: [{ x: 1, y: 10 }, { x: 2, y: 10 }] }],
+        thresholds: [{ type: 'error', value: 15, highlightIntersections: true }],
+      })
+      expect(result).toEqual([])
+    })
+
+    it.each([
+      ['rise above at beginning', [10, 20, 20], 1.5, 3],
+      ['rise above at middle', [10, 20, 10], 1.5, 2.5],
+      ['rise above at end', [10, 10, 20], 2.5, 3],
+      ['fall below at beginning', [20, 10, 10], 1, 1.5],
+      ['stay fully above', [20, 20], 1, 2],
+    ])('Detects threshold line intersections that %s', (title, yValues, expectedStart, expectedEnd) => {
+      const result = getResult({
+        datasets: [{ data: yValues.map((y, index) => ({ x: index + 1, y })) }],
+        thresholds: [{ type: 'error', value: 15, highlightIntersections: true }],
+      })
+
+      expect(result).toEqual([
+        { start: expectedStart, end: expectedEnd, type: 'error' },
+      ])
+    })
+
+    it('Detects multiple threshold intersections', () => {
+      const result = getResult({
+        datasets: [{ data: [
+          { x: 1, y: 20 },
+          { x: 2, y: 10 },
+          { x: 3, y: 20 },
+          { x: 4, y: 10 },
+          { x: 5, y: 20 },
+          { x: 5, y: 10 },
+        ] }],
+        thresholds: [{ type: 'error', value: 15, highlightIntersections: true }],
+      })
+
+      expect(result).toEqual([
+        { start: 1, end: 1.5, type: 'error' },
+        { start: 2.5, end: 3.5, type: 'error' },
+        { start: 4.5, end: 5, type: 'error' },
+      ])
+    })
   })
-  it('detects intersections correctly', () => {
-    const chart = {
-      data: {
-        datasets: [
-          { data: [{ x: 1, y: 10 }, { x: 2, y: 20 }, { x: 3, y: 10 }] },
-        ],
-      },
-      getDatasetMeta: () => ({ visible: true }),
-    } as any
 
-    const thresholds: Threshold[] = [{ type: 'error', value: 15, highlightIntersections: true }]
-    const result = getThresholdIntersections(chart, thresholds)
-    expect(result).toEqual([
-      { start: 1.5, end: 2.5, type: 'error' },
-    ])
-  })
-
-  it('merges overlapping intersections of the same type', () => {
-    const intersections: ThresholdIntersection[] = [
-      { start: 1, end: 3, type: 'error' },
-      { start: 2, end: 4, type: 'error' },
-      { start: 5, end: 6, type: 'warning' },
-      { start: 6, end: 7, type: 'warning' },
-    ]
-    const result = mergeThresholdIntersections(intersections)
-    expect(result).toEqual([
-      { start: 1, end: 4, type: 'error' },
-      { start: 5, end: 7, type: 'warning' },
-    ])
+  describe('mergeThresholdIntersections', () => {
+    it('merges overlapping intersections of the same type', () => {
+      const intersections: ThresholdIntersection[] = [
+        { start: 1, end: 3, type: 'error' },
+        { start: 2, end: 4, type: 'error' },
+        { start: 5, end: 6, type: 'warning' },
+        { start: 6, end: 7, type: 'warning' },
+      ]
+      const result = mergeThresholdIntersections(intersections)
+      expect(result).toEqual([
+        { start: 1, end: 4, type: 'error' },
+        { start: 5, end: 7, type: 'warning' },
+      ])
+    })
   })
 })


### PR DESCRIPTION
Helps satisfy some of [ma-4362](https://konghq.atlassian.net/browse/MA-4362)

# Description

Update the highlighting plugin to highlight even when the series starts above the threshold.

### Screenshots

**Before**

<img width="1256" height="508" alt="Screenshot 2025-10-07 at 7 47 55 PM" src="https://github.com/user-attachments/assets/f1154721-b1d3-4b69-947c-ec6e18f6d367" />

**After**

<img width="1249" height="523" alt="Screenshot 2025-10-07 at 7 47 43 PM" src="https://github.com/user-attachments/assets/d5d1e5b9-476f-4be7-a604-0fd6a95cc88b" />