### PR TITLE
fix(entities-plugins): convert existing consumer_claim to consumer_claims

### DIFF
--- a/packages/core/forms/src/components/forms/OIDCForm.vue
+++ b/packages/core/forms/src/components/forms/OIDCForm.vue
@@ -368,6 +368,18 @@ export default {
             }
           }
         }
+
+        // Migrate deprecated consumer_claim → consumer_claims
+        // consumer_claim is string[], consumer_claims is string[][]
+        const deprecatedValue = this.formModel['config-consumer_claim']
+        if (deprecatedValue !== undefined && deprecatedValue !== null && deprecatedValue !== '') {
+          if (!this.formModel['config-consumer_claims'] || this.formModel['config-consumer_claims'].length === 0) {
+            const claimArray = Array.isArray(deprecatedValue) ? deprecatedValue : [deprecatedValue]
+            // eslint-disable-next-line vue/no-mutating-props
+            this.formModel['config-consumer_claims'] = [claimArray]
+            this.onModelUpdated()
+          }
+        }
       }
     },
     getAuthMethodsValue(prop, evt) {

--- a/packages/core/forms/src/components/forms/__tests__/OIDCForm.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCForm.spec.ts
@@ -1,19 +1,111 @@
 // Vitest unit test spec file
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import OIDCForm from '../OIDCForm.vue'
 import { OIDCFormSchema, OIDCModel } from './OIDCSchema'
+
+const baseProps = {
+  formSchema: OIDCFormSchema,
+  isEditing: false,
+  onPartialToggled: vi.fn(),
+}
 
 describe('<PluginForms />', () => {
   it('renders', () => {
     const wrapper = mount(OIDCForm, {
       props: {
-        formSchema: OIDCFormSchema,
-        formModel: OIDCModel,
+        ...baseProps,
+        formModel: { ...OIDCModel },
+        onModelUpdated: vi.fn(),
       },
     })
 
     expect(wrapper.isVisible()).toBe(true)
+  })
+
+  describe('consumer_claim deprecation migration', () => {
+    it('copies config-consumer_claim into config-consumer_claims when consumer_claims is empty, preserving the original', () => {
+      const onModelUpdated = vi.fn()
+      const formModel = {
+        ...OIDCModel,
+        'config-consumer_claim': ['sub'],
+        'config-consumer_claims': null,
+      }
+
+      mount(OIDCForm, {
+        props: {
+          ...baseProps,
+          formModel,
+          onModelUpdated,
+        },
+      })
+
+      // deprecated field is preserved so it is included in the submitted payload
+      expect(formModel['config-consumer_claim']).toEqual(['sub'])
+      // consumer_claims is string[][] — the claim array is wrapped in an outer array
+      expect(formModel['config-consumer_claims']).toEqual([['sub']])
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+
+    it('wraps a string value from config-consumer_claim into string[][]', () => {
+      const onModelUpdated = vi.fn()
+      const formModel = {
+        ...OIDCModel,
+        'config-consumer_claim': 'sub',
+        'config-consumer_claims': null,
+      }
+
+      mount(OIDCForm, {
+        props: {
+          ...baseProps,
+          formModel,
+          onModelUpdated,
+        },
+      })
+
+      expect(formModel['config-consumer_claims']).toEqual([['sub']])
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+
+    it('does not overwrite existing config-consumer_claims', () => {
+      const onModelUpdated = vi.fn()
+      const formModel = {
+        ...OIDCModel,
+        'config-consumer_claim': ['sub'],
+        'config-consumer_claims': ['username'],
+      }
+
+      mount(OIDCForm, {
+        props: {
+          ...baseProps,
+          formModel,
+          onModelUpdated,
+        },
+      })
+
+      expect(formModel['config-consumer_claims']).toEqual(['username'])
+    })
+
+    it('does not call onModelUpdated when config-consumer_claim is null', () => {
+      const onModelUpdated = vi.fn()
+      const formModel = {
+        ...OIDCModel,
+        'config-consumer_claim': null,
+        'config-consumer_claims': null,
+      }
+
+      mount(OIDCForm, {
+        props: {
+          ...baseProps,
+          formModel,
+          onModelUpdated,
+        },
+      })
+
+      expect(formModel['config-consumer_claims']).toBeNull()
+      // onModelUpdated may still be called for other reasons (auth_methods etc.), so we
+      // only verify consumer_claims was not populated
+    })
   })
 })


### PR DESCRIPTION
# Summary

On form init, if config-consumer_claim has a value and config-consumer_claims is empty, automatically populate consumer_claims with the deprecated value wrapped in an outer array (string[] → string[][])
The original consumer_claim value is not passed in payload because it's in shorthand_fields and marked deprecated
Adds unit tests covering array migration, string normalization, no-overwrite, and null cases

# Why
consumer_claim is deprecated in favor of consumer_claims but existing users may have data stored under the old field. Without this migration the UI would render an empty consumer_claims field and discard consumer_claim field even when data exists.