### PR TITLE
fix(page-layout): detect overflow using resize observer [KHCP-20425]

### DIFF
--- a/packages/core/page-layout/docs/page-layout.md
+++ b/packages/core/page-layout/docs/page-layout.md
@@ -250,9 +250,10 @@ The `PageLayoutTabs` component is an internal component used by `PageLayout` to 
 
 The tab bar dynamically measures the available container width and determines how many tabs can fit. Tabs that exceed the available space are moved into a "More" dropdown menu powered by Kongponents `KDropdown`.
 
-- Layout is computed on mount and recalculated on window resize (debounced at 150ms)
-- A skeleton loading state is displayed while the layout is being computed
-- The "More" button displays a badge with the count of hidden tabs
+- Layout is computed on mount and recalculated whenever the tab bar's own size changes (observed via [`useResizeObserver`](https://vueuse.org/core/useResizeObserver), debounced at 150ms). This means the overflow recomputes correctly even when the window size doesn't change but the available width does (for example, when a sidebar is collapsed/expanded or a parent container is resized).
+- The overflow is also recomputed automatically when the `tabs` prop changes (added, removed, or replaced).
+- A skeleton loading state is displayed while the layout is being computed.
+- The "More" button displays a badge with the count of hidden tabs.
 
 ### Navigation Handling
 

--- a/packages/core/page-layout/sandbox/pages/HomePage.vue
+++ b/packages/core/page-layout/sandbox/pages/HomePage.vue
@@ -1,22 +1,24 @@
 <template>
-  <PageLayout
-    back-to="/"
-    :breadcrumbs="breadcrumbs"
-    :tabs="tabs"
-    title="Umbrella R&D Dev"
-  >
-    <template #actions>
-      <KButton
-        appearance="secondary"
-        icon
-      >
-        <MoreIcon />
-      </KButton>
-    </template>
-    <template #title-after>
-      <KBadge>Info</KBadge>
-    </template>
-  </PageLayout>
+  <div class="page-layout-sandbox-wrapper">
+    <PageLayout
+      back-to="/"
+      :breadcrumbs="breadcrumbs"
+      :tabs="tabs"
+      title="Umbrella R&D Dev"
+    >
+      <template #actions>
+        <KButton
+          appearance="secondary"
+          icon
+        >
+          <MoreIcon />
+        </KButton>
+      </template>
+      <template #title-after>
+        <KBadge>Info</KBadge>
+      </template>
+    </PageLayout>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -89,3 +91,11 @@ const tabs: PageLayoutTab[] = [
   },
 ]
 </script>
+
+<style lang="scss" scoped>
+.page-layout-sandbox-wrapper {
+  overflow-x: auto;
+  resize: horizontal;
+  width: 90%;
+}
+</style>

--- a/packages/core/page-layout/sandbox/pages/NestedPage.vue
+++ b/packages/core/page-layout/sandbox/pages/NestedPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-for="i in 5"
+    v-for="i in 3"
     :key="i"
     class="page-content-block"
   />
@@ -8,8 +8,8 @@
 
 <style lang="scss" scoped>
 .page-content-block {
-  background-color: $kui-color-background-neutral-weak;
-  border-radius: $kui-border-radius-30;
+  background-color: var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak);
+  border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
   height: 20vh;
 }
 </style>

--- a/packages/core/page-layout/src/components/PageLayoutTabs.cy.ts
+++ b/packages/core/page-layout/src/components/PageLayoutTabs.cy.ts
@@ -136,6 +136,49 @@ describe('<PageLayoutTabs />', () => {
     cy.getTestId('tabs-overflow-dropdown-button').should('be.visible')
   })
 
+  it('recomputes the tab layout when its container is resized', () => {
+    const tabs: PageLayoutTab[] = [
+      { key: 'tab1', label: 'Tab 1', to: '/tab1' },
+      { key: 'tab2', label: 'Tab 2', to: '/tab2' },
+      { key: 'tab3', label: 'Tab 3', to: '/tab3' },
+      { key: 'tab4', label: 'Tab 4', to: '/tab4' },
+      { key: 'tab5', label: 'Tab 5', to: '/tab5' },
+      { key: 'tab6', label: 'Tab 6', to: '/tab6' },
+      { key: 'tab7', label: 'Tab 7', to: '/tab7' },
+      { key: 'tab8', label: 'Tab 8', to: '/tab8' },
+    ]
+
+    // Use a wide viewport so the layout is driven by the container width below, not the viewport width
+    cy.viewport(1200, 400)
+
+    const containerWidth = ref('1100px')
+
+    cy.mount(defineComponent({
+      setup: () => () => h(
+        'div',
+        { style: { width: containerWidth.value } },
+        [h(PageLayoutTabs, { tabs })],
+      ),
+    }))
+
+    // All tabs fit in the wide container, so the overflow dropdown should not appear
+    cy.getTestId('tabs-overflow-dropdown-button').should('not.exist')
+
+    // Shrink the container; the ResizeObserver should detect the change and recompute overflow
+    cy.then(() => {
+      containerWidth.value = '300px'
+    })
+
+    cy.getTestId('tabs-overflow-dropdown-button').should('be.visible')
+
+    // Grow the container back; the dropdown should disappear once everything fits again
+    cy.then(() => {
+      containerWidth.value = '1100px'
+    })
+
+    cy.getTestId('tabs-overflow-dropdown-button').should('not.exist')
+  })
+
   it('uses the navigateTo injectable to navigate to the tab', () => {
     const navigateToStub = cy.stub().as('navigateTo')
 

--- a/packages/core/page-layout/src/components/PageLayoutTabs.vue
+++ b/packages/core/page-layout/src/components/PageLayoutTabs.vue
@@ -86,7 +86,7 @@ import { useRouter } from 'vue-router'
 import type { PageLayoutTabsProps, PageLayoutTab } from '../types'
 import composables from '../composables'
 import { KUI_SPACE_60 } from '@kong/design-tokens'
-import { useEventListener } from '@vueuse/core'
+import { useResizeObserver } from '@vueuse/core'
 import { inject } from 'vue'
 
 const {
@@ -176,7 +176,7 @@ const handleResize = () => {
 
 onMounted(() => {
   computeTabLayoutOverflow()
-  useEventListener(window, 'resize', handleResize)
+  useResizeObserver(pageLayoutTabsRef, handleResize)
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-20425

Instead of window resize event, rely on `resizeObserver` to detect overflow in PageLayoutTabs

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
