### PR TITLE
feat(workspace): add workspace support to shared and gateway service

### DIFF
--- a/packages/entities/entities-gateway-services/docs/gateway-service-config-card.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-config-card.md
@@ -53,7 +53,7 @@ A config card component for gateway services.
     - type: `string`
     - required: `true`
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-gateway-services/docs/gateway-service-form.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-form.md
@@ -60,7 +60,7 @@ A form component for gateway services.
     - type: `string`
     - required: `true`
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-gateway-services/docs/gateway-service-list.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-list.md
@@ -83,7 +83,7 @@ A table component for gateway services.
     - type: `string`
     - required: `true`
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
@@ -944,4 +944,76 @@ describe('<GatewayServiceForm />', { viewportHeight: 800, viewportWidth: 700 }, 
       })
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('includes workspace in GET URL when loading with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/services/${gatewayService1.id}`,
+        },
+        { statusCode: 200, body: gatewayService1 },
+      ).as('getServiceWithWorkspace')
+
+      cy.mount(GatewayServiceForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          gatewayServiceId: gatewayService1.id,
+        },
+      })
+
+      cy.wait('@getServiceWithWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/services/${gatewayService1.id}`,
+        },
+        { statusCode: 200, body: gatewayService1 },
+      ).as('getServiceWithWorkspace')
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/services/${gatewayService1.id}`,
+        },
+        { statusCode: 200, body: gatewayService1 },
+      ).as('updateServiceWithWorkspace')
+
+      cy.mount(GatewayServiceForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          gatewayServiceId: gatewayService1.id,
+          isEditing: true,
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getServiceWithWorkspace').then(() => {
+        cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+        cy.wait('@updateServiceWithWorkspace')
+      })
+    })
+
+    it('omits workspace segment in GET URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/services/${gatewayService1.id}`,
+        },
+        { statusCode: 200, body: gatewayService1 },
+      ).as('getServiceNoWorkspace')
+
+      cy.mount(GatewayServiceForm, {
+        props: {
+          config: baseConfigKonnect,
+          gatewayServiceId: gatewayService1.id,
+        },
+      })
+
+      cy.wait('@getServiceNoWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+  })
 })

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -988,12 +988,11 @@ const submitUrl = computed<string>(() => {
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
-  // Always replace the id when editing
-  url = url.replace(/{id}/gi, props.gatewayServiceId)
+
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, props.gatewayServiceId) // Always replace the id when editing
 })
 
 const tlsSansPayload = computed(() => {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -821,4 +821,80 @@ describe('<GatewayServiceList />', () => {
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/services*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(GatewayServiceList, {
+        props: {
+          cacheIdentifier: `gateway-service-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-gateway-services-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/services*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(GatewayServiceList, {
+        props: {
+          cacheIdentifier: `gateway-service-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-gateway-services-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/services*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(GatewayServiceList, {
+        props: {
+          cacheIdentifier: `gateway-service-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-gateway-services-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -396,14 +396,11 @@ const fetcherBaseUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app].all}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 const baseRequestUrl = computed((): URL => {
   return props.config.apiBaseUrl.startsWith('/')

--- a/packages/entities/entities-gateway-services/src/gateway-services-endpoints.ts
+++ b/packages/entities/entities-gateway-services/src/gateway-services-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {

--- a/packages/entities/entities-shared/docs/entity-base-config-card.md
+++ b/packages/entities/entities-shared/docs/entity-base-config-card.md
@@ -60,7 +60,7 @@ A base display component for an entity's record data.
     - type: `string`
     - required: `true`
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-shared/docs/entity-base-form.md
+++ b/packages/entities/entities-shared/docs/entity-base-form.md
@@ -59,7 +59,7 @@ A base form component for entity create/edit views.
     - type: `string`
     - required: `true`
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
@@ -556,6 +556,140 @@ describe('<EntityBaseConfigCard />', () => {
     })
   })
 
+  describe('Konnect workspace URL building', () => {
+    const wsControlPlaneId = '1234-abcd-ilove-cats-too'
+    const wsEntityId = '1234-cats-rule'
+    const wsBaseUrl = '/us/kong-api'
+
+    const workspaceFetchUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}/services/{id}'
+    const plainFetchUrl = '/v2/control-planes/{controlPlaneId}/core-entities/services/{id}'
+
+    const configWithWorkspace = (workspace: string): KonnectBaseEntityConfig => ({
+      app: 'konnect',
+      apiBaseUrl: wsBaseUrl,
+      controlPlaneId: wsControlPlaneId,
+      workspace,
+      entityId: wsEntityId,
+    })
+
+    const configNoWorkspace: KonnectBaseEntityConfig = {
+      app: 'konnect',
+      apiBaseUrl: wsBaseUrl,
+      controlPlaneId: wsControlPlaneId,
+      entityId: wsEntityId,
+    }
+
+    it('includes workspace name in fetch URL when workspace is provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/default/services/${wsEntityId}`,
+        },
+        { statusCode: 200, body: gatewayServiceRecord },
+      ).as('fetchWithWorkspace')
+
+      cy.mount(EntityBaseConfigCard, {
+        props: {
+          config: configWithWorkspace('default'),
+          configSchema,
+          entityType,
+          fetchUrl: workspaceFetchUrl,
+        },
+      })
+
+      cy.wait('@fetchWithWorkspace')
+      cy.getTestId('config-card-fetch-error').should('not.exist')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/test/services/${wsEntityId}`,
+        },
+        { statusCode: 200, body: gatewayServiceRecord },
+      ).as('fetchWithTestWorkspace')
+
+      cy.mount(EntityBaseConfigCard, {
+        props: {
+          config: configWithWorkspace('test'),
+          configSchema,
+          entityType,
+          fetchUrl: workspaceFetchUrl,
+        },
+      })
+
+      cy.wait('@fetchWithTestWorkspace')
+      cy.getTestId('config-card-fetch-error').should('not.exist')
+    })
+
+    it('omits workspace segment in fetch URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/services/${wsEntityId}`,
+        },
+        { statusCode: 200, body: gatewayServiceRecord },
+      ).as('fetchNoWorkspace')
+
+      cy.mount(EntityBaseConfigCard, {
+        props: {
+          config: configNoWorkspace,
+          configSchema,
+          entityType,
+          fetchUrl: workspaceFetchUrl,
+        },
+      })
+
+      cy.wait('@fetchNoWorkspace')
+      cy.getTestId('config-card-fetch-error').should('not.exist')
+    })
+
+    it('shows fetch error when load fails with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/default/services/${wsEntityId}`,
+        },
+        { statusCode: 500, body: {} },
+      ).as('fetchError')
+
+      cy.mount(EntityBaseConfigCard, {
+        props: {
+          config: configWithWorkspace('default'),
+          configSchema,
+          entityType,
+          fetchUrl: workspaceFetchUrl,
+        },
+      })
+
+      cy.wait('@fetchError')
+      cy.getTestId('config-card-fetch-error').should('be.visible')
+    })
+
+    it('ignores workspace config when fetchUrl has no {workspace} placeholder', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/services/${wsEntityId}`,
+        },
+        { statusCode: 200, body: gatewayServiceRecord },
+      ).as('fetchPlain')
+
+      cy.mount(EntityBaseConfigCard, {
+        props: {
+          config: configWithWorkspace('default'),
+          configSchema,
+          entityType,
+          fetchUrl: plainFetchUrl,
+        },
+      })
+
+      cy.wait('@fetchPlain')
+      cy.getTestId('config-card-fetch-error').should('not.exist')
+    })
+  })
+
   describe('Slots', () => {
     it('allows slotting label and value', () => {
       const key = 'id'

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -608,14 +608,11 @@ const fetcherUrl = computed<string>(() => {
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  // Always replace the id for editing
-  url = url.replace(/{id}/gi, props.config.entityId)
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, props.config.entityId) // Always replace the id for editing
 })
 
 watch(isLoading, (loading: boolean) => {

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.cy.ts
@@ -211,4 +211,198 @@ describe('<EntityBaseForm />', () => {
     cy.getTestId('form-content').should('contain.text', content)
     cy.getTestId('form-actions').should('contain.text', action)
   })
+
+  describe('Konnect workspace URL building', () => {
+    const wsControlPlaneId = '123abc-ilove-cats'
+    const wsEditId = '1234-ideclare-athumb-war'
+    const wsBaseUrl = '/us/kong-api'
+    const wsEntityType = SupportedEntityType.Route
+
+    // fetchUrl with {controlPlaneId} and {workspace} placeholders (realistic endpoint format)
+    const workspaceFetchUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}/routes/{id}'
+    // fetchUrl without {workspace} placeholder (endpoint not supporting workspace)
+    const plainFetchUrl = '/v2/control-planes/{controlPlaneId}/core-entities/routes/{id}'
+
+    const configWithWorkspace = (workspace: string): KonnectBaseFormConfig => ({
+      app: 'konnect',
+      apiBaseUrl: wsBaseUrl,
+      controlPlaneId: wsControlPlaneId,
+      workspace,
+      cancelRoute: { name: '/' },
+    })
+
+    const configNoWorkspace: KonnectBaseFormConfig = {
+      app: 'konnect',
+      apiBaseUrl: wsBaseUrl,
+      controlPlaneId: wsControlPlaneId,
+      cancelRoute: { name: '/' },
+    }
+
+    it('includes workspace name in fetch URL when workspace is provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/default/routes/${wsEditId}`,
+        },
+        { statusCode: 200, body: {} },
+      ).as('fetchWithWorkspace')
+
+      cy.mount(EntityBaseForm, {
+        props: {
+          config: configWithWorkspace('default'),
+          formFields: route,
+          entityType: wsEntityType,
+          editId: wsEditId,
+          fetchUrl: workspaceFetchUrl,
+          canSubmit: true,
+        },
+      })
+
+      cy.wait('@fetchWithWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/test/routes/${wsEditId}`,
+        },
+        { statusCode: 200, body: {} },
+      ).as('fetchWithTestWorkspace')
+
+      cy.mount(EntityBaseForm, {
+        props: {
+          config: configWithWorkspace('test'),
+          formFields: route,
+          entityType: wsEntityType,
+          editId: wsEditId,
+          fetchUrl: workspaceFetchUrl,
+          canSubmit: true,
+        },
+      })
+
+      cy.wait('@fetchWithTestWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+
+    it('omits workspace segment in fetch URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/routes/${wsEditId}`,
+        },
+        { statusCode: 200, body: {} },
+      ).as('fetchNoWorkspace')
+
+      cy.mount(EntityBaseForm, {
+        props: {
+          config: configNoWorkspace,
+          formFields: route,
+          entityType: wsEntityType,
+          editId: wsEditId,
+          fetchUrl: workspaceFetchUrl,
+          canSubmit: true,
+        },
+      })
+
+      cy.wait('@fetchNoWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+
+    it('renders edit form correctly when load succeeds with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/default/routes/${wsEditId}`,
+        },
+        { statusCode: 200, body: {} },
+      )
+
+      cy.mount(EntityBaseForm, {
+        props: {
+          config: configWithWorkspace('default'),
+          formFields: route,
+          entityType: wsEntityType,
+          editId: wsEditId,
+          fetchUrl: workspaceFetchUrl,
+          canSubmit: true,
+        },
+      })
+
+      cy.getTestId('form-fetch-error').should('not.exist')
+      cy.getTestId(`${wsEntityType}-edit-form-cancel`).should('be.enabled')
+      cy.getTestId(`${wsEntityType}-edit-form-submit`).should('be.enabled')
+    })
+
+    it('shows fetch error when load fails with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/default/routes/${wsEditId}`,
+        },
+        { statusCode: 500, body: {} },
+      )
+
+      cy.mount(EntityBaseForm, {
+        props: {
+          config: configWithWorkspace('default'),
+          formFields: route,
+          entityType: wsEntityType,
+          editId: wsEditId,
+          fetchUrl: workspaceFetchUrl,
+        },
+      })
+
+      cy.getTestId('form-fetch-error').should('be.visible')
+    })
+
+    it('ignores workspace config when fetchUrl has no {workspace} placeholder', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/routes/${wsEditId}`,
+        },
+        { statusCode: 200, body: {} },
+      ).as('fetchPlain')
+
+      cy.mount(EntityBaseForm, {
+        props: {
+          config: configWithWorkspace('default'),
+          formFields: route,
+          entityType: wsEntityType,
+          editId: wsEditId,
+          fetchUrl: plainFetchUrl,
+          canSubmit: true,
+        },
+      })
+
+      cy.wait('@fetchPlain')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+
+    it('handles workspace name with hyphens and numbers', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsBaseUrl}/v2/control-planes/${wsControlPlaneId}/core-entities/my-workspace-123/routes/${wsEditId}`,
+        },
+        { statusCode: 200, body: {} },
+      ).as('fetchWithComplexWorkspace')
+
+      cy.mount(EntityBaseForm, {
+        props: {
+          config: configWithWorkspace('my-workspace-123'),
+          formFields: route,
+          entityType: wsEntityType,
+          editId: wsEditId,
+          fetchUrl: workspaceFetchUrl,
+          canSubmit: true,
+        },
+      })
+
+      cy.wait('@fetchWithComplexWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+  })
 })

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -310,9 +310,9 @@ const fetcherUrl = computed<string>(() => {
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
+
+  url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 
   if (!props.editId) {
     // strip placeholder /{id}/ from  post request url

--- a/packages/entities/entities-shared/src/composables/useDebouncedFilter.ts
+++ b/packages/entities/entities-shared/src/composables/useDebouncedFilter.ts
@@ -42,15 +42,13 @@ export default function useDebouncedFilter(
   const allRecords = ref<Array<Record<string, any>> | undefined>(undefined)
 
   const url = computed(() => {
-    const url = `${config.apiBaseUrl}${unref(baseUrl)}`
+    let url = `${config.apiBaseUrl}${unref(baseUrl)}`
 
     if (config.app === 'konnect') {
-      return url.replace(/{controlPlaneId}/gi, config?.controlPlaneId || '')
-    } else if (config.app === 'kongManager') {
-      return url.replace(/\/{workspace}/gi, config?.workspace ? `/${config.workspace}` : '')
+      url = url.replace(/{controlPlaneId}/gi, config?.controlPlaneId || '')
     }
 
-    return url
+    return url.replace(/\/{workspace}/gi, config?.workspace ? `/${config.workspace}` : '')
   })
 
   const { isValidUuid } = useHelpers()

--- a/packages/entities/entities-shared/src/types/app-config.ts
+++ b/packages/entities/entities-shared/src/types/app-config.ts
@@ -16,6 +16,8 @@ export interface KonnectConfig extends BaseAppConfig {
   app: 'konnect'
   /** The control plane id */
   controlPlaneId: string
+  /** Optional workspace name or identifier */
+  workspace?: string
   /** Identifies whether the Control Plane type is a Control Plane Group or not */
   isControlPlaneGroup?: boolean
   /** Identifies whether the control plane is a member of a control plane group (not the group itself) */


### PR DESCRIPTION
Expose the `workspace` prop to Konnect.

The `workspace` prop used to be available only in Kong Manager. We’re now introducing it to Konnect as well, so users can specify which `(control plane, workspace)` they want to work with when using Konnect.

Because this is a big change that affects all core entities, we’re first rolling it out in the `entities-shared` and `entities-gateway-services` packages, and then propagating it to the rest of the codebase. It's safe because the `workspace` prop is still optional and will not take any effect when not specified.

Tests were added to cover the new workspace prop in both entities-shared and entities-gateway-services.

JIRA: KM-2445