### PR TITLE
fix(entities-plugins): prefill default values with prepareFormData

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.cy.ts
@@ -72,6 +72,27 @@ const mountForm = (options: {
   })
 }
 
+describe('MeteringAndBillingForm - schema defaults', () => {
+  it('populates schema defaults alongside ingest_endpoint for new Konnect plugin', () => {
+    mountForm({ geoApiServerUrl: 'https://us.api.konghq.com' })
+
+    cy.getTestId('ff-config.ingest_endpoint').should('have.value', 'https://us.api.konghq.com/v3/openmeter/events')
+    cy.getTestId('ff-config.meter_api_requests').should('be.checked')
+    cy.getTestId('ff-config.ssl_verify').should('be.checked')
+    cy.getTestId('ff-config.timeout').should('have.value', '10000')
+    cy.getTestId('ff-config.keepalive').should('have.value', '60000')
+  })
+
+  it('populates schema defaults for new Kong Manager plugin', () => {
+    mountForm({ app: 'kongManager' })
+
+    cy.getTestId('ff-config.meter_api_requests').should('be.checked')
+    cy.getTestId('ff-config.ssl_verify').should('be.checked')
+    cy.getTestId('ff-config.timeout').should('have.value', '10000')
+    cy.getTestId('ff-config.keepalive').should('have.value', '60000')
+  })
+})
+
 describe('MeteringAndBillingForm - ingest_endpoint prefill', () => {
   it('prefills with region-based URL when geoApiServerUrl is available', () => {
     mountForm({ geoApiServerUrl: 'https://us.api.konghq.com' })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
@@ -1,6 +1,7 @@
 <template>
   <StandardLayout
-    v-bind="{ ...props, model: modelWithDefaults }"
+    v-bind="props"
+    :form-config="formConfig"
     :plugin-config-description="t('plugins.free-form.metering-and-billing.sections.plugin_config.description')"
   >
     <template #field-renderers>
@@ -238,19 +239,36 @@ const ingestEndpointUrl = computed(() => {
     : 'https://{{region}}.api.konghq.com/v3/openmeter/events'
 })
 
-// Prefill ingest_endpoint for new Konnect plugins; Kong Manager has no regional endpoint
-const modelWithDefaults = computed(() => {
-  if (props.isEditing || props.model?.config?.ingest_endpoint || (appConfig as KonnectBaseFormConfig)?.app !== 'konnect') {
-    return props.model
+function getScopesFromFormModel(): Record<string, any> {
+  const data: Record<string, any> = {}
+  const scopeModelFields = ['service-id', 'route-id', 'consumer-id', 'consumer_group-id']
+  for (const field of scopeModelFields) {
+    if (props.formModel[field]) {
+      const name = field.split('-')[0]
+      if (name) data[name] = { id: props.formModel[field] }
+    }
   }
-  return {
-    ...props.model,
-    config: {
-      ...props.model?.config,
-      ingest_endpoint: ingestEndpointUrl.value,
-    },
-  }
-})
+  return data
+}
+
+const formConfig = {
+  hasValue: (data: any): boolean => !!data && Object.keys(data).length > 0,
+  prepareFormData: (data: any): any => {
+    if (props.isEditing) return data
+
+    const withScopes = { ...data, ...getScopesFromFormModel() }
+
+    // Prefill ingest_endpoint for new Konnect plugins; Kong Manager has no regional endpoint
+    if ((appConfig as KonnectBaseFormConfig)?.app === 'konnect' && !withScopes?.config?.ingest_endpoint) {
+      return {
+        ...withScopes,
+        config: { ...withScopes?.config, ingest_endpoint: ingestEndpointUrl.value },
+      }
+    }
+
+    return withScopes
+  },
+}
 
 const meteringExpanded = ref(true)
 const attributesExpanded = ref(true)


### PR DESCRIPTION
# Summary

Replace `modelWithDefaults` with `formConfig` containing `prepareFormData` hook to correctly initialize metering&billing form initial value and inject geo based `ingest_endpoint` properly. `modelWithDefaults` bypasses `getDefaultFromSchema `