### PR TITLE
fix(freeform): pre-select developer consumer id

### DIFF
--- a/packages/core/forms/src/components/fields/FieldScopedEntitySelect.vue
+++ b/packages/core/forms/src/components/fields/FieldScopedEntitySelect.vue
@@ -109,7 +109,6 @@ const {
   fields?: string[]
   selectedItem?: SelectItem<string>
   selectedItemLoading?: boolean
-  initialItemSelected?: boolean
   domId: string
   id: string
   entity: string

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -13,6 +13,7 @@
       <component
         :is="freeformComponent"
         v-if="freeformComponent"
+        :developer="developer"
         :field-renderers="pluginConfig?.fieldRenderers"
         :form-model="formModel"
         :form-schema="formSchema"
@@ -236,6 +237,12 @@ const props = defineProps({
     type: String as PropType<'vfg' | 'freeform'>,
     required: false,
     default: undefined,
+  },
+
+  /** For Kong Manager portal developers */
+  developer: {
+    type: Boolean,
+    default: false,
   },
 })
 

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -47,6 +47,7 @@
       <PluginEntityForm
         :config="config"
         :credential="treatAsCredential"
+        :developer="developer"
         :editing="formType === EntityBaseFormType.Edit"
         :enable-redis-partial="enableRedisPartial"
         :enable-vault-secret-picker="props.enableVaultSecretPicker"

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ScopeEntityField.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ScopeEntityField.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { h, defineComponent } from 'vue'
+import { FORMS_API_KEY } from '@kong-ui-public/forms'
+import Form from './Form.vue'
+import ScopeEntityField from './ScopeEntityField.vue'
+
+const CONSUMER_ID = 'test-consumer-uuid'
+
+const schema = {
+  type: 'record' as const,
+  fields: [
+    { consumer: { type: 'foreign' as const, reference: 'consumers' } },
+  ],
+}
+
+const FieldScopedEntitySelectStub = defineComponent({
+  name: 'FieldScopedEntitySelect',
+  props: {
+    selectedItem: { default: undefined },
+    selectedItemLoading: Boolean,
+    initialItemSelected: Boolean,
+    id: String,
+    disabled: Boolean,
+    domId: String,
+    entity: String,
+    fieldDisabled: Boolean,
+    fields: Array,
+    labelField: String,
+    placeholder: String,
+    allowUuidSearch: Boolean,
+  },
+  emits: ['change'],
+  template: '<div data-testid="entity-select" />',
+})
+
+function createWrapper(developer?: boolean, apiStatus: 200 | 404 = 404) {
+  const mockApi = {
+    getOne: vi.fn().mockResolvedValue({
+      status: apiStatus,
+      data: apiStatus === 200
+        ? { id: CONSUMER_ID, username: 'test-user' }
+        : {},
+    }),
+  }
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () => h(
+        Form,
+        { schema, data: { consumer: { id: CONSUMER_ID } } },
+        { default: () => h(ScopeEntityField, { name: 'consumer', entity: 'consumers', developer }) },
+      )
+    },
+  })
+
+  const wrapper = mount(Wrapper, {
+    global: {
+      provide: { [FORMS_API_KEY]: mockApi },
+      stubs: { FieldScopedEntitySelect: FieldScopedEntitySelectStub, KLabel: true },
+    },
+  })
+
+  return { wrapper, mockApi }
+}
+
+describe('ScopeEntityField', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('fetches and displays the entity when found (200)', async () => {
+    const { wrapper } = createWrapper(false, 200)
+    await flushPromises()
+
+    const stub = wrapper.findComponent(FieldScopedEntitySelectStub)
+    expect(stub.props('selectedItem')).toMatchObject({ value: CONSUMER_ID })
+  })
+
+  it('clears selectedItem when entity not found (404) and developer=false', async () => {
+    const { wrapper } = createWrapper(false, 404)
+    await flushPromises()
+
+    const stub = wrapper.findComponent(FieldScopedEntitySelectStub)
+    expect(stub.props('selectedItem')).toBeUndefined()
+  })
+
+  it('uses id as fallback selectedItem when entity not found (404) and developer=true', async () => {
+    const { wrapper } = createWrapper(true, 404)
+    await flushPromises()
+
+    const stub = wrapper.findComponent(FieldScopedEntitySelectStub)
+    expect(stub.props('selectedItem')).toEqual({ label: CONSUMER_ID, value: CONSUMER_ID })
+  })
+
+})

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ScopeEntityField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ScopeEntityField.vue
@@ -62,6 +62,8 @@ interface ScopeEntityFieldProps extends BaseFieldProps {
   placeholder?: string
   help?: string
   disabled?: boolean
+  /** Whether the plugin is being created for a portal developer (consumer may not appear in consumers API) */
+  developer?: boolean
 }
 
 const {
@@ -72,6 +74,7 @@ const {
   disabled,
   placeholder,
   help,
+  developer,
   ...props
 } = defineProps<ScopeEntityFieldProps>()
 
@@ -108,6 +111,13 @@ onMounted(async () => {
       validateStatus: (status: number) => (status >= 200 && status < 300) || status === 404,
     })
     if (res.status === 404) {
+      if (developer) {
+        // Developer consumers may not appear in the consumers API; use the known ID as fallback
+        const item: SelectItem<string> = { label: currentId, value: currentId }
+        initialItem.value = item
+        selectedItem.value = item
+        return
+      }
       throw new Error(`Entity of type ${entity} with id ${currentId} not found`)
     }
     const entityData: EntityData = res.data

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ScopeEntityField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ScopeEntityField.vue
@@ -19,7 +19,6 @@
       :entity="entity"
       :field-disabled="disabled"
       :fields="searchFields"
-      :initial-item-selected="initialValueSelected"
       :label-field="labelField"
       :placeholder="loading ? t('actions.loading_spinner') : (placeholder || fieldAttrs.placeholder)"
       :selected-item="selectedItem"
@@ -96,10 +95,6 @@ const allowUuidSearch = computed(() => fields.includes('id'))
 // --- Edit mode: fetch the currently selected entity ---
 const loading = ref(false)
 const selectedItem = ref<SelectItem<string> | undefined>()
-const initialItem = ref<SelectItem<string> | undefined>()
-const initialValueSelected = computed(() => {
-  return (fieldValue?.value?.id ?? '') === (initialItem.value?.value ?? '')
-})
 
 onMounted(async () => {
   const currentId = fieldValue?.value?.id
@@ -114,7 +109,6 @@ onMounted(async () => {
       if (developer) {
         // Developer consumers may not appear in the consumers API; use the known ID as fallback
         const item: SelectItem<string> = { label: currentId, value: currentId }
-        initialItem.value = item
         selectedItem.value = item
         return
       }
@@ -126,7 +120,6 @@ onMounted(async () => {
       label: entityData[labelField] ?? entityData.id,
       value: entityData.id,
     }
-    initialItem.value = item
     selectedItem.value = item
   } catch (err) {
     console.error('Failed to load selected entity:', err)

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -82,6 +82,7 @@
           <ScopeEntityField
             v-for="scopeField in scopeEntityFields"
             :key="scopeField.name"
+            :developer="developer"
             :disabled="scopeField.disabled"
             :disabled-tooltip="scopeField.disabledTooltip"
             :entity="scopeField.entity"
@@ -230,6 +231,8 @@ export type Props<T extends FreeFormPluginData = any> = {
   pluginName: string
   /** Konnect-managed Redis UI, from plugin form config */
   isKonnectManagedRedisEnabled?: boolean
+  /** Whether the plugin is being created for a portal developer */
+  developer?: boolean
 }
 </script>
 


### PR DESCRIPTION
# Summary

KM-2595

`ScopeEntityField.vue` — add developer prop; tolerate 404 by using the entity ID as a fallback label instead of nulling the field
`StandardLayout.vue` — add developer to Props; pass it to each `ScopeEntityField`
`PluginEntityForm.vue` — add developer to defineProps; pass it to the freeform component
`PluginForm.vue` — pass :developer="developer" to `PluginEntityForm`
`ScopeEntityField.spec.ts `— new unit tests covering the 200, developer+404, and non-developer+404 cases