### PR TITLE
chore(entities-plugins): metering&billing improvements

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.cy.ts
@@ -46,8 +46,13 @@ const mountForm = (options: {
   isEditing?: boolean
   model?: Record<string, any>
   geoApiServerUrl?: string
+  app?: 'konnect' | 'kongManager'
 }) => {
-  const { isEditing = false, model = {}, geoApiServerUrl } = options
+  const { isEditing = false, model = {}, geoApiServerUrl, app = 'konnect' } = options
+
+  const formsConfig = app === 'konnect'
+    ? { app: 'konnect' as const, apiBaseUrl: '/us/kong-api', controlPlaneId: '123', ...(geoApiServerUrl ? { geoApiServerUrl } : {}) }
+    : { app: 'kongManager' as const, apiBaseUrl: '/kong-manager' }
 
   cy.mount(MeteringAndBillingForm, {
     props: {
@@ -58,16 +63,10 @@ const mountForm = (options: {
       isEditing,
       pluginName: 'metering-and-billing',
       onFormChange: cy.spy().as('onFormChange'),
-      onValidityChange: cy.spy().as('onValidityChange'),
     },
     global: {
       provide: {
-        [FORMS_CONFIG]: {
-          app: 'konnect' as const,
-          apiBaseUrl: '/us/kong-api',
-          controlPlaneId: '123',
-          ...(geoApiServerUrl ? { geoApiServerUrl } : {}),
-        },
+        [FORMS_CONFIG]: formsConfig,
       },
     },
   })
@@ -103,5 +102,11 @@ describe('MeteringAndBillingForm - ingest_endpoint prefill', () => {
     })
 
     cy.getTestId('ff-config.ingest_endpoint').should('have.value', 'https://custom.example.com/events')
+  })
+
+  it('does not prefill ingest_endpoint in Kong Manager', () => {
+    mountForm({ app: 'kongManager' })
+
+    cy.getTestId('ff-config.ingest_endpoint').should('have.value', '')
   })
 })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.cy.ts
@@ -73,22 +73,17 @@ const mountForm = (options: {
   })
 }
 
-const getIngestEndpointInput = () =>
-  cy.get('[data-testid="ff-config.ingest_endpoint"] input')
-
 describe('MeteringAndBillingForm - ingest_endpoint prefill', () => {
   it('prefills with region-based URL when geoApiServerUrl is available', () => {
     mountForm({ geoApiServerUrl: 'https://us.api.konghq.com' })
 
-    getIngestEndpointInput()
-      .should('have.value', 'https://us.api.konghq.com/v3/openmeter/events')
+    cy.getTestId('ff-config.ingest_endpoint').should('have.value', 'https://us.api.konghq.com/v3/openmeter/events')
   })
 
   it('prefills with {{region}} placeholder when geoApiServerUrl is not available', () => {
     mountForm({})
 
-    getIngestEndpointInput()
-      .should('have.value', 'https://{{region}}.api.konghq.com/v3/openmeter/events')
+    cy.getTestId('ff-config.ingest_endpoint').should('have.value', 'https://{{region}}.api.konghq.com/v3/openmeter/events')
   })
 
   it('does not overwrite an existing ingest_endpoint in create mode', () => {
@@ -97,8 +92,7 @@ describe('MeteringAndBillingForm - ingest_endpoint prefill', () => {
       geoApiServerUrl: 'https://us.api.konghq.com',
     })
 
-    getIngestEndpointInput()
-      .should('have.value', 'https://custom.example.com/events')
+    cy.getTestId('ff-config.ingest_endpoint').should('have.value', 'https://custom.example.com/events')
   })
 
   it('does not overwrite an existing ingest_endpoint in edit mode', () => {
@@ -108,7 +102,6 @@ describe('MeteringAndBillingForm - ingest_endpoint prefill', () => {
       geoApiServerUrl: 'https://us.api.konghq.com',
     })
 
-    getIngestEndpointInput()
-      .should('have.value', 'https://custom.example.com/events')
+    cy.getTestId('ff-config.ingest_endpoint').should('have.value', 'https://custom.example.com/events')
   })
 })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.cy.ts
@@ -1,0 +1,114 @@
+import MeteringAndBillingForm from './MeteringAndBillingForm.vue'
+import { FORMS_CONFIG } from '@kong-ui-public/forms'
+import type { FormSchema } from '../../../../types/plugins/form-schema'
+
+const createSchema = (): FormSchema => ({
+  type: 'record',
+  fields: [{
+    config: {
+      type: 'record',
+      required: true,
+      fields: [
+        { ingest_endpoint: { type: 'string' } },
+        { api_token: { type: 'string' } },
+        { meter_api_requests: { type: 'boolean', default: true } },
+        { meter_ai_token_usage: { type: 'boolean', default: false } },
+        { ssl_verify: { type: 'boolean', default: true } },
+        { timeout: { type: 'integer', default: 10000 } },
+        { keepalive: { type: 'integer', default: 60000 } },
+        {
+          subject: {
+            type: 'record',
+            fields: [
+              { look_up_value_in: { type: 'string', one_of: ['header', 'query', 'uri_captures', 'shared_variables', 'route_tags'] } },
+              { field: { type: 'string' } },
+            ],
+          },
+        },
+        {
+          queue: {
+            type: 'record',
+            fields: [
+              { max_coalescing_delay: { type: 'number' } },
+              { initial_retry_delay: { type: 'number' } },
+              { max_retry_delay: { type: 'number' } },
+              { max_retry_time: { type: 'number' } },
+            ],
+          },
+        },
+        { attributes: { type: 'array', elements: { type: 'record', fields: [{ look_up_value_in: { type: 'string' } }, { event_property_name: { type: 'string' } }] } } },
+      ],
+    },
+  }],
+})
+
+const mountForm = (options: {
+  isEditing?: boolean
+  model?: Record<string, any>
+  geoApiServerUrl?: string
+}) => {
+  const { isEditing = false, model = {}, geoApiServerUrl } = options
+
+  cy.mount(MeteringAndBillingForm, {
+    props: {
+      schema: createSchema(),
+      formSchema: {},
+      formModel: {},
+      model,
+      isEditing,
+      pluginName: 'metering-and-billing',
+      onFormChange: cy.spy().as('onFormChange'),
+      onValidityChange: cy.spy().as('onValidityChange'),
+    },
+    global: {
+      provide: {
+        [FORMS_CONFIG]: {
+          app: 'konnect' as const,
+          apiBaseUrl: '/us/kong-api',
+          controlPlaneId: '123',
+          ...(geoApiServerUrl ? { geoApiServerUrl } : {}),
+        },
+      },
+    },
+  })
+}
+
+const getIngestEndpointInput = () =>
+  cy.get('[data-testid="ff-config.ingest_endpoint"] input')
+
+describe('MeteringAndBillingForm - ingest_endpoint prefill', () => {
+  it('prefills with region-based URL when geoApiServerUrl is available', () => {
+    mountForm({ geoApiServerUrl: 'https://us.api.konghq.com' })
+
+    getIngestEndpointInput()
+      .should('have.value', 'https://us.api.konghq.com/v3/openmeter/events')
+  })
+
+  it('prefills with {{region}} placeholder when geoApiServerUrl is not available', () => {
+    mountForm({})
+
+    getIngestEndpointInput()
+      .should('have.value', 'https://{{region}}.api.konghq.com/v3/openmeter/events')
+  })
+
+  it('does not overwrite an existing ingest_endpoint in create mode', () => {
+    mountForm({
+      model: { config: { ingest_endpoint: 'https://custom.example.com/events' } },
+      geoApiServerUrl: 'https://us.api.konghq.com',
+    })
+
+    getIngestEndpointInput()
+      .should('have.value', 'https://custom.example.com/events')
+  })
+
+  it('does not overwrite an existing ingest_endpoint in edit mode', () => {
+    mountForm({
+      isEditing: true,
+      model: { config: { ingest_endpoint: 'https://custom.example.com/events' } },
+      geoApiServerUrl: 'https://us.api.konghq.com',
+    })
+
+    getIngestEndpointInput()
+      .should('have.value', 'https://custom.example.com/events')
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
@@ -1,6 +1,6 @@
 <template>
   <StandardLayout
-    v-bind="props"
+    v-bind="{ ...props, model: modelWithDefaults }"
     :plugin-config-description="t('plugins.free-form.metering-and-billing.sections.plugin_config.description')"
   >
     <template #field-renderers>
@@ -140,6 +140,11 @@
       <ObjectField
         :label="t('plugins.free-form.metering-and-billing.sections.subject.title')"
         name="config.subject"
+        :render-rules="{
+          dependencies: {
+            'field': ['look_up_value_in', ['query', 'header']],
+          },
+        }"
         reset-label-path="reset"
       />
     </div>
@@ -194,8 +199,9 @@
 </template>
 
 <script setup lang="ts">
-import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
-import { provide, ref } from 'vue'
+import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME, FORMS_CONFIG } from '@kong-ui-public/forms'
+import { computed, inject, provide, ref } from 'vue'
+import type { KonnectBaseFormConfig, KongManagerBaseFormConfig } from '@kong-ui-public/entities-shared'
 import { KLabel } from '@kong/kongponents'
 import StandardLayout from '../../shared/layout/StandardLayout.vue'
 import FieldRenderer from '../../shared/FieldRenderer.vue'
@@ -221,6 +227,30 @@ const slots = defineSlots<{
 provide(AUTOFILL_SLOT, slots?.[AUTOFILL_SLOT_NAME])
 
 const { i18n: { t } } = useI18n()
+
+const appConfig = inject<KonnectBaseFormConfig | KongManagerBaseFormConfig | undefined>(FORMS_CONFIG)
+
+const ingestEndpointUrl = computed(() => {
+  const geo = (appConfig as KonnectBaseFormConfig)?.geoApiServerUrl
+  const region = geo ? new URL(geo).hostname.split('.')[0] : null
+  return region
+    ? `https://${region}.api.konghq.com/v3/openmeter/events`
+    : 'https://{{region}}.api.konghq.com/v3/openmeter/events'
+})
+
+// Prefill ingest_endpoint for new plugins when region is known, otherwise show placeholder
+const modelWithDefaults = computed(() => {
+  if (props.isEditing || props.model?.config?.ingest_endpoint) {
+    return props.model
+  }
+  return {
+    ...props.model,
+    config: {
+      ...props.model?.config,
+      ingest_endpoint: ingestEndpointUrl.value,
+    },
+  }
+})
 
 const meteringExpanded = ref(true)
 const attributesExpanded = ref(true)

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
@@ -238,9 +238,9 @@ const ingestEndpointUrl = computed(() => {
     : 'https://{{region}}.api.konghq.com/v3/openmeter/events'
 })
 
-// Prefill ingest_endpoint for new plugins when region is known, otherwise show placeholder
+// Prefill ingest_endpoint for new Konnect plugins; Kong Manager has no regional endpoint
 const modelWithDefaults = computed(() => {
-  if (props.isEditing || props.model?.config?.ingest_endpoint) {
+  if (props.isEditing || props.model?.config?.ingest_endpoint || (appConfig as KonnectBaseFormConfig)?.app !== 'konnect') {
     return props.model
   }
   return {

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
@@ -142,7 +142,7 @@
         name="config.subject"
         :render-rules="{
           dependencies: {
-            'field': ['look_up_value_in', ['query', 'header']],
+            field: ['look_up_value_in', ['query', 'header']],
           },
         }"
         reset-label-path="reset"

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.ts
@@ -379,8 +379,11 @@ export function createRenderRuleRegistry(onChange: () => void, getSchemaMap: () 
             ? utils.removeRootSymbol(utils.resolve(path, fieldName))
             : fieldName
 
-          // Skip if dependency condition is met
-          if (isEqual(actualDepFieldValue, expectedDepFieldValue)) {
+          // Skip if dependency condition is met (array = any-of, value = exact match)
+          const meetsCondition = Array.isArray(expectedDepFieldValue)
+            ? expectedDepFieldValue.includes(actualDepFieldValue)
+            : isEqual(actualDepFieldValue, expectedDepFieldValue)
+          if (meetsCondition) {
             hiddenPaths.value.delete(sourceFieldPath) // Unhide the field
             onChange()
             return

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.ts
@@ -379,9 +379,9 @@ export function createRenderRuleRegistry(onChange: () => void, getSchemaMap: () 
             ? utils.removeRootSymbol(utils.resolve(path, fieldName))
             : fieldName
 
-          // Skip if dependency condition is met (array = any-of, value = exact match)
+          // Skip if dependency condition is met
           const meetsCondition = Array.isArray(expectedDepFieldValue)
-            ? expectedDepFieldValue.includes(actualDepFieldValue)
+            ? expectedDepFieldValue.some((v) => isEqual(actualDepFieldValue, v))
             : isEqual(actualDepFieldValue, expectedDepFieldValue)
           if (meetsCondition) {
             hiddenPaths.value.delete(sourceFieldPath) // Unhide the field

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.ts
@@ -7,6 +7,32 @@ import type { MaybeRefOrGetter } from 'vue'
 import type { RenderRules } from '../types'
 import type { UnionFieldSchema } from '../../../../types/plugins/form-schema'
 
+/**
+ * Symbol used internally to tag values created by `renderRuleExactMatch`.
+ * Using a Symbol prevents accidental collision with plain domain objects
+ * that happen to share the same key names.
+ */
+export const RENDER_RULE_EXACT_MATCH = Symbol('ff-render-rule-exact-match')
+
+/**
+ * Wraps a value so that dependency checks use **exact deep equality** instead
+ * of the default any-of semantics that apply when an array is passed.
+ *
+ * Use this when the dependency field itself holds an array value and you need
+ * to match it precisely.
+ *
+ * @example
+ * ```ts
+ * import { renderRuleExactMatch } from './composables/render-rules'
+ *
+ * // Show 'field_b' only when 'field_a' equals exactly ['x', 'y']
+ * dependencies: { field_b: ['field_a', renderRuleExactMatch(['x', 'y'])] }
+ * ```
+ */
+export function renderRuleExactMatch<T>(value: T): { [RENDER_RULE_EXACT_MATCH]: T } {
+  return { [RENDER_RULE_EXACT_MATCH]: value }
+}
+
 export function createRenderRuleRegistry(onChange: () => void, getSchemaMap: () => Record<string, UnionFieldSchema>) {
   type RenderRulesMap = Record<string, RenderRules>
   const registry = ref<RenderRulesMap>({})
@@ -379,10 +405,16 @@ export function createRenderRuleRegistry(onChange: () => void, getSchemaMap: () 
             ? utils.removeRootSymbol(utils.resolve(path, fieldName))
             : fieldName
 
-          // Skip if dependency condition is met
-          const meetsCondition = Array.isArray(expectedDepFieldValue)
-            ? expectedDepFieldValue.some((v) => isEqual(actualDepFieldValue, v))
-            : isEqual(actualDepFieldValue, expectedDepFieldValue)
+          // Skip if dependency condition is met:
+          // - array → any-of (common case: string field, show when value matches any element)
+          // - renderRuleExactMatch(value) → exact deep equality (rare case: field itself holds an array)
+          // - anything else → exact deep equality
+          const isExactWrapper = typeof expectedDepFieldValue === 'object' && expectedDepFieldValue !== null && RENDER_RULE_EXACT_MATCH in expectedDepFieldValue
+          const meetsCondition = isExactWrapper
+            ? isEqual(actualDepFieldValue, (expectedDepFieldValue as Record<typeof RENDER_RULE_EXACT_MATCH, unknown>)[RENDER_RULE_EXACT_MATCH])
+            : Array.isArray(expectedDepFieldValue)
+              ? expectedDepFieldValue.some((v: unknown) => isEqual(actualDepFieldValue, v))
+              : isEqual(actualDepFieldValue, expectedDepFieldValue)
           if (meetsCondition) {
             hiddenPaths.value.delete(sourceFieldPath) // Unhide the field
             onChange()

--- a/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
@@ -126,6 +126,7 @@ export type GlobalAction = 'notify'
  * Rules to control the rendering of form fields.
  * Only `Form` and `ObjectField` components can accept these rules
  */
+
 export interface RenderRules {
   /**
    * Bundles of fields to be rendered together.
@@ -147,20 +148,30 @@ export interface RenderRules {
    * Dependencies between fields to control their visibility.
    * - A field will be shown only if its dependency is satisfied.
    * - A field will only have a value if its dependency is satisfied.
-   * - The `fieldValue` will be deeply compared.
    * - Field and its dependency should be in the same level.
    * - Circular dependencies are not allowed.
+   *
+   * The `fieldValue` can be:
+   * - A primitive or plain object — deeply compared with `isEqual`.
+   * - An array — treated as **any-of**: shown when the dependency value matches any element. Suitable for string fields.
+   * - `renderRuleExactMatch(value)` — for rare cases where the dependency field itself holds an array value
+   *   and exact deep equality is required. Using a Symbol-keyed wrapper avoids collision with plain objects.
+   *
    * @example
    * ```ts
+   * import { renderRuleExactMatch } from '../types'
+   *
    * {
    *   'config.redis': ['config.strategy', 'redis'],
+   *   'config.mode': ['config.strategy', ['redis', 'cluster']], // any-of: shown when strategy is 'redis' or 'cluster'
+   *   'config.tags': ['config.required_tags', renderRuleExactMatch(['a', 'b'])], // exact array match
    *   'config.cache.redis': ['config.strategy', 'cache'], // ❌ different levels are not allowed
    *   'config.strategy': ['config.redis', {}], // ❌ circular dependency not allowed
    * }
    * ```
    */
   dependencies?: {
-    [fieldPath: string]: [fieldPath: string, fieldValue: any]
+    [fieldPath: string]: [fieldPath: string, fieldValue: unknown]
   }
 }
 

--- a/packages/entities/entities-plugins/src/components/free-form/test/free-form-render-rules.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/test/free-form-render-rules.cy.ts
@@ -1,5 +1,6 @@
 import Form from '../shared/Form.vue'
 import type { FormSchema } from '../../../types/plugins/form-schema'
+import { renderRuleExactMatch } from '../shared/composables/render-rules'
 import type { RenderRules } from '../shared/types'
 
 const fieldPrefix = 'field'
@@ -370,6 +371,91 @@ describe('Render Rules', () => {
         cy.getTestId(getFieldTestId(getFieldName('a'))).type('value')
 
         // field_b should be hidden
+        cy.getTestId(getFieldTestId(getFieldName('b'))).should('not.be.visible')
+      })
+    })
+
+    describe('Array any-of dependencies', () => {
+      it('should toggle visibility when switching between matching and non-matching values', () => {
+        const schema = createSchema('a', 'b')
+
+        const renderRules: RenderRules = {
+          dependencies: {
+            [getFieldName('b')]: [getFieldName('a'), ['valueA', 'valueB']],
+          },
+        }
+
+        cy.mount(Form, { props: { schema, renderRules } })
+
+        cy.getTestId(getFieldTestId(getFieldName('b'))).should('not.be.visible')
+
+        cy.getTestId(getFieldTestId(getFieldName('a'))).type('valueA')
+        cy.getTestId(getFieldTestId(getFieldName('b'))).should('be.visible')
+
+        cy.getTestId(getFieldTestId(getFieldName('a'))).clear()
+        cy.getTestId(getFieldTestId(getFieldName('a'))).type('other')
+        cy.getTestId(getFieldTestId(getFieldName('b'))).should('not.be.visible')
+
+        cy.getTestId(getFieldTestId(getFieldName('a'))).clear()
+        cy.getTestId(getFieldTestId(getFieldName('a'))).type('valueB')
+        cy.getTestId(getFieldTestId(getFieldName('b'))).should('be.visible')
+      })
+    })
+
+    describe('Exact array value dependencies', () => {
+      it('should show field when dependency exactly equals the specified array', () => {
+        const schema = createSchema('a', 'b')
+
+        const renderRules: RenderRules = {
+          dependencies: {
+            [getFieldName('b')]: [getFieldName('a'), renderRuleExactMatch(['x', 'y'])],
+          },
+        }
+
+        cy.mount(Form, {
+          props: {
+            schema,
+            renderRules,
+            data: { [getFieldName('a')]: ['x', 'y'] },
+          },
+        })
+
+        cy.getTestId(getFieldTestId(getFieldName('b'))).should('be.visible')
+      })
+
+      it('should hide field when dependency is a partial match of the array', () => {
+        const schema = createSchema('a', 'b')
+
+        const renderRules: RenderRules = {
+          dependencies: {
+            [getFieldName('b')]: [getFieldName('a'), renderRuleExactMatch(['x', 'y'])],
+          },
+        }
+
+        cy.mount(Form, {
+          props: {
+            schema,
+            renderRules,
+            data: { [getFieldName('a')]: ['x'] },
+          },
+        })
+
+        cy.getTestId(getFieldTestId(getFieldName('b'))).should('not.be.visible')
+      })
+
+      it('should not treat { type: "exact" } as any-of when dependency value is a plain string element', () => {
+        const schema = createSchema('a', 'b')
+
+        const renderRules: RenderRules = {
+          dependencies: {
+            [getFieldName('b')]: [getFieldName('a'), renderRuleExactMatch(['x', 'y'])],
+          },
+        }
+
+        cy.mount(Form, { props: { schema, renderRules } })
+
+        // 'x' is an element of the array but should NOT satisfy an exact-match against ['x', 'y']
+        cy.getTestId(getFieldTestId(getFieldName('a'))).type('x')
         cy.getTestId(getFieldTestId(getFieldName('b'))).should('not.be.visible')
       })
     })

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -834,7 +834,7 @@
           },
           "ingest_endpoint": {
             "description": "The URL of the metering data ingest endpoint.",
-            "help": "For Konnect Metering&Billing, use the regional endpoint from your Metering&Billing settings. For self-hosted OpenMeter, use your ingest URL."
+            "help": "For Konnect Metering & Billing, use the regional endpoint from your Metering & Billing settings. For self-hosted OpenMeter, use your ingest URL."
           },
           "api_token": {
             "description": "Bearer token for authenticating requests to the ingest endpoint."


### PR DESCRIPTION
# Summary

- Support array of expected values in render-rules dependencies (['query', 'header'] = any-of). Introduce a new Symbol `RENDER_RULE_EXACT_MATCH` for explicitly stating that an array in render-rules is to be exactly matched 
- Prefill ingest_endpoint from geoApiServerUrl region on create; fall back to https://{{region}}.api.konghq.com/v3/openmeter/events
- Hide subject field unless look_up_value_in is query or header
- Fix "Metering&Billing" → "Metering & Billing" in locale
- Add component tests for ingest_endpoint prefill behavior
