### PR TITLE
feat(analytics): export dashboard to pdf [MA-5195]

### DIFF
--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
@@ -51,8 +51,8 @@ import type { MapFeatureCollection, MetricUnits } from '../types'
 import type { Feature, MultiPolygon, Geometry, GeoJsonProperties, FeatureCollection } from 'geojson'
 import composables from '../composables'
 import 'maplibre-gl/dist/maplibre-gl.css'
-import { CAPTURE_PREPARE_EVENT, CAPTURE_RESTORE_EVENT } from '@kong-ui-public/analytics-utilities'
-import type { ExploreAggregations, CountryISOA2, CapturePrepareDetail } from '@kong-ui-public/analytics-utilities'
+import type { ExploreAggregations, CountryISOA2 } from '@kong-ui-public/analytics-utilities'
+import { registerWebglCapture } from '@kong-ui-public/analytics-utilities'
 import lakes from '../ne_110m_lakes.json'
 import * as geobuf from 'geobuf'
 import Pbf from 'pbf'
@@ -241,55 +241,18 @@ const emitBounds = () => {
 
 const debouncedEmitBounds = debounce(emitBounds, 300)
 
-// For PDF export the canvas will temporarily be an <img> to allow for
-// snapshotting the draw buffer of WebGL.
-let restoreSnapshot: (() => void) | null = null
-
-async function createCaptureSnapshot(): Promise<void> {
-  const glCanvas = map.value?.getCanvas()
-
-  if (!map.value || !glCanvas) {
-    return
-  }
-
-  // Recreates the drawing buffer for `toDataURL`
-  map.value.redraw()
-
-  const snapshot = new Image()
-  snapshot.src = glCanvas.toDataURL('image/png')
-
-  await snapshot.decode()
-
-  snapshot.style.cssText = `position:absolute;top:0;left:0;width:${glCanvas.clientWidth}px;height:${glCanvas.clientHeight}px;`
-  glCanvas.parentElement?.appendChild(snapshot)
-  glCanvas.style.visibility = 'hidden'
-
-  // Get rid of the <img> element and return the canvas to normal
-  restoreSnapshot = () => {
-    snapshot.remove()
-    glCanvas.style.visibility = ''
-  }
-}
-
-function onCapturePrepare(event: Event): void {
-  (event as CustomEvent<CapturePrepareDetail>).detail?.waitUntil(createCaptureSnapshot())
-}
-
-function onCaptureRestore(): void {
-  restoreSnapshot?.()
-  restoreSnapshot = null
-}
+// For PDF export the WebGL canvas is temporarily swapped for a static <img> so
+// its draw buffer can be captured
+const stopWebglCapture = registerWebglCapture(
+  () => map.value?.getCanvas(),
+  { redraw: () => map.value?.redraw() },
+)
 
 onUnmounted(() => {
-  window.removeEventListener(CAPTURE_PREPARE_EVENT, onCapturePrepare)
-  window.removeEventListener(CAPTURE_RESTORE_EVENT, onCaptureRestore)
-  onCaptureRestore()
+  stopWebglCapture()
 })
 
 onMounted(async () => {
-  window.addEventListener(CAPTURE_PREPARE_EVENT, onCapturePrepare)
-  window.addEventListener(CAPTURE_RESTORE_EVENT, onCaptureRestore)
-
   try {
     const countriesPbfUrl = await countriesPbfUrlPromise
     const response = await fetch(countriesPbfUrl)

--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
@@ -44,14 +44,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch, computed, useId, toRef } from 'vue'
+import { ref, onMounted, onUnmounted, watch, computed, useId, toRef } from 'vue'
 import { Map } from 'maplibre-gl'
 import type { ColorSpecification, DataDrivenPropertyValueSpecification, ExpressionSpecification, LngLatBoundsLike, MapOptions } from 'maplibre-gl'
 import type { MapFeatureCollection, MetricUnits } from '../types'
 import type { Feature, MultiPolygon, Geometry, GeoJsonProperties, FeatureCollection } from 'geojson'
 import composables from '../composables'
 import 'maplibre-gl/dist/maplibre-gl.css'
-import type { ExploreAggregations, CountryISOA2 } from '@kong-ui-public/analytics-utilities'
+import { CAPTURE_PREPARE_EVENT, CAPTURE_RESTORE_EVENT } from '@kong-ui-public/analytics-utilities'
+import type { ExploreAggregations, CountryISOA2, CapturePrepareDetail } from '@kong-ui-public/analytics-utilities'
 import lakes from '../ne_110m_lakes.json'
 import * as geobuf from 'geobuf'
 import Pbf from 'pbf'
@@ -240,7 +241,55 @@ const emitBounds = () => {
 
 const debouncedEmitBounds = debounce(emitBounds, 300)
 
+// For PDF export the canvas will temporarily be an <img> to allow for
+// snapshotting the draw buffer of WebGL.
+let restoreSnapshot: (() => void) | null = null
+
+async function createCaptureSnapshot(): Promise<void> {
+  const glCanvas = map.value?.getCanvas()
+
+  if (!map.value || !glCanvas) {
+    return
+  }
+
+  // Recreates the drawing buffer for `toDataURL`
+  map.value.redraw()
+
+  const snapshot = new Image()
+  snapshot.src = glCanvas.toDataURL('image/png')
+
+  await snapshot.decode()
+
+  snapshot.style.cssText = `position:absolute;top:0;left:0;width:${glCanvas.clientWidth}px;height:${glCanvas.clientHeight}px;`
+  glCanvas.parentElement?.appendChild(snapshot)
+  glCanvas.style.visibility = 'hidden'
+
+  // Get rid of the <img> element and return the canvas to normal
+  restoreSnapshot = () => {
+    snapshot.remove()
+    glCanvas.style.visibility = ''
+  }
+}
+
+function onCapturePrepare(event: Event): void {
+  (event as CustomEvent<CapturePrepareDetail>).detail?.waitUntil(createCaptureSnapshot())
+}
+
+function onCaptureRestore(): void {
+  restoreSnapshot?.()
+  restoreSnapshot = null
+}
+
+onUnmounted(() => {
+  window.removeEventListener(CAPTURE_PREPARE_EVENT, onCapturePrepare)
+  window.removeEventListener(CAPTURE_RESTORE_EVENT, onCaptureRestore)
+  onCaptureRestore()
+})
+
 onMounted(async () => {
+  window.addEventListener(CAPTURE_PREPARE_EVENT, onCapturePrepare)
+  window.addEventListener(CAPTURE_RESTORE_EVENT, onCaptureRestore)
+
   try {
     const countriesPbfUrl = await countriesPbfUrlPromise
     const response = await fetch(countriesPbfUrl)

--- a/packages/analytics/analytics-utilities/src/captureProtocol.spec.ts
+++ b/packages/analytics/analytics-utilities/src/captureProtocol.spec.ts
@@ -1,0 +1,87 @@
+import type { CapturePrepareDetail } from './captureProtocol'
+
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  CAPTURE_PREPARE_EVENT,
+  CAPTURE_RESTORE_EVENT,
+  prepareForCapture,
+  restoreAfterCapture,
+} from './captureProtocol'
+
+describe('captureProtocol', () => {
+  const listeners: Array<[string, EventListener]> = []
+
+  const listen = (eventName: string, handler: EventListener) => {
+    window.addEventListener(eventName, handler)
+    listeners.push([eventName, handler])
+  }
+
+  afterEach(() => {
+    listeners.splice(0).forEach(([eventName, handler]) => window.removeEventListener(eventName, handler))
+  })
+
+  describe('prepareForCapture', () => {
+    it('resolves immediately when nothing is listening', async () => {
+      await expect(prepareForCapture()).resolves.toBeUndefined()
+    })
+
+    it('waits for promises registered via waitUntil', async () => {
+      let releasePreparation: () => void
+      let prepared = false
+
+      listen(CAPTURE_PREPARE_EVENT, (event) => {
+        const { waitUntil } = (event as CustomEvent<CapturePrepareDetail>).detail
+        waitUntil(new Promise<void>((resolve) => {
+          releasePreparation = () => {
+            prepared = true
+            resolve()
+          }
+        }))
+      })
+
+      const pending = prepareForCapture()
+      expect(prepared).toBe(false)
+
+      releasePreparation!()
+      await pending
+      expect(prepared).toBe(true)
+    })
+
+    it('registers events from multiple listeners', async () => {
+      const done: string[] = []
+      const register = (name: string) => (event: Event) => {
+        const { waitUntil } = (event as CustomEvent<CapturePrepareDetail>).detail
+        waitUntil((async () => {
+          done.push(name)
+        })())
+      }
+
+      listen(CAPTURE_PREPARE_EVENT, register('first'))
+      listen(CAPTURE_PREPARE_EVENT, register('second'))
+
+      await prepareForCapture()
+      expect(done.sort()).toEqual(['first', 'second'])
+    })
+
+    it('resolves even when a registered promise rejects', async () => {
+      listen(CAPTURE_PREPARE_EVENT, (event) => {
+        const { waitUntil } = (event as CustomEvent<CapturePrepareDetail>).detail
+        waitUntil(Promise.reject(new Error('snapshot failed')))
+      })
+
+      await expect(prepareForCapture()).resolves.toBeUndefined()
+    })
+  })
+
+  describe('restoreAfterCapture', () => {
+    it('dispatches the restore event', () => {
+      let restored = 0
+      listen(CAPTURE_RESTORE_EVENT, () => {
+        restored++
+      })
+
+      restoreAfterCapture()
+      expect(restored).toBe(1)
+    })
+  })
+})

--- a/packages/analytics/analytics-utilities/src/captureProtocol.spec.ts
+++ b/packages/analytics/analytics-utilities/src/captureProtocol.spec.ts
@@ -1,10 +1,12 @@
 import type { CapturePrepareDetail } from './captureProtocol'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   CAPTURE_PREPARE_EVENT,
   CAPTURE_RESTORE_EVENT,
   prepareForCapture,
+  registerCapture,
+  registerWebglCapture,
   restoreAfterCapture,
 } from './captureProtocol'
 
@@ -82,6 +84,101 @@ describe('captureProtocol', () => {
 
       restoreAfterCapture()
       expect(restored).toBe(1)
+    })
+  })
+
+  describe('registerCapture', () => {
+    it('runs prepare on capture and the returned restore afterwards', async () => {
+      const order: string[] = []
+      const unregister = registerCapture(() => {
+        order.push('prepare')
+        return () => order.push('restore')
+      })
+
+      await prepareForCapture()
+      expect(order).toEqual(['prepare'])
+
+      restoreAfterCapture()
+      expect(order).toEqual(['prepare', 'restore'])
+
+      unregister()
+    })
+
+    it('blocks capture until an async prepare settles', async () => {
+      let releasePreparation: () => void
+      let prepared = false
+
+      const unregister = registerCapture(() => new Promise<void>((resolve) => {
+        releasePreparation = () => {
+          prepared = true
+          resolve()
+        }
+      }))
+
+      const pending = prepareForCapture()
+      expect(prepared).toBe(false)
+
+      releasePreparation!()
+      await pending
+      expect(prepared).toBe(true)
+
+      unregister()
+    })
+
+    it('stops listening and undoes itself when finished', async () => {
+      const prepare = vi.fn(() => () => {})
+      const unregister = registerCapture(prepare)
+
+      await prepareForCapture()
+      unregister()
+
+      await prepareForCapture()
+      expect(prepare).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('registerWebglCapture', () => {
+    let parent: HTMLElement
+    let canvas: { style: { visibility: string }, clientWidth: number, clientHeight: number, parentElement: HTMLElement, toDataURL: () => string }
+
+    beforeEach(() => {
+      window.HTMLImageElement.prototype.decode = vi.fn().mockResolvedValue(undefined)
+
+      parent = document.createElement('div')
+      canvas = {
+        style: { visibility: '' },
+        clientWidth: 100,
+        clientHeight: 80,
+        parentElement: parent,
+        toDataURL: vi.fn(() => 'data:image/png;base64,stub'),
+      }
+    })
+
+    it('redraws and swaps the canvas for an <img> then restores it', async () => {
+      const redraw = vi.fn()
+      const unregister = registerWebglCapture(() => canvas as unknown as HTMLCanvasElement, { redraw })
+
+      await prepareForCapture()
+
+      expect(redraw).toHaveBeenCalledOnce()
+      expect(canvas.style.visibility).toBe('hidden')
+      expect(parent.querySelector('img')).not.toBeNull()
+
+      restoreAfterCapture()
+
+      expect(canvas.style.visibility).toBe('')
+      expect(parent.querySelector('img')).toBeNull()
+
+      unregister()
+    })
+
+    it('no-op when no canvas is available', async () => {
+      const unregister = registerWebglCapture(() => undefined)
+
+      await expect(prepareForCapture()).resolves.toBeUndefined()
+      expect(parent.querySelector('img')).toBeNull()
+
+      unregister()
     })
   })
 })

--- a/packages/analytics/analytics-utilities/src/captureProtocol.ts
+++ b/packages/analytics/analytics-utilities/src/captureProtocol.ts
@@ -1,0 +1,27 @@
+// Protocol for preparing WebGL content for PDF export.
+//
+// MapLibre renders into a WebGL canvas with `preserveDrawingBuffer: false`,
+// so capture libraries that read canvases using `toDataURL()` get a blank image.
+// This will temporarily swap the canvas for a static <img> while capturing.
+
+export const CAPTURE_PREPARE_EVENT = 'kapture:prepare'
+export const CAPTURE_RESTORE_EVENT = 'kapture:restore'
+
+export interface CapturePrepareDetail {
+  // Forces sanpdom to wait before starting the capture.
+  waitUntil: (promise: Promise<void>) => void
+}
+
+export async function prepareForCapture(): Promise<void> {
+  const pending: Array<Promise<void>> = []
+
+  window.dispatchEvent(new CustomEvent<CapturePrepareDetail>(CAPTURE_PREPARE_EVENT, {
+    detail: { waitUntil: (promise) => pending.push(promise) },
+  }))
+
+  await Promise.allSettled(pending)
+}
+
+export function restoreAfterCapture(): void {
+  window.dispatchEvent(new CustomEvent(CAPTURE_RESTORE_EVENT))
+}

--- a/packages/analytics/analytics-utilities/src/captureProtocol.ts
+++ b/packages/analytics/analytics-utilities/src/captureProtocol.ts
@@ -1,8 +1,4 @@
 // Protocol for preparing WebGL content for PDF export.
-//
-// MapLibre renders into a WebGL canvas with `preserveDrawingBuffer: false`,
-// so capture libraries that read canvases using `toDataURL()` get a blank image.
-// This will temporarily swap the canvas for a static <img> while capturing.
 
 export const CAPTURE_PREPARE_EVENT = 'kapture:prepare'
 export const CAPTURE_RESTORE_EVENT = 'kapture:restore'
@@ -24,4 +20,88 @@ export async function prepareForCapture(): Promise<void> {
 
 export function restoreAfterCapture(): void {
   window.dispatchEvent(new CustomEvent(CAPTURE_RESTORE_EVENT))
+}
+
+// Callback from prepare to undo whatever it did once capture is done.
+export type CaptureRestore = (() => void) | void
+
+/**
+ * Use this for anything that isn't a plain WebGL canvas. For WebGL
+ * canvases use {@link registerWebglCapture} instead.
+ *
+ * @param prepare Runs when a capture starts; Return a {@link CaptureRestore} to undo itself
+ * @returns An unregister function, **call it on unmount!**
+ */
+export function registerCapture(
+  prepare: () => Promise<CaptureRestore> | CaptureRestore,
+): () => void {
+  let restore: CaptureRestore
+
+  const runRestore = () => {
+    restore?.()
+    restore = undefined
+  }
+
+  const onPrepare = (event: Event) => {
+    (event as CustomEvent<CapturePrepareDetail>).detail?.waitUntil(
+      (async () => {
+        restore = await prepare()
+      })(),
+    )
+  }
+
+  window.addEventListener(CAPTURE_PREPARE_EVENT, onPrepare)
+  window.addEventListener(CAPTURE_RESTORE_EVENT, runRestore)
+
+  return () => {
+    window.removeEventListener(CAPTURE_PREPARE_EVENT, onPrepare)
+    window.removeEventListener(CAPTURE_RESTORE_EVENT, runRestore)
+
+    runRestore()
+  }
+}
+
+export interface WebglCaptureOptions {
+  // Called right before the drawing buffer is read. Needed for renderers
+  // running with `preserveDrawingBuffer: false` like MapLibre, you can omit this if the
+  // renderer preserves its buffer.
+  redraw?: () => void
+}
+
+/**
+ * This will temporarily swap the canvas for a static <img> while capturing.
+ *
+ * @param getCanvas Returns the canvas to capture
+ * @param options See {@link WebglCaptureOptions}
+ * @returns An unregister function, **call it on unmount!**
+ */
+export function registerWebglCapture(
+  getCanvas: () => HTMLCanvasElement | null | undefined,
+  options: WebglCaptureOptions = {},
+): () => void {
+  return registerCapture(async () => {
+    const canvas = getCanvas()
+
+    if (!canvas) {
+      return
+    }
+
+    // Recreates the drawing buffer for `toDataURL`
+    options.redraw?.()
+
+    const snapshot = new Image()
+    snapshot.src = canvas.toDataURL('image/png')
+
+    await snapshot.decode()
+
+    snapshot.style.cssText = `position:absolute;top:0;left:0;width:${canvas.clientWidth}px;height:${canvas.clientHeight}px;`
+    canvas.parentElement?.appendChild(snapshot)
+    canvas.style.visibility = 'hidden'
+
+    // Get rid of the <img> element and return the canvas to normal
+    return () => {
+      snapshot.remove()
+      canvas.style.visibility = ''
+    }
+  })
 }

--- a/packages/analytics/analytics-utilities/src/index.ts
+++ b/packages/analytics/analytics-utilities/src/index.ts
@@ -1,3 +1,4 @@
+export * from './captureProtocol'
 export * from './constants'
 export * from './dashboardSchema.v2'
 export * from './types'

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -55,7 +55,9 @@
     "cypress-real-events": "^1.15.0",
     "pinia": ">= 3.0.4 < 4",
     "swrv": "^1.2.0",
-    "vue": "^3.5.35"
+    "vue": "^3.5.35",
+    "@zumer/snapdom": "^2.6.0",
+    "jspdf": "^4.2.1"
   },
   "repository": {
     "type": "git",
@@ -85,7 +87,9 @@
     "@kong/icons": "^1.58.0",
     "@kong/kongponents": "^9.59.0",
     "swrv": "^1.2.0",
-    "vue": ">= 3.3.13 < 4"
+    "vue": ">= 3.3.13 < 4",
+    "@zumer/snapdom": "^2.6.0",
+    "jspdf": "^4.2.1"
   },
   "dependencies": {
     "@kong-ui-public/core": "workspace:^",

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@kong-ui-public/core": "workspace:^",
     "@zumer/snapdom": "^2.6.0",
+    "date-fns": "^4.4.0",
     "gridstack": "^11.5.1",
     "jspdf": "^4.2.1",
     "p-queue": "^8.1.1"

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -55,9 +55,7 @@
     "cypress-real-events": "^1.15.0",
     "pinia": ">= 3.0.4 < 4",
     "swrv": "^1.2.0",
-    "vue": "^3.5.35",
-    "@zumer/snapdom": "^2.6.0",
-    "jspdf": "^4.2.1"
+    "vue": "^3.5.35"
   },
   "repository": {
     "type": "git",
@@ -87,13 +85,13 @@
     "@kong/icons": "^1.58.0",
     "@kong/kongponents": "^9.59.0",
     "swrv": "^1.2.0",
-    "vue": ">= 3.3.13 < 4",
-    "@zumer/snapdom": "^2.6.0",
-    "jspdf": "^4.2.1"
+    "vue": ">= 3.3.13 < 4"
   },
   "dependencies": {
     "@kong-ui-public/core": "workspace:^",
+    "@zumer/snapdom": "^2.6.0",
     "gridstack": "^11.5.1",
+    "jspdf": "^4.2.1",
     "p-queue": "^8.1.1"
   }
 }

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -326,7 +326,7 @@ const addTile = () => {
 const exportPdf = () => {
   dashboardRendererRef.value?.exportPdf({
     title: 'Sandbox Editable Dashboard',
-    dashboardUrl: 'https://cloud.konghq.com/analytics/dashboards?ref=pdf',
+    dashboardUrl: 'https://cloud.konghq.com/analytics/dashboards?utm_source=pdf',
   })
 }
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -20,6 +20,13 @@
         >
           Add tile
         </KButton>
+        <KButton
+          appearance="primary"
+          size="small"
+          @click="exportPdf"
+        >
+          Export as PDF
+        </KButton>
         <KInputSwitch
           v-model="editableSwitch"
           label="Editable"
@@ -313,6 +320,13 @@ const addTile = () => {
         rows: 2,
       },
     },
+  })
+}
+
+const exportPdf = () => {
+  dashboardRendererRef.value?.exportPdf({
+    title: 'Sandbox Editable Dashboard',
+    dashboardUrl: 'https://cloud.konghq.com/analytics/dashboards?ref=pdf',
   })
 }
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -21,6 +21,13 @@
         >
           Toggle fullscreen
         </KButton>
+        <KButton
+          appearance="primary"
+          size="small"
+          @click="exportPdf"
+        >
+          Export as PDF
+        </KButton>
         <KInputSwitch
           v-model="isToggled"
           :label="isToggled ? 'Custom styling' : 'Normal styling'"
@@ -461,6 +468,13 @@ const refresh = () => {
 
 const toggleFullscreen = () => {
   dashboardRendererRef.value?.toggleFullscreen()
+}
+
+const exportPdf = () => {
+  dashboardRendererRef.value?.exportPdf({
+    title: 'Sandbox Dashboard',
+    dashboardUrl: 'https://cloud.konghq.com/analytics/dashboards?ref=pdf',
+  })
 }
 </script>
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -473,7 +473,7 @@ const toggleFullscreen = () => {
 const exportPdf = () => {
   dashboardRendererRef.value?.exportPdf({
     title: 'Sandbox Dashboard',
-    dashboardUrl: 'https://cloud.konghq.com/analytics/dashboards?ref=pdf',
+    dashboardUrl: 'https://cloud.konghq.com/analytics/dashboards?utm_source=pdf',
   })
 }
 </script>

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -52,10 +52,10 @@
             :query-ready="queryReady"
             :tile-id="tile.id"
             :tile-type="tile.type"
-            @chart-data="onChartData(tile)"
             @duplicate-tile="onDuplicateTile(tile)"
             @edit-tile="onEditTile(tile)"
             @remove-tile="onRemoveTile(tile)"
+            @tile-loaded="onTileLoaded(tile)"
             @tile-time-range-zoom="emit('tile-time-range-zoom', $event)"
           />
         </template>
@@ -134,7 +134,7 @@ composables.useRequestQueue()
 
 const { exportPdf, exportState: pdfExportState } = composables.useExportPdf(layoutContainer)
 
-const onChartData = (tile: GridTile<TileDefinition>) => {
+const onTileLoaded = (tile: GridTile<TileDefinition>) => {
   loadedTileIds.add((tile.id as string))
 
   const expectedCount = gridTiles.value.filter(t => !isSlottableTile(t)).length

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -52,6 +52,7 @@
             :query-ready="queryReady"
             :tile-id="tile.id"
             :tile-type="tile.type"
+            @chart-data="onChartData(tile)"
             @duplicate-tile="onDuplicateTile(tile)"
             @edit-tile="onEditTile(tile)"
             @remove-tile="onRemoveTile(tile)"
@@ -101,6 +102,7 @@ const {
 const emit = defineEmits<{
   (e: 'edit-tile', tile: GridTile<TileDefinition>): void
   (e: 'tile-time-range-zoom', newTimeRange: TileZoomEvent): void
+  (e: 'tiles-loaded', done: boolean): void
 }>()
 
 const model = defineModel<DashboardConfig>({ required: true })
@@ -113,7 +115,8 @@ const dashboardContainer = ref()
 const layoutContainer = ref<HTMLElement>()
 const scale = ref('scale(1)')
 
-const { exportPdf, exportState: pdfExportState } = composables.useExportPdf(layoutContainer)
+// Track which tiles (except for slottable tiles) have completed their queries.
+const loadedTileIds = new Set<string>()
 
 // Note: queryBridge is not directly used by the DashboardRenderer component.  It is required by many of the
 // subcomponents that get rendered in the dashboard, however.  Check for its existence here in order to catch
@@ -128,6 +131,18 @@ if (!queryBridge) {
 
 // Enable a request queue on the query bridge for all subcomponents.
 composables.useRequestQueue()
+
+const { exportPdf, exportState: pdfExportState } = composables.useExportPdf(layoutContainer)
+
+const onChartData = (tile: GridTile<TileDefinition>) => {
+  loadedTileIds.add((tile.id as string))
+
+  const expectedCount = gridTiles.value.filter(t => !isSlottableTile(t)).length
+
+  if (loadedTileIds.size >= expectedCount) {
+    emit('tiles-loaded', true)
+  }
+}
 
 const tileSortFn = (a: TileConfig, b: TileConfig) => {
   const rowDiff = a.layout.position.row - b.layout.position.row
@@ -225,9 +240,11 @@ const onRemoveTile = (tile: GridTile<TileDefinition>) => {
   if (gridLayoutRef.value) {
     gridLayoutRef.value.removeWidget(tile.id)
   }
+  loadedTileIds.delete((tile.id as string))
 }
 
 const refreshTiles = () => {
+  loadedTileIds.clear()
   refreshCounter.value++
 }
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -110,8 +110,10 @@ const refreshCounter = ref(0)
 const gridLayoutRef = ref<ComponentPublicInstance<DraggableGridLayoutExpose<TileDefinition>> | null>(null)
 
 const dashboardContainer = ref()
-const layoutContainer = ref()
+const layoutContainer = ref<HTMLElement>()
 const scale = ref('scale(1)')
+
+const { exportPdf, exportState: pdfExportState } = composables.useExportPdf(layoutContainer)
 
 // Note: queryBridge is not directly used by the DashboardRenderer component.  It is required by many of the
 // subcomponents that get rendered in the dashboard, however.  Check for its existence here in order to catch
@@ -288,6 +290,8 @@ const { internalContext, queryReady } = composables.useDashboardInternalContext(
 defineExpose({
   refresh: refreshTiles,
   toggleFullscreen,
+  exportPdf,
+  pdfExportState,
 })
 </script>
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -233,6 +233,7 @@ const refresh = () => {
 
 const emit = defineEmits<{
   (e: 'chart-data', chartData: ExploreResultV4): void
+  (e: 'tile-loaded'): void
   (e: 'edit-tile', tile: TileDefinition): void
   (e: 'duplicate-tile', tile: TileDefinition): void
   (e: 'remove-tile', tile: TileDefinition): void
@@ -490,14 +491,20 @@ const onChartData = (data: ExploreResultV4) => {
   chartData.value = data
   loadingChartData.value = false
   emit('chart-data', data)
+  emit('tile-loaded')
 }
 
 const onQueryComplete = () => {
   loadingChartData.value = false
+  emit('tile-loaded')
 }
 
 const onLoadingChange = (isLoading: boolean) => {
   loadingChartData.value = isLoading
+
+  if (!isLoading) {
+    emit('tile-loaded')
+  }
 }
 
 const hideExportModal = () => {

--- a/packages/analytics/dashboard-renderer/src/composables/index.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/index.ts
@@ -4,12 +4,14 @@ import useRequestQueue from './useRequestQueue'
 import useContextLinks from './useContextLinks'
 import useIssueQuery from './useIssueQuery'
 import useDashboardInternalContext from './useDashboardInternalContext'
+import useExportPdf from './useExportPdf'
 
 // All composables must be exported as part of the default object for Cypress test stubs
 export default {
   useContextLinks,
   useDashboardInternalContext,
   useEvaluateFeatureFlag,
+  useExportPdf,
   useI18n,
   useIssueQuery,
   useRequestQueue,

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest'
+import { buildFilename, calculatePageSlices, getRowBoundaries, slugify } from './useExportPdf'
+
+const stubRect = (el: HTMLElement, top: number, height: number) => {
+  el.getBoundingClientRect = () => ({
+    top,
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 0,
+    width: 0,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect)
+}
+
+describe('slugify', () => {
+  it('lowercases and replaces non-alphanumerics with hyphens', () => {
+    expect(slugify('API Usage Dashboard')).toBe('api-usage-dashboard')
+    expect(slugify('  My  (test) dashboard!  ')).toBe('my-test-dashboard')
+  })
+
+  it('collapses consecutive separators and trims leading/trailing hyphens', () => {
+    expect(slugify('--a__b--')).toBe('a-b')
+  })
+})
+
+describe('buildFilename', () => {
+  const now = new Date(2026, 6, 8)
+
+  it('appends the date to an explicit filename', () => {
+    expect(buildFilename('my-report', 'Ignored Title', now)).toBe('my-report-2026-07-08.pdf')
+  })
+
+  it('slugifies the title when no filename is given', () => {
+    expect(buildFilename(undefined, 'API Usage Dashboard', now)).toBe('api-usage-dashboard-2026-07-08.pdf')
+  })
+
+  it('falls back to dashboard-export when neither is given', () => {
+    expect(buildFilename(undefined, undefined, now)).toBe('dashboard-export-2026-07-08.pdf')
+  })
+
+  it('prepends zeros to single-digit months and days', () => {
+    expect(buildFilename('x', undefined, new Date(2026, 0, 5))).toBe('x-2026-01-05.pdf')
+  })
+})
+
+describe('calculatePageSlices', () => {
+  it('slices at fixed page height intervals when there are no row boundaries', () => {
+    expect(calculatePageSlices([], 2500, 1000, 2)).toEqual([
+      { startY: 0, height: 1000 },
+      { startY: 1000, height: 1000 },
+      { startY: 2000, height: 500 },
+    ])
+  })
+
+  it('returns a single page when all rows fit', () => {
+    const rows = [
+      { top: 0, bottom: 200 },
+      { top: 220, bottom: 420 },
+    ]
+
+    expect(calculatePageSlices(rows, 840, 1000, 2)).toEqual([
+      { startY: 0, height: 840 },
+    ])
+  })
+
+  it('breaks pages at row tops so no row is split', () => {
+    const rows = [
+      { top: 0, bottom: 200 },
+      { top: 220, bottom: 420 },
+      { top: 440, bottom: 640 },
+    ]
+
+    // scale 1x, page height 400, rows 2 and 3 each overflow the running page
+    expect(calculatePageSlices(rows, 640, 400, 1)).toEqual([
+      { startY: 0, height: 220 },
+      { startY: 220, height: 220 },
+      { startY: 440, height: 200 },
+    ])
+  })
+
+  it('applies the capture scale to row boundaries', () => {
+    const rows = [
+      { top: 0, bottom: 200 },
+      { top: 220, bottom: 420 },
+    ]
+
+    // scales 2x, row bottoms are 400 and 840 canvas px
+    expect(calculatePageSlices(rows, 840, 800, 2)).toEqual([
+      { startY: 0, height: 440 },
+      { startY: 440, height: 400 },
+    ])
+  })
+
+  it('does not split or emit an empty page for a single row taller than a page', () => {
+    const rows = [{ top: 0, bottom: 1500 }]
+
+    expect(calculatePageSlices(rows, 1500, 1000, 1)).toEqual([
+      { startY: 0, height: 1500 },
+    ])
+  })
+
+  it('includes trailing canvas content below the last row on the final page', () => {
+    const rows = [{ top: 0, bottom: 200 }]
+
+    expect(calculatePageSlices(rows, 300, 1000, 1)).toEqual([
+      { startY: 0, height: 300 },
+    ])
+  })
+})
+
+describe('getRowBoundaries', () => {
+  const buildGrid = (
+    gridClass: string,
+    cellClass: string,
+    cells: Array<{ top: number, height: number, extraClass?: string }>,
+    containerTop = 0,
+  ): HTMLElement => {
+    const container = document.createElement('div')
+    stubRect(container, containerTop, 1000)
+
+    const grid = document.createElement('div')
+    grid.className = gridClass
+    container.appendChild(grid)
+
+    cells.forEach(({ top, height, extraClass }) => {
+      const cell = document.createElement('div')
+      cell.className = extraClass ? `${cellClass} ${extraClass}` : cellClass
+      stubRect(cell, top, height)
+      grid.appendChild(cell)
+    })
+
+    return container
+  }
+
+  it('returns empty when there is no grid layout', () => {
+    expect(getRowBoundaries(document.createElement('div'))).toEqual([])
+  })
+
+  it('returns empty when the grid has no cells', () => {
+    expect(getRowBoundaries(buildGrid('kong-ui-public-grid-layout', 'grid-cell', []))).toEqual([])
+  })
+
+  it('groups view mode grid cells into sorted rows, keeping the tallest bottom per row', () => {
+    const container = buildGrid('kong-ui-public-grid-layout', 'grid-cell', [
+      { top: 220, height: 200 },
+      { top: 0, height: 200 },
+      { top: 0, height: 150 }, // shorter cell in the first row
+    ])
+
+    expect(getRowBoundaries(container)).toEqual([
+      { top: 0, bottom: 200 },
+      { top: 220, bottom: 420 },
+    ])
+  })
+
+  it('ignores empty cells', () => {
+    const container = buildGrid('kong-ui-public-grid-layout', 'grid-cell', [
+      { top: 0, height: 200 },
+      { top: 220, height: 200, extraClass: 'empty-cell' },
+    ])
+
+    expect(getRowBoundaries(container)).toEqual([
+      { top: 0, bottom: 200 },
+    ])
+  })
+
+  it('supports edit mode gridstack markup', () => {
+    const container = buildGrid('grid-stack', 'grid-stack-item', [
+      { top: 0, height: 200 },
+      { top: 220, height: 200 },
+    ])
+
+    expect(getRowBoundaries(container)).toEqual([
+      { top: 0, bottom: 200 },
+      { top: 220, bottom: 420 },
+    ])
+  })
+
+  it('measures relative to the container, not the viewport', () => {
+    const container = buildGrid('kong-ui-public-grid-layout', 'grid-cell', [
+      { top: 350, height: 200 },
+    ], 300) // container offset to viewport top 300
+
+    expect(getRowBoundaries(container)).toEqual([
+      { top: 50, bottom: 250 },
+    ])
+  })
+
+  it('groups cells whose tops differ only by subpixel amounts into one row', () => {
+    const container = buildGrid('kong-ui-public-grid-layout', 'grid-cell', [
+      { top: 100, height: 200 },
+      { top: 100.4, height: 200 },
+    ])
+
+    expect(getRowBoundaries(container)).toEqual([
+      { top: 100, bottom: 300 },
+    ])
+  })
+})

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
@@ -1,5 +1,30 @@
-import { describe, it, expect } from 'vitest'
-import { buildFilename, calculatePageSlices, getRowBoundaries, slugify } from './useExportPdf'
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { CAPTURE_PREPARE_EVENT, CAPTURE_RESTORE_EVENT } from '@kong-ui-public/analytics-utilities'
+import useExportPdf, { buildFilename, calculatePageSlices, getRowBoundaries, slugify } from './useExportPdf'
+import { snapdom } from '@zumer/snapdom'
+
+vi.mock('@zumer/snapdom', () => ({
+  snapdom: { toCanvas: vi.fn() },
+}))
+
+vi.mock('jspdf', () => ({
+  jsPDF: vi.fn().mockImplementation(() => ({
+    internal: { pageSize: { getWidth: () => 297, getHeight: () => 210 } },
+    addPage: vi.fn(),
+    addImage: vi.fn(),
+    setFont: vi.fn(),
+    setFontSize: vi.fn(),
+    setTextColor: vi.fn(),
+    setDrawColor: vi.fn(),
+    text: vi.fn(),
+    textWithLink: vi.fn(),
+    getTextWidth: () => 10,
+    line: vi.fn(),
+    output: vi.fn(() => new Blob()),
+    save: vi.fn(),
+  })),
+}))
 
 const stubRect = (el: HTMLElement, top: number, height: number) => {
   el.getBoundingClientRect = () => ({
@@ -198,5 +223,82 @@ describe('getRowBoundaries', () => {
     expect(getRowBoundaries(container)).toEqual([
       { top: 100, bottom: 300 },
     ])
+  })
+})
+
+describe('exportPdf WebGL capture protocol', () => {
+  const events: string[] = []
+  const onPrepare = () => {
+    events.push('prepare')
+  }
+  const onRestore = () => {
+    events.push('restore')
+  }
+
+  // Simulates snapdom hooks for beforeClone and afterClone
+  const toCanvasRunningPlugins = (result: () => HTMLCanvasElement) =>
+    async (element: HTMLElement, options: any) => {
+      for (const plugin of options?.plugins ?? []) {
+        await plugin.beforeClone?.({ element, options })
+      }
+
+      for (const plugin of options?.plugins ?? []) {
+        await plugin.afterClone?.({ element, options })
+      }
+
+      return result()
+    }
+
+  const fakeCanvas = () => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 800
+    canvas.height = 600
+
+    return canvas
+  }
+
+  beforeEach(() => {
+    events.length = 0
+    window.addEventListener(CAPTURE_PREPARE_EVENT, onPrepare)
+    window.addEventListener(CAPTURE_RESTORE_EVENT, onRestore)
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({ drawImage: vi.fn() } as any)
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue('data:image/png;base64,')
+  })
+
+  afterEach(() => {
+    window.removeEventListener(CAPTURE_PREPARE_EVENT, onPrepare)
+    window.removeEventListener(CAPTURE_RESTORE_EVENT, onRestore)
+    vi.restoreAllMocks()
+  })
+
+  it('WebGL beforeClone calls prepare and restores afterwards', async () => {
+    vi.mocked(snapdom.toCanvas).mockImplementation(toCanvasRunningPlugins(fakeCanvas) as any)
+
+    const { exportPdf, exportState } = useExportPdf(ref(document.createElement('div')))
+    await exportPdf({ output: 'blob' })
+
+    expect(exportState.value.status).toBe('complete')
+    expect(events[0]).toBe('prepare')
+    expect(events[1]).toBe('restore')
+    expect(vi.mocked(snapdom.toCanvas).mock.calls[0][1]).toMatchObject({
+      plugins: [expect.objectContaining({ name: 'kong-webgl-snapshot' })],
+    })
+  })
+
+  it('restores canvas when cloning fails', async () => {
+    vi.mocked(snapdom.toCanvas).mockImplementation(async (element: any, options: any) => {
+      for (const plugin of options?.plugins ?? []) {
+        await plugin.beforeClone?.({ element, options })
+      }
+
+      throw new Error('clone failed')
+    })
+
+    const { exportPdf, exportState } = useExportPdf(ref(document.createElement('div')))
+    await exportPdf({ output: 'blob' })
+
+    expect(exportState.value.status).toBe('error')
+    expect(events).toEqual(['prepare', 'restore'])
   })
 })

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
@@ -1,0 +1,299 @@
+import type { Ref } from 'vue'
+import type { jsPDF } from 'jspdf'
+import type { PdfExportOptions, PdfExportState } from '../types/renderer-types'
+
+import { readonly, ref } from 'vue'
+import useI18n from './useI18n'
+
+interface RowBoundary {
+  top: number
+  bottom: number
+}
+
+interface PageSlice {
+  startY: number
+  height: number
+}
+
+const HEADER_HEIGHT_MM = 12
+const FOOTER_HEIGHT_MM = 12
+
+interface PageMetaContext {
+  title?: string
+  dashboardUrl?: string
+  generatedAt: string
+  branding: string
+  dashboardNote: string
+  pageLabel: string
+  pageWidth: number
+  pageHeight: number
+  margin: number
+}
+
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function buildFilename(filename: string | undefined, title: string | undefined, now: Date): string {
+  const base = filename || (title && slugify(title)) || 'dashboard-export'
+  const yyyy = now.getFullYear()
+  const mm = String(now.getMonth() + 1).padStart(2, '0')
+  const dd = String(now.getDate()).padStart(2, '0')
+
+  return `${base}-${yyyy}-${mm}-${dd}.pdf`
+}
+
+function drawPageMeta(pdf: jsPDF, ctx: PageMetaContext): void {
+  const { pageWidth, pageHeight, margin } = ctx
+  const headerBaseline = margin + 5
+  const headerRuleY = margin + HEADER_HEIGHT_MM - 3
+  const footerRuleY = pageHeight - margin - FOOTER_HEIGHT_MM + 3
+  const footerBaseline = footerRuleY + 5
+
+  // Header title aligned left, timestamp right
+  if (ctx.title) {
+    pdf.setFont('helvetica', 'bold')
+    pdf.setFontSize(11)
+    pdf.setTextColor(60)
+    pdf.text(ctx.title, margin, headerBaseline)
+  }
+
+  pdf.setFont('helvetica', 'normal')
+  pdf.setFontSize(8)
+  pdf.setTextColor(120)
+  pdf.text(ctx.generatedAt, pageWidth - margin, headerBaseline, { align: 'right' })
+
+  pdf.setDrawColor(220)
+  pdf.line(margin, headerRuleY, pageWidth - margin, headerRuleY)
+
+  // Footer branding and dashboard note aligned left, page number right
+  pdf.line(margin, footerRuleY, pageWidth - margin, footerRuleY)
+
+  pdf.setFont('helvetica', 'bold')
+  pdf.setTextColor(60)
+  pdf.text(ctx.branding, margin, footerBaseline)
+  const brandingWidth = pdf.getTextWidth(ctx.branding)
+
+  pdf.setFont('helvetica', 'normal')
+  const note = ` ${ctx.dashboardNote}`
+
+  if (ctx.dashboardUrl) {
+    pdf.setTextColor(0, 68, 204)
+    pdf.textWithLink(note, margin + brandingWidth, footerBaseline, { url: ctx.dashboardUrl })
+  } else {
+    pdf.setTextColor(120)
+    pdf.text(note, margin + brandingWidth, footerBaseline)
+  }
+
+  pdf.setTextColor(120)
+  pdf.text(ctx.pageLabel, pageWidth - margin, footerBaseline, { align: 'right' })
+}
+
+export function getRowBoundaries(container: HTMLElement): RowBoundary[] {
+  const gridLayout = container.querySelector<HTMLElement>('.kong-ui-public-grid-layout, .grid-stack')
+
+  if (!gridLayout) {
+    return []
+  }
+
+  const cells = gridLayout.querySelectorAll<HTMLElement>(':scope > .grid-cell:not(.empty-cell), :scope > .grid-stack-item')
+
+  if (!cells.length) {
+    return []
+  }
+
+  // This will measure relative to the grid-stack container
+  const containerTop = container.getBoundingClientRect().top
+
+  const rowMap = new Map<number, number>()
+  cells.forEach(cell => {
+    const rect = cell.getBoundingClientRect()
+    const top = Math.round(rect.top - containerTop)
+    const bottom = Math.round(rect.bottom - containerTop)
+    const existing = rowMap.get(top)
+
+    // Keep the tallest cell's bottom for each row
+    rowMap.set(top, existing !== undefined ? Math.max(existing, bottom) : bottom)
+  })
+
+  return [...rowMap.entries()]
+    .map(([top, bottom]) => ({ top, bottom }))
+    .sort((a, b) => a.top - b.top)
+}
+
+// Groups rows into pages without splitting any row across a page break
+export function calculatePageSlices(
+  rows: RowBoundary[],
+  canvasHeight: number,
+  pageHeightPx: number,
+  scale: number,
+): PageSlice[] {
+  if (!rows.length) {
+    const pages: PageSlice[] = []
+    let y = 0
+
+    while (y < canvasHeight) {
+      const height = Math.min(pageHeightPx, canvasHeight - y)
+      pages.push({ startY: y, height })
+      y += height
+    }
+
+    return pages
+  }
+
+  const pages: PageSlice[] = []
+  let pageStartY = 0
+
+  for (let i = 0; i < rows.length; i++) {
+    const rowTopPx = rows[i].top * scale
+    const rowBottomPx = rows[i].bottom * scale
+
+    // Would this row exceed the current page?
+    if (rowBottomPx - pageStartY > pageHeightPx && pageStartY < rowTopPx) {
+      // Close the current page at the top of this row
+      pages.push({ startY: pageStartY, height: rowTopPx - pageStartY })
+      pageStartY = rowTopPx
+    }
+  }
+
+  if (pageStartY < canvasHeight) {
+    pages.push({ startY: pageStartY, height: canvasHeight - pageStartY })
+  }
+
+  return pages
+}
+
+function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
+  const { i18n } = useI18n()
+  const exportState = ref<PdfExportState>({ status: 'idle' })
+
+  async function exportPdf(options: PdfExportOptions = {}): Promise<Blob | undefined> {
+    const {
+      filename,
+      title,
+      dashboardUrl,
+      orientation = 'landscape',
+      margin = 10,
+      scale = 2,
+      exclude = ['.tile-actions', '.tooltip', '.popover', '.dropdown-popover'],
+      output = 'download',
+      onBeforeCapture,
+      onAfterCapture,
+    } = options
+
+    const element = layoutContainerRef.value
+
+    if (!element) {
+      exportState.value = { status: 'error', error: new Error('Dashboard layout container not found.') }
+
+      return
+    }
+
+    try {
+      exportState.value = { status: 'preparing' }
+      await onBeforeCapture?.()
+
+      const rowBoundaries = getRowBoundaries(element)
+
+      const [{ snapdom }, { jsPDF }] = await Promise.all([
+        import('@zumer/snapdom'),
+        import('jspdf'),
+      ])
+
+      exportState.value = { status: 'capturing' }
+      const canvas = await snapdom.toCanvas(element, { scale, exclude })
+
+      exportState.value = { status: 'generating' }
+
+      const now = new Date()
+      const pdf = new jsPDF({ orientation, unit: 'mm', format: 'a4' })
+      const pageWidth = pdf.internal.pageSize.getWidth()
+      const pageHeight = pdf.internal.pageSize.getHeight()
+      const contentWidth = pageWidth - margin * 2
+      const contentHeight = pageHeight - margin * 2 - HEADER_HEIGHT_MM - FOOTER_HEIGHT_MM
+
+      const pxPerMm = canvas.width / contentWidth
+      const pageHeightPx = contentHeight * pxPerMm
+
+      const pages = calculatePageSlices(rowBoundaries, canvas.height, pageHeightPx, scale)
+
+      const pageMeta: Omit<PageMetaContext, 'pageLabel'> = {
+        title,
+        dashboardUrl,
+        generatedAt: i18n.t('pdfExport.generated', {
+          timestamp: now.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }),
+        }),
+        branding: i18n.t('pdfExport.branding'),
+        dashboardNote: i18n.t('pdfExport.dashboardNote'),
+        pageWidth,
+        pageHeight,
+        margin,
+      }
+
+      for (let i = 0; i < pages.length; i++) {
+        if (i > 0) {
+          pdf.addPage()
+        }
+
+        const { startY, height } = pages[i]
+
+        const sliceCanvas = document.createElement('canvas')
+
+        sliceCanvas.width = canvas.width
+        sliceCanvas.height = height
+
+        const ctx = sliceCanvas.getContext('2d')!
+
+        ctx.drawImage(
+          canvas,
+          0, startY,
+          canvas.width, height,
+          0, 0,
+          canvas.width, height,
+        )
+
+        pdf.addImage(
+          sliceCanvas.toDataURL('image/png'),
+          'PNG',
+          margin,
+          margin + HEADER_HEIGHT_MM,
+          contentWidth,
+          height / pxPerMm,
+        )
+
+        drawPageMeta(pdf, {
+          ...pageMeta,
+          pageLabel: i18n.t('pdfExport.pageOf', { page: String(i + 1), total: String(pages.length) }),
+        })
+      }
+
+      if (output === 'blob') {
+        // This won't do much for now other than return the type and size of the blob.
+        const blob = pdf.output('blob')
+        exportState.value = { status: 'complete' }
+
+        return blob
+      }
+
+      pdf.save(buildFilename(filename, title, now))
+      exportState.value = { status: 'complete' }
+    } catch (error) {
+      exportState.value = { status: 'error', error }
+    } finally {
+      await onAfterCapture?.()
+    }
+
+    return undefined
+  }
+
+  return {
+    exportPdf,
+    exportState: readonly(exportState),
+  }
+}
+
+export default useExportPdf

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
@@ -4,6 +4,7 @@ import type { SnapdomPlugin } from '@zumer/snapdom'
 import type { PdfExportOptions, PdfExportState } from '../types/renderer-types'
 
 import { readonly, ref } from 'vue'
+import { format } from 'date-fns'
 import { prepareForCapture, restoreAfterCapture } from '@kong-ui-public/analytics-utilities'
 import useI18n from './useI18n'
 
@@ -45,11 +46,9 @@ export function slugify(value: string): string {
 
 export function buildFilename(filename: string | undefined, title: string | undefined, now: Date): string {
   const base = filename || (title && slugify(title)) || 'dashboard-export'
-  const yyyy = now.getFullYear()
-  const mm = String(now.getMonth() + 1).padStart(2, '0')
-  const dd = String(now.getDate()).padStart(2, '0')
+  const dateString = format(now, 'yyyy-MM-dd')
 
-  return `${base}-${yyyy}-${mm}-${dd}.pdf`
+  return `${base}-${dateString}.pdf`
 }
 
 function drawPageMeta(pdf: jsPDF, ctx: PageMetaContext): void {
@@ -188,6 +187,7 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
       subtitle,
       dashboardUrl,
       orientation = 'landscape',
+      pageSize = 'letter',
       margin = 4,
       scale = 2,
       exclude = ['.tile-actions', '.tooltip', '.popover', '.dropdown-popover'],
@@ -231,7 +231,7 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
       exportState.value = { status: 'generating' }
 
       const now = new Date()
-      const pdf = new jsPDF({ orientation, unit: 'mm', format: 'a4' })
+      const pdf = new jsPDF({ orientation, unit: 'mm', format: pageSize })
       const pageWidth = pdf.internal.pageSize.getWidth()
       const pageHeight = pdf.internal.pageSize.getHeight()
       const headerHeight = HEADER_HEIGHT_MM + (subtitle ? SUBTITLE_HEIGHT_MM : 0)

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
@@ -1,8 +1,10 @@
 import type { Ref } from 'vue'
 import type { jsPDF } from 'jspdf'
+import type { SnapdomPlugin } from '@zumer/snapdom'
 import type { PdfExportOptions, PdfExportState } from '../types/renderer-types'
 
 import { readonly, ref } from 'vue'
+import { prepareForCapture, restoreAfterCapture } from '@kong-ui-public/analytics-utilities'
 import useI18n from './useI18n'
 
 interface RowBoundary {
@@ -15,11 +17,13 @@ interface PageSlice {
   height: number
 }
 
-const HEADER_HEIGHT_MM = 12
-const FOOTER_HEIGHT_MM = 12
+const HEADER_HEIGHT_MM = 6
+const FOOTER_HEIGHT_MM = 6
+const SUBTITLE_HEIGHT_MM = 4
 
 interface PageMetaContext {
   title?: string
+  subtitle?: string
   dashboardUrl?: string
   generatedAt: string
   branding: string
@@ -27,6 +31,7 @@ interface PageMetaContext {
   pageLabel: string
   pageWidth: number
   pageHeight: number
+  headerHeight: number
   margin: number
 }
 
@@ -49,10 +54,10 @@ export function buildFilename(filename: string | undefined, title: string | unde
 
 function drawPageMeta(pdf: jsPDF, ctx: PageMetaContext): void {
   const { pageWidth, pageHeight, margin } = ctx
-  const headerBaseline = margin + 5
-  const headerRuleY = margin + HEADER_HEIGHT_MM - 3
+  const headerBaseline = margin + 1
+  const headerRuleY = margin + ctx.headerHeight - 3
   const footerRuleY = pageHeight - margin - FOOTER_HEIGHT_MM + 3
-  const footerBaseline = footerRuleY + 5
+  const footerBaseline = footerRuleY + 4
 
   // Header title aligned left, timestamp right
   if (ctx.title) {
@@ -66,6 +71,11 @@ function drawPageMeta(pdf: jsPDF, ctx: PageMetaContext): void {
   pdf.setFontSize(8)
   pdf.setTextColor(120)
   pdf.text(ctx.generatedAt, pageWidth - margin, headerBaseline, { align: 'right' })
+
+  // Subtitle below the header
+  if (ctx.subtitle) {
+    pdf.text(ctx.subtitle, margin, headerBaseline + SUBTITLE_HEIGHT_MM)
+  }
 
   pdf.setDrawColor(220)
   pdf.line(margin, headerRuleY, pageWidth - margin, headerRuleY)
@@ -175,9 +185,10 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
     const {
       filename,
       title,
+      subtitle,
       dashboardUrl,
       orientation = 'landscape',
-      margin = 10,
+      margin = 4,
       scale = 2,
       exclude = ['.tile-actions', '.tooltip', '.popover', '.dropdown-popover'],
       output = 'download',
@@ -205,7 +216,17 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
       ])
 
       exportState.value = { status: 'capturing' }
-      const canvas = await snapdom.toCanvas(element, { scale, exclude })
+
+      // In order to take a snapshot of the map canvas (WebGL under the hood), this will
+      // temporarily transform the draw buffer into an <img> and restore it after capture.
+      // See `captureProtocol` in analytics-utilities
+      const webglSnapshotPlugin: SnapdomPlugin = {
+        name: 'kong-webgl-snapshot',
+        beforeClone: () => prepareForCapture(),
+        afterClone: () => restoreAfterCapture(),
+      }
+
+      const canvas = await snapdom.toCanvas(element, { scale, exclude, plugins: [webglSnapshotPlugin] })
 
       exportState.value = { status: 'generating' }
 
@@ -213,8 +234,9 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
       const pdf = new jsPDF({ orientation, unit: 'mm', format: 'a4' })
       const pageWidth = pdf.internal.pageSize.getWidth()
       const pageHeight = pdf.internal.pageSize.getHeight()
+      const headerHeight = HEADER_HEIGHT_MM + (subtitle ? SUBTITLE_HEIGHT_MM : 0)
       const contentWidth = pageWidth - margin * 2
-      const contentHeight = pageHeight - margin * 2 - HEADER_HEIGHT_MM - FOOTER_HEIGHT_MM
+      const contentHeight = pageHeight - margin * 2 - headerHeight - FOOTER_HEIGHT_MM
 
       const pxPerMm = canvas.width / contentWidth
       const pageHeightPx = contentHeight * pxPerMm
@@ -223,6 +245,7 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
 
       const pageMeta: Omit<PageMetaContext, 'pageLabel'> = {
         title,
+        subtitle,
         dashboardUrl,
         generatedAt: i18n.t('pdfExport.generated', {
           timestamp: now.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }),
@@ -231,6 +254,7 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
         dashboardNote: i18n.t('pdfExport.dashboardNote'),
         pageWidth,
         pageHeight,
+        headerHeight,
         margin,
       }
 
@@ -260,7 +284,7 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
           sliceCanvas.toDataURL('image/png'),
           'PNG',
           margin,
-          margin + HEADER_HEIGHT_MM,
+          margin + headerHeight,
           contentWidth,
           height / pxPerMm,
         )
@@ -274,16 +298,18 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
       if (output === 'blob') {
         // This won't do much for now other than return the type and size of the blob.
         const blob = pdf.output('blob')
-        exportState.value = { status: 'complete' }
+        exportState.value = { status: 'complete', pageCount: pages.length }
 
         return blob
       }
 
       pdf.save(buildFilename(filename, title, now))
-      exportState.value = { status: 'complete' }
+      exportState.value = { status: 'complete', pageCount: pages.length }
     } catch (error) {
       exportState.value = { status: 'error', error }
     } finally {
+      // restore regardless of error
+      restoreAfterCapture()
       await onAfterCapture?.()
     }
 

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -19,6 +19,12 @@
     "delete": "Delete",
     "as_of_today": "As of today"
   },
+  "pdfExport": {
+    "branding": "Kong Konnect",
+    "generated": "Generated {timestamp}",
+    "dashboardNote": "For a live, interactive experience, open this dashboard in Konnect",
+    "pageOf": "{page} / {total}"
+  },
   "csvExport": {
     "defaultFilename": "Chart export",
     "exportAsCsv": "Export as CSV"

--- a/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
@@ -39,6 +39,8 @@ export interface PdfExportOptions {
   dashboardUrl?: string
   /** Page orientation. Defaults to 'landscape'. */
   orientation?: 'portrait' | 'landscape'
+  /** Page size. Defaults to 'letter'. */
+  pageSize?: 'letter' | 'a4'
   /** Page margin in mm. Defaults to 4. */
   margin?: number
   /** Scale factor for capture resolution. Higher = better quality, larger file. Defaults to 2. */

--- a/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
@@ -25,6 +25,42 @@ export interface DashboardRendererContextInternal extends Required<DashboardRend
   showTileZoomActions: boolean
 }
 
+export interface PdfExportOptions {
+  /**
+   * PDF filename without .pdf extension, a date stamp is always appended.
+   * Defaults to a slug of `title`, falling back to 'dashboard-export'.
+   */
+  filename?: string
+  /** Dashboard name used in the header */
+  title?: string
+  /** URL to the dashboard in the footer. */
+  dashboardUrl?: string
+  /** Page orientation. Defaults to 'landscape'. */
+  orientation?: 'portrait' | 'landscape'
+  /** Page margin in mm. Defaults to 10. */
+  margin?: number
+  /** Scale factor for capture resolution. Higher = better quality, larger file. Defaults to 2. */
+  scale?: number
+  /** CSS selectors to exclude from capture (e.g. tooltips, dropdowns). */
+  exclude?: string[]
+  /**
+   * 'download' is for client-side generation, 'blob' returns the PDF as a Blob
+   * which is needed for headless. Defaults to 'download'.
+   */
+  output?: 'download' | 'blob'
+  /** Called before DOM capture starts (e.g. to hide interactive UI). */
+  onBeforeCapture?: () => void | Promise<void>
+  /** Called after DOM capture completes (e.g. to restore UI). */
+  onAfterCapture?: () => void | Promise<void>
+}
+
+export type PdfExportStatus = 'idle' | 'preparing' | 'capturing' | 'generating' | 'complete' | 'error'
+
+export interface PdfExportState {
+  status: PdfExportStatus
+  error?: unknown
+}
+
 export interface ChartRendererProps<T> {
   query: ValidDashboardChartQuery
   context: DashboardRendererContextInternal

--- a/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
@@ -33,11 +33,13 @@ export interface PdfExportOptions {
   filename?: string
   /** Dashboard name used in the header */
   title?: string
+  /** Second header line */
+  subtitle?: string
   /** URL to the dashboard in the footer. */
   dashboardUrl?: string
   /** Page orientation. Defaults to 'landscape'. */
   orientation?: 'portrait' | 'landscape'
-  /** Page margin in mm. Defaults to 10. */
+  /** Page margin in mm. Defaults to 4. */
   margin?: number
   /** Scale factor for capture resolution. Higher = better quality, larger file. Defaults to 2. */
   scale?: number
@@ -58,6 +60,8 @@ export type PdfExportStatus = 'idle' | 'preparing' | 'capturing' | 'generating' 
 
 export interface PdfExportState {
   status: PdfExportStatus
+  /** Number of pages in the generated document. Set when status is 'complete'. */
+  pageCount?: number
   error?: unknown
 }
 

--- a/packages/analytics/dashboard-renderer/vite.config.ts
+++ b/packages/analytics/dashboard-renderer/vite.config.ts
@@ -26,6 +26,8 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
         '@kong-ui-public/analytics-geo-map',
         '@kong-ui-public/table-data-grid',
         'swrv',
+        '@zumer/snapdom',
+        'jspdf',
       ],
       output: {
         // Provide global variables to use in the UMD build for externalized deps
@@ -37,6 +39,8 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
           '@kong-ui-public/analytics-geo-map': 'kong-ui-public-analytics-geo-map',
           '@kong-ui-public/table-data-grid': 'kong-ui-public-table-data-grid',
           swrv: 'swrv',
+          '@zumer/snapdom': 'snapdom',
+          jspdf: 'jspdf',
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,9 +401,15 @@ importers:
       '@kong-ui-public/core':
         specifier: workspace:^
         version: link:../../core/core
+      '@zumer/snapdom':
+        specifier: ^2.6.0
+        version: 2.15.0
       gridstack:
         specifier: ^11.5.1
         version: 11.5.1
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
       p-queue:
         specifier: ^8.1.1
         version: 8.1.1
@@ -444,18 +450,12 @@ importers:
       '@kong/kongponents':
         specifier: 9.60.7
         version: 9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
-      '@zumer/snapdom':
-        specifier: ^2.6.0
-        version: 2.15.0
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
       cypress-real-events:
         specifier: ^1.15.0
         version: 1.15.0(cypress@13.17.0)
-      jspdf:
-        specifier: ^4.2.1
-        version: 4.2.1
       pinia:
         specifier: '>= 3.0.4 < 4'
         version: 3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,12 +444,18 @@ importers:
       '@kong/kongponents':
         specifier: 9.60.7
         version: 9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
+      '@zumer/snapdom':
+        specifier: ^2.6.0
+        version: 2.15.0
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
       cypress-real-events:
         specifier: ^1.15.0
         version: 1.15.0(cypress@13.17.0)
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
       pinia:
         specifier: '>= 3.0.4 < 4'
         version: 3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))
@@ -624,7 +630,7 @@ importers:
         version: 2.0.1
       '@kong/kongponents':
         specifier: 9.60.7
-        version: 9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
+        version: 9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -636,10 +642,10 @@ importers:
         version: 1.1.0(monaco-editor@0.55.1)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))
+        version: 1.6.0(rollup@4.59.0)(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))
+        version: 3.6.0(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))
       vue:
         specifier: ^3.5.35
         version: 3.5.38(typescript@5.9.3)
@@ -1434,13 +1440,13 @@ importers:
         version: 2.0.1
       '@kong/kongponents':
         specifier: 9.60.7
-        version: 9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
+        version: 9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
       '@types/prismjs':
         specifier: ^1.26.6
         version: 1.26.6
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.2.0
-        version: 4.2.0(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3))
+        version: 4.2.0(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
       vue:
         specifier: ^3.5.35
         version: 3.5.38(typescript@5.9.3)
@@ -1468,10 +1474,10 @@ importers:
         version: 2.0.1
       '@kong/kongponents':
         specifier: 9.60.7
-        version: 9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
+        version: 9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.1
-        version: 1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))
+        version: 1.1.1(rollup@4.59.0)(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -1710,6 +1716,10 @@ packages:
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -4035,6 +4045,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
   '@types/papaparse@5.5.2':
     resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
 
@@ -4049,6 +4062,9 @@ packages:
 
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
 
   '@types/ramda@0.29.12':
     resolution: {integrity: sha512-sgIEjpJhdQPB52gDF4aphs9nl0xe54CR22DPdWqT8gQHjZYmVApgA0R3/CpMbl0Y8az2TEZrPNL2zy0EvjbkLA==}
@@ -4490,6 +4506,9 @@ packages:
     resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
     hasBin: true
 
+  '@zumer/snapdom@2.15.0':
+    resolution: {integrity: sha512-rdayfg832lYhy2v2DRr4LwzhIT0ZMeGKYicVmtzbji95KhUd7Z1g6/5jTsDEU4q32a6ywbIpAixO45hubsEftQ==}
+
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
@@ -4795,6 +4814,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4976,6 +4999,10 @@ packages:
 
   caniuse-lite@1.0.30001761:
     resolution: {integrity: sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -5364,6 +5391,9 @@ packages:
     resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
     deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -5417,6 +5447,9 @@ packages:
   css-functions-list@3.3.3:
     resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
     engines: {node: '>=12'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-loader@7.1.4:
     resolution: {integrity: sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==}
@@ -6306,6 +6339,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fast-uri@4.0.0:
     resolution: {integrity: sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==}
 
@@ -6875,6 +6911,10 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
@@ -7086,6 +7126,9 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -7519,6 +7562,9 @@ packages:
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
@@ -8597,6 +8643,9 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
+  pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
+
   papaparse@5.5.3:
     resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
 
@@ -9083,6 +9132,9 @@ packages:
   quickselect@3.0.0:
     resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   ramda-adjunct@5.1.0:
     resolution: {integrity: sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==}
     engines: {node: '>=0.10.3'}
@@ -9278,6 +9330,9 @@ packages:
   regenerator-runtime@0.11.1:
     resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -9370,6 +9425,10 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   right-pad@1.0.1:
     resolution: {integrity: sha512-bYBjgxmkvTAfgIYy328fmkwhp39v8lwVgWhhrzxPV3yHtcSqyYKe9/XOhvW48UFjATg3VuJbpsp5822ACNvkmw==}
@@ -9895,6 +9954,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   stampit@4.3.2:
     resolution: {integrity: sha512-pE2org1+ZWQBnIxRPrBM2gVupkuDD0TTNIo1H6GdT/vO82NXli2z8lRE8cu/nBIHrcOCXFBAHpb9ZldrB2/qOA==}
 
@@ -10099,6 +10162,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
@@ -10210,6 +10277,9 @@ packages:
   text-extensions@1.9.0:
     resolution: {integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==}
     engines: {node: '>=0.10'}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   thingies@2.6.0:
     resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
@@ -10634,6 +10704,9 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
@@ -11527,6 +11600,8 @@ snapshots:
       core-js-pure: 3.47.0
 
   '@babel/runtime@7.28.4': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -12541,31 +12616,6 @@ snapshots:
       - solid-js
       - svelte
 
-  '@kong/kongponents@9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))':
-    dependencies:
-      '@floating-ui/vue': 1.1.11(vue@3.5.38(typescript@5.9.3))
-      '@kong/icons': 1.60.0(vue@3.5.38(typescript@5.9.3))
-      '@popperjs/core': 2.11.8
-      date-fns: 2.30.0
-      date-fns-tz: 2.0.1(date-fns@2.30.0)
-      focus-trap: 7.8.0
-      focus-trap-vue: 4.1.0(focus-trap@7.8.0)(vue@3.5.38(typescript@5.9.3))
-      lodash-es: 4.18.1
-      nanoid: 5.1.11
-      sortablejs: 1.15.7
-      swrv: 1.2.0(vue@3.5.38(typescript@5.9.3))
-      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.5.38(typescript@5.9.3))
-      virtua: 0.49.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue@3.5.38(typescript@5.9.3))
-      vue: 3.5.38(typescript@5.9.3)
-      vue-draggable-next: 2.3.0(sortablejs@1.15.7)(vue@3.5.38(typescript@5.9.3))
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - react
-      - react-dom
-      - solid-js
-      - svelte
-
   '@kong/kongponents@9.60.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))':
     dependencies:
       '@floating-ui/vue': 1.1.11(vue@3.5.38(typescript@5.9.3))
@@ -12732,12 +12782,12 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))':
+  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.59.0)
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
-      vite: 5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)
+      vite: 8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
 
@@ -13045,8 +13095,7 @@ snapshots:
 
   '@one-ini/wasm@0.1.1': {}
 
-  '@oxc-project/types@0.133.0':
-    optional: true
+  '@oxc-project/types@0.133.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -14238,6 +14287,8 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/pako@2.0.4': {}
+
   '@types/papaparse@5.5.2':
     dependencies:
       '@types/node': 24.13.2
@@ -14249,6 +14300,9 @@ snapshots:
   '@types/prop-types@15.7.13': {}
 
   '@types/qs@6.15.1': {}
+
+  '@types/raf@3.4.3':
+    optional: true
 
   '@types/ramda@0.29.12':
     dependencies:
@@ -14437,13 +14491,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.2.0(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.0)
-      vite: 5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)
+      vite: 8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0)
       vue: 3.5.38(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
@@ -14832,6 +14886,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  '@zumer/snapdom@2.15.0': {}
+
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -15141,6 +15197,9 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-arraybuffer@1.0.2:
+    optional: true
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.11: {}
@@ -15367,6 +15426,18 @@ snapshots:
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001761: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/raf': 3.4.3
+      core-js: 3.49.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   caseless@0.12.0: {}
 
@@ -15750,6 +15821,9 @@ snapshots:
 
   core-js@2.6.12: {}
 
+  core-js@3.49.0:
+    optional: true
+
   core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
@@ -15801,6 +15875,11 @@ snapshots:
       which: 2.0.2
 
   css-functions-list@3.3.3: {}
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   css-loader@7.1.4(webpack@5.107.2):
     dependencies:
@@ -16239,8 +16318,7 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node@2.1.0: {}
 
@@ -16897,6 +16975,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.2.0
+
   fast-uri@4.0.0: {}
 
   fastest-levenshtein@1.0.16: {}
@@ -17515,6 +17599,12 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
   htmlparser2@8.0.2:
     dependencies:
       domelementtype: 2.3.0
@@ -17803,6 +17893,8 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  iobuffer@5.4.0: {}
 
   ip-address@10.1.0: {}
 
@@ -18176,6 +18268,17 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      fast-png: 6.4.0
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      html2canvas: 1.4.1
+
   jsprim@2.0.2:
     dependencies:
       assert-plus: 1.0.0
@@ -18382,7 +18485,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
-    optional: true
 
   lines-and-columns@1.2.4: {}
 
@@ -19583,6 +19685,8 @@ snapshots:
       - kerberos
       - supports-color
 
+  pako@2.2.0: {}
+
   papaparse@5.5.3: {}
 
   parent-module@1.0.1:
@@ -20064,6 +20168,11 @@ snapshots:
 
   quickselect@3.0.0: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   ramda-adjunct@5.1.0(ramda@0.30.1):
     dependencies:
       ramda: 0.30.1
@@ -20297,6 +20406,9 @@ snapshots:
 
   regenerator-runtime@0.11.1: {}
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -20375,6 +20487,9 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rgbcolor@1.0.1:
+    optional: true
+
   right-pad@1.0.1: {}
 
   rimraf@2.7.1:
@@ -20412,7 +20527,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.3
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
-    optional: true
 
   rollup-plugin-babel@4.4.0(@babel/core@7.28.0)(rollup@4.59.0):
     dependencies:
@@ -20989,6 +21103,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   stampit@4.3.2: {}
 
   statuses@1.5.0: {}
@@ -21227,6 +21344,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   svg-tags@1.0.0: {}
 
   swagger-client@3.26.7:
@@ -21383,6 +21503,11 @@ snapshots:
   text-encoding@0.6.4: {}
 
   text-extensions@1.9.0: {}
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   thingies@2.6.0(tslib@2.8.1):
     dependencies:
@@ -21800,6 +21925,11 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
+
   uuid@10.0.0: {}
 
   uuid@14.0.1: {}
@@ -21927,13 +22057,13 @@ snapshots:
     dependencies:
       monaco-editor: 0.55.1
 
-  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)):
+  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
       '@swc/core': 1.15.7
       '@swc/wasm': 1.15.7
       uuid: 10.0.0
-      vite: 5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)
+      vite: 8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
@@ -21969,9 +22099,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-wasm@3.6.0(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)):
+  vite-plugin-wasm@3.6.0(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0)):
     dependencies:
-      vite: 5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)
+      vite: 8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0)
 
   vite@5.4.21(@types/node@24.13.2)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1):
     dependencies:
@@ -21980,19 +22110,6 @@ snapshots:
       rollup: 4.59.0
     optionalDependencies:
       '@types/node': 24.13.2
-      fsevents: 2.3.3
-      lightningcss: 1.32.0
-      sass: 1.101.0
-      sass-embedded: 1.80.3
-      terser: 5.43.1
-
-  vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.16
-      rollup: 4.59.0
-    optionalDependencies:
-      '@types/node': 26.0.0
       fsevents: 2.3.3
       lightningcss: 1.32.0
       sass: 1.101.0
@@ -22032,7 +22149,6 @@ snapshots:
       sass-embedded: 1.80.3
       terser: 5.43.1
       yaml: 2.9.0
-    optional: true
 
   vitest@3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(@vitest/ui@3.2.6)(jsdom@29.1.1)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1):
     dependencies:
@@ -22131,31 +22247,6 @@ snapshots:
       '@vue/compiler-sfc': 3.5.38
       pinia: 3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))
       vite: 5.4.21(@types/node@24.13.2)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)
-
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1))(vue@3.5.38(typescript@5.9.3)):
-    dependencies:
-      '@babel/generator': 8.0.0-rc.6
-      '@vue-macros/common': 3.1.2(vue@3.5.38(typescript@5.9.3))
-      '@vue/devtools-api': 8.1.2
-      ast-walker-scope: 0.9.0
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      scule: 1.3.0
-      tinyglobby: 0.2.17
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.38(typescript@5.9.3)
-      yaml: 2.9.0
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.38
-      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))
-      vite: 5.4.21(@types/node@26.0.0)(lightningcss@1.32.0)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)
 
   vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vite@8.0.16(@types/node@26.0.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.101.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
       '@zumer/snapdom':
         specifier: ^2.6.0
         version: 2.15.0
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       gridstack:
         specifier: ^11.5.1
         version: 11.5.1


### PR DESCRIPTION
# Summary

Close [MA-5195](https://konghq.atlassian.net/browse/MA-5195)

This will add an available function to the DashboardRenderer for exporting a dashboard as a PDF.

It uses [snapdom](https://github.com/zumerlab/snapdom) to create a canvas of the dom, then provides the canvas to [jspdf](https://github.com/parallax/jsPDF) to generate a PDF from the canvas with calculation to ensure tiles aren't split between pages but attempts to retain the layout of a dashboard.

A bit of nuance surrounding map tiles requires a workaround due to the snapdom attempting to capture the draw buffer from WebGL which is not saved (available to capture) after writing to the frame buffer (what we see in the browser).

In order for those tiles to work, the draw buffer needs to be redrawn before the capture event happens. This happens by a `kapture:prepare` event that the `AnalyticsGeoMap` will listen for on mount (removed on unmount), when that event is caught the map is redrawn and temporarily converted into an `<img>` element which gives snapdom something to capture. Once captured the `<img>` is removed and the canvas is restored back to normal.


<details closed>
<summary>Sandbox demo</summary>

[export-pdf.webm](https://github.com/user-attachments/assets/e1090b4c-46f1-420f-b9b6-bd57834fab11)

</details>


Snapdom seemed the most capable and well maintained when comparing with [html2canvas](https://github.com/niklasvh/html2canvas). [jsPDF](https://github.com/parallax/jsPDF) is likely the best library for this job as it's actively maintained and fairly lightweight.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-5195]: https://konghq.atlassian.net/browse/MA-5195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ