### PR TITLE
fix(entities): forms slideout top offset prop [KHCP-19694]

### DIFF
--- a/packages/core/documentation/src/components/ProductDocumentModal.vue
+++ b/packages/core/documentation/src/components/ProductDocumentModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport to="#kong-ui-app-layout-teleport-default-slot">
     <KModal
       class="edit-document-modal"
       data-testid="edit-document-modal"

--- a/packages/core/documentation/src/components/ProductDocumentModal.vue
+++ b/packages/core/documentation/src/components/ProductDocumentModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="#kong-ui-app-layout-teleport-default-slot">
+  <Teleport to="body">
     <KModal
       class="edit-document-modal"
       data-testid="edit-document-modal"

--- a/packages/entities/entities-certificates/src/components/CACertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="requestBody"
       :is-readonly="form.isReadonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
       @fetch:success="initForm"
@@ -114,6 +115,13 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-certificates/src/components/CACertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateForm.vue
@@ -120,7 +120,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-certificates/src/components/CertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="requestBody"
       :is-readonly="form.isReadonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
       @fetch:success="initForm"
@@ -193,6 +194,13 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-certificates/src/components/CertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.vue
@@ -199,7 +199,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
@@ -136,7 +136,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="getPayload"
       :is-readonly="state.readonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler($event)"
       @fetch:success="updateFormValues"
@@ -130,6 +131,13 @@ const props = defineProps({
   hideConsumers: {
     type: Boolean,
     default: false,
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-consumers/src/components/ConsumerForm.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerForm.vue
@@ -151,7 +151,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-consumers/src/components/ConsumerForm.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="payload"
       :is-readonly="state.readonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler($event)"
       @fetch:success="updateFormValues"
@@ -145,6 +146,13 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -552,7 +552,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -8,6 +8,7 @@
       :fetch-url="fetchUrl"
       :form-fields="getPayload"
       :is-readonly="form.isReadonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
       @fetch:success="initForm"
@@ -546,6 +547,13 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: true,
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-key-sets/src/components/KeySetForm.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetForm.vue
@@ -105,7 +105,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-key-sets/src/components/KeySetForm.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="requestBody"
       :is-readonly="form.isReadonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
       @fetch:success="initForm"
@@ -99,6 +100,13 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-keys/src/components/KeyForm.vue
+++ b/packages/entities/entities-keys/src/components/KeyForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="requestBody"
       :is-readonly="form.isReadonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
       @fetch:success="initForm"
@@ -253,6 +254,13 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-keys/src/components/KeyForm.vue
+++ b/packages/entities/entities-keys/src/components/KeyForm.vue
@@ -259,7 +259,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
@@ -491,7 +491,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
@@ -7,6 +7,7 @@
       :error-message="state.errorMessage"
       :form-fields="state.fields"
       :is-readonly="state.readonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="cancelHandler"
       @submit="submitData"
     >
@@ -485,6 +486,13 @@ const props = defineProps({
   unsupportedTypes: {
     type: Array as PropType<CustomPluginFormType[]>,
     default: () => [],
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -32,6 +32,7 @@
       :form-fields="getRequestBody"
       :is-readonly="form.isReadonly"
       no-validate
+      :slideout-top-offset="slideoutTopOffset"
       :wrapper-component="noCardWrapper ? 'div' : undefined"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
@@ -106,7 +107,7 @@
       :close-on-blur="false"
       data-testid="form-view-configuration-slideout"
       :has-overlay="false"
-      :offset-top="60"
+      :offset-top="slideoutTopOffset"
       :title="t('view_configuration.title')"
       :visible="isToggled"
       @close="toggle"
@@ -339,6 +340,13 @@ const props = defineProps({
     type: String as PropType<'vfg' | 'freeform'>,
     required: false,
     default: undefined,
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -345,7 +345,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.cy.ts
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.cy.ts
@@ -870,11 +870,11 @@ describe('<RedisConfigurationForm />', {
         cy.getTestId('redis-update-warning-alert').should('not.exist')
       })
 
-      it('props `slidoutTopOffset` should be working', () => {
+      it('props `slideoutTopOffset` should be working', () => {
         cy.mount(RedisConfigurationForm, {
           props: {
             config,
-            slidoutTopOffset: 0,
+            slideoutTopOffset: 0,
           },
         })
 

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.vue
@@ -14,7 +14,7 @@
       :fetch-url="fetchUrl"
       :form-fields="formField"
       :is-readonly="form.readonly"
-      :slideout-top-offset="slideoutTopOffset ?? String(slidoutTopOffset)"
+      :slideout-top-offset="slideoutTopOffset ?? slidoutTopOffset"
       :wrapper-component="isManagedKonnectLayout ? 'div' : 'KCard'"
       @cancel="cancelHandler"
       @code-block-tab-change="(tab: string) => codeBlockType = tab"
@@ -575,7 +575,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
   /**

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.vue
@@ -14,7 +14,7 @@
       :fetch-url="fetchUrl"
       :form-fields="formField"
       :is-readonly="form.readonly"
-      :slideout-top-offset="slideoutTopOffset"
+      :slideout-top-offset="slideoutTopOffset ?? slidoutTopOffset"
       :wrapper-component="isManagedKonnectLayout ? 'div' : 'KCard'"
       @cancel="cancelHandler"
       @code-block-tab-change="(tab: string) => codeBlockType = tab"

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.vue
@@ -14,7 +14,7 @@
       :fetch-url="fetchUrl"
       :form-fields="formField"
       :is-readonly="form.readonly"
-      :slideout-top-offset="slideoutTopOffset ?? slidoutTopOffset"
+      :slideout-top-offset="slideoutTopOffset ?? String(slidoutTopOffset)"
       :wrapper-component="isManagedKonnectLayout ? 'div' : 'KCard'"
       @cancel="cancelHandler"
       @code-block-tab-change="(tab: string) => codeBlockType = tab"

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.vue
@@ -14,7 +14,7 @@
       :fetch-url="fetchUrl"
       :form-fields="formField"
       :is-readonly="form.readonly"
-      :slidout-top-offset="slidoutTopOffset"
+      :slideout-top-offset="slideoutTopOffset"
       :wrapper-component="isManagedKonnectLayout ? 'div' : 'KCard'"
       @cancel="cancelHandler"
       @code-block-tab-change="(tab: string) => codeBlockType = tab"
@@ -573,6 +573,13 @@ const props = defineProps({
   },
   /**
    * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
+  },
+  /**
+   * @deprecated Use `slideoutTopOffset` instead
    */
   slidoutTopOffset: {
     type: Number,

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="payload"
       :is-readonly="state.isReadonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"
       @fetch:success="updateFormValues"
@@ -228,6 +229,13 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -234,7 +234,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -88,7 +88,7 @@
       :close-on-blur="false"
       data-testid="form-view-configuration-slideout"
       :has-overlay="false"
-      :offset-top="slidoutTopOffset"
+      :offset-top="slideoutTopOffset ?? slidoutTopOffset"
       :title="t('baseForm.configuration.title')"
       :visible="isToggled"
       @close="toggle()"
@@ -264,6 +264,13 @@ const props = defineProps({
   },
   /**
    * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
+  },
+  /**
+   * @deprecated Use `slideoutTopOffset` instead
    */
   slidoutTopOffset: {
     type: Number,

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -266,7 +266,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
   /**

--- a/packages/entities/entities-snis/src/components/SniForm.vue
+++ b/packages/entities/entities-snis/src/components/SniForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="requestBody"
       :is-readonly="form.isReadonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
       @fetch:success="initForm"
@@ -148,6 +149,13 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-snis/src/components/SniForm.vue
+++ b/packages/entities/entities-snis/src/components/SniForm.vue
@@ -154,7 +154,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
@@ -163,7 +163,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
@@ -18,6 +18,7 @@
           :fetch-url="fetchUrl"
           :form-fields="requestBody"
           :is-readonly="form.isReadonly"
+          :slideout-top-offset="slideoutTopOffset"
           @cancel="onCancel"
           @fetch:error="(err: any) => $emit('error', err)"
           @fetch:success="initForm"
@@ -157,6 +158,13 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="upstreamPayload"
       :is-readonly="state.readonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"
       @fetch:success="updateFormValues"
@@ -145,6 +146,13 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
@@ -151,7 +151,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-vaults/src/components/SecretFormInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretFormInner.vue
@@ -106,7 +106,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-vaults/src/components/SecretFormInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretFormInner.vue
@@ -8,6 +8,7 @@
     :fetch-url="fetchUrl"
     :form-fields="payload"
     :is-readonly="state.readonly"
+    :slideout-top-offset="slideoutTopOffset"
     @cancel="cancelHandler"
     @fetch:error="fetchErrorHandler"
     @fetch:success="updateFormValues"
@@ -100,6 +101,13 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -999,7 +999,7 @@ const props = defineProps({
    * Top offset for the slideout
    */
   slideoutTopOffset: {
-    type: String,
+    type: [String, Number],
     required: false,
   },
 })

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="getPayload"
       :is-readonly="form.isReadonly"
+      :slideout-top-offset="slideoutTopOffset"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"
       @fetch:success="updateFormValues"
@@ -993,6 +994,13 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  /**
+   * Top offset for the slideout
+   */
+  slideoutTopOffset: {
+    type: String,
+    required: false,
   },
 })
 


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-19694

Changes:
- in EntityBaseForm and RedisConfigurationForm:
  - deprecate `slidoutTopOffset` because of typo in prop name and replace it with almost identical `slideoutTopOffset`
- in the rest of the form components:
  - introduce `slideoutTopOffset` as a pass-through prop for setting offset on a KSlideout in EntityBaseForm

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
