### PR TITLE
feat(entities-shared): customize decK config before copying and generate Konnect PAT

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -1,5 +1,17 @@
 <template>
   <div class="plugin-form-sandbox">
+    <div class="sandbox-controls">
+      <KInputSwitch
+        v-model="enableDeckConfigCustomization"
+        label="Enable decK configuration customization"
+      />
+
+      <KInputSwitch
+        v-model="enableDeckCallout"
+        label="Show decK config callout above YAML config"
+      />
+    </div>
+
     <div
       id="plugin-form-page-actions"
       class="actions"
@@ -94,7 +106,10 @@ useProvideExperimentalFreeForms([
   'proxy-cache-advanced',
 ])
 
-const konnectConfig = ref<KonnectPluginFormConfig>({
+const enableDeckConfigCustomization = ref(false)
+const enableDeckCallout = ref(false)
+
+const konnectConfig = computed<KonnectPluginFormConfig>(() => ({
   app: 'konnect',
   apiBaseUrl: '/us/kong-api', // `/{geo}/kong-api`, with leading slash and no trailing slash; Consuming app would pass in something like `https://us.api.konghq.com`
   // Set the root `.env.development.local` variable to a control plane your PAT can access
@@ -111,9 +126,20 @@ const konnectConfig = ref<KonnectPluginFormConfig>({
   experimentalRenders: {
     keyAuthIdentityRealms: true,
   },
-})
+  enableDeckTab: {
+    ...enableDeckConfigCustomization.value && {
+      customization: {
+        generateKonnectPat: async () => {
+          await new Promise(resolve => setTimeout(resolve, 1000))
+          return 'kpat_test'
+        },
+      },
+    },
+    calloutPreferenceKey: enableDeckCallout.value ? 'konnect-entities-plugin-form-deck-callout-sandbox' : undefined,
+  },
+}))
 
-const kongManagerConfig = ref<KongManagerPluginFormConfig>({
+const kongManagerConfig = computed<KongManagerPluginFormConfig>(() => ({
   app: 'kongManager',
   workspace: 'default',
   apiBaseUrl: '/kong-manager', // For local dev server proxy
@@ -126,7 +152,8 @@ const kongManagerConfig = ref<KongManagerPluginFormConfig>({
   viewConsumerRoute: (consumerId: string) => ({ name: 'view-consumer', params: { id: consumerId } }),
   viewConsumerGroupRoute: (consumerGroupId: string) => ({ name: 'view-consumer_group', params: { id: consumerGroupId } }),
   viewCertificateRoute: (certId: string) => ({ name: 'view-certificate', params: { id: certId } }),
-})
+  deckCalloutPreferenceKey: enableDeckCallout.value ? 'kong-manager-entities-plugin-form-deck-callout-sandbox' : undefined,
+}))
 
 const onUpdate = (payload: Record<string, any>) => {
   console.log('update', payload)
@@ -153,6 +180,13 @@ const handleGlobalAction = (action: GlobalAction, payload: any) => {
 
   .actions {
     align-self: flex-end;
+  }
+
+  .sandbox-controls {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+    margin-bottom: 20px;
   }
 }
 </style>

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPlayground.vue
@@ -1,5 +1,17 @@
 <template>
   <div class="plugin-form-playground-sandbox">
+    <div class="sandbox-controls">
+      <KInputSwitch
+        v-model="enableDeckConfigCustomization"
+        label="Enable decK configuration customization"
+      />
+
+      <KInputSwitch
+        v-model="enableDeckCallout"
+        label="Show decK config callout above YAML config"
+      />
+    </div>
+
     <KSlideout
       :close-on-blur="false"
       :has-overlay="false"
@@ -93,6 +105,9 @@ function load(type: 'pluginType' | 'schema', defaultValue?: unknown) {
   return stored ? JSON.parse(stored) : defaultValue
 }
 
+const enableDeckConfigCustomization = ref(false)
+const enableDeckCallout = ref(false)
+
 const router = useRouter()
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 
@@ -150,7 +165,7 @@ const parseError = computed(() => {
 
 const text = useTemplateRef('text')
 
-const konnectConfig = ref<KonnectPluginFormConfig>({
+const konnectConfig = computed<KonnectPluginFormConfig>(() => ({
   app: 'konnect',
   apiBaseUrl: '/us/kong-api', // `/{geo}/kong-api`, with leading slash and no trailing slash; Consuming app would pass in something like `https://us.api.konghq.com`
   // Set the root `.env.development.local` variable to a control plane your PAT can access
@@ -163,8 +178,18 @@ const konnectConfig = ref<KonnectPluginFormConfig>({
     keyAuthIdentityRealms: true,
   },
   geoApiServerUrl: 'https://us.api.konghq.tech',
-  enableDeckTab: true,
-})
+  enableDeckTab: {
+    ...enableDeckConfigCustomization.value && {
+      customization: {
+        generateKonnectPat: async () => {
+          await new Promise(resolve => setTimeout(resolve, 1000))
+          return 'kpat_test'
+        },
+      },
+    },
+    calloutPreferenceKey: enableDeckCallout.value ? 'konnect-entities-plugins-form-playground-deck-callout-sandbox' : undefined,
+  },
+}))
 
 const kongManagerConfig = ref<KongManagerPluginFormConfig>({
   app: 'kongManager',

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -115,6 +115,7 @@
         {{ t('view_configuration.message') }}
       </div>
       <KTabs
+        v-model="configTab"
         data-testid="form-view-configuration-slideout-tabs"
         :tabs="tabs"
       >
@@ -127,7 +128,11 @@
           />
         </template>
         <template #yaml>
-          <YamlCodeBlock :entity-record="viewConfigurationRecord" />
+          <YamlCodeBlock
+            :deck-callout-preference-key="isDeckEnabled ? deckCalloutPreferenceKey : undefined"
+            :entity-record="viewConfigurationRecord"
+            @deck-callout:click-cta="configTab = '#deck'"
+          />
         </template>
         <template #terraform>
           <TerraformCodeBlock
@@ -137,14 +142,30 @@
           />
         </template>
         <template #deck>
+          <div
+            v-if="Boolean(deckCustomizationOptions)"
+            class="button-customize-deck-wrapper"
+          >
+            <KButton
+              appearance="secondary"
+              class="button-customize-deck"
+              @click="isDeckCustomizationVisible = true"
+            >
+              {{ t('plugins.form.button_deck_customize') }}
+            </KButton>
+          </div>
+
           <DeckCodeBlock
             :app="config.app"
             :control-plane-name="config.app === 'konnect' ? config.controlPlaneName : undefined"
+            :customization-options="deckCustomizationOptions"
             :entity-record="viewConfigurationRecord"
             :entity-type="SupportedEntityType.Plugin"
             :geo-api-server-url="config.app === 'konnect' ? config.geoApiServerUrl : undefined"
+            :is-customization-modal-visible="isDeckCustomizationVisible"
             :kong-admin-api-url="config.app === 'kongManager' ? config.apiBaseUrl : undefined"
             :workspace="config.app === 'kongManager' ? config.workspace : undefined"
+            @customization-close="isDeckCustomizationVisible = false"
           />
         </template>
       </KTabs>
@@ -162,6 +183,7 @@ import {
   DeckCodeBlock,
   SupportedEntityType,
   useAxios,
+  useBaseFormDeckOptions,
   useErrors,
   useHelpers,
   useStringHelpers,
@@ -381,6 +403,18 @@ provide(REDIS_PARTIAL_INFO, {
   redisPath: pluginRedisPath,
   isEditing: isEditing.value,
 })
+
+const isDeckCustomizationVisible = ref(false)
+
+const {
+  isDeckEnabled,
+  deckCustomizationOptions,
+  deckCalloutPreferenceKey,
+} = useBaseFormDeckOptions(
+  () => props.config,
+  SupportedEntityType.Plugin,
+)
+
 const formLoading = ref(false)
 const formFieldsOriginal = reactive<PluginFormFields>({
   enabled: true,
@@ -419,12 +453,14 @@ if (props.config.app === 'konnect') {
   })
 }
 
-if (props.config.app === 'kongManager' || props.config.enableDeckTab) {
+if (isDeckEnabled.value) {
   tabs.value.push({
     title: t('view_configuration.deck'),
     hash: '#deck',
   })
 }
+
+const configTab = ref(tabs.value[0].hash)
 
 // For array-typed fields, if their elements are deeply nested objects,
 // we need this variable to record the key of the array field.
@@ -1603,6 +1639,13 @@ onBeforeMount(async () => {
         margin-inline-start: unset!important;
       }
     }
+  }
+
+  .button-customize-deck-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    margin-bottom: var(--kui-space-60, $kui-space-60);
   }
 }
 </style>

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -646,6 +646,7 @@
       }
     },
     "form": {
+      "button_deck_customize": "Customize before copying to CLI",
       "disable_data_retrieving": "You do not have permission to select {scope}",
       "disable_source_scope_change": "Changing the {scope} is not allowed when configuring a plugin under it",
       "no_selection": "No selection...",

--- a/packages/entities/entities-plugins/vite.config.ts
+++ b/packages/entities/entities-plugins/vite.config.ts
@@ -10,7 +10,7 @@ const sanitizedPackageName = sanitizePackageName(packageName)
 // Merge the shared Vite config with the local one defined below
 const config = mergeConfig(sharedViteConfig, defineConfig({
   plugins: [monaco({
-    languages: ['yaml'],
+    languages: ['powershell', 'shell', 'yaml'],
   })],
   build: {
     lib: {

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -22,23 +22,27 @@
   },
   "peerDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong-ui-public/monaco-editor": "workspace:^",
     "@kong/icons": "^1.52.0",
     "@kong/kongponents": "^9.52.11",
     "@shikijs/core": "^3.23.0",
     "@shikijs/engine-javascript": "^3.23.0",
     "axios": "^1.15.2",
+    "monaco-editor": "^0.55.1",
     "shiki": "^3.23.0",
     "vue": ">= 3.3.13 < 4",
     "vue-router": "^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
+    "@kong-ui-public/monaco-editor": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
     "@kong/kongponents": "9.52.11",
     "@shikijs/core": "^3.23.0",
     "@shikijs/engine-javascript": "^3.23.0",
     "axios": "^1.15.2",
+    "monaco-editor": "^0.55.1",
     "shiki": "^3.23.0",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"
@@ -73,7 +77,7 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "680KB"
+    "errorLimit": "750KB"
   },
   "dependencies": {
     "@kong-ui-public/core": "workspace:^",

--- a/packages/entities/entities-shared/sandbox/pages/EntityBaseConfigCardPage.vue
+++ b/packages/entities/entities-shared/sandbox/pages/EntityBaseConfigCardPage.vue
@@ -1,6 +1,19 @@
 <template>
   <div class="sandbox-container">
+    <div class="sandbox-controls">
+      <KInputSwitch
+        v-model="enableDeckConfigCustomization"
+        label="Enable decK configuration customization"
+      />
+
+      <KInputSwitch
+        v-model="enableDeckCallout"
+        label="Show decK config callout above YAML config"
+      />
+    </div>
+
     <h2>Konnect API</h2>
+
     <EntityBaseConfigCard
       :config="konnectConfig"
       :config-schema="configSchema"
@@ -55,7 +68,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import type { ConfigurationSchema, KonnectBaseEntityConfig, KongManagerBaseEntityConfig } from '../../src'
 import {
   EntityBaseConfigCard,
@@ -67,30 +80,45 @@ import composables from '../../src/composables'
 
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 // replace with your own endpoint
-const konnectFetchUrl = ref('/v2/control-planes/{controlPlaneId}/core-entities/upstreams/{id}')
-const kmFetchUrl = ref('/{workspace}/upstreams/{id}')
+const konnectFetchUrl = ref('/v2/control-planes/{controlPlaneId}/core-entities/services/{id}')
+const kmFetchUrl = ref('/{workspace}/services/{id}')
 // replace with you own ID
-const entityType = SupportedEntityType.Upstream
-const entityId = '1b8099a8-743a-4b1a-bed5-15689af430fd'
+const entityType = SupportedEntityType.GatewayService
+const entityId = '34a20e3c-38e3-49ce-920b-0f176ad720e6'
 // const entityId = 'a8859647-45fd-4604-bb72-fea7eeae3618'
 
 const { convertKeyToTitle } = composables.useStringHelpers()
 
-const konnectConfig = ref<KonnectBaseEntityConfig>({
+const enableDeckConfigCustomization = ref(false)
+const enableDeckCallout = ref(false)
+
+const konnectConfig = computed<KonnectBaseEntityConfig>(() => ({
   app: 'konnect',
   apiBaseUrl: '/us/kong-api', // `/{geo}/kong-api`, with leading slash and no trailing slash; Consuming app would pass in something like `https://us.api.konghq.com`
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   entityId,
-  enableDeckConfig: true,
+  enableDeckConfig: {
+    ...enableDeckConfigCustomization.value && {
+      customization: {
+        generateKonnectPat: async () => {
+          await new Promise(resolve => setTimeout(resolve, 1000))
+          return 'kpat_test'
+        },
+      },
+    },
+    calloutPreferenceKey: enableDeckCallout.value ? 'konnect-entities-base-config-card-deck-callout-sandbox' : undefined,
+  },
   formatPreferenceKey: 'konnect-entities-base-config-card-format-sandbox',
-})
+}))
+
 const kongManagerConfig = ref<KongManagerBaseEntityConfig>({
   app: 'kongManager',
   workspace: 'default',
   apiBaseUrl: '/kong-manager', // For local dev server proxy
   entityId,
   formatPreferenceKey: 'kong-manager-entities-base-config-card-format-sandbox',
+  deckCalloutPreferenceKey: enableDeckCallout.value ? 'kong-manager-entities-base-config-card-deck-callout-sandbox' : undefined,
 })
 
 const configSchema = ref<ConfigurationSchema>({
@@ -122,5 +150,12 @@ const handleLoading = (val: boolean) => {
 <style lang="scss" scoped>
 .sandbox-container {
   padding: 40px;
+
+  .sandbox-controls {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+    margin-bottom: 20px;
+  }
 }
 </style>

--- a/packages/entities/entities-shared/sandbox/pages/EntityBaseFormPage.vue
+++ b/packages/entities/entities-shared/sandbox/pages/EntityBaseFormPage.vue
@@ -1,5 +1,17 @@
 <template>
   <div class="sandbox-container">
+    <div class="sandbox-controls">
+      <KInputSwitch
+        v-model="enableDeckConfigCustomization"
+        label="Enable decK configuration customization"
+      />
+
+      <KInputSwitch
+        v-model="enableDeckCallout"
+        label="Show decK config callout above YAML config"
+      />
+    </div>
+
     <EntityBaseForm
       :can-submit="canSubmit"
       :config="konnectConfig"
@@ -53,15 +65,28 @@ const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 const konnectFetchUrl = ref(`/v2/control-planes/${controlPlaneId}/core-entities/services`)
 const entityType = SupportedEntityType.GatewayService
 
-const konnectConfig = ref<KonnectBaseFormConfig>({
+const enableDeckConfigCustomization = ref(false)
+const enableDeckCallout = ref(false)
+
+const konnectConfig = computed<KonnectBaseFormConfig>(() => ({
   app: 'konnect',
   apiBaseUrl: '/us/kong-api', // `/{geo}/kong-api`, with leading slash and no trailing slash; Consuming app would pass in something like `https://us.api.konghq.com`
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   cancelRoute: { name: '/' },
-  enableDeckTab: true,
+  enableDeckTab: {
+    ...enableDeckConfigCustomization.value && {
+      customization: {
+        generateKonnectPat: async () => {
+          await new Promise(resolve => setTimeout(resolve, 1000))
+          return 'kpat_test'
+        },
+      },
+    },
+    calloutPreferenceKey: enableDeckCallout.value ? 'konnect-entities-base-form-deck-callout-sandbox' : undefined,
+  },
   geoApiServerUrl: 'https://us.api.konghq.tech',
-})
+}))
 
 const canSubmit = computed((): boolean => !!form.fields.name)
 
@@ -86,6 +111,13 @@ const handleCancel = (): void => {
 <style lang="scss" scoped>
 .sandbox-container {
   padding: 40px;
+
+  .sandbox-controls {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+    margin-bottom: 20px;
+  }
 }
 
 .entity-name {

--- a/packages/entities/entities-shared/src/components/common/DeckCallout.cy.ts
+++ b/packages/entities/entities-shared/src/components/common/DeckCallout.cy.ts
@@ -1,0 +1,25 @@
+import DeckCallout from './DeckCallout.vue'
+import composables from '../../composables'
+
+describe('<DeckCallout />', () => {
+  const { i18n: { t } } = composables.useI18n()
+
+  beforeEach(() => {
+    cy.mount(DeckCallout)
+  })
+
+  it('renders the callout copy with the CTA', () => {
+    cy.get('.deck-callout').should('be.visible')
+    cy.get('.deck-callout .cta').should('contain.text', t('deckCallout.cta'))
+  })
+
+  it('emits "click-cta" when the CTA is clicked', () => {
+    cy.get('.deck-callout .cta').click()
+    cy.then(() => Cypress.vueWrapper.emitted('click-cta')).should('have.length', 1)
+  })
+
+  it('emits "dismiss" when the alert is dismissed', () => {
+    cy.get('.deck-callout .alert-dismiss-icon').click()
+    cy.then(() => Cypress.vueWrapper.emitted('dismiss')).should('have.length', 1)
+  })
+})

--- a/packages/entities/entities-shared/src/components/common/DeckCallout.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCallout.vue
@@ -1,0 +1,48 @@
+<template>
+  <KAlert
+    class="deck-callout"
+    dismissible
+    @dismiss="$emit('dismiss')"
+  >
+    <i18nT keypath="deckCallout.body">
+      <template #cta>
+        <button
+          class="cta"
+          type="button"
+          @click="$emit('click-cta')"
+        >
+          {{ t('deckCallout.cta') }}
+        </button>
+      </template>
+    </i18nT>
+  </KAlert>
+</template>
+
+<script setup lang="ts">
+import composables from '../../composables'
+
+const { i18n: { t }, i18nT } = composables.useI18n()
+
+defineEmits<{
+  'click-cta': []
+  dismiss: []
+}>()
+</script>
+
+<style lang="scss" scoped>
+.deck-callout {
+  margin-bottom: var(--kui-space-60, $kui-space-60);
+
+  // A button was used for better accessibility
+  .cta {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+    padding: 0;
+    text-decoration: underline;
+  }
+}
+</style>

--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlock.vue
@@ -1,185 +1,66 @@
 <template>
-  <div class="deck-config config-card-code-block">
-    <KSelect
-      v-model="shell"
-      :items="shells"
-    >
-      <template #item-template="{ item }">
-        <LanguageShellIcon v-if="item.value === 'powershell'" />
-        <LanguageBashIcon v-else />
-        {{ item.label }}
-      </template>
-      <template #selected-item-template="{ item }">
-        <LanguageShellIcon v-if="item.value === 'powershell'" />
-        <LanguageBashIcon v-else />
-        {{ item.label }}
-      </template>
-    </KSelect>
-    <i18nT
-      :data-testid="`deck-hint-${app}`"
-      :keypath="`deckCodeBlock.hint.${app}`"
-      tag="p"
-    >
-      <template
-        v-if="app === 'konnect'"
-        #token
-      >
-        <KBadge>DECK_KONNECT_TOKEN</KBadge>
-      </template>
-      <template #link>
-        <KExternalLink :href="app === 'konnect' ? 'https://developer.konghq.com/deck/get-started/' : 'https://developer.konghq.com/deck/gateway/configuration/'">
-          {{ i18n.t('deckCodeBlock.documentation') }}
-        </KExternalLink>
-      </template>
-    </i18nT>
-    <KCodeBlock
-      v-if="app === 'konnect'"
-      id="deck-env-codeblock"
-      :code="envCommand"
-      :language="shell"
-      single-line
-      theme="dark"
-      @code-block-render="highlightCodeBlock"
+  <DeckCodeBlockInternal
+    v-if="props.entityRecord"
+    v-bind="$attrs"
+    :app="props.app"
+    :control-plane-name="props.app === 'konnect' ? props.controlPlaneName : undefined"
+    :entity-record="props.entityRecord"
+    :entity-type="(props.entityType as SupportedEntityDeck)"
+    :geo-api-server-url="props.app === 'konnect' ? props.geoApiServerUrl : undefined"
+    :kong-admin-api-url="props.app === 'kongManager' ? props.kongAdminApiUrl : undefined"
+    :workspace="props.app === 'kongManager' ? props.workspace : undefined"
+  />
+
+  <KModal
+    v-if="props.entityRecord"
+    action-button-appearance="tertiary"
+    :action-button-text="t('baseConfigCard.actions.deck_customize_cancel')"
+    hide-cancel-button
+    max-width="640px"
+    :title="t('deckCodeBlock.customization.title')"
+    :visible="props.isCustomizationModalVisible"
+    @cancel="$emit('customization-close')"
+    @proceed="$emit('customization-close')"
+  >
+    <DeckCodeBlockInternal
+      :app="props.app"
+      :control-plane-name="props.app === 'konnect' ? props.controlPlaneName : undefined"
+      :entity-record="props.entityRecord"
+      :entity-type="(props.entityType as SupportedEntityDeck)"
+      :generate-konnect-pat="generateKonnectPat"
+      :geo-api-server-url="props.app === 'konnect' ? props.geoApiServerUrl : undefined"
+      is-customizing
+      :kong-admin-api-url="props.app === 'kongManager' ? props.kongAdminApiUrl : undefined"
+      :workspace="props.app === 'kongManager' ? props.workspace : undefined"
     />
-    <KCodeBlock
-      v-if="props.entityRecord"
-      id="deck-codeblock"
-      :code="deckCommand"
-      :language="shell"
-      theme="dark"
-      @code-block-render="highlightCodeBlock"
-    />
-  </div>
+  </KModal>
 </template>
 
 <script setup lang="ts">
-import yaml from 'js-yaml'
-import { computed, ref } from 'vue'
-import { KExternalLink } from '@kong/kongponents'
-import { LanguageShellIcon, LanguageBashIcon } from '@kong/icons'
-import { highlightCodeBlock } from '../../utils/code-block'
-import composables from '../../composables'
-import { SupportedEntityType } from '../../types'
-import type { SupportedEntityDeck } from '../../types'
+import { computed } from 'vue'
 
-const props = defineProps<{
-  app: 'konnect' | 'kongManager'
-  /** A record to indicate the entity's configuration, used to populate the decK code block */
-  entityRecord: Record<string, any>
-  entityType: SupportedEntityDeck
-  /** e.g. https://us.api.konghq.tech, used to pass --konnect-addr parameter to decK */
-  geoApiServerUrl?: string
-  controlPlaneName?: string
-  /** e.g. https://localhost:8001, used to pass --kong-addr parameter to decK */
-  kongAdminApiUrl?: string
-  workspace?: string
+import composables from '../../composables'
+import DeckCodeBlockInternal from './DeckCodeBlockInternal.vue'
+
+import type { DeckCodeBlockProps, DeckCustomizationOptions, SupportedEntityDeck } from '../../types'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps<DeckCodeBlockProps & {
+  customizationOptions?: boolean | DeckCustomizationOptions
+  isCustomizationModalVisible?: boolean
 }>()
 
-const { i18n, i18nT } = composables.useI18n()
+defineEmits<{
+  'customization-close': []
+}>()
 
-const shells = [
-  { value: 'bash', label: 'Linux / macOS Bash' },
-  { value: 'powershell', label: 'Windows PowerShell' },
-]
+const { i18n: { t } } = composables.useI18n()
 
-const shell = ref((() => {
-  const userAgent = navigator.userAgent.toLowerCase()
-  if (userAgent.includes('windows')) {
-    return 'powershell'
-  } else {
-    return 'bash'
+const generateKonnectPat = computed(() => {
+  if (props.app === 'konnect' && props.customizationOptions && typeof props.customizationOptions !== 'boolean') {
+    return props.customizationOptions.generateKonnectPat
   }
-})())
-
-const baseObject = computed(() => {
-  const obj: Record<string, any> = {
-    _format_version: '3.0',
-  }
-  if (props.controlPlaneName) {
-    obj._konnect = {
-      control_plane_name: props.controlPlaneName,
-    }
-  } else if (props.workspace) {
-    obj._workspace = props.workspace
-  }
-  return obj
+  return undefined
 })
-
-const yamlContent = computed((): string => {
-  // filter out null values, empty strings, and empty arrays since decK doesn't accept them [KHCP-10642]
-  const filteredRecord = Object.fromEntries(Object.entries(props.entityRecord).filter(([, value]) => value !== null && value !== '' && (Array.isArray(value) ? value.length !== 0 : true)))
-
-  // transfer parent object `{id: string}` to just id string for decK compatibility [KM-2056]
-  if (props.entityType === SupportedEntityType.Plugin) {
-    if (filteredRecord.service?.id) {
-      filteredRecord.service = filteredRecord.service.id
-    }
-    if (filteredRecord.route?.id) {
-      filteredRecord.route = filteredRecord.route.id
-    }
-    if (filteredRecord.consumer?.id) {
-      filteredRecord.consumer = filteredRecord.consumer.id
-    }
-    if (filteredRecord.consumer_group?.id) {
-      filteredRecord.consumer_group = filteredRecord.consumer_group.id
-    }
-  } else if (props.entityType === SupportedEntityType.Key) {
-    if (filteredRecord.key_set?.id) {
-      filteredRecord.key_set = filteredRecord.key_set.id
-    }
-  }
-
-  // KeySet is 'set' in terraform but 'key_set' in decK
-  const entityKey = props.entityType === SupportedEntityType.KeySet ? 'key_sets' : props.entityType + 's'
-
-  const fullRecord = {
-    ...baseObject.value,
-    [entityKey]: [filteredRecord],
-  }
-
-  return yaml.dump(fullRecord, { quotingType: '"' }).trim()
-})
-
-const envCommand = computed((): string => {
-  if (shell.value === 'bash') {
-    return 'export DECK_KONNECT_TOKEN=\'YOUR_KONNECT_PAT\''
-  } else {
-    return '$env:DECK_KONNECT_TOKEN = "YOUR_KONNECT_PAT"'
-  }
-})
-
-const deckCommand = computed((): string => {
-  let command = 'deck gateway apply -'
-
-  if (props.geoApiServerUrl) {
-    command += ` --konnect-addr ${props.geoApiServerUrl}`
-  } else if (props.kongAdminApiUrl) {
-    command += ` --kong-addr ${props.kongAdminApiUrl}`
-  }
-
-  if (shell.value === 'bash') {
-    // Bash uses echo with single quotes
-    return `echo '
-${yamlContent.value}
-' | ${command}`
-  } else {
-    // PowerShell uses @' '@ for multi-line strings
-    return `@'
-${yamlContent.value}
-'@ | ${command}`
-  }
-})
-
 </script>
-
-<style lang="scss" scoped>
-.deck-config {
-  .k-select {
-    margin-bottom: var(--kui-space-60, $kui-space-60);
-  }
-
-  .k-code-block {
-    margin-top: var(--kui-space-50, $kui-space-50);
-  }
-}
-</style>

--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.cy.ts
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.cy.ts
@@ -9,7 +9,7 @@ function selectShell(shell: 'bash' | 'powershell') {
 }
 
 
-describe('<DeckCodeBlock />', () => {
+describe('<DeckCodeBlockInternal />', () => {
   // Konnect specific props
   const controlPlaneName = 'test-control-plane'
   const geoApiServerUrl = 'https://us.api.konghq.tech'

--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
@@ -1,0 +1,297 @@
+<template>
+  <div
+    class="deck-config config-card-code-block"
+    v-bind="$attrs"
+  >
+    <KSelect
+      v-model="shell"
+      :items="shells"
+    >
+      <template #item-template="{ item }">
+        <LanguageShellIcon v-if="item.value === 'powershell'" />
+        <LanguageBashIcon v-else />
+        {{ item.label }}
+      </template>
+      <template #selected-item-template="{ item }">
+        <LanguageShellIcon v-if="item.value === 'powershell'" />
+        <LanguageBashIcon v-else />
+        {{ item.label }}
+      </template>
+    </KSelect>
+
+    <div class="step-title">
+      {{ t('deckCodeBlock.steps.step_1') }}
+    </div>
+
+    <i18nT
+      v-if="!isCustomizing"
+      :data-testid="`deck-hint-${app}`"
+      :keypath="`deckCodeBlock.hint.${app}`"
+      tag="p"
+    >
+      <template
+        v-if="app === 'konnect'"
+        #token
+      >
+        <KBadge>DECK_KONNECT_TOKEN</KBadge>
+      </template>
+      <template #link>
+        <KExternalLink :href="app === 'konnect' ? 'https://developer.konghq.com/deck/get-started/' : 'https://developer.konghq.com/deck/gateway/configuration/'">
+          {{ i18n.t('deckCodeBlock.documentation') }}
+        </KExternalLink>
+      </template>
+    </i18nT>
+    <KCodeBlock
+      v-if="app === 'konnect'"
+      id="deck-env-codeblock"
+      :class="{ customization: props.isCustomizing }"
+      :code="envCommand"
+      :language="shell"
+      single-line
+      :theme="isCustomizing ? 'light' : 'dark'"
+      @code-block-render="highlightCodeBlock"
+    />
+    <KAlert
+      v-if="Boolean(konnectPat)"
+      class="copy-konnect-pat-alert"
+    >
+      {{ t('deckCodeBlock.customization.copy_pat') }}
+    </KAlert>
+
+    <div
+      v-else-if="props.isCustomizing && props.generateKonnectPat"
+      class="konnect-pat-actions"
+    >
+      <KButton
+        appearance="secondary"
+        @click="isGeneratePatModalVisible = true"
+      >
+        {{ t('deckCodeBlock.customization.generate_pat') }}
+      </KButton>
+      <div>{{ t('deckCodeBlock.customization.reuse_pat') }}</div>
+    </div>
+
+    <div class="step-title">
+      {{ t('deckCodeBlock.steps.step_2') }}
+    </div>
+
+    <KCodeBlock
+      v-if="props.entityRecord && !props.isCustomizing"
+      id="deck-codeblock"
+      :class="{ customization: props.isCustomizing }"
+      :code="deckCommand"
+      :language="shell"
+      :theme="isCustomizing ? 'light' : 'dark'"
+      @code-block-render="highlightCodeBlock"
+    />
+
+    <DeckCommandEditor
+      v-else-if="props.entityRecord && props.isCustomizing"
+      v-model="deckCommand"
+      :language="shell"
+    />
+
+    <KAlert
+      v-if="props.isCustomizing"
+      class="customization-footer-reminder"
+    >
+      <template #icon>
+        <InfoIcon />
+      </template>
+
+      {{ t('deckCodeBlock.customization.footer_reminder') }}
+    </KAlert>
+  </div>
+
+  <GeneratePatModal
+    v-if="props.isCustomizing && props.generateKonnectPat"
+    :generate-konnect-pat="props.generateKonnectPat"
+    :visible="isGeneratePatModalVisible"
+    @dismiss="isGeneratePatModalVisible = false"
+    @generated="handleKonnectPatGenerated"
+  />
+</template>
+
+<script setup lang="ts">
+import { InfoIcon, LanguageBashIcon, LanguageShellIcon } from '@kong/icons'
+import { KExternalLink } from '@kong/kongponents'
+import yaml from 'js-yaml'
+import { computed, defineAsyncComponent, ref, watchEffect } from 'vue'
+
+import composables from '../../composables'
+import { SupportedEntityType } from '../../types'
+import { highlightCodeBlock } from '../../utils/code-block'
+import DeckCommandEditorLoading from './DeckCommandEditorLoading.vue'
+import GeneratePatModal from './GeneratePatModal.vue'
+
+import type { DeckCodeBlockProps } from '../../types'
+
+/**
+ * Lazy load the Monaco Editor inside when customization mode is enabled.
+ */
+const DeckCommandEditor = defineAsyncComponent({
+  loader: () => import('./DeckCommandEditor.vue'),
+  loadingComponent: DeckCommandEditorLoading,
+  delay: 200,
+})
+
+const props = defineProps<DeckCodeBlockProps & {
+  isCustomizing?: boolean
+  /**
+   * A function to generate a Konnect Personal Access Token (PAT).
+   * This enables the user to generate a PAT directly from the UI.
+   */
+  generateKonnectPat?: (name: string, expiresAt: Date) => string | Promise<string>
+}>()
+
+const { i18n, i18nT } = composables.useI18n()
+const { t } = i18n
+
+const konnectPat = ref<string>('')
+const deckCommand = ref<string>('')
+const isGeneratePatModalVisible = ref(false)
+
+const shells = [
+  { value: 'bash', label: 'Linux / macOS Bash' },
+  { value: 'powershell', label: 'Windows PowerShell' },
+]
+
+const shell = ref<'bash' | 'powershell'>((() => {
+  const userAgent = navigator.userAgent.toLowerCase()
+  if (userAgent.includes('windows')) {
+    return 'powershell'
+  } else {
+    return 'bash'
+  }
+})())
+
+const baseObject = computed(() => {
+  const obj: Record<string, any> = {
+    _format_version: '3.0',
+  }
+  if (props.controlPlaneName) {
+    obj._konnect = {
+      control_plane_name: props.controlPlaneName,
+    }
+  } else if (props.workspace) {
+    obj._workspace = props.workspace
+  }
+  return obj
+})
+
+const yamlContent = computed((): string => {
+  // filter out null values, empty strings, and empty arrays since decK doesn't accept them [KHCP-10642]
+  const filteredRecord = Object.fromEntries(Object.entries(props.entityRecord).filter(([, value]) => value !== null && value !== '' && (Array.isArray(value) ? value.length !== 0 : true)))
+
+  // transfer parent object `{id: string}` to just id string for decK compatibility [KM-2056]
+  if (props.entityType === SupportedEntityType.Plugin) {
+    if (filteredRecord.service?.id) {
+      filteredRecord.service = filteredRecord.service.id
+    }
+    if (filteredRecord.route?.id) {
+      filteredRecord.route = filteredRecord.route.id
+    }
+    if (filteredRecord.consumer?.id) {
+      filteredRecord.consumer = filteredRecord.consumer.id
+    }
+    if (filteredRecord.consumer_group?.id) {
+      filteredRecord.consumer_group = filteredRecord.consumer_group.id
+    }
+  } else if (props.entityType === SupportedEntityType.Key) {
+    if (filteredRecord.key_set?.id) {
+      filteredRecord.key_set = filteredRecord.key_set.id
+    }
+  }
+
+  // KeySet is 'set' in terraform but 'key_set' in decK
+  const entityKey = props.entityType === SupportedEntityType.KeySet ? 'key_sets' : props.entityType + 's'
+
+  const fullRecord = {
+    ...baseObject.value,
+    [entityKey]: [filteredRecord],
+  }
+
+  return yaml.dump(fullRecord, { quotingType: '"' }).trim()
+})
+
+const envCommand = computed((): string => {
+  if (shell.value === 'bash') {
+    return `export DECK_KONNECT_TOKEN='${konnectPat.value || 'YOUR_KONNECT_PAT'}'`
+  } else {
+    return `$env:DECK_KONNECT_TOKEN = "${konnectPat.value || 'YOUR_KONNECT_PAT'}"`
+  }
+})
+
+function handleKonnectPatGenerated(token: string) {
+  konnectPat.value = token
+  isGeneratePatModalVisible.value = false
+}
+
+watchEffect(() => {
+  let command = 'deck gateway apply -'
+
+  if (props.geoApiServerUrl) {
+    command += ` --konnect-addr ${props.geoApiServerUrl}`
+  } else if (props.kongAdminApiUrl) {
+    command += ` --kong-addr ${props.kongAdminApiUrl}`
+  }
+
+  if (shell.value === 'bash') {
+    // Bash uses echo with single quotes
+    deckCommand.value = `echo '
+${yamlContent.value}
+' | ${command}`
+  } else {
+    // PowerShell uses @' '@ for multi-line strings
+    deckCommand.value = `@'
+${yamlContent.value}
+'@ | ${command}`
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.deck-config {
+  .k-select {
+    margin-bottom: var(--kui-space-60, $kui-space-60);
+  }
+
+  .k-code-block {
+    margin-top: var(--kui-space-50, $kui-space-50);
+
+    &.customization {
+      background-color: var(--kui-color-background, $kui-color-background);
+      border: 1px solid var(--kui-color-border, $kui-color-border);
+      border-radius: var(--kui-border-radius-40, $kui-border-radius-40);
+    }
+  }
+
+  .step-title {
+    align-items: center;
+    align-self: stretch;
+    font-size: var(--kui-font-size-40, $kui-font-size-40);
+    font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
+    gap: 16px;
+
+    &:not(:first-child) {
+      margin-top: var(--kui-space-60, $kui-space-60);
+    }
+  }
+
+  .konnect-pat-actions {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    gap: var(--kui-space-40, $kui-space-40);
+    margin-top: var(--kui-space-40, $kui-space-40);
+  }
+
+  .copy-konnect-pat-alert {
+    margin-top: var(--kui-space-40, $kui-space-40);
+  }
+
+  .customization-footer-reminder {
+    margin-top: var(--kui-space-60, $kui-space-60);
+  }
+}
+</style>

--- a/packages/entities/entities-shared/src/components/common/DeckCommandEditor.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCommandEditor.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="deck-command-editor-wrapper">
+    <MonacoEditor
+      v-model="code"
+      appearance="standalone"
+      class="deck-command-editor"
+      :language="language"
+      :options="monacoOptions"
+      theme="light"
+    />
+    <div class="deck-command-copy-button">
+      <KCodeBlockIconButton
+        :aria-label="t('deckCodeBlock.copy_tooltip')"
+        :copy-tooltip="t('deckCodeBlock.copy_tooltip')"
+        theme="light"
+        @click="copyDeckCommand()"
+      >
+        <CopyIcon decorative />
+      </KCodeBlockIconButton>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { MonacoEditor } from '@kong-ui-public/monaco-editor'
+import { CopyIcon } from '@kong/icons'
+import { KCodeBlockIconButton } from '@kong/kongponents'
+
+import '@kong-ui-public/monaco-editor/dist/runtime/style.css'
+
+import composables from '../../composables'
+
+import type * as monaco from 'monaco-editor'
+
+defineProps<{
+  language: 'bash' | 'powershell'
+}>()
+
+const code = defineModel<string>({ required: true })
+
+const { i18n: { t } } = composables.useI18n()
+
+const monacoOptions = {
+  scrollbar: {
+    alwaysConsumeMouseWheel: false,
+  },
+  autoIndent: 'keep',
+  editContext: false,
+} as const satisfies Partial<monaco.editor.IStandaloneEditorConstructionOptions>
+
+/**
+ * Borrowed from {@link https://github.com/Kong/kongponents/blob/5d82c77d767a35f08a37c27ffcd6ae11c97fe91d/src/components/KCodeBlock/KCodeBlock.vue}
+ */
+async function copyDeckCommand() {
+  await copyTextToClipboard(code.value)
+}
+
+/**
+ * Borrowed from {@link https://github.com/Kong/kongponents/blob/5d82c77d767a35f08a37c27ffcd6ae11c97fe91d/src/utilities/copyTextToClipboard.ts}
+ *
+ * Not importing directly as it was not formally exported from @kong/kongponents.
+ */
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Do nothing and let the remaining logic try to be successful.
+    }
+  }
+
+  const textArea = document?.createElement('textarea')
+
+  if (textArea) {
+    textArea.style.position = 'fixed'
+    textArea.style.top = '0'
+    textArea.style.left = '0'
+    textArea.style.width = '32px'
+    textArea.style.height = '32px'
+    textArea.style.padding = '0'
+    textArea.style.border = 'none'
+    textArea.style.outline = 'none'
+    textArea.style.boxShadow = 'none'
+    textArea.style.background = 'transparent'
+
+    textArea.value = text
+
+    document?.body?.appendChild(textArea)
+    textArea.focus()
+    textArea.select()
+  }
+
+  let isSuccess: boolean
+
+  try {
+    isSuccess = document?.execCommand('copy')
+  } catch {
+    isSuccess = false
+  } finally {
+    document?.body?.removeChild(textArea)
+  }
+
+  return isSuccess
+}
+</script>
+
+<style lang="scss" scoped>
+.deck-command-editor-wrapper {
+  position: relative;
+
+  .deck-command-editor {
+    height: 300px;
+    margin-top: var(--kui-space-50, $kui-space-50);
+    width: 100%;
+  }
+
+  .deck-command-copy-button {
+    opacity: 0;
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    transition: opacity linear var(--kui-animation-duration-20, $kui-animation-duration-20);
+  }
+
+  &:hover .deck-command-copy-button {
+    opacity: 1;
+  }
+}
+</style>

--- a/packages/entities/entities-shared/src/components/common/DeckCommandEditorLoading.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCommandEditorLoading.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="editor-skeleton">
+    <KSkeleton
+      v-for="i in 5"
+      :key="i"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.editor-skeleton {
+  margin-top: var(--kui-space-20, $kui-space-20);
+}
+</style>

--- a/packages/entities/entities-shared/src/components/common/GeneratePatModal.cy.ts
+++ b/packages/entities/entities-shared/src/components/common/GeneratePatModal.cy.ts
@@ -1,0 +1,124 @@
+import GeneratePatModal from './GeneratePatModal.vue'
+import composables from '../../composables'
+
+describe('<GeneratePatModal />', () => {
+  const { i18n: { t } } = composables.useI18n()
+
+  const cancelLabel = t('generatePatModal.actions.cancel')
+  const generateLabel = t('generatePatModal.actions.generate')
+  const generatingLabel = t('generatePatModal.actions.generating')
+  const namePlaceholder = t('generatePatModal.fields.name.placeholder')
+
+  const nameInput = () => cy.get(`input[placeholder="${namePlaceholder}"]`)
+
+  it('renders nothing when not visible', () => {
+    cy.mount(GeneratePatModal, {
+      props: {
+        visible: false,
+        generateKonnectPat: cy.stub().as('generate'),
+      },
+    })
+
+    cy.contains(t('generatePatModal.title')).should('not.exist')
+  })
+
+  it('renders title and description when visible', () => {
+    cy.mount(GeneratePatModal, {
+      props: {
+        visible: true,
+        generateKonnectPat: cy.stub().as('generate'),
+      },
+    })
+
+    cy.contains(t('generatePatModal.title')).should('be.visible')
+    cy.contains(t('generatePatModal.description')).should('be.visible')
+    nameInput().should('be.visible')
+  })
+
+  it('keeps the Generate button disabled until a name is entered', () => {
+    cy.mount(GeneratePatModal, {
+      props: {
+        visible: true,
+        generateKonnectPat: cy.stub().as('generate'),
+      },
+    })
+
+    cy.contains('button', generateLabel).should('be.disabled')
+    nameInput().type('my-token')
+    cy.contains('button', generateLabel).should('not.be.disabled')
+  })
+
+  it('emits "dismiss" when the Cancel button is clicked', () => {
+    cy.mount(GeneratePatModal, {
+      props: {
+        visible: true,
+        generateKonnectPat: cy.stub().as('generate'),
+      },
+    })
+
+    cy.contains('button', cancelLabel).click()
+    cy.then(() => Cypress.vueWrapper.emitted('dismiss')).should('have.length', 1)
+  })
+
+  it('calls generateKonnectPat with name + expiresAt and emits "generated" on success', () => {
+    const before = new Date()
+    const generate = cy.stub().as('generate').resolves('kpat_test')
+
+    cy.mount(GeneratePatModal, {
+      props: {
+        visible: true,
+        generateKonnectPat: generate,
+      },
+    })
+
+    nameInput().type('my-token')
+    cy.contains('button', generateLabel).click()
+    cy.get('@generate').should('have.been.calledOnce')
+    cy.get('@generate').then((stub: any) => {
+      const [name, expiresAt] = stub.firstCall.args
+      expect(name).to.equal('my-token')
+      expect(expiresAt).to.be.instanceOf(Date)
+      // default is 30 days; allow a little clock slack around the boundary
+      const diffDays = (expiresAt.getTime() - before.getTime()) / 86_400_000
+      expect(diffDays).to.be.within(29.9, 30.1)
+    })
+    cy.then(() => Cypress.vueWrapper.emitted('generated')).should('deep.equal', [['kpat_test']])
+  })
+
+  it('shows an error alert when generateKonnectPat rejects', () => {
+    const generate = cy.stub().as('generate').rejects(new Error('boom'))
+
+    cy.mount(GeneratePatModal, {
+      props: {
+        visible: true,
+        generateKonnectPat: generate,
+      },
+    })
+
+    nameInput().type('my-token')
+    cy.contains('button', generateLabel).click()
+    cy.contains('boom').should('be.visible')
+    cy.then(() => Cypress.vueWrapper.emitted('generated')).should('be.undefined')
+  })
+
+  it('disables the button and shows the pending label while generating', () => {
+    let resolvePromise!: (value: string) => void
+    const pending = new Promise<string>((resolve) => resolvePromise = resolve)
+    const generate = cy.stub().as('generate').returns(pending)
+
+    cy.mount(GeneratePatModal, {
+      props: {
+        visible: true,
+        generateKonnectPat: generate,
+      },
+    })
+
+    nameInput().type('my-token')
+    cy.contains('button', generateLabel).click()
+
+    cy.contains('button', generatingLabel).should('be.disabled').then(() => {
+      resolvePromise('kpat_test')
+    })
+    cy.contains('button', generateLabel).should('not.be.disabled')
+  })
+})

--- a/packages/entities/entities-shared/src/components/common/GeneratePatModal.vue
+++ b/packages/entities/entities-shared/src/components/common/GeneratePatModal.vue
@@ -1,0 +1,116 @@
+<template>
+  <KModal
+    class="generate-pat-modal"
+    max-width="640px"
+    :title="t('generatePatModal.title')"
+    :visible="visible"
+    @cancel="handleCancel"
+    @proceed="handleGenerate"
+  >
+    <div>
+      {{ t('generatePatModal.description') }}
+    </div>
+
+    <KInput
+      v-model="tokenName"
+      :label="t('generatePatModal.fields.name.label')"
+      :placeholder="t('generatePatModal.fields.name.placeholder')"
+      required
+    />
+
+    <KSelect
+      v-model="expirationDays"
+      :items="expirationItems"
+      :label="t('generatePatModal.fields.expiresAt.label')"
+      :placeholder="t('generatePatModal.fields.expiresAt.placeholder')"
+      required
+    />
+
+    <KAlert
+      v-if="errorMessage"
+      appearance="danger"
+      :message="errorMessage"
+    />
+
+    <template #footer-actions>
+      <KButton
+        appearance="tertiary"
+        @click="handleCancel"
+      >
+        {{ t('generatePatModal.actions.cancel') }}
+      </KButton>
+      <KButton
+        appearance="primary"
+        :disabled="!tokenName || isWorking"
+        @click="handleGenerate"
+      >
+        {{ isWorking ? t('generatePatModal.actions.generating') : t('generatePatModal.actions.generate') }}
+      </KButton>
+    </template>
+  </KModal>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import composables from '../../composables'
+
+const props = defineProps<{
+  visible: boolean
+  generateKonnectPat: (name: string, expiresAt: Date) => string | Promise<string>
+}>()
+
+const emit = defineEmits<{
+  generated: [token: string]
+  dismiss: []
+}>()
+
+const { i18n: { t } } = composables.useI18n()
+
+const tokenName = ref('')
+const expirationDays = ref('30')
+const isWorking = ref(false)
+const errorMessage = ref('')
+
+const expirationItems = [
+  { value: '30', label: t('generatePatModal.fields.expiresAt.n_days', { n: 30 }) },
+  { value: '60', label: t('generatePatModal.fields.expiresAt.n_days', { n: 60 }) },
+  { value: '90', label: t('generatePatModal.fields.expiresAt.n_days', { n: 90 }) },
+  { value: '180', label: t('generatePatModal.fields.expiresAt.n_days', { n: 180 }) },
+  { value: '365', label: t('generatePatModal.fields.expiresAt.n_days', { n: 365 }) },
+]
+
+const handleCancel = () => {
+  emit('dismiss')
+}
+
+const handleGenerate = async () => {
+  if (!tokenName.value) return
+
+  errorMessage.value = ''
+  isWorking.value = true
+
+  const expiresAt = new Date()
+  expiresAt.setDate(expiresAt.getDate() + Number(expirationDays.value))
+
+  try {
+    const token = await props.generateKonnectPat(tokenName.value, expiresAt)
+    emit('generated', token)
+  } catch (e) {
+    console.error('Failed to create PAT:', e)
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    isWorking.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.generate-pat-modal {
+  :deep(.modal-content) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--kui-space-70, $kui-space-70);
+  }
+}
+</style>

--- a/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
@@ -1,5 +1,14 @@
 <template>
-  <div class="yaml-config config-card-code-block">
+  <DeckCallout
+    v-if="props.deckCalloutPreferenceKey && deckCalloutPreference === 'visible'"
+    @click-cta="$emit('deck-callout:click-cta')"
+    @dismiss="handleDeckCalloutDismiss()"
+  />
+
+  <div
+    class="yaml-config config-card-code-block"
+    v-bind="$attrs"
+  >
     <KCodeBlock
       v-if="props.entityRecord"
       id="yaml-codeblock"
@@ -13,9 +22,16 @@
 
 <script setup lang="ts">
 import yaml from 'js-yaml'
-import type { PropType } from 'vue'
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
+
 import { highlightCodeBlock } from '../../utils/code-block'
+import DeckCallout from './DeckCallout.vue'
+
+import type { PropType } from 'vue'
+
+import type { DeckCalloutPreference } from '../../types'
+
+defineOptions({ inheritAttrs: false })
 
 const props = defineProps({
   /** A record to indicate the entity's configuration, used to populate the YAML code block */
@@ -23,7 +39,23 @@ const props = defineProps({
     type: Object as PropType<Record<string, any>>,
     required: true,
   },
+  /**
+   * The localStorage key to use to persist the visibility preference for the decK format callout.
+   * Omitting this will hide the callout in any case.
+   */
+  deckCalloutPreferenceKey: {
+    type: String,
+    required: false,
+    default: '',
+  },
 })
+
+const emit = defineEmits<{
+  'deck-callout:click-cta': []
+  'deck-callout:dismiss': []
+}>()
+
+const deckCalloutPreference = ref<DeckCalloutPreference>('visible')
 
 const yamlContent = computed((): string => {
   // filter out null values, empty strings, and empty arrays since decK doesn't accept them [KHCP-10642]
@@ -31,4 +63,23 @@ const yamlContent = computed((): string => {
   // if empty object, display empty yaml, else convert to yaml and remove any trailing whitespace
   return (Object.keys(filteredRecord).length === 0 && filteredRecord.constructor === Object) ? '' : yaml.dump(filteredRecord).trim()
 })
+
+watch(() => props.deckCalloutPreferenceKey, (key) => {
+  if (key) {
+    const storedValue = localStorage.getItem(key)
+    deckCalloutPreference.value = storedValue === 'dismissed' ? 'dismissed' : 'visible'
+  }
+}, { immediate: true })
+
+watch(deckCalloutPreference, (preference) => {
+  const key = props.deckCalloutPreferenceKey
+  if (key) {
+    localStorage.setItem(key, preference)
+  }
+})
+
+function handleDeckCalloutDismiss() {
+  deckCalloutPreference.value = 'dismissed'
+  emit('deck-callout:dismiss')
+}
 </script>

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
@@ -61,7 +61,9 @@
   />
   <YamlCodeBlock
     v-if="format === 'yaml' && entityRecord"
+    :deck-callout-preference-key="isDeckEnabled ? deckCalloutPreferenceKey : undefined"
     :entity-record="entityRecord"
+    @deck-callout:click-cta="$emit('request-deck-format')"
   />
   <TerraformCodeBlock
     v-if="format === 'terraform' && entityRecord"
@@ -73,11 +75,14 @@
     v-if="format === 'deck' && entityRecord"
     :app="config.app"
     :control-plane-name="config.app === 'konnect' ? config.controlPlaneName : undefined"
+    :customization-options="deckCustomizationOptions"
     :entity-record="entityRecord"
-    :entity-type="props.entityType as SupportedEntityDeck"
+    :entity-type="(props.entityType as SupportedEntityDeck)"
     :geo-api-server-url="config.app === 'konnect' ? config.geoApiServerUrl : undefined"
+    :is-customization-modal-visible="isDeckCustomizationVisible"
     :kong-admin-api-url="config.app === 'kongManager' ? config.apiBaseUrl : undefined"
     :workspace="config.app === 'kongManager' ? config.workspace : undefined"
+    @customization-close="$emit('deck-customization:close')"
   />
 </template>
 
@@ -176,7 +181,17 @@ const props = defineProps({
     required: false,
     default: (entityRecord: Record<string, any>) => entityRecord,
   },
+  isDeckCustomizationVisible: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 })
+
+defineEmits<{
+  'deck-customization:close': []
+  'request-deck-format': []
+}>()
 
 const slots = useSlots()
 const { i18n: { t } } = composables.useI18n()
@@ -213,6 +228,15 @@ const fetchUrlJsonBlock = computed(() => {
   return props.fetcherUrl
     .replace(/(\?|&)__ui_data=true/, '')
 })
+
+const {
+  isDeckEnabled,
+  deckCustomizationOptions,
+  deckCalloutPreferenceKey,
+} = composables.useBaseEntityDeckOptions(
+  () => props.config,
+  () => props.entityType,
+)
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -20,6 +20,14 @@
     <template #actions>
       <div class="config-card-actions">
         <slot name="actions" />
+        <KButton
+          v-if="configFormat === 'deck' && Boolean(deckCustomizationOptions)"
+          appearance="secondary"
+          class="button-customize-deck"
+          @click="isDeckCustomizationVisible = true"
+        >
+          {{ t('baseConfigCard.actions.deck_customize') }}
+        </KButton>
         <KLabel
           class="config-format-select-label"
           data-testid="config-format-select-label"
@@ -81,11 +89,14 @@
           :entity-type="entityType"
           :fetcher-url="fetcherUrl"
           :format="configFormat"
+          :is-deck-customization-visible="isDeckCustomizationVisible"
           :preserve-code-block-timestamps="preserveCodeBlockTimestamps"
           :prop-list-types="propListTypes"
           :property-collections="propertyLists"
           :record="record"
           :sub-entity-type="subEntityType"
+          @deck-customization:close="isDeckCustomizationVisible = false"
+          @request-deck-format="configFormat = 'deck'"
         >
           <!-- Pass through slots except `after-fields` -->
           <template
@@ -128,7 +139,7 @@ import type {
   SupportedEntityType,
   PolicyConfigurationSchema,
 } from '../../types'
-import { ConfigurationSchemaType, ConfigurationSchemaSection, SupportedEntityTypesArray, isSupportedDeckEntityType } from '../../types'
+import { ConfigurationSchemaType, ConfigurationSchemaSection, SupportedEntityTypesArray } from '../../types'
 import composables from '../../composables'
 import ConfigCardDisplay from './ConfigCardDisplay.vue'
 import { BookIcon } from '@kong/icons'
@@ -305,12 +316,22 @@ const { axiosInstance } = composables.useAxios(props.config?.axiosRequestConfig)
 
 const slots = useSlots()
 
+const isDeckCustomizationVisible = ref(false)
+
 /** Every dynamic slot (title, type etc) oter than `after-fields` is passed through to ConfigCardDisplay */
 const configCardDisplaySlotKeys = computed(() =>
   Object.keys(slots).filter((name) => !RESERVED_ENTITY_CONFIG_CARD_SLOTS.has(name)),
 )
 
 const hasAfterFieldsSlot = computed((): boolean => Boolean(slots['after-fields']))
+
+const {
+  isDeckEnabled,
+  deckCustomizationOptions,
+} = composables.useBaseEntityDeckOptions(
+  () => props.config,
+  () => props.entityType,
+)
 
 /** KSelect items: built in display order, then filtered by `formatsToHide` */
 const configFormatItems = computed(() => {
@@ -339,11 +360,7 @@ const configFormatItems = computed(() => {
     })
   }
 
-  // decK is only available for certain entity types
-  // https://developer.konghq.com/deck/reference/entities/
-  const isSupportedEntity = isSupportedDeckEntityType(props.entityType)
-  const isDeckEnabled = props.config.app === 'kongManager' || props.config.enableDeckConfig
-  if (isDeckEnabled && isSupportedEntity) {
+  if (isDeckEnabled.value) {
     items.push({
       label: t('baseForm.configuration.deck'),
       value: 'deck',
@@ -700,6 +717,10 @@ onBeforeMount(async () => {
   .config-card-actions {
     align-items: center;
     display: flex;
+
+    .button-customize-deck {
+      margin-inline-end: var(--kui-space-60, $kui-space-60);
+    }
 
     .config-format-select-label {
       margin-bottom: var(--kui-space-0, $kui-space-0);

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -99,6 +99,7 @@
         </slot>
       </div>
       <KTabs
+        v-model="configTab"
         data-testid="form-view-configuration-slideout-tabs"
         :tabs="tabs"
         @change="hash => emit('codeBlockTabChange', hash.replace('#', ''))"
@@ -112,7 +113,11 @@
           />
         </template>
         <template #yaml>
-          <YamlCodeBlock :entity-record="props.formFields" />
+          <YamlCodeBlock
+            :deck-callout-preference-key="isDeckEnabled ? deckCalloutPreferenceKey : undefined"
+            :entity-record="props.formFields"
+            @deck-callout:click-cta="configTab = '#deck'"
+          />
         </template>
         <template #terraform>
           <TerraformCodeBlock
@@ -122,14 +127,30 @@
           />
         </template>
         <template #deck>
+          <div
+            v-if="Boolean(deckCustomizationOptions)"
+            class="button-customize-deck-wrapper"
+          >
+            <KButton
+              appearance="secondary"
+              class="button-customize-deck"
+              @click="isDeckCustomizationVisible = true"
+            >
+              {{ t('baseConfigCard.actions.deck_customize') }}
+            </KButton>
+          </div>
+
           <DeckCodeBlock
             :app="config.app"
             :control-plane-name="config.app === 'konnect' ? config.controlPlaneName : undefined"
+            :customization-options="deckCustomizationOptions"
             :entity-record="props.formFields"
-            :entity-type="entityType as SupportedEntityDeck"
+            :entity-type="(entityType as SupportedEntityDeck)"
             :geo-api-server-url="config.app === 'konnect' ? config.geoApiServerUrl : undefined"
+            :is-customization-modal-visible="isDeckCustomizationVisible"
             :kong-admin-api-url="config.app === 'kongManager' ? config.apiBaseUrl : undefined"
             :workspace="config.app === 'kongManager' ? config.workspace : undefined"
+            @customization-close="isDeckCustomizationVisible = false"
           />
         </template>
       </KTabs>
@@ -143,7 +164,7 @@ import { computed, ref, onBeforeMount, watch, inject } from 'vue'
 import { useRouter } from 'vue-router'
 import type { AxiosError } from 'axios'
 import type { KonnectBaseFormConfig, KongManagerBaseFormConfig, SupportedEntityDeck } from '../../types'
-import { SupportedEntityTypesArray, SupportedEntityType, isSupportedDeckEntityType } from '../../types'
+import { SupportedEntityTypesArray, SupportedEntityType } from '../../types'
 import composables from '../../composables'
 import type { Tab } from '@kong/kongponents'
 import JsonCodeBlock from '../common/JsonCodeBlock.vue'
@@ -326,6 +347,17 @@ const fetcherUrl = computed<string>(() => {
   return url
 })
 
+const isDeckCustomizationVisible = ref(false)
+
+const {
+  isDeckEnabled,
+  deckCustomizationOptions,
+  deckCalloutPreferenceKey,
+} = composables.useBaseFormDeckOptions(
+  () => props.config,
+  () => props.entityType,
+)
+
 const toggle = (): void => {
   isToggled.value = !isToggled.value
 }
@@ -372,17 +404,14 @@ if (props.config.app === 'konnect' && props.entityType !== SupportedEntityType.O
   })
 }
 
-// decK is only available for certain entity types
-// https://developer.konghq.com/deck/reference/entities/
-const isSupportedEntity = isSupportedDeckEntityType(props.entityType)
-const isDeckEnabled = props.config.app === 'kongManager' || props.config.enableDeckTab
-
-if (isDeckEnabled && isSupportedEntity) {
+if (isDeckEnabled.value) {
   tabs.value.push({
     title: t('baseForm.configuration.deck'),
     hash: '#deck',
   })
 }
+
+const configTab = ref(tabs.value[0].hash)
 
 watch(() => isLoading.value, (val: boolean) => {
   // Emit the loading state for the host app
@@ -465,6 +494,13 @@ defineExpose({
     .form-error {
       margin: var(--kui-space-70, $kui-space-70) 0 0 var(--kui-space-60, $kui-space-60);
     }
+  }
+
+  .button-customize-deck-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    margin-bottom: var(--kui-space-60, $kui-space-60);
   }
 }
 

--- a/packages/entities/entities-shared/src/composables/index.ts
+++ b/packages/entities/entities-shared/src/composables/index.ts
@@ -1,5 +1,6 @@
 import useAxios from './useAxios'
 import useDebouncedFilter from './useDebouncedFilter'
+import { useBaseEntityDeckOptions, useBaseFormDeckOptions } from './useDeckOptions'
 import useDeleteUrlBuilder from './useDeleteUrlBuilder'
 import useErrors from './useErrors'
 import useExternalLinkCreator from './useExternalLinkCreator'
@@ -19,6 +20,8 @@ export default {
   useAxios,
   useDebouncedFilter,
   useDeleteUrlBuilder,
+  useBaseEntityDeckOptions,
+  useBaseFormDeckOptions,
   useErrors,
   useExternalLinkCreator,
   useFetcher,

--- a/packages/entities/entities-shared/src/composables/tests/useDeckOptions.spec.ts
+++ b/packages/entities/entities-shared/src/composables/tests/useDeckOptions.spec.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+
+import { useBaseEntityDeckOptions, useBaseFormDeckOptions } from '../useDeckOptions'
+import { SupportedEntityType } from '../../types'
+
+import type {
+  DeckConfigOptions,
+  KongManagerBaseEntityConfig,
+  KongManagerBaseFormConfig,
+  KonnectBaseEntityConfig,
+  KonnectBaseFormConfig,
+} from '../../types'
+
+const konnectEntityBase = {
+  app: 'konnect',
+  apiBaseUrl: '/',
+  controlPlaneId: 'cp-1',
+  entityId: 'e-1',
+} satisfies KonnectBaseEntityConfig
+
+const kongManagerEntityBase = {
+  app: 'kongManager',
+  apiBaseUrl: '/',
+  workspace: 'default',
+  entityId: 'e-1',
+} satisfies KongManagerBaseEntityConfig
+
+const konnectFormBase = {
+  app: 'konnect',
+  apiBaseUrl: '/',
+  controlPlaneId: 'cp-1',
+} satisfies KonnectBaseFormConfig
+
+const kongManagerFormBase = {
+  app: 'kongManager',
+  apiBaseUrl: '/',
+  workspace: 'default',
+} satisfies KongManagerBaseFormConfig
+
+describe('useBaseEntityDeckOptions()', () => {
+  describe('isDeckEnabled', () => {
+    it('returns false when the entity type is not supported by decK', () => {
+      const { isDeckEnabled } = useBaseEntityDeckOptions(
+        { ...kongManagerEntityBase },
+        SupportedEntityType.Other,
+      )
+
+      expect(isDeckEnabled.value).toBe(false)
+    })
+
+    it('is enabled for Kong Manager on a supported entity', () => {
+      const { isDeckEnabled } = useBaseEntityDeckOptions(
+        { ...kongManagerEntityBase },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(isDeckEnabled.value).toBe(true)
+    })
+
+    it('is disabled for Konnect without `enableDeckConfig`', () => {
+      const { isDeckEnabled } = useBaseEntityDeckOptions(
+        { ...konnectEntityBase },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(isDeckEnabled.value).toBe(false)
+    })
+
+    it('is enabled for Konnect with `enableDeckConfig: true`', () => {
+      const { isDeckEnabled } = useBaseEntityDeckOptions(
+        { ...konnectEntityBase, enableDeckConfig: true },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(isDeckEnabled.value).toBe(true)
+    })
+
+    it('is enabled for Konnect with an `enableDeckConfig` object', () => {
+      const { isDeckEnabled } = useBaseEntityDeckOptions(
+        { ...konnectEntityBase, enableDeckConfig: {} },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(isDeckEnabled.value).toBe(true)
+    })
+  })
+
+  describe('deckCustomizationOptions', () => {
+    it('is undefined for Kong Manager', () => {
+      const { deckCustomizationOptions } = useBaseEntityDeckOptions(
+        { ...kongManagerEntityBase },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(deckCustomizationOptions.value).toBeUndefined()
+    })
+
+    it('is undefined when `enableDeckConfig` is a boolean', () => {
+      const { deckCustomizationOptions } = useBaseEntityDeckOptions(
+        { ...konnectEntityBase, enableDeckConfig: true },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(deckCustomizationOptions.value).toBeUndefined()
+    })
+
+    it('returns the nested `customization` field', () => {
+      const customization = { generateKonnectPat: async () => 'pat' }
+      const { deckCustomizationOptions } = useBaseEntityDeckOptions(
+        { ...konnectEntityBase, enableDeckConfig: { customization } },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(deckCustomizationOptions.value).toBe(customization)
+    })
+  })
+
+  describe('deckCalloutPreferenceKey', () => {
+    it('returns `deckCalloutPreferenceKey` for Kong Manager configs', () => {
+      const { deckCalloutPreferenceKey } = useBaseEntityDeckOptions(
+        { ...kongManagerEntityBase, deckCalloutPreferenceKey: 'km-key' },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(deckCalloutPreferenceKey.value).toBe('km-key')
+    })
+
+    it('returns the nested `calloutPreferenceKey` for Konnect configs', () => {
+      const { deckCalloutPreferenceKey } = useBaseEntityDeckOptions(
+        { ...konnectEntityBase, enableDeckConfig: { calloutPreferenceKey: 'konnect-key' } },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(deckCalloutPreferenceKey.value).toBe('konnect-key')
+    })
+
+    it('is undefined when Konnect `enableDeckConfig` is a boolean', () => {
+      const { deckCalloutPreferenceKey } = useBaseEntityDeckOptions(
+        { ...konnectEntityBase, enableDeckConfig: true },
+        SupportedEntityType.GatewayService,
+      )
+
+      expect(deckCalloutPreferenceKey.value).toBeUndefined()
+    })
+  })
+
+  it('reacts to config and entity type updates', () => {
+    const config = ref<KonnectBaseEntityConfig | KongManagerBaseEntityConfig>({ ...konnectEntityBase })
+    const entityType = ref(SupportedEntityType.Other)
+
+    const { isDeckEnabled, deckCalloutPreferenceKey } = useBaseEntityDeckOptions(config, entityType)
+
+    expect(isDeckEnabled.value).toBe(false)
+
+    entityType.value = SupportedEntityType.GatewayService
+    expect(isDeckEnabled.value).toBe(false)
+
+    config.value = { ...konnectEntityBase, enableDeckConfig: { calloutPreferenceKey: 'k' } }
+    expect(isDeckEnabled.value).toBe(true)
+    expect(deckCalloutPreferenceKey.value).toBe('k')
+
+    config.value = { ...kongManagerEntityBase, deckCalloutPreferenceKey: 'km' }
+    expect(isDeckEnabled.value).toBe(true)
+    expect(deckCalloutPreferenceKey.value).toBe('km')
+  })
+})
+
+describe('useBaseFormDeckOptions()', () => {
+  describe('isDeckEnabled', () => {
+    it('returns false when the entity type is not supported by decK', () => {
+      const { isDeckEnabled } = useBaseFormDeckOptions(
+        { ...kongManagerFormBase },
+        SupportedEntityType.Other,
+      )
+
+      expect(isDeckEnabled.value).toBe(false)
+    })
+
+    it('is enabled for Kong Manager on a supported entity', () => {
+      const { isDeckEnabled } = useBaseFormDeckOptions(
+        { ...kongManagerFormBase },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(isDeckEnabled.value).toBe(true)
+    })
+
+    it('is disabled for Konnect without `enableDeckTab`', () => {
+      const { isDeckEnabled } = useBaseFormDeckOptions(
+        { ...konnectFormBase },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(isDeckEnabled.value).toBe(false)
+    })
+
+    it('is enabled for Konnect with `enableDeckTab: true`', () => {
+      const { isDeckEnabled } = useBaseFormDeckOptions(
+        { ...konnectFormBase, enableDeckTab: true },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(isDeckEnabled.value).toBe(true)
+    })
+
+    it('is enabled for Konnect with an `enableDeckTab` object', () => {
+      const options: DeckConfigOptions = {}
+      const { isDeckEnabled } = useBaseFormDeckOptions(
+        { ...konnectFormBase, enableDeckTab: options },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(isDeckEnabled.value).toBe(true)
+    })
+  })
+
+  describe('deckCustomizationOptions', () => {
+    it('is undefined for Kong Manager', () => {
+      const { deckCustomizationOptions } = useBaseFormDeckOptions(
+        { ...kongManagerFormBase },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(deckCustomizationOptions.value).toBeUndefined()
+    })
+
+    it('is undefined when `enableDeckTab` is a boolean', () => {
+      const { deckCustomizationOptions } = useBaseFormDeckOptions(
+        { ...konnectFormBase, enableDeckTab: true },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(deckCustomizationOptions.value).toBeUndefined()
+    })
+
+    it('returns the nested `customization` field', () => {
+      const customization = { generateKonnectPat: async () => 'pat' }
+      const { deckCustomizationOptions } = useBaseFormDeckOptions(
+        { ...konnectFormBase, enableDeckTab: { customization } },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(deckCustomizationOptions.value).toBe(customization)
+    })
+  })
+
+  describe('deckCalloutPreferenceKey', () => {
+    it('returns `deckCalloutPreferenceKey` for Kong Manager configs', () => {
+      const { deckCalloutPreferenceKey } = useBaseFormDeckOptions(
+        { ...kongManagerFormBase, deckCalloutPreferenceKey: 'km-key' },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(deckCalloutPreferenceKey.value).toBe('km-key')
+    })
+
+    it('returns the nested `calloutPreferenceKey` for Konnect configs', () => {
+      const { deckCalloutPreferenceKey } = useBaseFormDeckOptions(
+        { ...konnectFormBase, enableDeckTab: { calloutPreferenceKey: 'konnect-key' } },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(deckCalloutPreferenceKey.value).toBe('konnect-key')
+    })
+
+    it('is undefined when Konnect `enableDeckTab` is a boolean', () => {
+      const { deckCalloutPreferenceKey } = useBaseFormDeckOptions(
+        { ...konnectFormBase, enableDeckTab: true },
+        SupportedEntityType.Plugin,
+      )
+
+      expect(deckCalloutPreferenceKey.value).toBeUndefined()
+    })
+  })
+})

--- a/packages/entities/entities-shared/src/composables/useDeckOptions.ts
+++ b/packages/entities/entities-shared/src/composables/useDeckOptions.ts
@@ -1,0 +1,79 @@
+import { computed, toValue } from 'vue'
+
+import { isSupportedDeckEntityType } from '../types'
+
+import type { MaybeRefOrGetter } from 'vue'
+
+import type {
+  KongManagerBaseEntityConfig,
+  KongManagerBaseFormConfig,
+  KonnectBaseEntityConfig,
+  KonnectBaseFormConfig,
+  SupportedEntityType,
+} from '../types'
+
+export function useBaseEntityDeckOptions(
+  config: MaybeRefOrGetter<KonnectBaseEntityConfig | KongManagerBaseEntityConfig>,
+  entityType: MaybeRefOrGetter<SupportedEntityType>,
+) {
+  const isDeckEnabled = computed(() => {
+    const c = toValue(config)
+    const enabled = c.app === 'kongManager' || Boolean(c.app === 'konnect' && c.enableDeckConfig)
+    return enabled && isSupportedDeckEntityType(toValue(entityType))
+  })
+
+  const deckCustomizationOptions = computed(() => {
+    const c = toValue(config)
+    return c.app === 'konnect' && c.enableDeckConfig && typeof c.enableDeckConfig !== 'boolean'
+      ? c.enableDeckConfig.customization
+      : undefined
+  })
+
+  const deckCalloutPreferenceKey = computed(() => {
+    const c = toValue(config)
+    return c.app === 'konnect' && c.enableDeckConfig && typeof c.enableDeckConfig !== 'boolean'
+      ? c.enableDeckConfig.calloutPreferenceKey
+      : c.app === 'kongManager'
+        ? c.deckCalloutPreferenceKey
+        : undefined
+  })
+
+  return {
+    isDeckEnabled,
+    deckCustomizationOptions,
+    deckCalloutPreferenceKey,
+  }
+}
+
+export function useBaseFormDeckOptions(
+  config: MaybeRefOrGetter<KonnectBaseFormConfig | KongManagerBaseFormConfig>,
+  entityType: MaybeRefOrGetter<SupportedEntityType>,
+) {
+  const isDeckEnabled = computed(() => {
+    const c = toValue(config)
+    const enabled = c.app === 'kongManager' || Boolean(c.app === 'konnect' && c.enableDeckTab)
+    return enabled && isSupportedDeckEntityType(toValue(entityType))
+  })
+
+  const deckCustomizationOptions = computed(() => {
+    const c = toValue(config)
+    return c.app === 'konnect' && c.enableDeckTab && typeof c.enableDeckTab !== 'boolean'
+      ? c.enableDeckTab.customization
+      : undefined
+  })
+
+  const deckCalloutPreferenceKey = computed(() => {
+    const c = toValue(config)
+    return c.app === 'konnect' && c.enableDeckTab && typeof c.enableDeckTab !== 'boolean'
+      ? c.enableDeckTab.calloutPreferenceKey
+      : c.app === 'kongManager'
+        ? c.deckCalloutPreferenceKey
+        : undefined
+  })
+
+  return {
+    isDeckEnabled,
+    deckCustomizationOptions,
+    deckCalloutPreferenceKey,
+  }
+}

--- a/packages/entities/entities-shared/src/index.ts
+++ b/packages/entities/entities-shared/src/index.ts
@@ -16,6 +16,7 @@ import JsonCodeBlock from './components/common/JsonCodeBlock.vue'
 import TerraformCodeBlock from './components/common/TerraformCodeBlock.vue'
 import YamlCodeBlock from './components/common/YamlCodeBlock.vue'
 import DeckCodeBlock from './components/common/DeckCodeBlock.vue'
+import GeneratePatModal from './components/common/GeneratePatModal.vue'
 import TableTags from './components/common/TableTags.vue'
 import composables from './composables'
 
@@ -23,7 +24,7 @@ import composables from './composables'
 const { useAxios, useDeleteUrlBuilder, useBaseEntityDeckOptions, useBaseFormDeckOptions, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchemaProvider, useTableState } = composables
 
 // Components
-export { EntityBaseConfigCard, ConfigCardItem, ConfigCardDisplay, InternalLinkItem, EntityBaseForm, EntityBaseTable, EntityDeleteModal, EntityFilter, EntityToggleModal, PermissionsWrapper, EntityFormSection, EntityFormBlock, EntityLink, EntityEmptyState, JsonCodeBlock, TerraformCodeBlock, YamlCodeBlock, DeckCodeBlock, TableTags }
+export { EntityBaseConfigCard, ConfigCardItem, ConfigCardDisplay, InternalLinkItem, EntityBaseForm, EntityBaseTable, EntityDeleteModal, EntityFilter, EntityToggleModal, PermissionsWrapper, EntityFormSection, EntityFormBlock, EntityLink, EntityEmptyState, JsonCodeBlock, TerraformCodeBlock, YamlCodeBlock, DeckCodeBlock, GeneratePatModal, TableTags }
 
 // Composables
 export { useAxios, useDeleteUrlBuilder, useBaseEntityDeckOptions, useBaseFormDeckOptions, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchemaProvider, useTableState }

--- a/packages/entities/entities-shared/src/index.ts
+++ b/packages/entities/entities-shared/src/index.ts
@@ -20,13 +20,13 @@ import TableTags from './components/common/TableTags.vue'
 import composables from './composables'
 
 // Extract specific composables to export
-const { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchemaProvider, useTableState } = composables
+const { useAxios, useDeleteUrlBuilder, useBaseEntityDeckOptions, useBaseFormDeckOptions, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchemaProvider, useTableState } = composables
 
 // Components
 export { EntityBaseConfigCard, ConfigCardItem, ConfigCardDisplay, InternalLinkItem, EntityBaseForm, EntityBaseTable, EntityDeleteModal, EntityFilter, EntityToggleModal, PermissionsWrapper, EntityFormSection, EntityFormBlock, EntityLink, EntityEmptyState, JsonCodeBlock, TerraformCodeBlock, YamlCodeBlock, DeckCodeBlock, TableTags }
 
 // Composables
-export { useAxios, useDeleteUrlBuilder, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchemaProvider, useTableState }
+export { useAxios, useDeleteUrlBuilder, useBaseEntityDeckOptions, useBaseFormDeckOptions, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchemaProvider, useTableState }
 
 // Types
 export * from './types'

--- a/packages/entities/entities-shared/src/locales/en.json
+++ b/packages/entities/entities-shared/src/locales/en.json
@@ -41,7 +41,9 @@
   "baseConfigCard": {
     "title": "Configuration",
     "actions": {
-      "copy": "Copy JSON"
+      "copy": "Copy JSON",
+      "deck_customize": "Customize before copying to CLI",
+      "deck_customize_cancel": "Cancel"
     },
     "sections": {
       "advanced": "Advanced",
@@ -119,6 +121,42 @@
       "konnect": "The {token} environment variable must be added first. See {link} for details.",
       "kongManager": "If your Admin API is secured, set up authentication following {link}."
     },
-    "documentation": "the documentation"
+    "documentation": "the documentation",
+    "steps": {
+      "step_1": "Step 1: Export token",
+      "step_2": "Step 2: Apply configuration"
+    },
+    "customization": {
+      "title": "Customize before copying to CLI",
+      "copy_pat": "Make sure to copy your personal access token now. You won't be able to see it again.",
+      "reuse_pat": "Use an existing PAT if you've already generated one.",
+      "generate_pat": "Generate PAT",
+      "footer_reminder": "Changes made here won't affect your configuration."
+    },
+    "copy_tooltip": "Copy"
+  },
+  "deckCallout": {
+    "body": "Want a ready-to-use CLI command? {cta} to view this configuration as a decK sync snippet you can copy directly.",
+    "cta": "Switch to decK format"
+  },
+  "generatePatModal": {
+    "title": "Generate a Personal Access Token",
+    "description": "Personal access tokens are used to authenticate decK commands and Konnect API requests.",
+    "fields": {
+      "name": {
+        "label": "Name",
+        "placeholder": "Enter token name"
+      },
+      "expiresAt": {
+        "label": "Expiration Date",
+        "placeholder": "Select an expiration date",
+        "n_days": "{n} days"
+      }
+    },
+    "actions": {
+      "cancel": "Cancel",
+      "generate": "Generate",
+      "generating": "Generating…"
+    }
   }
 }

--- a/packages/entities/entities-shared/src/types/deck.ts
+++ b/packages/entities/entities-shared/src/types/deck.ts
@@ -1,0 +1,37 @@
+import type { SupportedEntityDeck } from './entity-base-config-card'
+
+export interface DeckCodeBlockProps {
+  app: 'konnect' | 'kongManager'
+  /** A record to indicate the entity's configuration, used to populate the decK code block */
+  entityRecord: Record<string, any>
+  entityType: SupportedEntityDeck
+  /** e.g. https://us.api.konghq.tech, used to pass --konnect-addr parameter to decK */
+  geoApiServerUrl?: string
+  controlPlaneName?: string
+  /** e.g. https://localhost:8001, used to pass --kong-addr parameter to decK */
+  kongAdminApiUrl?: string
+  workspace?: string
+}
+
+export interface DeckCustomizationOptions {
+  /**
+   * A function to generate a Konnect Personal Access Token (PAT).
+   * This enables the user to generate a PAT directly from the UI.
+   */
+  generateKonnectPat?: (name: string, expiresAt: Date) => string | Promise<string>
+}
+
+export interface DeckConfigOptions {
+  /**
+   * This option enables the "Customize before copying" feature on the decK config.
+   * See {@link DeckCustomizationOptions} for extra options.
+   */
+  customization?: boolean | DeckCustomizationOptions
+  /**
+   * The localStorage key to use while persisting the visibility preference for the
+   * decK format callout. Omitting this will hide the callout in any case.
+   */
+  calloutPreferenceKey?: string
+}
+
+export type DeckCalloutPreference = 'visible' | 'dismissed'

--- a/packages/entities/entities-shared/src/types/entity-base-config-card.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-config-card.ts
@@ -1,3 +1,4 @@
+import type { DeckConfigOptions } from './deck'
 import type { KonnectConfig, KongManagerConfig } from './index'
 
 /**
@@ -85,11 +86,17 @@ export interface BaseEntityConfig {
 
 /** Konnect base form config */
 export interface KonnectBaseEntityConfig extends KonnectConfig, BaseEntityConfig {
-  enableDeckConfig?: boolean
+  enableDeckConfig?: boolean | DeckConfigOptions
 }
 
 /** Kong Manager base form config */
-export interface KongManagerBaseEntityConfig extends KongManagerConfig, BaseEntityConfig { }
+export interface KongManagerBaseEntityConfig extends KongManagerConfig, BaseEntityConfig {
+  /**
+   * The localStorage key to use while persisting the visibility preference for the
+   * decK format callout. Omitting this will hide the callout in any case.
+   */
+  deckCalloutPreferenceKey?: string
+}
 
 export enum ConfigurationSchemaType {
   ID = 'id',

--- a/packages/entities/entities-shared/src/types/entity-base-form.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-form.ts
@@ -1,5 +1,6 @@
 import type { RouteLocationRaw } from 'vue-router'
 import type { KonnectConfig, KongManagerConfig } from './index'
+import type { DeckConfigOptions } from './deck'
 
 export interface BaseFormConfig {
   /** Route to return to if canceling create/edit an entity */
@@ -11,11 +12,17 @@ export interface BaseFormConfig {
 /** Konnect base form config */
 export interface KonnectBaseFormConfig extends KonnectConfig, BaseFormConfig {
   /** Whether to enable the deck tab */
-  enableDeckTab?: boolean
+  enableDeckTab?: boolean | DeckConfigOptions
 }
 
 /** Kong Manager base form config */
-export interface KongManagerBaseFormConfig extends KongManagerConfig, BaseFormConfig {}
+export interface KongManagerBaseFormConfig extends KongManagerConfig, BaseFormConfig {
+  /**
+   * The localStorage key to use while persisting the visibility preference for the
+   * decK format callout. Omitting this will hide the callout in any case.
+   */
+  deckCalloutPreferenceKey?: string
+}
 
 export enum EntityBaseFormType {
   Edit = 'edit',

--- a/packages/entities/entities-shared/src/types/index.ts
+++ b/packages/entities/entities-shared/src/types/index.ts
@@ -4,6 +4,7 @@
 // Example:
 export * from './app-config'
 export * from './base'
+export * from './deck'
 export * from './entity-delete-modal'
 export * from './entity-base-form'
 export * from './entity-base-table'

--- a/packages/entities/entities-shared/vite.config.ts
+++ b/packages/entities/entities-shared/vite.config.ts
@@ -1,6 +1,7 @@
 import sharedViteConfig, { getApiProxies, sanitizePackageName } from '../../../vite.config.shared'
 import { resolve } from 'path'
 import { defineConfig, mergeConfig } from 'vite'
+import monaco from '@kong-ui-public/monaco-editor/vite-plugin'
 
 // Package name MUST always match the kebab-case package name inside the component's package.json file and the name of your `/packages/{package-name}` directory
 const packageName = 'entities-shared'
@@ -8,6 +9,9 @@ const sanitizedPackageName = sanitizePackageName(packageName)
 
 // Merge the shared Vite config with the local one defined below
 const config = mergeConfig(sharedViteConfig, defineConfig({
+  plugins: [monaco({
+    languages: ['powershell', 'shell'],
+  })],
   build: {
     lib: {
       // The kebab-case name of the exposed global variable. MUST be in the format `kong-ui-public-{package-name}`
@@ -17,7 +21,12 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       fileName: (format) => `${sanitizedPackageName}.${format}.js`,
     },
     rollupOptions: {
-      external: [/^@shikijs\//],
+      external: [
+        '@kong-ui-public/monaco-editor',
+        '@kong-ui-public/monaco-editor/dist/runtime/style.css',
+        'monaco-editor',
+        /^@shikijs\//,
+      ],
     },
   },
   server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,10 +621,10 @@ importers:
         version: 1.1.0(monaco-editor@0.55.1)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 1.6.0(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 3.6.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -1087,7 +1087,7 @@ importers:
         version: 2.0.0
       '@playwright/experimental-ct-vue':
         specifier: ^1.59.1
-        version: 1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)
+        version: 1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -1252,6 +1252,9 @@ importers:
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n
+      '@kong-ui-public/monaco-editor':
+        specifier: workspace:^
+        version: link:../../core/monaco-editor
       '@kong/design-tokens':
         specifier: 1.20.1
         version: 1.20.1
@@ -1270,6 +1273,9 @@ importers:
       axios:
         specifier: ^1.15.2
         version: 1.15.2
+      monaco-editor:
+        specifier: ^0.55.1
+        version: 0.55.1
       shiki:
         specifier: ^3.23.0
         version: 3.23.0
@@ -1382,7 +1388,7 @@ importers:
         version: 1.26.6
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.2.0
-        version: 4.2.0(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))
+        version: 4.2.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -1413,7 +1419,7 @@ importers:
         version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.1
-        version: 1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 1.1.1(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -12281,12 +12287,12 @@ snapshots:
     dependencies:
       langium: 4.2.2
 
-  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))':
+  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.59.0)
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
-      vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
 
@@ -12755,10 +12761,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-vue@1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)':
+  '@playwright/experimental-ct-vue@1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
       '@playwright/experimental-ct-core': 1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13880,9 +13886,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
+      '@rolldown/pluginutils': 1.0.0-beta.32
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.0)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
+      vue: 3.5.33(typescript@5.9.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vue: 3.5.33(typescript@5.9.3)
+
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
       vue: 3.5.33(typescript@5.9.3)
 
   '@vitest/expect@3.2.4':
@@ -21328,13 +21350,13 @@ snapshots:
     dependencies:
       monaco-editor: 0.55.1
 
-  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)):
+  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
       '@swc/core': 1.15.7
       '@swc/wasm': 1.15.7
       uuid: 10.0.0
-      vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
@@ -21370,9 +21392,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-wasm@3.6.0(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)):
+  vite-plugin-wasm@3.6.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)):
     dependencies:
-      vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
 
   vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1):
     dependencies:


### PR DESCRIPTION
- Allow showing a "Customize before copy" button in the decK config format
- Lazy load Monaco Editor when needed
- Allow showing a callout to switch to the decK config format in the YAML config format

<details>
<summary>Screenshots</summary>
<img width="1025" height="751" alt="Screenshot 2026-04-24 at 16 49 53" src="https://github.com/user-attachments/assets/a610c68b-4565-4493-8343-c9d9cb8c0c09" />
<br>
<img width="672" height="808" alt="Screenshot 2026-04-24 at 17 25 26" src="https://github.com/user-attachments/assets/f7834463-2722-4aa0-bb1d-e2a1c5a9b36c" />
<br>
<img width="686" height="444" alt="Screenshot 2026-04-24 at 16 57 43" src="https://github.com/user-attachments/assets/27f95e35-f68e-409e-879c-f857acdb7493" />
<br>
<img width="1029" height="515" alt="Screenshot 2026-04-24 at 16 57 58" src="https://github.com/user-attachments/assets/1d57c6f1-90a8-418c-a048-c4cec38a6ee0" />
</details>

---

KM-2473