### PR TITLE
feat(analytics): display metric names in single value chart [MA-4926]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
@@ -174,17 +174,29 @@ describe('<SingleValue />', () => {
       },
     })
 
+    const getBaseline = (el: HTMLElement) => {
+      const range = document.createRange()
+      range.selectNodeContents(el)
+      const rects = range.getClientRects()
+      return rects[rects.length - 1].bottom
+    }
+
     // Verify value and unit appear horizontally, not stacked vertically
     cy.get('.single-value').then($value => {
       cy.get('.single-value-unit').then($unit => {
         const valueRect = $value[0].getBoundingClientRect()
         const unitRect = $unit[0].getBoundingClientRect()
 
-        // With baseline alignment, bottoms should be identical
-        expect(Math.abs(valueRect.bottom - unitRect.bottom)).to.equal(1)
+        const valueBaseline = getBaseline($value[0])
+        const unitBaseline = getBaseline($unit[0])
 
         // Unit should start after the value horizontally, not below it
         expect(unitRect.left).to.be.greaterThan(valueRect.left)
+
+        // Baselines of selections are sometimes as different as 3 pixels. This
+        // doesn't mean the text isn't aligned, it just means there are rendering
+        // differences depending on the relative font sizes and glyphs used.
+        expect(Math.abs(valueBaseline - unitBaseline)).to.be.lessThan(3)
       })
     })
   })

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
@@ -16,18 +16,23 @@
       class="single-value-wrapper"
     >
       <div class="single-value-metric">
-        <span
-          class="single-value"
-          data-testid="single-value-chart"
-        >
-          {{ formattedValue }}
-        </span>
-        <span
-          v-if="displayMetricUnit && metricUnit"
-          class="single-value-unit"
-        >
-          &nbsp;{{ metricUnit }}
-        </span>
+        <div class="name-unit-alignment">
+          <span
+            class="single-value"
+            data-testid="single-value-chart"
+          >
+            {{ formattedValue }}
+          </span>
+          <span
+            v-if="displayMetricUnit && metricUnit"
+            class="single-value-unit"
+          >
+            &nbsp;{{ metricUnit }}
+          </span>
+        </div>
+        <div class="single-value-metric-name">
+          {{ formattedMetricName }}
+        </div>
       </div>
       <div
         v-if="showTrend"
@@ -118,6 +123,11 @@ const alignmentClass = computed(() => `align-${props.leftAlign ? 'left' : props.
 
 const records = computed<AnalyticsExploreRecord[]>(() => props.data.data)
 const metricName = computed((): AllAggregations | undefined => props.data.meta?.metric_names?.[0])
+const formattedMetricName = computed((): string => {
+  return i18n.te(`chartLabels.${metricName.value}` as any)
+    ? i18n.t(`chartLabels.${metricName.value}` as any)
+    : ''
+})
 const metricUnit = computed((): string | undefined => {
   const unit = metricName.value ? props.data.meta?.metric_units?.[metricName.value] : undefined
   if (unit) {
@@ -278,14 +288,21 @@ onMounted(() => {
   }
 
   .single-value-wrapper {
-    align-items: baseline;
     display: flex;
     flex-direction: column;
     gap: 12px;
+    margin-top: -4px; // to account for .tile-content top padding :(
 
     .single-value-metric {
-      align-items: baseline;
-      display: inline-flex;
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .single-value-metric-name {
+      color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+      font-size: var(--kui-font-size-10, $kui-font-size-10);
+      line-height: var(--kui-line-height-10, $kui-line-height-10);
     }
 
     .single-value {
@@ -353,6 +370,11 @@ onMounted(() => {
         font-size: var(--kui-font-size-90, $kui-font-size-90);
         line-height: var(--kui-line-height-90, $kui-line-height-90);
       }
+
+      .single-value-metric-name {
+        font-size: var(--kui-font-size-10, $kui-font-size-10);
+        line-height: var(--kui-line-height-10, $kui-line-height-10);
+      }
     }
 
     @container (min-width: 500px) {
@@ -364,6 +386,11 @@ onMounted(() => {
       .single-value-unit {
         font-size: var(--kui-font-size-100, $kui-font-size-100);
         line-height: var(--kui-line-height-100, $kui-line-height-100);
+      }
+
+      .single-value-metric-name {
+        font-size: var(--kui-font-size-20, $kui-font-size-20);
+        line-height: var(--kui-line-height-20, $kui-line-height-20);
       }
     }
 
@@ -377,6 +404,11 @@ onMounted(() => {
         font-size: 56px;
         line-height: 64px;
       }
+
+      .single-value-metric-name {
+        font-size: var(--kui-font-size-20, $kui-font-size-20);
+        line-height: var(--kui-line-height-20, $kui-line-height-20);
+      }
     }
 
     @container (min-width: 1000px) {
@@ -389,6 +421,11 @@ onMounted(() => {
         font-size: 64px;
         line-height: 72px;
       }
+
+      .single-value-metric-name {
+        font-size: var(--kui-font-size-40, $kui-font-size-40);
+        line-height: var(--kui-line-height-40, $kui-line-height-40);
+      }
     }
 
     @container (min-width: 1200px) {
@@ -400,6 +437,11 @@ onMounted(() => {
       .single-value-unit {
         font-size: 80px;
         line-height: 88px;
+      }
+
+      .single-value-metric-name {
+        font-size: var(--kui-font-size-40, $kui-font-size-40);
+        line-height: var(--kui-line-height-40, $kui-line-height-40);
       }
     }
   }


### PR DESCRIPTION
Satisfies [MA-4926](https://konghq.atlassian.net/browse/MA-4926)

# Summary

Metric names aren't displayed in single value chart. This makes some metrics EXTREMELY confusing without additional context.

### Screenshots

**Before**

<img width="1915" height="966" alt="Screenshot 2026-04-09 at 6 36 28 PM" src="https://github.com/user-attachments/assets/6b48b33e-5c8a-4e9c-a496-185abba88512" />

**After**

<img width="1917" height="963" alt="Screenshot 2026-04-09 at 6 04 46 PM" src="https://github.com/user-attachments/assets/2021aabe-58e8-48e3-8171-bfa8ece31bdf" />

[MA-4926]: https://konghq.atlassian.net/browse/MA-4926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ