### PR TITLE
fix: vue-router semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@evilmartians/lefthook": "^2.1.6",
     "@kong/design-tokens": "1.20.1",
     "@kong/eslint-config-kong-ui": "^1.6.2",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@stylistic/stylelint-plugin": "^5.1.0",
     "@types/flat": "^5.0.5",
     "@types/js-yaml": "^4.0.9",
@@ -71,7 +71,7 @@
     "vite-plugin-vue-devtools": "^7.7.9",
     "vitest": "^3.2.4",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4",
+    "vue-router": "^5.0.6",
     "vue-tsc": "^3.2.7"
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "vite-plugin-vue-devtools": "^7.7.9",
     "vitest": "^3.2.4",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6",
+    "vue-router": "^4.6.4",
     "vue-tsc": "^3.2.7"
   },
   "pnpm": {

--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -29,7 +29,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@types/uuid": "^11.0.0",
     "file-saver": "^2.0.5",
     "lodash.mapkeys": "^4.6.0",

--- a/packages/analytics/analytics-geo-map/package.json
+++ b/packages/analytics/analytics-geo-map/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@types/geobuf": "^3.0.4",
     "@types/geojson": "^7946.0.16",
     "maplibre-gl": "^5.23.0",

--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -67,7 +67,7 @@
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "pinia": ">= 3.0.4 < 4"
   }
 }

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -49,7 +49,7 @@
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "ajv": "^8.18.0",
     "cypress-real-events": "^1.15.0",
     "pinia": ">= 3.0.4 < 4",

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "@kong/kongponents": "^9.52.11",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "dependencies": {
     "@kong/icons": "^1.52.0",
@@ -55,7 +55,7 @@
     "@kong/kongponents": "9.52.11",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "repository": {
     "type": "git",

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -52,10 +52,10 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "repository": {
     "type": "git",

--- a/packages/core/documentation/package.json
+++ b/packages/core/documentation/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33"
   },

--- a/packages/core/entities-config-editor/package.json
+++ b/packages/core/entities-config-editor/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "vue": "^3.5.33"
   },
   "repository": {

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@kong/atc-router": "1.6.0-rc.1",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@types/uuid": "^11.0.0",
     "monaco-editor": "^0.55.1",
     "vite-plugin-monaco-editor": "^1.1.0",

--- a/packages/core/forms/package.json
+++ b/packages/core/forms/package.json
@@ -67,7 +67,7 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@types/lodash-es": "^4.17.12",
     "axios": "^1.15.2",
     "pug": "^3.0.4"

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "vue": "^3.5.33"
   },
   "repository": {

--- a/packages/core/monaco-editor/package.json
+++ b/packages/core/monaco-editor/package.json
@@ -80,7 +80,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@peculiar/x509": "^2.0.0",
     "jsonc-parser": "^3.3.1",
     "monaco-editor": "^0.55.1",

--- a/packages/core/page-layout/package.json
+++ b/packages/core/page-layout/package.json
@@ -44,7 +44,7 @@
     "@kong/icons": "^1.52.0",
     "@kong/kongponents": "9.52.11",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "repository": {
     "type": "git",
@@ -68,7 +68,7 @@
     "@kong/icons": "^1.52.0",
     "@kong/kongponents": "^9.52.11",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "dependencies": {
     "@vueuse/core": "^14.2.1"

--- a/packages/core/page-layout/package.json
+++ b/packages/core/page-layout/package.json
@@ -42,9 +42,9 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "repository": {
     "type": "git",

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -40,9 +40,9 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "repository": {
     "type": "git",

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -42,7 +42,7 @@
     "@kong/design-tokens": "1.20.1",
     "@kong/kongponents": "9.52.11",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "repository": {
     "type": "git",

--- a/packages/core/split-pane/package.json
+++ b/packages/core/split-pane/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "vue": "^3.5.33"
   },
   "repository": {

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -34,10 +34,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -34,10 +34,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -34,10 +34,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -34,10 +34,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-data-plane-nodes/package.json
+++ b/packages/entities/entities-data-plane-nodes/package.json
@@ -34,10 +34,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-data-plane-nodes/package.json
+++ b/packages/entities/entities-data-plane-nodes/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -34,10 +34,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -33,10 +33,10 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -36,7 +36,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -34,10 +34,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -51,7 +51,7 @@
     "axios": "^1.15.2",
     "monaco-editor": "^0.55.1",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6",
+    "vue-router": "^4.6.4 || ^5.0.6",
     "zod": ">= 4.1.3 < 5"
   },
   "peerDependenciesMeta": {
@@ -88,7 +88,7 @@
     "nanoid": "^5.1.9",
     "reflect-metadata": "^0.2.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6",
+    "vue-router": "^4.6.4",
     "zod": "^4.3.6"
   },
   "scripts": {

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -70,7 +70,7 @@
     "@kong-ui-public/monaco-editor": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@peculiar/x509": "^2.0.0",
     "@playwright/experimental-ct-vue": "^1.59.1",
     "@playwright/test": "^1.59.1",
@@ -88,7 +88,7 @@
     "nanoid": "^5.1.9",
     "reflect-metadata": "^0.2.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4",
+    "vue-router": "^5.0.6",
     "zod": "^4.3.6"
   },
   "scripts": {

--- a/packages/entities/entities-redis-configurations/package.json
+++ b/packages/entities/entities-redis-configurations/package.json
@@ -45,12 +45,12 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@types/uuid": "^11.0.0",
     "axios": "^1.15.2",
     "swrv": "^1.2.0",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "repository": {
     "type": "git",

--- a/packages/entities/entities-redis-configurations/package.json
+++ b/packages/entities/entities-redis-configurations/package.json
@@ -50,7 +50,7 @@
     "axios": "^1.15.2",
     "swrv": "^1.2.0",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "repository": {
     "type": "git",
@@ -79,7 +79,7 @@
     "axios": "^1.15.2",
     "swrv": "^1.2.0",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "dependencies": {
     "@kong-ui-public/entities-plugins-icon": "workspace:^",

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -39,7 +39,7 @@
     "axios": "^1.15.2",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -34,12 +34,12 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@types/lodash.isequal": "^4.5.8",
     "axios": "^1.15.2",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -29,7 +29,7 @@
     "axios": "^1.15.2",
     "shiki": "^3.23.0",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
@@ -41,7 +41,7 @@
     "axios": "^1.15.2",
     "shiki": "^3.23.0",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -38,14 +38,14 @@
     "@kong-ui-public/monaco-editor": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@shikijs/core": "^3.23.0",
     "@shikijs/engine-javascript": "^3.23.0",
     "axios": "^1.15.2",
     "monaco-editor": "^0.55.1",
     "shiki": "^3.23.0",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -34,10 +34,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -34,10 +34,10 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -33,10 +33,10 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^4.6.4"
+    "vue-router": "^5.0.6"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -27,7 +27,7 @@
     "@kong/kongponents": "^9.52.11",
     "axios": "^1.15.2",
     "vue": ">= 3.3.13 < 4",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4 || ^5.0.6"
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
@@ -36,7 +36,7 @@
     "@kong/kongponents": "9.52.11",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
-    "vue-router": "^5.0.6"
+    "vue-router": "^4.6.4"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/portal/document-viewer/package.json
+++ b/packages/portal/document-viewer/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@types/prismjs": "^1.26.6",
     "@vitejs/plugin-vue-jsx": "^4.2.0",
     "vue": "^3.5.33"

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.52.13",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/uuid": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: ^1.6.2
         version: 1.6.2(@typescript-eslint/parser@8.50.0(eslint@9.39.4(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.5.1))(typescript@5.9.3)
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@stylistic/stylelint-plugin':
         specifier: ^5.1.0
         version: 5.1.0(stylelint@17.8.0(typescript@5.9.3))
@@ -179,8 +179,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.7
         version: 3.2.7(typescript@5.9.3)
@@ -246,8 +246,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -301,8 +301,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/geobuf':
         specifier: ^3.0.4
         version: 3.0.4
@@ -347,8 +347,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       pinia:
         specifier: '>= 3.0.4 < 4'
         version: 3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3))
@@ -427,8 +427,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -482,8 +482,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -491,8 +491,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/core/cli:
     devDependencies:
@@ -550,8 +550,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -565,8 +565,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -608,8 +608,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -657,8 +657,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -690,8 +690,8 @@ importers:
         specifier: workspace:^
         version: link:../i18n
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -718,8 +718,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@peculiar/x509':
         specifier: ^2.0.0
         version: 2.0.0
@@ -758,14 +758,14 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/core/sandbox-layout:
     dependencies:
@@ -777,14 +777,14 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/core/split-pane:
     dependencies:
@@ -802,8 +802,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -827,8 +827,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -836,8 +836,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-consumer-credentials:
     devDependencies:
@@ -854,8 +854,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -863,8 +863,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-consumer-groups:
     devDependencies:
@@ -881,8 +881,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -890,8 +890,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-consumers:
     devDependencies:
@@ -908,8 +908,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -917,8 +917,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-data-plane-nodes:
     devDependencies:
@@ -935,8 +935,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -944,8 +944,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-gateway-services:
     devDependencies:
@@ -962,8 +962,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -971,8 +971,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-key-sets:
     devDependencies:
@@ -986,8 +986,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -995,8 +995,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-keys:
     devDependencies:
@@ -1013,8 +1013,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1022,8 +1022,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-plugins:
     dependencies:
@@ -1080,8 +1080,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@peculiar/x509':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1134,8 +1134,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1182,8 +1182,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -1197,8 +1197,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-routes:
     dependencies:
@@ -1222,8 +1222,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/lodash.isequal':
         specifier: ^4.5.8
         version: 4.5.8
@@ -1237,8 +1237,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-shared:
     dependencies:
@@ -1262,8 +1262,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@shikijs/core':
         specifier: ^3.23.0
         version: 3.23.0
@@ -1283,8 +1283,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-snis:
     devDependencies:
@@ -1301,8 +1301,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1310,8 +1310,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-upstreams-targets:
     devDependencies:
@@ -1328,8 +1328,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1337,8 +1337,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-vaults:
     dependencies:
@@ -1356,8 +1356,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1365,8 +1365,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^4.6.4
-        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
   packages/portal/document-viewer:
     dependencies:
@@ -1381,8 +1381,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/prismjs':
         specifier: ^1.26.6
         version: 1.26.6
@@ -1415,8 +1415,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.52.13
+        version: 9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.1
         version: 1.1.1(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
@@ -1437,7 +1437,7 @@ importers:
     dependencies:
       '@kong/swagger-ui-kong-theme-universal':
         specifier: ^4.3.3
-        version: 4.3.3(@babel/core@7.28.0)(axios@1.15.2)(mkdirp@1.0.4)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 4.3.3(@babel/core@7.28.0)(axios@1.15.2)(mkdirp@1.0.4)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2552,6 +2552,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -2622,12 +2625,12 @@ packages:
       vue: 3.5.33
       vue-router: ^4.2.4
 
-  '@kong/kongponents@9.52.11':
-    resolution: {integrity: sha512-OVo//aG6Ra9lPCsz/C0vwULYxf02wahLS3JR1NNZfKEIAr0vt99R9HcL6hWzD+iySRkWCUNpq3+zhEIZ0Gw4uw==}
+  '@kong/kongponents@9.52.13':
+    resolution: {integrity: sha512-Ju2ZLM/D8xR1OncO+k26UlXOYKOWvRnuQ7SGYONhVUr0CSjgSs9y8tqyfH7EvkqRJCHOzTS2IWK/MQwRNHnggA==}
     engines: {node: '>=v16.20.2 || >=18.12.1 || >=20.14.0 || >=22.14.0', pnpm: '>=10.28.2'}
     peerDependencies:
       vue: 3.5.33
-      vue-router: ^4.6.4
+      vue-router: 4 || 5
 
   '@kong/markdown@1.9.7':
     resolution: {integrity: sha512-88GVb1RWaVKPtlBaExl6jmxqgudFx1dsmeZW8o97fYWzYUrhu+LWrrVlqwBQlpsnI8J814f1scLvg+MTO8oENA==}
@@ -3988,6 +3991,15 @@ packages:
     peerDependencies:
       vue: 3.5.33
 
+  '@vue-macros/common@3.1.2':
+    resolution: {integrity: sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      vue: 3.5.33
+    peerDependenciesMeta:
+      vue:
+        optional: true
+
   '@vue/babel-helper-vue-transform-on@1.5.0':
     resolution: {integrity: sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==}
 
@@ -4028,11 +4040,11 @@ packages:
   '@vue/compiler-ssr@3.5.33':
     resolution: {integrity: sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==}
 
-  '@vue/devtools-api@6.6.4':
-    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
-
   '@vue/devtools-api@7.7.9':
     resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
+
+  '@vue/devtools-api@8.1.1':
+    resolution: {integrity: sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==}
 
   '@vue/devtools-core@7.7.9':
     resolution: {integrity: sha512-48jrBSwG4GVQRvVeeXn9p9+dlx+ISgasM7SxZZKczseohB0cBz+ITKr4YbLWjmJdy45UHL7UMPlR4Y0CWTRcSQ==}
@@ -4042,8 +4054,14 @@ packages:
   '@vue/devtools-kit@7.7.9':
     resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
 
+  '@vue/devtools-kit@8.1.1':
+    resolution: {integrity: sha512-gVBaBv++i+adg4JpH71k9ppl4soyR7Y2McEqO5YNgv0BI1kMZ7BDX5gnwkZ5COYgiCyhejZG+yGNrBAjj6Coqg==}
+
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
+
+  '@vue/devtools-shared@8.1.1':
+    resolution: {integrity: sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==}
 
   '@vue/language-core@3.2.7':
     resolution: {integrity: sha512-Gn4q/tRxbpVGLEuARQ43p3YELlNAFgRUVCgW9U5Cr+5q4vfD2bWDWpl3ABbJMXUt5xlE1dF8dkigg2aUq7JYYw==}
@@ -4433,6 +4451,14 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-kit@2.2.0:
+    resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
+    engines: {node: '>=20.19.0'}
+
+  ast-walker-scope@0.8.3:
+    resolution: {integrity: sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==}
+    engines: {node: '>=20.19.0'}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -4795,6 +4821,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -4986,6 +5016,9 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -6004,6 +6037,9 @@ packages:
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
@@ -7365,6 +7401,10 @@ packages:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
 
+  local-pkg@1.1.2:
+    resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
+    engines: {node: '>=14'}
+
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
@@ -7486,6 +7526,10 @@ packages:
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
+  magic-string-ast@1.0.3:
+    resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
+    engines: {node: '>=20.19.0'}
 
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
@@ -8389,6 +8433,9 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
@@ -8435,6 +8482,9 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
   pkijs@3.3.3:
     resolution: {integrity: sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==}
@@ -8722,6 +8772,9 @@ packages:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
@@ -8907,6 +8960,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -9275,6 +9332,9 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -10217,6 +10277,14 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin-utils@0.3.1:
+    resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
+    engines: {node: '>=20.19.0'}
+
+  unplugin@3.0.0:
+    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   unraw@3.0.0:
     resolution: {integrity: sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==}
 
@@ -10549,10 +10617,20 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
-  vue-router@4.6.4:
-    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+  vue-router@5.0.6:
+    resolution: {integrity: sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w==}
     peerDependencies:
+      '@pinia/colada': '>=0.21.2'
+      '@vue/compiler-sfc': ^3.5.17
+      pinia: ^3.0.4
       vue: 3.5.33
+    peerDependenciesMeta:
+      '@pinia/colada':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      pinia:
+        optional: true
 
   vue-screen-utils@1.0.0-beta.13:
     resolution: {integrity: sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==}
@@ -10653,6 +10731,9 @@ packages:
   webpack-sources@3.3.4:
     resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
     engines: {node: '>=10.13.0'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   webpack@5.106.2:
     resolution: {integrity: sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==}
@@ -11952,6 +12033,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.30
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/source-map@0.3.11':
@@ -12023,7 +12109,7 @@ snapshots:
     dependencies:
       vue: 3.5.33(typescript@5.9.3)
 
-  '@kong/kongponents@8.127.0(axios@1.15.2)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
+  '@kong/kongponents@8.127.0(axios@1.15.2)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       axios: 1.15.2
       date-fns: 2.30.0
@@ -12037,9 +12123,9 @@ snapshots:
       v-calendar: 3.0.0-alpha.8(vue@3.5.33(typescript@5.9.3))
       vue: 3.5.33(typescript@5.9.3)
       vue-draggable-next: 2.3.0(sortablejs@1.15.7)(vue@3.5.33(typescript@5.9.3))
-      vue-router: 4.6.4(vue@3.5.33(typescript@5.9.3))
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
-  '@kong/kongponents@9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
+  '@kong/kongponents@9.52.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       '@floating-ui/vue': 1.1.11(vue@3.5.33(typescript@5.9.3))
       '@kong/icons': 1.52.0(vue@3.5.33(typescript@5.9.3))
@@ -12056,7 +12142,7 @@ snapshots:
       virtua: 0.49.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue@3.5.33(typescript@5.9.3))
       vue: 3.5.33(typescript@5.9.3)
       vue-draggable-next: 2.3.0(sortablejs@1.15.7)(vue@3.5.33(typescript@5.9.3))
-      vue-router: 4.6.4(vue@3.5.33(typescript@5.9.3))
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - react
@@ -12100,10 +12186,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@kong/swagger-ui-kong-theme-universal@4.3.3(@babel/core@7.28.0)(axios@1.15.2)(mkdirp@1.0.4)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
+  '@kong/swagger-ui-kong-theme-universal@4.3.3(@babel/core@7.28.0)(axios@1.15.2)(mkdirp@1.0.4)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       '@braintree/sanitize-url': 6.0.2
-      '@kong/kongponents': 8.127.0(axios@1.15.2)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+      '@kong/kongponents': 8.127.0(axios@1.15.2)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@kyleshockey/xml': 1.0.2
       classnames: 2.5.1
       curl-to-har: 1.0.1
@@ -13907,6 +13993,16 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
+  '@vue-macros/common@3.1.2(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-sfc': 3.5.33
+      ast-kit: 2.2.0
+      local-pkg: 1.1.2
+      magic-string-ast: 1.0.3
+      unplugin-utils: 0.3.1
+    optionalDependencies:
+      vue: 3.5.33(typescript@5.9.3)
+
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
 
   '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.28.0)':
@@ -13996,11 +14092,13 @@ snapshots:
       '@vue/compiler-dom': 3.5.33
       '@vue/shared': 3.5.33
 
-  '@vue/devtools-api@6.6.4': {}
-
   '@vue/devtools-api@7.7.9':
     dependencies:
       '@vue/devtools-kit': 7.7.9
+
+  '@vue/devtools-api@8.1.1':
+    dependencies:
+      '@vue/devtools-kit': 8.1.1
 
   '@vue/devtools-core@7.7.9(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
@@ -14024,9 +14122,18 @@ snapshots:
       speakingurl: 14.0.1
       superjson: 2.2.6
 
+  '@vue/devtools-kit@8.1.1':
+    dependencies:
+      '@vue/devtools-shared': 8.1.1
+      birpc: 2.9.0
+      hookable: 5.5.3
+      perfect-debounce: 2.1.0
+
   '@vue/devtools-shared@7.7.9':
     dependencies:
       rfdc: 1.4.1
+
+  '@vue/devtools-shared@8.1.1': {}
 
   '@vue/language-core@3.2.7':
     dependencies:
@@ -14401,6 +14508,16 @@ snapshots:
   assert-plus@1.0.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-kit@2.2.0:
+    dependencies:
+      '@babel/parser': 7.29.2
+      pathe: 2.0.3
+
+  ast-walker-scope@0.8.3:
+    dependencies:
+      '@babel/parser': 7.29.2
+      ast-kit: 2.2.0
 
   astral-regex@2.0.0: {}
 
@@ -14844,6 +14961,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4:
     optional: true
 
@@ -15017,6 +15138,8 @@ snapshots:
       typedarray: 0.0.6
 
   confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -16243,6 +16366,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  exsolve@1.0.8: {}
 
   ext@1.7.0:
     dependencies:
@@ -17757,6 +17882,12 @@ snapshots:
       emojis-list: 3.0.0
       json5: 2.2.3
 
+  local-pkg@1.1.2:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
+      quansync: 0.2.11
+
   locate-path@2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -17858,6 +17989,10 @@ snapshots:
       es5-ext: 0.10.64
 
   lunr@2.3.9: {}
+
+  magic-string-ast@1.0.3:
+    dependencies:
+      magic-string: 0.30.21
 
   magic-string@0.25.9:
     dependencies:
@@ -19013,6 +19148,8 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  perfect-debounce@2.1.0: {}
+
   performance-now@2.1.0: {}
 
   picocolors@1.1.1: {}
@@ -19046,6 +19183,12 @@ snapshots:
     dependencies:
       confbox: 0.1.8
       mlly: 1.8.2
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
       pathe: 2.0.3
 
   pkijs@3.3.3:
@@ -19351,6 +19494,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  quansync@0.2.11: {}
+
   querystringify@2.2.0: {}
 
   queue-lit@1.5.0: {}
@@ -19566,6 +19711,8 @@ snapshots:
       picomatch: 4.0.4
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   rechoir@0.8.0:
     dependencies:
@@ -19920,6 +20067,8 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
+
+  scule@1.3.0: {}
 
   section-matter@1.0.0:
     dependencies:
@@ -21024,6 +21173,17 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin-utils@0.3.1:
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.4
+
+  unplugin@3.0.0:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
   unraw@3.0.0: {}
 
   untildify@4.0.0: {}
@@ -21353,10 +21513,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)):
+  vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)):
     dependencies:
-      '@vue/devtools-api': 6.6.4
+      '@babel/generator': 7.29.1
+      '@vue-macros/common': 3.1.2(vue@3.5.33(typescript@5.9.3))
+      '@vue/devtools-api': 8.1.1
+      ast-walker-scope: 0.8.3
+      chokidar: 5.0.0
+      json5: 2.2.3
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      muggle-string: 0.4.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      scule: 1.3.0
+      tinyglobby: 0.2.15
+      unplugin: 3.0.0
+      unplugin-utils: 0.3.1
       vue: 3.5.33(typescript@5.9.3)
+      yaml: 2.8.3
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.33
+      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3))
 
   vue-screen-utils@1.0.0-beta.13(vue@3.5.33(typescript@5.9.3)):
     dependencies:
@@ -21495,6 +21674,8 @@ snapshots:
       wildcard: 2.0.1
 
   webpack-sources@3.3.4: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   webpack@5.106.2(webpack-cli@7.0.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 1.6.2(@typescript-eslint/parser@8.50.0(eslint@9.39.4(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.5.1))(typescript@5.9.3)
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@stylistic/stylelint-plugin':
         specifier: ^5.1.0
         version: 5.1.0(stylelint@17.8.0(typescript@5.9.3))
@@ -179,8 +179,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.7
         version: 3.2.7(typescript@5.9.3)
@@ -247,7 +247,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -302,7 +302,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/geobuf':
         specifier: ^3.0.4
         version: 3.0.4
@@ -348,7 +348,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       pinia:
         specifier: '>= 3.0.4 < 4'
         version: 3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3))
@@ -428,7 +428,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -483,7 +483,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -491,8 +491,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/core/cli:
     devDependencies:
@@ -551,7 +551,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -566,7 +566,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -609,7 +609,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -621,10 +621,10 @@ importers:
         version: 1.1.0(monaco-editor@0.55.1)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 1.6.0(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 3.6.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -658,7 +658,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -691,7 +691,7 @@ importers:
         version: link:../i18n
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -719,7 +719,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@peculiar/x509':
         specifier: ^2.0.0
         version: 2.0.0
@@ -759,13 +759,13 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/core/sandbox-layout:
     dependencies:
@@ -778,13 +778,13 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/core/split-pane:
     dependencies:
@@ -803,7 +803,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -828,7 +828,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -836,8 +836,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-consumer-credentials:
     devDependencies:
@@ -855,7 +855,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -863,8 +863,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-consumer-groups:
     devDependencies:
@@ -882,7 +882,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -890,8 +890,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-consumers:
     devDependencies:
@@ -909,7 +909,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -917,8 +917,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-data-plane-nodes:
     devDependencies:
@@ -936,7 +936,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -944,8 +944,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-gateway-services:
     devDependencies:
@@ -963,7 +963,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -971,8 +971,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-key-sets:
     devDependencies:
@@ -987,7 +987,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -995,8 +995,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-keys:
     devDependencies:
@@ -1014,7 +1014,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1022,8 +1022,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-plugins:
     dependencies:
@@ -1081,13 +1081,13 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@peculiar/x509':
         specifier: ^2.0.0
         version: 2.0.0
       '@playwright/experimental-ct-vue':
         specifier: ^1.59.1
-        version: 1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)
+        version: 1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -1134,8 +1134,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1183,7 +1183,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -1197,8 +1197,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-routes:
     dependencies:
@@ -1223,7 +1223,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/lodash.isequal':
         specifier: ^4.5.8
         version: 4.5.8
@@ -1237,8 +1237,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-shared:
     dependencies:
@@ -1260,7 +1260,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@shikijs/core':
         specifier: ^3.23.0
         version: 3.23.0
@@ -1277,8 +1277,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-snis:
     devDependencies:
@@ -1296,7 +1296,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1304,8 +1304,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-upstreams-targets:
     devDependencies:
@@ -1323,7 +1323,7 @@ importers:
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1331,8 +1331,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/entities/entities-vaults:
     dependencies:
@@ -1351,7 +1351,7 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1359,8 +1359,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.6
-        version: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
   packages/portal/document-viewer:
     dependencies:
@@ -1376,13 +1376,13 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/prismjs':
         specifier: ^1.26.6
         version: 1.26.6
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.2.0
-        version: 4.2.0(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))
+        version: 4.2.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -1410,10 +1410,10 @@ importers:
         version: 1.20.1
       '@kong/kongponents':
         specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.1
-        version: 1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 1.1.1(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -1431,7 +1431,7 @@ importers:
     dependencies:
       '@kong/swagger-ui-kong-theme-universal':
         specifier: ^4.3.3
-        version: 4.3.3(@babel/core@7.28.0)(axios@1.15.2)(mkdirp@1.0.4)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        version: 4.3.3(@babel/core@7.28.0)(axios@1.15.2)(mkdirp@1.0.4)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2545,9 +2545,6 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
-
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -3985,15 +3982,6 @@ packages:
     peerDependencies:
       vue: 3.5.33
 
-  '@vue-macros/common@3.1.2':
-    resolution: {integrity: sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      vue: 3.5.33
-    peerDependenciesMeta:
-      vue:
-        optional: true
-
   '@vue/babel-helper-vue-transform-on@1.5.0':
     resolution: {integrity: sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==}
 
@@ -4034,11 +4022,11 @@ packages:
   '@vue/compiler-ssr@3.5.33':
     resolution: {integrity: sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==}
 
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
+
   '@vue/devtools-api@7.7.9':
     resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
-
-  '@vue/devtools-api@8.1.1':
-    resolution: {integrity: sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==}
 
   '@vue/devtools-core@7.7.9':
     resolution: {integrity: sha512-48jrBSwG4GVQRvVeeXn9p9+dlx+ISgasM7SxZZKczseohB0cBz+ITKr4YbLWjmJdy45UHL7UMPlR4Y0CWTRcSQ==}
@@ -4048,14 +4036,8 @@ packages:
   '@vue/devtools-kit@7.7.9':
     resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
 
-  '@vue/devtools-kit@8.1.1':
-    resolution: {integrity: sha512-gVBaBv++i+adg4JpH71k9ppl4soyR7Y2McEqO5YNgv0BI1kMZ7BDX5gnwkZ5COYgiCyhejZG+yGNrBAjj6Coqg==}
-
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
-
-  '@vue/devtools-shared@8.1.1':
-    resolution: {integrity: sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==}
 
   '@vue/language-core@3.2.7':
     resolution: {integrity: sha512-Gn4q/tRxbpVGLEuARQ43p3YELlNAFgRUVCgW9U5Cr+5q4vfD2bWDWpl3ABbJMXUt5xlE1dF8dkigg2aUq7JYYw==}
@@ -4445,14 +4427,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-kit@2.2.0:
-    resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
-    engines: {node: '>=20.19.0'}
-
-  ast-walker-scope@0.8.3:
-    resolution: {integrity: sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==}
-    engines: {node: '>=20.19.0'}
-
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -4815,10 +4789,6 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  chokidar@5.0.0:
-    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
-    engines: {node: '>= 20.19.0'}
-
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -5010,9 +4980,6 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
-  confbox@0.2.4:
-    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -6031,9 +5998,6 @@ packages:
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
-
-  exsolve@1.0.8:
-    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
@@ -7395,10 +7359,6 @@ packages:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
 
-  local-pkg@1.1.2:
-    resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
-    engines: {node: '>=14'}
-
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
@@ -7520,10 +7480,6 @@ packages:
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
-
-  magic-string-ast@1.0.3:
-    resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
-    engines: {node: '>=20.19.0'}
 
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
@@ -8427,9 +8383,6 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
-  perfect-debounce@2.1.0:
-    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
-
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
@@ -8476,9 +8429,6 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
-
-  pkg-types@2.3.0:
-    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   pkijs@3.3.3:
     resolution: {integrity: sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==}
@@ -8766,9 +8716,6 @@ packages:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
-  quansync@0.2.11:
-    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
-
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
@@ -8954,10 +8901,6 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
-
-  readdirp@5.0.0:
-    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
-    engines: {node: '>= 20.19.0'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -9326,9 +9269,6 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
-
-  scule@1.3.0:
-    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -10271,14 +10211,6 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin-utils@0.3.1:
-    resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
-    engines: {node: '>=20.19.0'}
-
-  unplugin@3.0.0:
-    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   unraw@3.0.0:
     resolution: {integrity: sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==}
 
@@ -10611,20 +10543,10 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
-  vue-router@5.0.6:
-    resolution: {integrity: sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w==}
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
     peerDependencies:
-      '@pinia/colada': '>=0.21.2'
-      '@vue/compiler-sfc': ^3.5.17
-      pinia: ^3.0.4
       vue: 3.5.33
-    peerDependenciesMeta:
-      '@pinia/colada':
-        optional: true
-      '@vue/compiler-sfc':
-        optional: true
-      pinia:
-        optional: true
 
   vue-screen-utils@1.0.0-beta.13:
     resolution: {integrity: sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==}
@@ -10725,9 +10647,6 @@ packages:
   webpack-sources@3.3.4:
     resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
     engines: {node: '>=10.13.0'}
-
-  webpack-virtual-modules@0.6.2:
-    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   webpack@5.106.2:
     resolution: {integrity: sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==}
@@ -12027,11 +11946,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.30
 
-  '@jridgewell/remapping@2.3.5':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
-
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/source-map@0.3.11':
@@ -12103,7 +12017,7 @@ snapshots:
     dependencies:
       vue: 3.5.33(typescript@5.9.3)
 
-  '@kong/kongponents@8.127.0(axios@1.15.2)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
+  '@kong/kongponents@8.127.0(axios@1.15.2)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       axios: 1.15.2
       date-fns: 2.30.0
@@ -12117,9 +12031,9 @@ snapshots:
       v-calendar: 3.0.0-alpha.8(vue@3.5.33(typescript@5.9.3))
       vue: 3.5.33(typescript@5.9.3)
       vue-draggable-next: 2.3.0(sortablejs@1.15.7)(vue@3.5.33(typescript@5.9.3))
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+      vue-router: 4.6.4(vue@3.5.33(typescript@5.9.3))
 
-  '@kong/kongponents@9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
+  '@kong/kongponents@9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       '@floating-ui/vue': 1.1.11(vue@3.5.33(typescript@5.9.3))
       '@kong/icons': 1.52.0(vue@3.5.33(typescript@5.9.3))
@@ -12136,7 +12050,7 @@ snapshots:
       virtua: 0.49.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue@3.5.33(typescript@5.9.3))
       vue: 3.5.33(typescript@5.9.3)
       vue-draggable-next: 2.3.0(sortablejs@1.15.7)(vue@3.5.33(typescript@5.9.3))
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+      vue-router: 4.6.4(vue@3.5.33(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - react
@@ -12180,10 +12094,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@kong/swagger-ui-kong-theme-universal@4.3.3(@babel/core@7.28.0)(axios@1.15.2)(mkdirp@1.0.4)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
+  '@kong/swagger-ui-kong-theme-universal@4.3.3(@babel/core@7.28.0)(axios@1.15.2)(mkdirp@1.0.4)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.59.0)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       '@braintree/sanitize-url': 6.0.2
-      '@kong/kongponents': 8.127.0(axios@1.15.2)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+      '@kong/kongponents': 8.127.0(axios@1.15.2)(vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@kyleshockey/xml': 1.0.2
       classnames: 2.5.1
       curl-to-har: 1.0.1
@@ -12281,12 +12195,12 @@ snapshots:
     dependencies:
       langium: 4.2.2
 
-  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))':
+  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.59.0)
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
-      vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
 
@@ -12755,10 +12669,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-vue@1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)':
+  '@playwright/experimental-ct-vue@1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
       '@playwright/experimental-ct-core': 1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13880,9 +13794,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
+      '@rolldown/pluginutils': 1.0.0-beta.32
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.0)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
+      vue: 3.5.33(typescript@5.9.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vue: 3.5.33(typescript@5.9.3)
+
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
       vue: 3.5.33(typescript@5.9.3)
 
   '@vitest/expect@3.2.4':
@@ -13970,16 +13900,6 @@ snapshots:
       vue: 3.5.33(typescript@5.9.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
-
-  '@vue-macros/common@3.1.2(vue@3.5.33(typescript@5.9.3))':
-    dependencies:
-      '@vue/compiler-sfc': 3.5.32
-      ast-kit: 2.2.0
-      local-pkg: 1.1.2
-      magic-string-ast: 1.0.3
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      vue: 3.5.33(typescript@5.9.3)
 
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
 
@@ -14070,13 +13990,11 @@ snapshots:
       '@vue/compiler-dom': 3.5.33
       '@vue/shared': 3.5.33
 
+  '@vue/devtools-api@6.6.4': {}
+
   '@vue/devtools-api@7.7.9':
     dependencies:
       '@vue/devtools-kit': 7.7.9
-
-  '@vue/devtools-api@8.1.1':
-    dependencies:
-      '@vue/devtools-kit': 8.1.1
 
   '@vue/devtools-core@7.7.9(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
@@ -14100,18 +14018,9 @@ snapshots:
       speakingurl: 14.0.1
       superjson: 2.2.6
 
-  '@vue/devtools-kit@8.1.1':
-    dependencies:
-      '@vue/devtools-shared': 8.1.1
-      birpc: 2.9.0
-      hookable: 5.5.3
-      perfect-debounce: 2.1.0
-
   '@vue/devtools-shared@7.7.9':
     dependencies:
       rfdc: 1.4.1
-
-  '@vue/devtools-shared@8.1.1': {}
 
   '@vue/language-core@3.2.7':
     dependencies:
@@ -14486,16 +14395,6 @@ snapshots:
   assert-plus@1.0.0: {}
 
   assertion-error@2.0.1: {}
-
-  ast-kit@2.2.0:
-    dependencies:
-      '@babel/parser': 7.29.2
-      pathe: 2.0.3
-
-  ast-walker-scope@0.8.3:
-    dependencies:
-      '@babel/parser': 7.29.2
-      ast-kit: 2.2.0
 
   astral-regex@2.0.0: {}
 
@@ -14939,10 +14838,6 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  chokidar@5.0.0:
-    dependencies:
-      readdirp: 5.0.0
-
   chownr@1.1.4:
     optional: true
 
@@ -15116,8 +15011,6 @@ snapshots:
       typedarray: 0.0.6
 
   confbox@0.1.8: {}
-
-  confbox@0.2.4: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -16344,8 +16237,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  exsolve@1.0.8: {}
 
   ext@1.7.0:
     dependencies:
@@ -17860,12 +17751,6 @@ snapshots:
       emojis-list: 3.0.0
       json5: 2.2.3
 
-  local-pkg@1.1.2:
-    dependencies:
-      mlly: 1.8.2
-      pkg-types: 2.3.0
-      quansync: 0.2.11
-
   locate-path@2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -17967,10 +17852,6 @@ snapshots:
       es5-ext: 0.10.64
 
   lunr@2.3.9: {}
-
-  magic-string-ast@1.0.3:
-    dependencies:
-      magic-string: 0.30.21
 
   magic-string@0.25.9:
     dependencies:
@@ -19126,8 +19007,6 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
-  perfect-debounce@2.1.0: {}
-
   performance-now@2.1.0: {}
 
   picocolors@1.1.1: {}
@@ -19161,12 +19040,6 @@ snapshots:
     dependencies:
       confbox: 0.1.8
       mlly: 1.8.2
-      pathe: 2.0.3
-
-  pkg-types@2.3.0:
-    dependencies:
-      confbox: 0.2.4
-      exsolve: 1.0.8
       pathe: 2.0.3
 
   pkijs@3.3.3:
@@ -19472,8 +19345,6 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  quansync@0.2.11: {}
-
   querystringify@2.2.0: {}
 
   queue-lit@1.5.0: {}
@@ -19689,8 +19560,6 @@ snapshots:
       picomatch: 4.0.4
 
   readdirp@4.1.2: {}
-
-  readdirp@5.0.0: {}
 
   rechoir@0.8.0:
     dependencies:
@@ -20045,8 +19914,6 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
-
-  scule@1.3.0: {}
 
   section-matter@1.0.0:
     dependencies:
@@ -21151,17 +21018,6 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-utils@0.3.1:
-    dependencies:
-      pathe: 2.0.3
-      picomatch: 4.0.4
-
-  unplugin@3.0.0:
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
-      webpack-virtual-modules: 0.6.2
-
   unraw@3.0.0: {}
 
   untildify@4.0.0: {}
@@ -21328,13 +21184,13 @@ snapshots:
     dependencies:
       monaco-editor: 0.55.1
 
-  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)):
+  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
       '@swc/core': 1.15.7
       '@swc/wasm': 1.15.7
       uuid: 10.0.0
-      vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
@@ -21370,9 +21226,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-wasm@3.6.0(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)):
+  vite-plugin-wasm@3.6.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)):
     dependencies:
-      vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
 
   vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1):
     dependencies:
@@ -21491,29 +21347,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)):
+  vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)):
     dependencies:
-      '@babel/generator': 7.29.1
-      '@vue-macros/common': 3.1.2(vue@3.5.33(typescript@5.9.3))
-      '@vue/devtools-api': 8.1.1
-      ast-walker-scope: 0.8.3
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.15
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
+      '@vue/devtools-api': 6.6.4
       vue: 3.5.33(typescript@5.9.3)
-      yaml: 2.8.3
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.33
-      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3))
 
   vue-screen-utils@1.0.0-beta.13(vue@3.5.33(typescript@5.9.3)):
     dependencies:
@@ -21652,8 +21489,6 @@ snapshots:
       wildcard: 2.0.1
 
   webpack-sources@3.3.4: {}
-
-  webpack-virtual-modules@0.6.2: {}
 
   webpack@5.106.2(webpack-cli@7.0.2):
     dependencies:


### PR DESCRIPTION
I think we were a little too fast upgrading to `vue-router@>5`. [Since the current version of `kongponent` didn't upgrade the peer of `vue-router` to `>5` ](https://github.com/Kong/kongponents/blob/7b1ff958b085f3390219111ac98ed2a5f6c9a74e/package.json#L80) the bump here introduces a lot more unmet peers. Additionally dependents are now forced to upgrade to `vue-router@^5.0.6` otherwise they can't upgrade the versions of their dependencies sourced from this repo without introducing conflicts.

I've kept `vue-router@^5.0.6` in the peer dependency semver range because as of https://router.vuejs.org/guide/migration/v4-to-v5.html#For-Vue-Router-4-Users-without-file-based-routing-
>No breaking changes.

So keeping the new major in the range allows smooth upgrading and as soon as `kongponents` includes `v5` in the peer semver range the dev version here can be bumped to `v5` too.

```
$ pnpm install --resolution-only

...

 WARN  Issues with peer dependencies found
.
├─┬ @kong/kongponents 9.52.11
│ └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6
└─┬ stylelint-config-recommended-vue 1.6.1
  └─┬ stylelint-config-recommended 14.0.1
    └── ✕ unmet peer stylelint@^16.1.0: found 17.8.0

packages/analytics/analytics-chart
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/analytics/analytics-geo-map
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/analytics/analytics-metric-provider
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/core/app-layout
├─┬ @kong/kongponents 9.52.11
│ └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6
└─┬ focus-trap-vue 4.1.0
  └── ✕ unmet peer focus-trap@^7.0.0: found 8.1.0

packages/core/documentation
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/core/entities-config-editor
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/core/expressions
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/core/forms
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/core/misc-widgets
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/core/monaco-editor
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/core/page-layout
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/core/sandbox-layout
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/core/split-pane
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-certificates
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-consumer-credentials
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-consumer-groups
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-consumers
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-data-plane-nodes
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-gateway-services
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-key-sets
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-keys
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-plugins
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-redis-configurations
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-routes
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-shared
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-snis
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-upstreams-targets
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/entities/entities-vaults
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/portal/document-viewer
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/portal/spec-renderer
└─┬ @kong/kongponents 9.52.11
  └── ✕ unmet peer vue-router@^4.6.4: found 5.0.6

packages/portal/swagger-ui-web-component
└─┬ @kong/swagger-ui-kong-theme-universal 4.3.3
  ├── ✕ unmet peer react@17.0.2: found 18.3.1
  ├─┬ @kong/kongponents 8.127.0
  │ └── ✕ unmet peer vue-router@^4.2.4: found 5.0.6
  └─┬ swagger2har 1.0.6
    └─┬ rollup-plugin-babel 4.4.0
      └── ✕ unmet peer rollup@">=0.60.0 <3": found 4.59.0
Done in 3.2s using pnpm v10.33.2
```

With the changes here we can reduce the peer issues:

```
$ pnpm install --resolution-only

...

 WARN  Issues with peer dependencies found
.
└─┬ stylelint-config-recommended-vue 1.6.1
  └─┬ stylelint-config-recommended 14.0.1
    └── ✕ unmet peer stylelint@^16.1.0: found 17.8.0

packages/core/app-layout
└─┬ focus-trap-vue 4.1.0
  └── ✕ unmet peer focus-trap@^7.0.0: found 8.1.0

packages/portal/swagger-ui-web-component
└─┬ @kong/swagger-ui-kong-theme-universal 4.3.3
  ├── ✕ unmet peer react@17.0.2: found 18.3.1
  └─┬ swagger2har 1.0.6
    └─┬ rollup-plugin-babel 4.4.0
      └── ✕ unmet peer rollup@">=0.60.0 <3": found 4.59.0
Done in 2.9s using pnpm v10.33.2
```