### PR TITLE
chore: add corepack version hash for packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,5 +136,5 @@
     "node": "24.14.1",
     "pnpm": "10.33.2"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"
 }


### PR DESCRIPTION
Include the version hash of `packageManager` generated via `corepack use pnpm@10.33.2` for version validation.
https://github.com/nodejs/corepack#when-authoring-packages
> The hash is optional but strongly recommended as a security practice.

With this change it's not possible to manually edit the version of the package manager anymore, but renovate can bump it, manually via `corepack up` or `corepack use pnpm@<version>`.

---

With this I'm just assuming that `corepack` is being used. As long as `corepack` is shipped with `node` it should be available for everyone. But it's still a different tool and if you prefer to keep `corepack` out of here, I'm closing this.
It might be that at some point `corepack` is not shipped with `node` anymore, which then would require a decision to keep it or not. If not, the hash needs to be removed or it requires a different strategy. Actually there is a decision already and it looks like `corepack` will not be distributed with `node >= 25` anymore.

At the very least, since we are using the `packageManager` field and as long we are using it, we should configure it more securely.