### PR TITLE
fix(entities-plugins): filter scoped plugins in featured plugin list

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginCatalog.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.cy.ts
@@ -216,6 +216,55 @@ describe('<PluginCatalog />', {
     cy.getTestId('acl-card').should('have.class', 'disabled')
   })
 
+  it('should show only scope-matching featured plugins when entityType is consumers', () => {
+    interceptKonnect()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: {
+          ...baseConfigKonnect,
+          entityType: 'consumers',
+          entityId: 'consumer-123',
+        },
+        // mix of consumer-scoped and non-consumer-scoped plugins
+        highlightedPluginIds: ['datakit', 'key-auth', 'openid-connect', 'cors', 'rate-limiting-advanced', 'request-transformer'],
+      },
+      router,
+    })
+
+    cy.wait('@getAvailablePlugins')
+
+    // Featured group should exist with in-scope plugins
+    cy.getTestId('plugin-group-Featured').should('be.visible')
+    cy.getTestId('rate-limiting-advanced-card').should('exist')
+    cy.getTestId('request-transformer-card').should('exist')
+    // out-of-scope plugins should not appear in Featured
+    cy.getTestId('plugin-group-Featured').within(() => {
+      cy.getTestId('key-auth-card').should('not.exist')
+    })
+  })
+
+  it('should exclude featured group entirely when all highlighted plugins are out of scope', () => {
+    interceptKonnect()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: {
+          ...baseConfigKonnect,
+          entityType: 'consumers',
+          entityId: 'consumer-123',
+        },
+        // none of these have CONSUMER scope
+        highlightedPluginIds: ['key-auth', 'openid-connect', 'cors'],
+      },
+      router,
+    })
+
+    cy.wait('@getAvailablePlugins')
+
+    cy.getTestId('plugin-group-Featured').should('not.exist')
+  })
+
   it('should clear selected filters when clear selection clicked', () => {
     interceptKonnect()
 

--- a/packages/entities/entities-plugins/src/components/PluginCatalog.vue
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.vue
@@ -417,11 +417,13 @@ const buildPluginList = (): PluginCardList => {
       return list
     }, {})
   // Pick highlighted plugin objects from pluginMetaData and assign to 'Featured'
+  // Only include plugins that passed scope filtering (i.e., already present in the list)
   if (props.highlightedPluginIds && props.highlightedPluginIds.length > 0) {
-    list[PluginGroup.FEATURED] = props.highlightedPluginIds
+    const scopedIds = new Set(Object.values(list).flat().map(p => p?.id))
+    const featuredPlugins = props.highlightedPluginIds
       .flatMap(pluginId => {
         const meta = pluginMetaData[pluginId]
-        if (!meta) return []
+        if (!meta || !scopedIds.has(pluginId)) return []
         return {
           ...meta,
           id: pluginId,
@@ -431,7 +433,10 @@ const buildPluginList = (): PluginCardList => {
           group: meta.group || PluginGroup.CUSTOM_PLUGINS,
         }
       })
-      .filter(Boolean) // remove undefined if any id not found in meta
+      .filter(Boolean)
+    if (featuredPlugins.length > 0) {
+      list[PluginGroup.FEATURED] = featuredPlugins
+    }
   }
   return list
 }


### PR DESCRIPTION
# Summary

For `PluginCatalog` under a certain scope, add filtering for `Featured` category so that it filter out plugin unavailable under this scope.