### PR TITLE
fix(entities-routes): disable service select instead of hiding when serviceId is provided

### DIFF
--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -84,7 +84,7 @@ If showing the `Edit` type form, the ID of the Route.
 - required: `false`
 - default: `''`
 
-If service is pre-selected, hides service select dropdown.
+If service is pre-selected, disables the service select dropdown.
 
 #### `hideSectionsInfo`
 

--- a/packages/entities/entities-routes/src/components/RouteForm.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteForm.cy.ts
@@ -873,8 +873,9 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
         // tags field should always be visible
         cy.getTestId('route-form-tags').should('be.visible')
 
-        // service id field should be hidden when serviceId is provided
-        cy.getTestId('route-form-service-id').should('not.exist')
+        // service id field should be visible but disabled when serviceId is provided
+        cy.getTestId('route-form-service-id').should('be.visible')
+        cy.getTestId('route-form-service-id').should('be.disabled')
 
         // sections info should be hidden when hideSectionsInfo is true
         cy.get('.form-section-info sticky').should('not.exist')
@@ -1847,8 +1848,9 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
         // tags field should always be visible
         cy.getTestId('route-form-tags').should('be.visible')
 
-        // service id field should be hidden when serviceId is provided
-        cy.getTestId('route-form-service-id').should('not.exist')
+        // service id field should be visible but disabled when serviceId is provided
+        cy.getTestId('route-form-service-id').should('be.visible')
+        cy.getTestId('route-form-service-id').should('be.disabled')
 
         // sections info should be hidden when hideSectionsInfo is true
         cy.get('.form-section-info sticky').should('not.exist')

--- a/packages/entities/entities-routes/src/components/RouteForm.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteForm.cy.ts
@@ -846,6 +846,8 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       })
 
       it(`should correctly render with all props and slot content, ${configFlavor}`, () => {
+        interceptKMServices()
+
         cy.mount(RouteForm, {
           props: {
             config: baseConfigKM,
@@ -859,6 +861,7 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
           },
         })
 
+        cy.wait('@getServices')
         cy.get('.kong-ui-entities-route-form').should('be.visible')
         cy.get('.kong-ui-entities-route-form form').should('be.visible')
         cy.getTestId('route-form-config-type-advanced').click()
@@ -1821,6 +1824,8 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       })
 
       it(`should correctly render with all props and slot content, ${configFlavor}`, () => {
+        interceptKonnectServices()
+
         cy.mount(RouteForm, {
           props: {
             config: baseConfigKonnect,
@@ -1834,6 +1839,7 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
           },
         })
 
+        cy.wait('@getServices')
         cy.get('.kong-ui-entities-route-form').should('be.visible')
         cy.get('.kong-ui-entities-route-form form').should('be.visible')
         cy.getTestId('route-form-config-type-advanced').click()

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -30,11 +30,12 @@
           :readonly="state.isReadonly"
           type="text"
         />
-        <div v-if="hideServiceField ? false : !serviceId">
+        <div v-if="!hideServiceField">
           <KSelect
             v-model="state.fields.service_id"
             clearable
             data-testid="route-form-service-id"
+            :disabled="!!serviceId"
             enable-filtering
             :filter-function="() => true"
             :items="availableServices"
@@ -181,7 +182,7 @@ const props = defineProps({
     required: false,
     default: '',
   },
-  /** If valid serviceId is provided, don't show service select field */
+  /** If valid serviceId is provided, disable the service select field */
   serviceId: {
     type: String,
     required: false,

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -610,10 +610,11 @@ const fetchServicesErrorMessage = computed((): string => servicesFetchError.valu
 const availableServices = computed((): SelectItem[] => servicesResults.value?.map(el => ({ label: el.id, name: el.name, value: el.id })))
 
 onBeforeMount(async () => {
-  if (!props.hideServiceField && !props.serviceId) {
-    // load services for filtering
+  if (!props.hideServiceField) {
+    // load services so the select can display the selected item even when disabled
     await loadServices()
-  } else {
+  }
+  if (props.serviceId) {
     state.fields.service_id = props.serviceId
   }
 })


### PR DESCRIPTION
## Summary

[KM-2506]

When `serviceId` prop is provided, the service select field is now shown but disabled, instead of being hidden

Preview: https://github.com/kong-konnect/konnect-ui-apps/pull/11127


[KM-2506]: https://konghq.atlassian.net/browse/KM-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ