### PR TITLE
feat(entities-gateway-services): add isTlsSansSupported

### DIFF
--- a/packages/entities/entities-gateway-services/docs/gateway-service-form.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-form.md
@@ -86,6 +86,15 @@ If showing the `Edit` type form, the ID of the Gateway Service.
 
 Show/hide `EntityFormSection` component info column.
 
+#### `isTlsSansSupported`
+
+- type: `Boolean`
+- required: `false`
+- default: `true`
+
+Controls whether `tls_sans` input fields are rendered and included in payload generation.
+When set to `false`, `tls_sans` fields are hidden and emitted payload sets `tls_sans` to `undefined`.
+
 ### Slots
 
 #### `form-actions`

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.cy.ts
@@ -378,6 +378,31 @@ describe('<GatewayServiceForm />', { viewportHeight: 800, viewportWidth: 700 }, 
       cy.getTestId('tls-sans-uris-input-0').should('have.value', 'spiffe://example.com/service')
     })
 
+    it('should hide tls_sans fields and emit tls_sans as undefined when isTlsSansSupported is false', () => {
+      cy.mount(GatewayServiceForm, {
+        props: {
+          config: baseConfigKonnect,
+          isTlsSansSupported: false,
+          onModelUpdated: cy.spy().as('onModelUpdatedSpy'),
+        },
+      })
+
+      cy.get('.kong-ui-entities-gateway-service-form').should('be.visible')
+      cy.getTestId('gateway-service-protocol-radio').click()
+      cy.getTestId('gateway-service-protocol-select').click()
+      cy.getTestId('select-item-https').click()
+      cy.getTestId('advanced-fields-collapse').findTestId('collapse-trigger-content').click()
+
+      cy.getTestId('gateway-service-tls-sans-dnsnames').should('not.exist')
+      cy.getTestId('gateway-service-tls-sans-uris').should('not.exist')
+
+      cy.get('@onModelUpdatedSpy').should('have.been.called')
+      cy.get('@onModelUpdatedSpy').then((spy: any) => {
+        const lastCall = spy.lastCall.args[0]
+        expect(lastCall.tls_sans).to.equal(undefined)
+      })
+    })
+
     it('should correctly pass getPayload as props to json/yaml code blocks', () => {
       interceptKonnect()
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -286,7 +286,7 @@
               </div>
 
               <GatewayServiceFormTlsSansField
-                v-if="showTlsFields"
+                v-if="showTlsFields && isTlsSansSupported"
                 v-model="form.fields.tls_sans.dnsnames"
                 :add-button-text="t('gateway_services.form.fields.tls_sans_dnsnames.add')"
                 class="gateway-service-form-margin-bottom"
@@ -301,7 +301,7 @@
               />
 
               <GatewayServiceFormTlsSansField
-                v-if="showTlsFields"
+                v-if="showTlsFields && isTlsSansSupported"
                 v-model="form.fields.tls_sans.uris"
                 :add-button-text="t('gateway_services.form.fields.tls_sans_uris.add')"
                 class="gateway-service-form-margin-bottom"
@@ -540,6 +540,12 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+  /** Whether tls_sans fields are supported */
+  isTlsSansSupported: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
 })
 
@@ -991,6 +997,14 @@ const submitUrl = computed<string>(() => {
 })
 
 const tlsSansPayload = computed(() => {
+  if (!props.isTlsSansSupported) {
+    return undefined
+  }
+
+  if (!showTlsFields.value) {
+    return null
+  }
+
   const dnsnames = form.fields.tls_sans.dnsnames.map(s => s.trim()).filter(Boolean)
   const uris = form.fields.tls_sans.uris.map(s => s.trim()).filter(Boolean)
   if (dnsnames.length || uris.length) {
@@ -1023,7 +1037,6 @@ const getPayload = computed((): Record<string, any> => {
 
   if (!showTlsFields.value) {
     requestBody.client_certificate = null
-    requestBody.tls_sans = null
   }
 
   if (form.fields.tls_verify_enabled && ['https', 'wss', 'tls'].includes(form.fields.protocol)) {


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Kong Manager OSS does not recognize `tls_sans`, so we need the ability to control whether this field is rendered and included in the payload. This PR introduces a new prop, which defaults to `true`, so that Kong Manager EE and Konnect code do not need to be updated.

<img width="1920" height="1080" alt="test-failed-1" src="https://github.com/user-attachments/assets/0b2d8121-7d45-437f-8b8a-c7e418f18d47" />

KM-2495