### PR TITLE
fix: updating actions to prevent node 20 warnings [KHCP-20416]

### DIFF
--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -8,4 +8,4 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@0dacdc5221a765732d16834dc6e902cf1562b182
+      - uses: Kong/auto-author-assign@7dbebfbadd984a53a3092c634ae3f8054ed4f81d

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Check if PR Up to Date
         id: 'up-to-date'
         if: ${{ github.event_name == 'push' }}
-        uses: Kong/public-shared-actions/pr-previews/up-to-date@181795782517d00eb0d968d7e0b28a9d180b4f76
+        uses: Kong/public-shared-actions/pr-previews/up-to-date@8d98bc15a5143332a36f206e6699296e6cc2adac
         with:
           github_token: ${{ env.GH_TOKEN }}
 
@@ -469,7 +469,7 @@ jobs:
         uses: Kong/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 #v3.0.3
 
       - name: Post Slack notification
-        uses: Kong/public-shared-actions/slack-actions/workflow-notification@181795782517d00eb0d968d7e0b28a9d180b4f76
+        uses: Kong/public-shared-actions/slack-actions/workflow-notification@8d98bc15a5143332a36f206e6699296e6cc2adac
         with:
           slack-webhook-url: ${{ env.WORKFLOW_CONCLUSION == 'failure' && secrets.SLACK_WEBHOOK_URL_ALERT || secrets.SLACK_WEBHOOK_URL_NOTIFY }}
           status: ${{ env.WORKFLOW_CONCLUSION == 'failure' && 'failure' || 'success' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
       # See 'changed_packages' below
       - name: Check for config file changes
         id: config-files-changed
-        uses: Kong/changed-files@1f31e0a3b1acd04d48dff8801048bb314c8a9e0d
+        uses: Kong/changed-files@cd69b79ca4e2a1198064c5e6564cce68920df311
         with:
           files: |
             ./vite.config.shared.ts
@@ -84,6 +84,7 @@ jobs:
             ./package.json
             ./eslintrc.cjs
             ./.stylelintrc.js
+            ./.github/**
 
       - name: Verify no packages are in the wrong scope and have the correct publishConfig.access
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Check if PR Up to Date
         id: 'up-to-date'
         if: ${{ github.event_name == 'push' }}
-        uses: Kong/public-shared-actions/pr-previews/up-to-date@main
+        uses: Kong/public-shared-actions/pr-previews/up-to-date@181795782517d00eb0d968d7e0b28a9d180b4f76
         with:
           github_token: ${{ env.GH_TOKEN }}
 
@@ -465,10 +465,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get aggregate Workflow status
-        uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 #v3.0.3
+        uses: Kong/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 #v3.0.3
 
       - name: Post Slack notification
-        uses: Kong/public-shared-actions/slack-actions/workflow-notification@a18abf762d6e2444bcbfd20de70451ea1e3bc1b1 # v4.0.1
+        uses: Kong/public-shared-actions/slack-actions/workflow-notification@181795782517d00eb0d968d7e0b28a9d180b4f76
         with:
           slack-webhook-url: ${{ env.WORKFLOW_CONCLUSION == 'failure' && secrets.SLACK_WEBHOOK_URL_ALERT || secrets.SLACK_WEBHOOK_URL_NOTIFY }}
           status: ${{ env.WORKFLOW_CONCLUSION == 'failure' && 'failure' || 'success' }}

--- a/.github/workflows/pr-audit.yaml
+++ b/.github/workflows/pr-audit.yaml
@@ -42,6 +42,6 @@ jobs:
 
       - name: PR Audit
         if: github.actor != 'renovate[bot]'
-        uses: Kong/public-shared-actions/pr-previews/audit@main
+        uses: Kong/public-shared-actions/pr-previews/audit@181795782517d00eb0d968d7e0b28a9d180b4f76
         with:
           renovate-pr-author: renovate[bot]

--- a/.github/workflows/pr-audit.yaml
+++ b/.github/workflows/pr-audit.yaml
@@ -42,6 +42,6 @@ jobs:
 
       - name: PR Audit
         if: github.actor != 'renovate[bot]'
-        uses: Kong/public-shared-actions/pr-previews/audit@181795782517d00eb0d968d7e0b28a9d180b4f76
+        uses: Kong/public-shared-actions/pr-previews/audit@8d98bc15a5143332a36f206e6699296e6cc2adac
         with:
           renovate-pr-author: renovate[bot]


### PR DESCRIPTION
# Summary

this is to prevent node 20 deprecation warnings during CI runs.