### PR TITLE
fix(*): ignore CVE-2026-39363 to fix audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
     "typedoc-plugin-markdown": "^4.9.0",
     "typescript": "~5.9.3",
     "uuid": "^11.1.0",
-    "vite": "^5.4.21",
+    "vite": "^8.0.5",
     "vite-plugin-externals": "^0.6.2",
     "vite-plugin-vue-devtools": "^7.7.9",
-    "vitest": "^3.2.4",
+    "vitest": "^4.1.2",
     "vue": "^3.5.27",
     "vue-router": "^4.6.4",
     "vue-tsc": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
     "typedoc-plugin-markdown": "^4.9.0",
     "typescript": "~5.9.3",
     "uuid": "^11.1.0",
-    "vite": "^8.0.5",
+    "vite": "^5.4.21",
     "vite-plugin-externals": "^0.6.2",
     "vite-plugin-vue-devtools": "^7.7.9",
-    "vitest": "^4.1.2",
+    "vitest": "^3.2.4",
     "vue": "^3.5.27",
     "vue-router": "^4.6.4",
     "vue-tsc": "^3.2.4"
@@ -88,6 +88,11 @@
       "path-to-regexp@<0.1.13": ">=0.1.13",
       "lodash-es@<=4.17.23": ">=4.18.0",
       "lodash@<=4.17.23": ">=4.18.0"
+    },
+    "auditConfig": {
+      "ignoreCves": [
+        "CVE-2026-39363"
+      ]
     },
     "onlyBuiltDependencies": [
       "@evilmartians/lefthook",


### PR DESCRIPTION
# Summary

Ignore `CVE-2026-39363` because all `vite` version fixing it is less than a day. Not until April 18 can we apply the fix version(12 days rule for newly published packages).
From claude:
> On April 6, the vite team released a coordinated security patch across all major versions:
6.4.2 — patches >=6.0.0 <=6.4.1
7.3.2 — patches >=7.0.0 <=7.3.1
8.0.5 — patches >=8.0.0 <=8.0.4
Your pnpm global config has minimumReleaseAge=17280 (12 days), which blocks any package released less than 12 days ago as a supply chain attack prevention measure. Since all three patches were released yesterday, none can be installed until April 18.
Every available vite version is either:
Too old → vulnerable
Too new → blocked by minimumReleaseAge
There is no installable patched vite today.


<img width="909" height="681" alt="截屏2026-04-07 上午11 32 21" src="https://github.com/user-attachments/assets/291daae7-ef0e-43e3-acf8-056cf5a4b464" />
