### PR TITLE
feat(entities-plugins): reslove cloned plugin engine via source

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -69,6 +69,7 @@ provide(FEATURE_FLAGS.KM_2262_CODE_MODE, true)
 provide(FEATURE_FLAGS.KM_2306_CONDITION_FIELD_314, true)
 provide(FEATURE_FLAGS.KM_2446_DATAKIT_JWT_NODES, true)
 provide(FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM, true)
+provide(FEATURE_FLAGS.KM_2485_CLONED_PLUGINS, true)
 
 useProvideExperimentalFreeForms([
   'service-protection',

--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -2064,6 +2064,116 @@ describe('<PluginForm />', () => {
       cy.get('.vue-form-generator').should('exist')
     })
 
+    describe('Cloned plugin engine resolution', () => {
+      const interceptClonedPlugin = (params: {
+        pluginName: string
+        link?: string
+        status?: number
+        alias?: string
+      }) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/cloned-plugins/${params.pluginName}`,
+          },
+          params.status === 404
+            ? { statusCode: 404, body: { message: 'Not found' } }
+            : {
+              statusCode: 200,
+              body: {
+                name: params.pluginName,
+                link: params.link!,
+                priority: null,
+                tags: null,
+                created_at: 1700000000,
+                updated_at: 1700000000,
+              },
+            },
+        ).as(params.alias ?? 'getClonedPlugin')
+      }
+
+      it('renders freeform for a non-cloned custom plugin when KM_2503 flag is on', () => {
+        const pluginType = 'my-custom-plugin'
+        interceptKonnectSchema({ mockData: customPluginSchema })
+        // Not a clone — backend returns 404
+        interceptClonedPlugin({ pluginName: pluginType, status: 404 })
+
+        cy.mount(PluginForm, {
+          props: {
+            config: baseConfigKonnect,
+            pluginType,
+          },
+          global: {
+            provide: {
+              [FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM]: true,
+              [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+            },
+          },
+          router,
+        })
+
+        cy.wait(['@getPluginSchema', '@getClonedPlugin'])
+        cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
+
+        // Freeform renders cards with data-testid="ff-*"
+        cy.get('[data-testid^="ff-"]').should('exist')
+      })
+
+      it('renders freeform for a cloned plugin when its source plugin uses freeform', () => {
+        // rate-limiting has a freeform component (experimental — needs whitelist).
+        const pluginType = 'rate-limiting-clone'
+        interceptKonnectSchema({ mockData: schemaRateLimiting })
+        interceptClonedPlugin({ pluginName: pluginType, link: 'rate-limiting' })
+
+        cy.mount(PluginForm, {
+          props: {
+            config: baseConfigKonnect,
+            pluginType,
+          },
+          global: {
+            provide: {
+              [FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM]: true,
+              [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+              [EXPERIMENTAL_FREE_FORM_PROVIDER as symbol]: ['rate-limiting'],
+            },
+          },
+          router,
+        })
+
+        cy.wait(['@getPluginSchema', '@getClonedPlugin'])
+        cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
+
+        cy.get('[data-testid^="ff-"]').should('exist')
+      })
+
+      it('renders VFG for a cloned plugin when its source plugin uses VFG', () => {
+        // cors has no freeform component, so the source — and therefore the clone — falls back to VFG.
+        const pluginType = 'cors-clone'
+        interceptKonnectSchema({ mockData: schemaCors })
+        interceptClonedPlugin({ pluginName: pluginType, link: 'cors' })
+
+        cy.mount(PluginForm, {
+          props: {
+            config: baseConfigKonnect,
+            pluginType,
+          },
+          global: {
+            provide: {
+              [FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM]: true,
+              [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+            },
+          },
+          router,
+        })
+
+        cy.wait(['@getPluginSchema', '@getClonedPlugin'])
+        cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
+
+        cy.get('.vue-form-generator').should('exist')
+        cy.get('[data-testid^="ff-"]').should('not.exist')
+      })
+    })
+
     describe('Condition field', () => {
       ;[
         {

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -356,12 +356,12 @@ const { getMessageFromError } = useErrors()
 const { capitalize } = useStringHelpers()
 const { objectsAreEqual } = useHelpers()
 
-const { axiosInstance: axiosInstanceIgnore404 } = useAxios({ konnect: { bypassGlobal404Handler: true } } as any)
+const { axiosInstance: axiosInstanceWithout404Redirect } = useAxios({ konnect: { bypassGlobal404Handler: true } } as any)
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const { getClonedPlugin: fetchClonedPluginDetail } = composables.useCustomPluginApi({
   // force bypassGlobal404Handler for this call
-  axiosInstance: axiosInstanceIgnore404,
+  axiosInstance: axiosInstanceWithout404Redirect,
   apiBaseUrl: props.config.apiBaseUrl,
   app: props.config.app,
   workspace: (props.config as KongManagerPluginFormConfig).workspace,
@@ -1511,7 +1511,7 @@ onBeforeMount(async () => {
       const shouldResolveClone = enabledClonedPlugin && isCustomPlugin.value
       const schemaPromise: Promise<any> = props.schema
         ? Promise.resolve(props.schema)
-        : axiosInstanceIgnore404.get(schemaUrl.value).then(res => res.data)
+        : axiosInstanceWithout404Redirect.get(schemaUrl.value).then(res => res.data)
       const [data] = await Promise.all([
         schemaPromise,
         shouldResolveClone ? getClonedPlugin(props.pluginType) : Promise.resolve(),

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -356,12 +356,13 @@ const { getMessageFromError } = useErrors()
 const { capitalize } = useStringHelpers()
 const { objectsAreEqual } = useHelpers()
 
-const { axiosInstance: axiosInstanceWithout404Redirect } = useAxios({ konnect: { bypassGlobal404Handler: true } } as any)
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
 const { getClonedPlugin: fetchClonedPluginDetail } = composables.useCustomPluginApi({
-  // force bypassGlobal404Handler for this call
-  axiosInstance: axiosInstanceWithout404Redirect,
+  axiosInstance: useAxios({
+    ...(props.config?.axiosRequestConfig ?? {}),
+    konnect: { bypassGlobal404Handler: true }, // force bypassGlobal404Handler for this call
+  } as any).axiosInstance,
   apiBaseUrl: props.config.apiBaseUrl,
   app: props.config.app,
   workspace: (props.config as KongManagerPluginFormConfig).workspace,
@@ -1511,7 +1512,7 @@ onBeforeMount(async () => {
       const shouldResolveClone = enabledClonedPlugin && isCustomPlugin.value
       const schemaPromise: Promise<any> = props.schema
         ? Promise.resolve(props.schema)
-        : axiosInstanceWithout404Redirect.get(schemaUrl.value).then(res => res.data)
+        : axiosInstance.get(schemaUrl.value).then(res => res.data)
       const [data] = await Promise.all([
         schemaPromise,
         shouldResolveClone ? getClonedPlugin(props.pluginType) : Promise.resolve(),

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -168,7 +168,7 @@ import {
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
 import type { Tab } from '@kong/kongponents'
-import type { AxiosError, AxiosResponse } from 'axios'
+import { isAxiosError, type AxiosError, type AxiosResponse } from 'axios'
 import { marked, type MarkedOptions } from 'marked'
 import { computed, onBeforeMount, provide, reactive, ref, watch, type PropType, inject } from 'vue'
 import { useRouter } from 'vue-router'
@@ -207,6 +207,7 @@ type ScopedEntitiesPermissions = Partial<Record<ScopedEntitiesType, ScopedEntity
 
 const enabledNewPluginLayout = inject(FEATURE_FLAGS.KM_1948_PLUGIN_FORM_LAYOUT, computed(() => false))
 const enableConditionField = inject<boolean>(PLUGIN_FEATURE_FLAGS.KM_2306_CONDITION_FIELD_314, false)
+const enabledClonedPlugin = inject<boolean>(PLUGIN_FEATURE_FLAGS.KM_2485_CLONED_PLUGINS, false)
 
 const emit = defineEmits<{
   (e: 'cancel'): void
@@ -355,7 +356,17 @@ const { getMessageFromError } = useErrors()
 const { capitalize } = useStringHelpers()
 const { objectsAreEqual } = useHelpers()
 
+const { axiosInstance: axiosInstanceIgnore404 } = useAxios({ konnect: { bypassGlobal404Handler: true } } as any)
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
+
+const { getClonedPlugin: fetchClonedPluginDetail } = composables.useCustomPluginApi({
+  // force bypassGlobal404Handler for this call
+  axiosInstance: axiosInstanceIgnore404,
+  apiBaseUrl: props.config.apiBaseUrl,
+  app: props.config.app,
+  workspace: (props.config as KongManagerPluginFormConfig).workspace,
+  controlPlaneId: (props.config as KonnectPluginFormConfig).controlPlaneId,
+})
 
 const isToggled = ref(false)
 const isEditing = computed(() => !!props.pluginId)
@@ -370,10 +381,18 @@ const pluginRedisPath = ref<string | undefined>() // specify the path to the red
 
 const customPluginFreeform = inject(PLUGIN_FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM, false)
 
+const clonedSourcePlugin = ref<string | null>(null)
+
+const isClonedPlugin = computed(() => clonedSourcePlugin.value !== null)
+
 const realEngine = computed<'vfg' | 'freeform' | undefined>(() => {
   if (props.engine) return props.engine
-  if (customPluginFreeform && isCustomPlugin.value) return 'freeform'
-  return undefined
+  if (!customPluginFreeform || !isCustomPlugin.value) return undefined
+  if (isClonedPlugin.value && clonedSourcePlugin.value) {
+    // Cloned plugin: defer to the source plugin's engine.
+    return isFreeForm(clonedSourcePlugin.value) ? 'freeform' : 'vfg'
+  }
+  return 'freeform'
 })
 
 provide(REDIS_PARTIAL_INFO, {
@@ -1487,7 +1506,16 @@ onBeforeMount(async () => {
       finalSchema.value = buildFormSchema('', data, {})
       schemaLoading.value = false
     } else { // handling for standard plugins
-      const data = props.schema ?? (await axiosInstance.get(schemaUrl.value)).data
+      // When the cloned-plugin feature flag is on and the plugin isn't a built-in,
+      // resolve its source plugin in parallel with the schema fetch (404 = not a clone).
+      const shouldResolveClone = enabledClonedPlugin && isCustomPlugin.value
+      const schemaPromise: Promise<any> = props.schema
+        ? Promise.resolve(props.schema)
+        : axiosInstanceIgnore404.get(schemaUrl.value).then(res => res.data)
+      const [data] = await Promise.all([
+        schemaPromise,
+        shouldResolveClone ? getClonedPlugin(props.pluginType) : Promise.resolve(),
+      ])
       loadedSchema.value = data
 
       if (data) {
@@ -1549,6 +1577,19 @@ onBeforeMount(async () => {
     schemaLoading.value = false
   }
 })
+
+async function getClonedPlugin(clonedPluginName: string): Promise<void> {
+  try {
+    const detail = await fetchClonedPluginDetail(clonedPluginName)
+    clonedSourcePlugin.value = detail?.link ?? null
+  } catch (error: unknown) {
+    // A 404 means this custom plugin is not a clone — leave clonedSourcePlugin null and stay quiet.
+    if (isAxiosError(error) && error.response?.status === 404) {
+      return
+    }
+    throw error
+  }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
@@ -194,6 +194,7 @@ export function useCustomPluginApi(options: UseCustomPluginApiOptions) {
     updateStreamedPlugin,
     getPluginByUnknownType,
     getPluginType,
+    getClonedPlugin,
     createClonedPlugin,
     updateClonedPlugin,
   }

--- a/packages/entities/entities-plugins/src/constants/index.ts
+++ b/packages/entities/entities-plugins/src/constants/index.ts
@@ -5,6 +5,7 @@ export const FEATURE_FLAGS = {
   KM_2306_CONDITION_FIELD_314: 'KM-2306-condition-field-314',
   KM_2446_DATAKIT_JWT_NODES: 'KM-2446-Datakit-JWT-nodes',
   KM_2503_CUSTOM_PLUGIN_FREEFORM: 'KM-2503-custom-plugin-freeform',
+  KM_2485_CLONED_PLUGINS: 'KM-2485-cloned-plugins',
 }
 
 export const TOASTER_PROVIDER = Symbol('TOASTER_PROVIDER')


### PR DESCRIPTION
# Summary
KM-2503

Resolving a cloned custom plugin’s form engine:
* Custom plugin
  * is a cloned plugin -> isFreeForm(sourcePlugin) ? `freeform` : `VFG`
  * not a cloned plugin -> freeform
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
