### PR TITLE
fix(deps): use range constraint for kongponents peerDependency

### DIFF
--- a/packages/core/page-layout/package.json
+++ b/packages/core/page-layout/package.json
@@ -66,7 +66,7 @@
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.48.0",
-    "@kong/kongponents": "9.52.5",
+    "@kong/kongponents": "^9.52.5",
     "vue": "^3.5.27",
     "vue-router": "^4.6.4"
   },


### PR DESCRIPTION
# Summary

We are unable to install `@kong-ui-public/page-layout` correctly because it specifies the host application MUST have EXACTLY version `9.52.5` installed. Our application is using `9.52.9` (using a range query)

Adding the caret should resolve this for all consumers.


