### PR TITLE
fix(entity-config-card): hide sensitive fields [khcp-20260]

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@evilmartians/lefthook": "^2.1.6",
     "@kong/design-tokens": "1.20.1",
     "@kong/eslint-config-kong-ui": "^1.6.2",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@stylistic/stylelint-plugin": "^5.1.0",
     "@types/flat": "^5.0.5",
     "@types/js-yaml": "^4.0.9",

--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -29,7 +29,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@types/uuid": "^11.0.0",
     "file-saver": "^2.0.5",
     "lodash.mapkeys": "^4.6.0",

--- a/packages/analytics/analytics-geo-map/package.json
+++ b/packages/analytics/analytics-geo-map/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@types/geobuf": "^3.0.4",
     "@types/geojson": "^7946.0.16",
     "maplibre-gl": "^5.23.0",

--- a/packages/analytics/analytics-metric-provider/package.json
+++ b/packages/analytics/analytics-metric-provider/package.json
@@ -67,7 +67,7 @@
     "@kong-ui-public/analytics-utilities": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "pinia": ">= 3.0.4 < 4"
   }
 }

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -49,7 +49,7 @@
     "@kong-ui-public/sandbox-layout": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "ajv": "^8.18.0",
     "cypress-real-events": "^1.15.0",
     "pinia": ">= 3.0.4 < 4",

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/core/documentation/package.json
+++ b/packages/core/documentation/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33"
   },

--- a/packages/core/entities-config-editor/package.json
+++ b/packages/core/entities-config-editor/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "vue": "^3.5.33"
   },
   "repository": {

--- a/packages/core/expressions/package.json
+++ b/packages/core/expressions/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@kong/atc-router": "1.6.0-rc.1",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@types/uuid": "^11.0.0",
     "monaco-editor": "^0.55.1",
     "vite-plugin-monaco-editor": "^1.1.0",

--- a/packages/core/forms/package.json
+++ b/packages/core/forms/package.json
@@ -67,7 +67,7 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@types/lodash-es": "^4.17.12",
     "axios": "^1.15.2",
     "pug": "^3.0.4"

--- a/packages/core/misc-widgets/package.json
+++ b/packages/core/misc-widgets/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "vue": "^3.5.33"
   },
   "repository": {

--- a/packages/core/monaco-editor/package.json
+++ b/packages/core/monaco-editor/package.json
@@ -80,7 +80,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@peculiar/x509": "^2.0.0",
     "jsonc-parser": "^3.3.1",
     "monaco-editor": "^0.55.1",

--- a/packages/core/page-layout/package.json
+++ b/packages/core/page-layout/package.json
@@ -42,7 +42,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"
   },

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"
   },

--- a/packages/core/split-pane/package.json
+++ b/packages/core/split-pane/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "vue": "^3.5.33"
   },
   "repository": {

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-data-plane-nodes/package.json
+++ b/packages/entities/entities-data-plane-nodes/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -33,7 +33,7 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -70,7 +70,7 @@
     "@kong-ui-public/monaco-editor": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@peculiar/x509": "^2.0.0",
     "@playwright/experimental-ct-vue": "^1.59.1",
     "@playwright/test": "^1.59.1",

--- a/packages/entities/entities-redis-configurations/package.json
+++ b/packages/entities/entities-redis-configurations/package.json
@@ -45,7 +45,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@types/uuid": "^11.0.0",
     "axios": "^1.15.2",
     "swrv": "^1.2.0",

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@types/lodash.isequal": "^4.5.8",
     "axios": "^1.15.2",
     "vite-plugin-monaco-editor": "^1.1.0",

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -38,7 +38,7 @@
     "@kong-ui-public/monaco-editor": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@shikijs/core": "^3.23.0",
     "@shikijs/engine-javascript": "^3.23.0",
     "axios": "^1.15.2",

--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlock.vue
@@ -8,6 +8,7 @@
     :entity-type="(props.entityType as SupportedEntityDeck)"
     :geo-api-server-url="props.app === 'konnect' ? props.geoApiServerUrl : undefined"
     :kong-admin-api-url="props.app === 'kongManager' ? props.kongAdminApiUrl : undefined"
+    :unredacted-record="props.unredactedRecord"
     :workspace="props.app === 'kongManager' ? props.workspace : undefined"
   />
 
@@ -31,6 +32,7 @@
       :geo-api-server-url="props.app === 'konnect' ? props.geoApiServerUrl : undefined"
       is-customizing
       :kong-admin-api-url="props.app === 'kongManager' ? props.kongAdminApiUrl : undefined"
+      :unredacted-record="props.unredactedRecord"
       :workspace="props.app === 'kongManager' ? props.workspace : undefined"
     />
   </KModal>

--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
@@ -80,7 +80,7 @@
       id="deck-codeblock"
       :class="{ customization: props.isCustomizing }"
       :code="deckCommand"
-      :copy-code="unredactedCommand"
+      :copy-code="unredactedDeckCommand"
       data-dd-privacy="mask"
       :language="shell"
       :theme="isCustomizing ? 'light' : 'dark'"

--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
@@ -80,6 +80,8 @@
       id="deck-codeblock"
       :class="{ customization: props.isCustomizing }"
       :code="deckCommand"
+      :copy-code="unredactedCommand"
+      data-dd-privacy="mask"
       :language="shell"
       :theme="isCustomizing ? 'light' : 'dark'"
       @code-block-render="highlightCodeBlock"
@@ -149,6 +151,7 @@ const { t } = i18n
 
 const konnectPat = ref<string>('')
 const deckCommand = ref<string>('')
+const unredactedDeckCommand = ref<string>('')
 const isGeneratePatModalVisible = ref(false)
 
 const shells = [
@@ -179,9 +182,9 @@ const baseObject = computed(() => {
   return obj
 })
 
-const yamlContent = computed((): string => {
+const buildYaml = (record: Record<string, any>): string => {
   // filter out null values, empty strings, and empty arrays since decK doesn't accept them [KHCP-10642]
-  const filteredRecord = Object.fromEntries(Object.entries(props.entityRecord).filter(([, value]) => value !== null && value !== '' && (Array.isArray(value) ? value.length !== 0 : true)))
+  const filteredRecord = Object.fromEntries(Object.entries(record).filter(([, value]) => value !== null && value !== '' && (Array.isArray(value) ? value.length !== 0 : true)))
 
   // transfer parent object `{id: string}` to just id string for decK compatibility [KM-2056]
   if (props.entityType === SupportedEntityType.Plugin) {
@@ -212,6 +215,14 @@ const yamlContent = computed((): string => {
   }
 
   return yaml.dump(fullRecord, { quotingType: '"' }).trim()
+}
+
+const yamlContent = computed((): string => {
+  return buildYaml(props.entityRecord)
+})
+
+const unredactedCommand = computed((): string => {
+  return buildYaml(props.unredactedRecord || props.entityRecord)
 })
 
 const envCommand = computed((): string => {
@@ -241,10 +252,18 @@ watchEffect(() => {
     deckCommand.value = `echo '
 ${yamlContent.value}
 ' | ${command}`
+    // unredacted Bash command
+    unredactedDeckCommand.value = `echo '
+${unredactedCommand.value}
+' | ${command}`
   } else {
     // PowerShell uses @' '@ for multi-line strings
     deckCommand.value = `@'
 ${yamlContent.value}
+'@ | ${command}`
+    // unredacted PowerShell command
+    unredactedDeckCommand.value = `@'
+${unredactedCommand.value}
 '@ | ${command}`
   }
 })

--- a/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
@@ -1,25 +1,27 @@
 <template>
   <div class="json-config config-card-code-block">
     <div
-      v-if="props.fetcherUrl"
+      v-if="fetcherUrl"
       class="json-endpoint"
     >
-      <KBadge :appearance="props.requestMethod">
-        {{ props.requestMethod }}
+      <KBadge :appearance="requestMethod">
+        {{ requestMethod }}
       </KBadge>
       <KCodeBlock
         id="json-endpoint-codeblock"
-        :code="props.fetcherUrl"
+        :code="fetcherUrl"
         language="plaintext"
         single-line
         theme="dark"
       />
     </div>
     <KCodeBlock
-      v-if="props.entityRecord"
+      v-if="entityRecord"
       id="json-codeblock"
-      :class="{ 'json-content': props.fetcherUrl }"
+      :class="{ 'json-content': fetcherUrl }"
       :code="JSON.stringify(jsonContent, null, 2)"
+      :copy-code="JSON.stringify(unredactedRecord || jsonContent, null, 2)"
+      data-dd-privacy="mask"
       language="json"
       theme="dark"
       @code-block-render="highlightCodeBlock"
@@ -46,16 +48,21 @@ const props = defineProps({
     required: false,
     default: '',
   },
-  /** A record to indicate the entity's configuration, used to populate the JSON code block */
-  entityRecord: {
-    type: Object as PropType<Record<string, any>>,
-    required: true,
-  },
   /** HTTP request method like GET, POST, PUT, used to make the api call. */
   requestMethod: {
     type: String as PropType<BadgeAppearance>,
     required: false,
     default: '',
+  },
+  /** A record to indicate the entity's configuration, the visible code content (may be redacted) */
+  entityRecord: {
+    type: Object as PropType<Record<string, any>>,
+    required: true,
+  },
+  /** The unredacted record, used for copy actions */
+  unredactedRecord: {
+    type: Object as PropType<Record<string, any>>,
+    default: null,
   },
 })
 

--- a/packages/entities/entities-shared/src/components/common/TerraformCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/TerraformCodeBlock.vue
@@ -4,6 +4,8 @@
       v-if="props.entityRecord"
       id="terraform-codeblock"
       :code="terraformContent"
+      :copy-code="unredactedTerraformContent"
+      data-dd-privacy="mask"
       language="terraform"
       theme="dark"
       @code-block-render="highlightCodeBlock"
@@ -22,10 +24,15 @@ const HEREDOC_DELIMITER = 'TF_MULTILINE_EOT'
 const CLOUD_GATEWAY_ADDON_ENTITY_TYPE = 'cloud_gateway_addon'
 
 const props = defineProps({
-  /** A record to indicate the entity's configuration, used to populate the Terraform code block */
+  /** A record to indicate the entity's configuration, the visible code content (may be redacted) */
   entityRecord: {
     type: Object as PropType<Record<string, any>>,
     required: true,
+  },
+  /** The unredacted record, used for copy actions */
+  unredactedRecord: {
+    type: Object as PropType<Record<string, any>>,
+    default: null,
   },
   entityType: {
     type: String as PropType<SupportedEntityType>,
@@ -219,11 +226,11 @@ const generateConfig = (record: Record<string, any>): string => {
   return escapeTerraformInterpolation(content)
 }
 
-const terraformContent = computed((): string => {
+const buildTerraformCode = (record: Record<string, any>): string => {
   // filter out null/undefined values since terraform doesn't accept them
   // this logic isn't recursive, so manually handle nested config object
-  const modifiedRecord = Object.fromEntries(Object.entries(props.entityRecord).filter(([, value]) => value !== null && value !== undefined))
-  const modifiedConfig = props.entityRecord.config ? Object.fromEntries(Object.entries(props.entityRecord?.config).filter(([, value]) => value !== null && value !== undefined)) : undefined
+  const modifiedRecord = Object.fromEntries(Object.entries(record).filter(([, value]) => value !== null && value !== undefined))
+  const modifiedConfig = record.config ? Object.fromEntries(Object.entries(record?.config).filter(([, value]) => value !== null && value !== undefined)) : undefined
   if (modifiedConfig) {
     modifiedRecord.config = modifiedConfig
   }
@@ -305,5 +312,13 @@ const terraformContent = computed((): string => {
   content += '}\n'
 
   return content
+}
+
+const terraformContent = computed((): string => {
+  return buildTerraformCode(props.entityRecord)
+})
+
+const unredactedTerraformContent = computed((): string => {
+  return buildTerraformCode(props.unredactedRecord || props.entityRecord)
 })
 </script>

--- a/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
@@ -13,6 +13,8 @@
       v-if="props.entityRecord"
       id="yaml-codeblock"
       :code="yamlContent"
+      :copy-code="unredactedYamlContent"
+      data-dd-privacy="mask"
       language="yaml"
       theme="dark"
       @code-block-render="highlightCodeBlock"
@@ -34,10 +36,15 @@ import type { DeckCalloutPreference } from '../../types'
 defineOptions({ inheritAttrs: false })
 
 const props = defineProps({
-  /** A record to indicate the entity's configuration, used to populate the YAML code block */
+  /** A record to indicate the entity's configuration, the visible code content (may be redacted) */
   entityRecord: {
     type: Object as PropType<Record<string, any>>,
     required: true,
+  },
+  /** The unredacted record, used for copy actions */
+  unredactedRecord: {
+    type: Object as PropType<Record<string, any>>,
+    default: null,
   },
   /**
    * The localStorage key to use to persist the visibility preference for the decK format callout.
@@ -57,11 +64,19 @@ const emit = defineEmits<{
 
 const deckCalloutPreference = ref<DeckCalloutPreference>('visible')
 
-const yamlContent = computed((): string => {
+const buildYaml = (record: Record<string, any>): string => {
   // filter out null values, empty strings, and empty arrays since decK doesn't accept them [KHCP-10642]
-  const filteredRecord = Object.fromEntries(Object.entries(props.entityRecord).filter(([, value]) => value !== null && value !== '' && (Array.isArray(value) ? value.length !== 0 : true)))
+  const filteredRecord = Object.fromEntries(Object.entries(record).filter(([, value]) => value !== null && value !== '' && (Array.isArray(value) ? value.length !== 0 : true)))
   // if empty object, display empty yaml, else convert to yaml and remove any trailing whitespace
   return (Object.keys(filteredRecord).length === 0 && filteredRecord.constructor === Object) ? '' : yaml.dump(filteredRecord).trim()
+}
+
+const yamlContent = computed((): string => {
+  return buildYaml(props.entityRecord)
+})
+
+const unredactedYamlContent = computed((): string => {
+  return buildYaml(props.unredactedRecord || props.entityRecord)
 })
 
 watch(() => props.deckCalloutPreferenceKey, (key) => {

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
@@ -58,11 +58,13 @@
     :entity-record="entityRecord"
     :fetcher-url="fetchUrlJsonBlock"
     request-method="get"
+    :unredacted-record="codeBlockRecord || record"
   />
   <YamlCodeBlock
     v-if="format === 'yaml' && entityRecord"
     :deck-callout-preference-key="isDeckEnabled ? deckCalloutPreferenceKey : undefined"
     :entity-record="entityRecord"
+    :unredacted-record="codeBlockRecord || record"
     @deck-callout:click-cta="$emit('request-deck-format')"
   />
   <TerraformCodeBlock
@@ -70,6 +72,7 @@
     :entity-record="entityRecord"
     :entity-type="props.entityType"
     :sub-entity-type="props.subEntityType"
+    :unredacted-record="codeBlockRecord || record"
   />
   <DeckCodeBlock
     v-if="format === 'deck' && entityRecord"
@@ -81,6 +84,7 @@
     :geo-api-server-url="config.app === 'konnect' ? config.geoApiServerUrl : undefined"
     :is-customization-modal-visible="isDeckCustomizationVisible"
     :kong-admin-api-url="config.app === 'kongManager' ? config.apiBaseUrl : undefined"
+    :unredacted-record="codeBlockRecord || record"
     :workspace="config.app === 'kongManager' ? config.workspace : undefined"
     @customization-close="$emit('deck-customization:close')"
   />

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
@@ -206,15 +206,7 @@ const { i18n: { t } } = composables.useI18n()
 const hasTooltip = (item: RecordItem): boolean => !!(item.tooltip || slots[`${item.key}-label-tooltip`])
 
 // Structured grid always uses `record`; code tabs uses `codeBlockRecordRedacted` or `codeBlockRecord` when the parent passes it
-const recordForCodeBlocks = computed((): Record<string, any> | undefined => {
-  if (props.codeBlockRecordRedacted !== undefined) {
-    return props.codeBlockRecordRedacted
-  } else if (props.codeBlockRecord !== undefined) {
-    return props.codeBlockRecord
-  }
-
-  return props.record
-})
+const recordForCodeBlocks = computed((): Record<string, any> | undefined => props.codeBlockRecordRedacted || props.codeBlockRecord || props.record)
 
 // Deep clone + optional timestamp strip + per-format shaping (`codeBlockRecordFormatter`)
 const entityRecord = computed((): Record<string, any> | undefined => {

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
@@ -160,6 +160,13 @@ const props = defineProps({
     default: undefined,
   },
   /**
+   * When set, JSON/YAML/TR/deck code blocks use this record instead of `codeBlockRecord`
+   */
+  codeBlockRecordRedacted: {
+    type: Object as PropType<Record<string, any>>,
+    default: undefined,
+  },
+  /**
    * When false/default, strip created_at/ updated_at per KHCP-9837
    * Set true to show full payloads
    */
@@ -198,10 +205,16 @@ const { i18n: { t } } = composables.useI18n()
 
 const hasTooltip = (item: RecordItem): boolean => !!(item.tooltip || slots[`${item.key}-label-tooltip`])
 
-// Structured grid always uses `record`; code tabs uses `codeBlockRecord` when the parent passes it
-const recordForCodeBlocks = computed((): Record<string, any> | undefined =>
-  props.codeBlockRecord !== undefined ? props.codeBlockRecord : props.record,
-)
+// Structured grid always uses `record`; code tabs uses `codeBlockRecordRedacted` or `codeBlockRecord` when the parent passes it
+const recordForCodeBlocks = computed((): Record<string, any> | undefined => {
+  if (props.codeBlockRecordRedacted !== undefined) {
+    return props.codeBlockRecordRedacted
+  } else if (props.codeBlockRecord !== undefined) {
+    return props.codeBlockRecord
+  }
+
+  return props.record
+})
 
 // Deep clone + optional timestamp strip + per-format shaping (`codeBlockRecordFormatter`)
 const entityRecord = computed((): Record<string, any> | undefined => {

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
@@ -4,7 +4,7 @@ import type {
   ConfigurationSchema,
   PluginConfigurationSchema,
 } from '../../types'
-import { ConfigurationSchemaSection, SupportedEntityType } from '../../types'
+import { ConfigurationSchemaSection, ConfigurationSchemaType, SupportedEntityType } from '../../types'
 import { gatewayServiceRecord, pluginRecord, emptyKey, keyWithValue } from '../../../fixtures/mockData'
 import composables from '../../composables'
 import EntityBaseConfigCard from './EntityBaseConfigCard.vue'
@@ -33,12 +33,14 @@ const customTooltip = 'Custom tooltip'
 const customLabel = 'CA Certificates'
 const unconfiguredKey = 'client_certificate'
 const untypedKey = 'extra'
+const sensitiveKey = 'host'
 const configSchema: ConfigurationSchema = {
   protocol: {
     section: ConfigurationSchemaSection.Basic,
   },
-  host: {
+  [sensitiveKey]: {
     section: ConfigurationSchemaSection.Basic,
+    type: ConfigurationSchemaType.Redacted,
   },
   path: {
     section: ConfigurationSchemaSection.Basic,
@@ -156,6 +158,66 @@ describe('<EntityBaseConfigCard />', () => {
       })
 
       cy.getTestId('select-config-format').should('exist')
+    })
+
+    it('KCheckbox to show sensitive fields is hidden on structured view', () => {
+      interceptFetch()
+
+      cy.mount(EntityBaseConfigCardMount, {
+        props: {
+          config,
+          configSchema,
+          entityType,
+          fetchUrl,
+        },
+      })
+
+      cy.getTestId('sensitive-fields-checkbox').should('not.exist')
+    })
+
+    it('displays KCheckbox to show sensitive fields on non-structured view', () => {
+      interceptFetch()
+
+      cy.mount(EntityBaseConfigCardMount, {
+        props: {
+          config,
+          configSchema,
+          entityType,
+          fetchUrl,
+        },
+      })
+
+      cy.getTestId('select-config-format').should('be.visible')
+      cy.getTestId('select-config-format').click()
+      cy.getTestId('select-item-json').click()
+
+      cy.getTestId('sensitive-fields-checkbox').should('be.visible')
+    })
+
+    it('redacts/unredacts sensitive fields when KCheckbox is checked/unchecked', () => {
+      interceptFetch()
+
+      cy.mount(EntityBaseConfigCardMount, {
+        props: {
+          config,
+          configSchema,
+          entityType,
+          fetchUrl,
+        },
+      })
+
+      cy.getTestId('select-config-format').should('be.visible')
+      cy.getTestId('select-config-format').click()
+      cy.getTestId('select-item-json').click()
+
+      // redacted by default
+      cy.get('#json-codeblock').findTestId('highlighted-code-block').should('contain.text', `"${sensitiveKey}": "********"`)
+      cy.get('#json-codeblock').findTestId('highlighted-code-block').should('not.contain.text', gatewayServiceRecord.host)
+
+      cy.getTestId('sensitive-fields-checkbox').should('be.visible')
+      cy.getTestId('sensitive-fields-checkbox').click()
+      // unredacted
+      cy.get('#json-codeblock').findTestId('highlighted-code-block').should('contain.text', gatewayServiceRecord.host)
     })
 
     it('displays KButton with book icon when `configCardDoc` prop is set correctly', () => {

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -479,6 +479,7 @@ const codeBlockRecordFromApi = computed((): Record<string, any> | undefined => {
   return props.codeBlockRecordResolver(rawFetchedData.value)
 })
 
+// redact sensitive fields by default
 const showSensitiveFields = ref(false)
 const redactedCodeBlockRecord = computed((): Record<string, any> => {
   const rec = { ...(codeBlockRecordFromApi.value || record.value) }
@@ -489,7 +490,7 @@ const redactedCodeBlockRecord = computed((): Record<string, any> => {
     }
   }
 
-  return rec
+  return props.codeBlockRecordResolver ? props.codeBlockRecordResolver(rec) : rec
 })
 
 // Handle sorting by 'order' prop

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -26,7 +26,7 @@
           v-model="showSensitiveFields"
           class="sensitive-fields-checkbox"
           data-testid="sensitive-fields-checkbox"
-          label="Show sensitive fields"
+          :label="t('baseConfigCard.actions.sensitive_fields')"
         />
 
         <KButton

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -20,6 +20,15 @@
     <template #actions>
       <div class="config-card-actions">
         <slot name="actions" />
+
+        <KCheckbox
+          v-if="configFormat !== 'structured'"
+          v-model="showSensitiveFields"
+          class="sensitive-fields-checkbox"
+          data-testid="sensitive-fields-checkbox"
+          label="Show sensitive fields"
+        />
+
         <KButton
           v-if="configFormat === 'deck' && Boolean(deckCustomizationOptions)"
           appearance="secondary"
@@ -28,18 +37,21 @@
         >
           {{ t('baseConfigCard.actions.deck_customize') }}
         </KButton>
-        <KLabel
-          class="config-format-select-label"
-          data-testid="config-format-select-label"
-        >
-          {{ label }}
-        </KLabel>
-        <KSelect
-          v-model="configFormat"
-          data-testid="select-config-format"
-          :items="configFormatItems"
-          @change="handleChange"
-        />
+
+        <div class="row">
+          <KLabel
+            class="config-format-select-label"
+            data-testid="config-format-select-label"
+          >
+            {{ label }}
+          </KLabel>
+          <KSelect
+            v-model="configFormat"
+            data-testid="select-config-format"
+            :items="configFormatItems"
+            @change="handleChange"
+          />
+        </div>
 
         <KButton
           v-if="configCardDoc"
@@ -85,7 +97,9 @@
         <ConfigCardDisplay
           :code-block-record="codeBlockRecordFromApi"
           :code-block-record-formatter="codeBlockRecordFormatter"
+          :code-block-record-redacted="!showSensitiveFields ? redactedCodeBlockRecord : undefined"
           :config="config"
+          :config-schema="configSchema"
           :entity-type="entityType"
           :fetcher-url="fetcherUrl"
           :format="configFormat"
@@ -465,6 +479,19 @@ const codeBlockRecordFromApi = computed((): Record<string, any> | undefined => {
   return props.codeBlockRecordResolver(rawFetchedData.value)
 })
 
+const showSensitiveFields = ref(false)
+const redactedCodeBlockRecord = computed((): Record<string, any> => {
+  const rec = { ...(codeBlockRecordFromApi.value || record.value) }
+
+  for (const key in rec) {
+    if (props.configSchema[key]?.type === ConfigurationSchemaType.Redacted) {
+      rec[key] = '********'
+    }
+  }
+
+  return rec
+})
+
 // Handle sorting by 'order' prop
 const orderedRecordArray = computed((): RecordItem[] => {
   if (!record.value) {
@@ -717,14 +744,24 @@ onBeforeMount(async () => {
   .config-card-actions {
     align-items: center;
     display: flex;
+    gap: var(--kui-space-60, $kui-space-60);
 
-    .button-customize-deck {
-      margin-inline-end: var(--kui-space-60, $kui-space-60);
+    .row {
+      align-items: center;
+      display: flex;
     }
 
     .config-format-select-label {
       margin-bottom: var(--kui-space-0, $kui-space-0);
       margin-right: var(--kui-space-40, $kui-space-40);
+    }
+
+    .sensitive-fields-checkbox {
+      align-items: center;
+
+      :deep(.checkbox-label) {
+        width: max-content;
+      }
     }
   }
 

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -99,7 +99,6 @@
           :code-block-record-formatter="codeBlockRecordFormatter"
           :code-block-record-redacted="!showSensitiveFields ? redactedCodeBlockRecord : undefined"
           :config="config"
-          :config-schema="configSchema"
           :entity-type="entityType"
           :fetcher-url="fetcherUrl"
           :format="configFormat"

--- a/packages/entities/entities-shared/src/locales/en.json
+++ b/packages/entities/entities-shared/src/locales/en.json
@@ -43,7 +43,8 @@
     "actions": {
       "copy": "Copy JSON",
       "deck_customize": "Customize before copying to CLI",
-      "deck_customize_cancel": "Cancel"
+      "deck_customize_cancel": "Cancel",
+      "sensitive_fields": "Show sensitive fields"
     },
     "sections": {
       "advanced": "Advanced",

--- a/packages/entities/entities-shared/src/types/deck.ts
+++ b/packages/entities/entities-shared/src/types/deck.ts
@@ -2,8 +2,10 @@ import type { SupportedEntityDeck } from './entity-base-config-card'
 
 export interface DeckCodeBlockProps {
   app: 'konnect' | 'kongManager'
-  /** A record to indicate the entity's configuration, used to populate the decK code block */
+  /** A record to indicate the entity's configuration, the visible code content (may be redacted) */
   entityRecord: Record<string, any>
+  /** The unredacted record, used for copy actions */
+  unredactedRecord?: Record<string, any>
   entityType: SupportedEntityDeck
   /** e.g. https://us.api.konghq.tech, used to pass --konnect-addr parameter to decK */
   geoApiServerUrl?: string

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -34,7 +34,7 @@
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -33,7 +33,7 @@
     "@kong-ui-public/entities-shared": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "axios": "^1.15.2",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6"

--- a/packages/portal/document-viewer/package.json
+++ b/packages/portal/document-viewer/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@types/prismjs": "^1.26.6",
     "@vitejs/plugin-vue-jsx": "^4.2.0",
     "vue": "^3.5.33"

--- a/packages/portal/spec-renderer/package.json
+++ b/packages/portal/spec-renderer/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "@kong/kongponents": "9.52.11",
+    "@kong/kongponents": "9.53.2",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/uuid": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: ^1.6.2
         version: 1.6.2(@typescript-eslint/parser@8.50.0(eslint@9.39.4(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.5.1))(typescript@5.9.3)
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@stylistic/stylelint-plugin':
         specifier: ^5.1.0
         version: 5.1.0(stylelint@17.8.0(typescript@5.9.3))
@@ -246,8 +246,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -301,8 +301,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/geobuf':
         specifier: ^3.0.4
         version: 3.0.4
@@ -347,8 +347,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       pinia:
         specifier: '>= 3.0.4 < 4'
         version: 3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3))
@@ -427,8 +427,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -482,8 +482,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -550,8 +550,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -565,8 +565,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -608,8 +608,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -657,8 +657,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -690,8 +690,8 @@ importers:
         specifier: workspace:^
         version: link:../i18n
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -718,8 +718,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@peculiar/x509':
         specifier: ^2.0.0
         version: 2.0.0
@@ -758,8 +758,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -777,8 +777,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -802,8 +802,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -827,8 +827,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -854,8 +854,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -881,8 +881,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -908,8 +908,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -935,8 +935,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -962,8 +962,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -986,8 +986,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1013,8 +1013,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1080,8 +1080,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@peculiar/x509':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1182,8 +1182,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -1222,8 +1222,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/lodash.isequal':
         specifier: ^4.5.8
         version: 4.5.8
@@ -1262,8 +1262,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@shikijs/core':
         specifier: ^3.23.0
         version: 3.23.0
@@ -1301,8 +1301,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1328,8 +1328,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0(vue@3.5.33(typescript@5.9.3))
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1356,8 +1356,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -1381,8 +1381,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@types/prismjs':
         specifier: ^1.26.6
         version: 1.26.6
@@ -1415,8 +1415,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       '@kong/kongponents':
-        specifier: 9.52.11
-        version: 9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+        specifier: 9.53.2
+        version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.1
         version: 1.1.1(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
@@ -1685,8 +1685,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@bufbuild/protobuf@2.11.0':
-    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+  '@bufbuild/protobuf@2.12.0':
+    resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
 
   '@cacheable/memory@2.0.7':
     resolution: {integrity: sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==}
@@ -2625,12 +2625,12 @@ packages:
       vue: 3.5.33
       vue-router: ^4.2.4
 
-  '@kong/kongponents@9.52.11':
-    resolution: {integrity: sha512-OVo//aG6Ra9lPCsz/C0vwULYxf02wahLS3JR1NNZfKEIAr0vt99R9HcL6hWzD+iySRkWCUNpq3+zhEIZ0Gw4uw==}
+  '@kong/kongponents@9.53.2':
+    resolution: {integrity: sha512-KtkSWlHyfyHdU2OuU4jD1r4GeiWZycvachRG9OnM63yMekxQQEHlSvabHgGSZbCEVNJ0NfvpNrU2HnM2cLiB7w==}
     engines: {node: '>=v16.20.2 || >=18.12.1 || >=20.14.0 || >=22.14.0', pnpm: '>=10.28.2'}
     peerDependencies:
       vue: 3.5.33
-      vue-router: ^4.6.4
+      vue-router: 4 || 5
 
   '@kong/markdown@1.9.7':
     resolution: {integrity: sha512-88GVb1RWaVKPtlBaExl6jmxqgudFx1dsmeZW8o97fYWzYUrhu+LWrrVlqwBQlpsnI8J814f1scLvg+MTO8oENA==}
@@ -3736,6 +3736,9 @@ packages:
 
   '@types/lodash@4.17.20':
     resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -7965,6 +7968,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   nanoid@5.1.9:
     resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
     engines: {node: ^18 || >=20}
@@ -11221,7 +11229,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@bufbuild/protobuf@2.11.0':
+  '@bufbuild/protobuf@2.12.0':
     optional: true
 
   '@cacheable/memory@2.0.7':
@@ -12125,7 +12133,7 @@ snapshots:
       vue-draggable-next: 2.3.0(sortablejs@1.15.7)(vue@3.5.33(typescript@5.9.3))
       vue-router: 5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
 
-  '@kong/kongponents@9.52.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
+  '@kong/kongponents@9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       '@floating-ui/vue': 1.1.11(vue@3.5.33(typescript@5.9.3))
       '@kong/icons': 1.52.0(vue@3.5.33(typescript@5.9.3))
@@ -12135,7 +12143,7 @@ snapshots:
       focus-trap: 7.8.0
       focus-trap-vue: 4.1.0(focus-trap@7.8.0)(vue@3.5.33(typescript@5.9.3))
       lodash-es: 4.18.1
-      nanoid: 5.1.9
+      nanoid: 5.1.11
       sortablejs: 1.15.7
       swrv: 1.2.0(vue@3.5.33(typescript@5.9.3))
       v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.5.33(typescript@5.9.3))
@@ -13659,6 +13667,8 @@ snapshots:
       '@types/lodash': 4.17.20
 
   '@types/lodash@4.17.20': {}
+
+  '@types/lodash@4.17.24': {}
 
   '@types/markdown-it@14.1.2':
     dependencies:
@@ -18570,6 +18580,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.11: {}
+
   nanoid@5.1.9: {}
 
   nanospinner@1.2.2:
@@ -19999,7 +20011,7 @@ snapshots:
 
   sass-embedded@1.80.3:
     dependencies:
-      '@bufbuild/protobuf': 2.11.0
+      '@bufbuild/protobuf': 2.12.0
       buffer-builder: 0.2.0
       colorjs.io: 0.5.2
       immutable: 4.3.8
@@ -21250,7 +21262,7 @@ snapshots:
   v-calendar@3.1.2(@popperjs/core@2.11.8)(vue@3.5.33(typescript@5.9.3)):
     dependencies:
       '@popperjs/core': 2.11.8
-      '@types/lodash': 4.17.20
+      '@types/lodash': 4.17.24
       '@types/resize-observer-browser': 0.1.11
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
Hide `encrypted` fields by default in Configuration page code blocks. Offer a checkbox to enable displaying redacted values.
Part of [KHCP-20260](https://konghq.atlassian.net/browse/KHCP-20260).

Configuration slideout on form pages will be handled in https://konghq.atlassian.net/browse/KHCP-20485

Functional testing:

- Drill into a control plane -> `Redis Configurations`
- Create a new redis configuration with a `name` and `password`
- View the details page -> set `Format` to anything other than `Structured`

Verify: 
- `password` is redacted by default
- Can use the `Show sensitive fields` checkbox to toggle visibility of the redacted fields
- The `copy` action always copies the unredacted object

<img width="725" height="384" alt="image" src="https://github.com/user-attachments/assets/689c9e77-1382-4348-bf2f-84589525ef36" />



[KHCP-20260]: https://konghq.atlassian.net/browse/KHCP-20260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ