### PR TITLE
fix(page-layout): recompute overflow when tabs change

### DIFF
--- a/packages/core/page-layout/src/components/PageLayoutTabs.cy.ts
+++ b/packages/core/page-layout/src/components/PageLayoutTabs.cy.ts
@@ -1,6 +1,7 @@
 import PageLayoutTabs from './PageLayoutTabs.vue'
 import { defineComponent, h, ref, type Ref } from 'vue'
 import { createRouter, createMemoryHistory } from 'vue-router'
+import type { PageLayoutTab } from '../types'
 
 const router = createRouter({
   history: createMemoryHistory(),
@@ -104,12 +105,12 @@ describe('<PageLayoutTabs />', () => {
   })
 
   it('recomputes the tab layout when tabs are pushed into the existing array', () => {
-    const initialTabs = [
+    const initialTabs: PageLayoutTab[] = [
       { key: 'tab1', label: 'Tab 1', to: '/tab1' },
       { key: 'tab2', label: 'Tab 2', to: '/tab2' },
     ]
 
-    const tabsToAppend = [
+    const tabsToAppend: PageLayoutTab[] = [
       { key: 'tab3', label: 'Tab 3', to: '/tab3' },
       { key: 'tab4', label: 'Tab 4', to: '/tab4' },
       { key: 'tab5', label: 'Tab 5', to: '/tab5' },
@@ -120,14 +121,10 @@ describe('<PageLayoutTabs />', () => {
 
     cy.viewport(300, 400)
 
-    let tabsRef!: Ref<typeof initialTabs>
+    const tabsRef: Ref<PageLayoutTab[]> = ref([...initialTabs])
 
     cy.mount(defineComponent({
-      setup() {
-        tabsRef = ref([...initialTabs])
-
-        return () => h(PageLayoutTabs, { tabs: tabsRef.value })
-      },
+      setup: () => () => h(PageLayoutTabs, { tabs: tabsRef.value }),
     }))
 
     cy.getTestId('tabs-overflow-dropdown-button').should('not.exist')

--- a/packages/core/page-layout/src/components/PageLayoutTabs.cy.ts
+++ b/packages/core/page-layout/src/components/PageLayoutTabs.cy.ts
@@ -1,4 +1,5 @@
 import PageLayoutTabs from './PageLayoutTabs.vue'
+import { defineComponent, h, ref, type Ref } from 'vue'
 import { createRouter, createMemoryHistory } from 'vue-router'
 
 const router = createRouter({
@@ -98,6 +99,42 @@ describe('<PageLayoutTabs />', () => {
     cy.getTestId('tabs-overflow-dropdown-button').should('not.exist')
 
     cy.then(() => vueWrapper.setProps({ tabs: manyTabs }))
+
+    cy.getTestId('tabs-overflow-dropdown-button').should('be.visible')
+  })
+
+  it('recomputes the tab layout when tabs are pushed into the existing array', () => {
+    const initialTabs = [
+      { key: 'tab1', label: 'Tab 1', to: '/tab1' },
+      { key: 'tab2', label: 'Tab 2', to: '/tab2' },
+    ]
+
+    const tabsToAppend = [
+      { key: 'tab3', label: 'Tab 3', to: '/tab3' },
+      { key: 'tab4', label: 'Tab 4', to: '/tab4' },
+      { key: 'tab5', label: 'Tab 5', to: '/tab5' },
+      { key: 'tab6', label: 'Tab 6', to: '/tab6' },
+      { key: 'tab7', label: 'Tab 7', to: '/tab7' },
+      { key: 'tab8', label: 'Tab 8', to: '/tab8' },
+    ]
+
+    cy.viewport(300, 400)
+
+    let tabsRef!: Ref<typeof initialTabs>
+
+    cy.mount(defineComponent({
+      setup() {
+        tabsRef = ref([...initialTabs])
+
+        return () => h(PageLayoutTabs, { tabs: tabsRef.value })
+      },
+    }))
+
+    cy.getTestId('tabs-overflow-dropdown-button').should('not.exist')
+
+    cy.then(() => {
+      tabsRef.value.push(...tabsToAppend)
+    })
 
     cy.getTestId('tabs-overflow-dropdown-button').should('be.visible')
   })

--- a/packages/core/page-layout/src/components/PageLayoutTabs.vue
+++ b/packages/core/page-layout/src/components/PageLayoutTabs.vue
@@ -187,7 +187,7 @@ onBeforeUnmount(() => {
 
 watch(() => tabs, () => {
   computeTabLayoutOverflow()
-})
+}, { deep: true })
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
# Summary

[KM-2500]

`PageLayoutTabs` should deep watch `tabs` to correctly trigger layout recalculation.

<img width="166" height="47" alt="image" src="https://github.com/user-attachments/assets/235a4190-512d-45ef-990a-09369450f64e" />

[KM-2500]: https://konghq.atlassian.net/browse/KM-2500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ