### PR TITLE
fix(plugins-endpoints): adjust called url [KOKO-3398]

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -1036,7 +1036,7 @@ describe('<PluginForm />', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/schemas/core-entities/plugins/*`,
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/schemas/plugins/*`,
         },
         {
           statusCode: 200,
@@ -1764,7 +1764,7 @@ describe('<PluginForm />', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/schemas/core-entities/plugins/cors`,
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/schemas/plugins/cors`,
         },
         {
           statusCode: 500,
@@ -1922,7 +1922,7 @@ describe('<PluginForm />', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/schemas/core-entities/plugins/*`,
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/schemas/plugins/*`,
         },
         {
           statusCode: 200,

--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -1037,7 +1037,7 @@ describe('<PluginForm />', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/schemas/core-entities/plugins/*`,
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/schemas/plugins/*`,
         },
         {
           statusCode: 200,
@@ -1770,7 +1770,7 @@ describe('<PluginForm />', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/schemas/core-entities/plugins/cors`,
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/schemas/plugins/cors`,
         },
         {
           statusCode: 500,
@@ -1972,7 +1972,7 @@ describe('<PluginForm />', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/schemas/core-entities/plugins/*`,
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/schemas/plugins/*`,
         },
         {
           statusCode: 200,

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -34,12 +34,12 @@ export default {
         all: `${konnectBaseApiUrl}/plugins/{id}`,
         forEntity: `${konnectBaseApiUrl}/{entityType}/{entityId}/plugins/{id}`,
       },
-      pluginSchema: '/v2/control-planes/{controlPlaneId}/schemas/core-entities/plugins/{plugin}',
+      pluginSchema: '/v2/control-planes/{controlPlaneId}/core-entities/schemas/plugins/{plugin}',
       credential: {
         create: `${konnectBaseApiUrl}/{resourceEndpoint}`,
         edit: `${konnectBaseApiUrl}/{resourceEndpoint}/{id}`,
       },
-      credentialSchema: '/v2/control-planes/{controlPlaneId}/schemas/core-entities/{plugin}',
+      credentialSchema: '/v2/control-planes/{controlPlaneId}/core-entities/schemas/{plugin}',
       // VFG endpoints24
       entityGetOne: `${konnectBaseApiUrl}/{entity}/{id}`,
       entityGetAll: `${konnectBaseApiUrl}/{entity}`,

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -38,12 +38,12 @@ export default {
         all: `${konnectBaseApiUrl}/plugins/{id}`,
         forEntity: `${konnectBaseApiUrl}/{entityType}/{entityId}/plugins/{id}`,
       },
-      pluginSchema: '/v2/control-planes/{controlPlaneId}/schemas/core-entities/plugins/{plugin}',
+      pluginSchema: '/v2/control-planes/{controlPlaneId}/core-entities/schemas/plugins/{plugin}',
       credential: {
         create: `${konnectBaseApiUrl}/{resourceEndpoint}`,
         edit: `${konnectBaseApiUrl}/{resourceEndpoint}/{id}`,
       },
-      credentialSchema: '/v2/control-planes/{controlPlaneId}/schemas/core-entities/{plugin}',
+      credentialSchema: '/v2/control-planes/{controlPlaneId}/core-entities/schemas/{plugin}',
       // VFG endpoints24
       entityGetOne: `${konnectBaseApiUrl}/{entity}/{id}`,
       entityGetAll: `${konnectBaseApiUrl}/{entity}`,


### PR DESCRIPTION
# Summary

This PR changes the following endpoints from:

- /v2/control-planes/{controlPlaneId}/**schemas/core-entities**/plugins/{plugin} -> /v2/control-planes/{controlPlaneId}/**core-entities/schemas**/plugins/{plugin}
- /v2/control-planes/{controlPlaneId}/**schemas/core-entities**/{plugin} -> /v2/control-planes/{controlPlaneId}/**core-entities/schemas**/{plugin}

First change ref:  https://developer.konghq.com/api/konnect/control-planes-config/v2/#/operations/fetch-plugin-schema (Get plugin schema)

<img width="1854" height="475" alt="image" src="https://github.com/user-attachments/assets/b420184e-0a5e-4721-8491-b351c5402111" />

Second change: This endpoint seems to never get called, this endpoint might be called if `treatAsCredential` is true, which would require `props.config.entityId` to be provided, but entityId is always commented:

- https://github.com/Kong/public-ui-components/blob/74ca9d142fc0db70a90485003e84576c66385df4/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue#L102
- https://github.com/Kong/public-ui-components/blob/74ca9d142fc0db70a90485003e84576c66385df4/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue#L120
- https://github.com/Kong/public-ui-components/blob/73d690d7be1d19fab7cfbadf28a325cb3eb9eeb4/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue#L160
- https://github.com/Kong/public-ui-components/blob/73d690d7be1d19fab7cfbadf28a325cb3eb9eeb4/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue#L175


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
--> 