### PR TITLE
refactor(entities-*): migrate to new plugin form layout state management

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -45,7 +45,6 @@
 </template>
 
 <script setup lang="ts">
-import { FEATURE_FLAGS as ENTITIES_SHARED_FEATURE_FLAGS } from '@kong-ui-public/entities-shared'
 import { computed, provide, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -76,7 +75,6 @@ defineProps({
 const router = useRouter()
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 const pluginFormEngine = import.meta.env.VITE_FORCE_PLUGIN_FORM_ENGINE || undefined
-provide(ENTITIES_SHARED_FEATURE_FLAGS.KM_1948_PLUGIN_FORM_LAYOUT, computed(() => pluginFormEngine === 'freeform'))
 provide(FEATURE_FLAGS.KM_2262_CODE_MODE, true)
 provide(FEATURE_FLAGS.KM_2306_CONDITION_FIELD_314, true)
 provide(FEATURE_FLAGS.KM_2446_DATAKIT_JWT_NODES, true)

--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.cy.ts
@@ -88,6 +88,8 @@ describe('<CustomPluginForm />', () => {
       // Submit and cancel buttons should be visible
       cy.getTestId('custom-plugin-form-submit').should('exist')
       cy.getTestId('custom-plugin-form-cancel').should('exist')
+
+      cy.get('.kong-ui-entity-base-form').should('have.class', 'new-form-layout')
     })
 
     it('should show step 2 files for installed type', () => {

--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
@@ -516,7 +516,7 @@ const {
 })
 
 // Force-enable the new plugin form layout
-provide(PLUGIN_FORM_LAYOUT_STATE, computed(() => true))
+provide(PLUGIN_FORM_LAYOUT_STATE, ref(true))
 
 const editMode = computed(() => !!props.pluginName)
 const isLoading = ref(false)

--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
@@ -420,7 +420,7 @@
 import {
   EntityBaseForm,
   EntityFormBlock,
-  FEATURE_FLAGS,
+  PLUGIN_FORM_LAYOUT_STATE,
   SupportedEntityType,
   useAxios,
   useErrors,
@@ -516,7 +516,7 @@ const {
 })
 
 // Force-enable the new plugin form layout
-provide(FEATURE_FLAGS.KM_1948_PLUGIN_FORM_LAYOUT, computed(() => true))
+provide(PLUGIN_FORM_LAYOUT_STATE, computed(() => true))
 
 const editMode = computed(() => !!props.pluginName)
 const isLoading = ref(false)

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -133,7 +133,7 @@ import {
 } from '@kong-ui-public/forms'
 import '@kong-ui-public/forms/dist/style.css'
 import type { AxiosRequestConfig, AxiosResponse } from 'axios'
-import { computed, inject, onBeforeMount, onBeforeUnmount, provide, reactive, ref, shallowRef, watch, type PropType, type Ref } from 'vue'
+import { computed, inject, onBeforeMount, onBeforeUnmount, provide, reactive, ref, shallowRef, watch, type PropType } from 'vue'
 import composables from '../composables'
 import useI18n from '../composables/useI18n'
 import { PLUGIN_METADATA } from '../definitions/metadata'
@@ -269,7 +269,7 @@ const { parseSchema } = composables.useSchemas({
 const { convertToDotNotation, unFlattenObject, dismissField, isObjectEmpty, unsetNullForeignKey } = composables.usePluginHelpers()
 
 const { shouldUseFreeForm, getFreeFormComponent } = composables.useFreeFormResolver()
-const pluginFormLayoutState = inject<Ref<boolean> | undefined>(PLUGIN_FORM_LAYOUT_STATE)
+const pluginFormLayoutState = inject(PLUGIN_FORM_LAYOUT_STATE)
 const setPluginFormLayoutState = (value: boolean) => {
   if (pluginFormLayoutState) {
     pluginFormLayoutState.value = value

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -120,7 +120,7 @@ import {
   VaultSecretPickerProvider,
 } from '@kong-ui-public/entities-vaults'
 import '@kong-ui-public/entities-vaults/dist/style.css'
-import { useAxios, useHelpers } from '@kong-ui-public/entities-shared'
+import { PLUGIN_FORM_LAYOUT_STATE, useAxios, useHelpers } from '@kong-ui-public/entities-shared'
 import {
   AUTOFILL_SLOT_NAME,
   FORMS_API_KEY,
@@ -133,7 +133,7 @@ import {
 } from '@kong-ui-public/forms'
 import '@kong-ui-public/forms/dist/style.css'
 import type { AxiosRequestConfig, AxiosResponse } from 'axios'
-import { computed, inject, onBeforeMount, provide, reactive, ref, shallowRef, watch, type PropType } from 'vue'
+import { computed, inject, onBeforeMount, onBeforeUnmount, provide, reactive, ref, shallowRef, watch, type PropType, type Ref } from 'vue'
 import composables from '../composables'
 import useI18n from '../composables/useI18n'
 import { PLUGIN_METADATA } from '../definitions/metadata'
@@ -269,6 +269,12 @@ const { parseSchema } = composables.useSchemas({
 const { convertToDotNotation, unFlattenObject, dismissField, isObjectEmpty, unsetNullForeignKey } = composables.usePluginHelpers()
 
 const { shouldUseFreeForm, getFreeFormComponent } = composables.useFreeFormResolver()
+const pluginFormLayoutState = inject<Ref<boolean> | undefined>(PLUGIN_FORM_LAYOUT_STATE)
+const setPluginFormLayoutState = (value: boolean) => {
+  if (pluginFormLayoutState) {
+    pluginFormLayoutState.value = value
+  }
+}
 
 const { objectsAreEqual } = useHelpers()
 const { i18n: { t } } = useI18n()
@@ -452,6 +458,26 @@ const setUpVaultSecretPicker = (setupValue: string, autofillAction: (secretRef: 
 const handleVaultSecretPickerAutofill = (secretRef: string) => {
   vaultSecretPickerAutofillAction.value?.(secretRef)
   vaultSecretPickerSetup.value = false
+}
+
+const syncFormRenderingMode = (pluginName?: string) => {
+  if (!pluginName) {
+    pluginConfig.value = undefined
+    freeformComponent.value = undefined
+    sharedFormName.value = ''
+
+    setPluginFormLayoutState(false)
+
+    return
+  }
+
+  pluginConfig.value = getPluginConfig(pluginName)
+  freeformComponent.value = shouldUseFreeForm(pluginName, props.engine)
+    ? (getFreeFormComponent(pluginName) ?? CommonForm)
+    : undefined
+  sharedFormName.value = getSharedFormName(pluginName)
+
+  setPluginFormLayoutState(Boolean(freeformComponent.value))
 }
 
 // This function transforms the form data into the correct structure to be submitted to the API
@@ -900,22 +926,18 @@ watch(() => props.schema, (newSchema, oldSchema) => {
   if (objectsAreEqual(newSchema || {}, oldSchema || {})) {
     return
   }
-  const form: Record<string, any> = parseSchema(newSchema, undefined, undefined, props.engine)
+  const parsedForm: Record<string, any> = parseSchema(newSchema, undefined, undefined, props.engine)
 
-  Object.assign(formModel, form.model)
+  Object.assign(formModel, parsedForm.model)
 
   formSchema.value = {
     fields: formSchema.value?.fields?.map((r: Record<string, any>) => {
       return { ...r, disabled: r.disabled || false }
     }),
   }
-  Object.assign(originalModel, JSON.parse(JSON.stringify(form.model)))
+  Object.assign(originalModel, JSON.parse(JSON.stringify(parsedForm.model)))
 
-  pluginConfig.value = getPluginConfig(form.model.name)
-  freeformComponent.value = shouldUseFreeForm(form.model.name, props.engine)
-    ? (getFreeFormComponent(form.model.name) ?? CommonForm)
-    : undefined
-  sharedFormName.value = getSharedFormName(form.model.name)
+  syncFormRenderingMode(parsedForm.model.name)
 
   initFormModel()
 }, { immediate: true, deep: true })
@@ -925,8 +947,13 @@ onBeforeMount(() => {
 
   Object.assign(formModel, form.value?.model || {})
   formSchema.value = form.value?.schema || {}
+  syncFormRenderingMode(form.value?.model?.name)
 
   initFormModel()
+})
+
+onBeforeUnmount(() => {
+  setPluginFormLayoutState(false)
 })
 </script>
 

--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -1957,6 +1957,8 @@ describe('<PluginForm />', () => {
 
       cy.wait('@getPluginSchema')
       cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
+      cy.get('.kong-ui-entities-plugin-form-container').should('not.have.class', 'new-form-layout')
+      cy.get('.kong-ui-entity-base-form').should('not.have.class', 'new-form-layout')
 
       // VFG renders traditional form fields with specific selectors like #config-*, not freeform
       // VFG uses vue-form-generator class
@@ -1987,6 +1989,8 @@ describe('<PluginForm />', () => {
 
       cy.wait('@getPluginSchema')
       cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
+      cy.get('.kong-ui-entities-plugin-form-container').should('have.class', 'new-form-layout')
+      cy.get('.kong-ui-entity-base-form').should('have.class', 'new-form-layout')
 
       // Freeform renders with data-testid="ff-*" pattern
       cy.get('[data-testid^="ff-"]').should('exist')

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="kong-ui-entities-plugin-form-container"
-    :class="{ 'new-form-layout': enabledNewPluginLayout }"
+    :class="{ 'new-form-layout': usesFreeformLayout }"
   >
     <KSkeleton
       v-if="schemaLoading"
@@ -219,7 +219,7 @@ import PluginFormActionsWrapper from './PluginFormActionsWrapper.vue'
 import unset from 'lodash-es/unset'
 import { REDIS_PARTIAL_INFO } from '../components/free-form/shared/const'
 import type { GlobalAction } from './free-form/shared/types'
-import { FEATURE_FLAGS } from '@kong-ui-public/entities-shared'
+import { PLUGIN_FORM_LAYOUT_STATE } from '@kong-ui-public/entities-shared'
 import { FEATURE_FLAGS as PLUGIN_FEATURE_FLAGS } from '../constants'
 
 type ScopedEntitiesType = 'consumer' | 'route' | 'service' | 'consumer_group'
@@ -227,9 +227,11 @@ type Permissions = 'canRetrieve' | 'canEdit' | 'canDelete'
 type ScopedEntityPermission = Partial<Record<Permissions, boolean>>
 type ScopedEntitiesPermissions = Partial<Record<ScopedEntitiesType, ScopedEntityPermission>>
 
-const enabledNewPluginLayout = inject(FEATURE_FLAGS.KM_1948_PLUGIN_FORM_LAYOUT, computed(() => false))
 const enableConditionField = inject<boolean>(PLUGIN_FEATURE_FLAGS.KM_2306_CONDITION_FIELD_314, false)
 const enabledClonedPlugin = inject<boolean>(PLUGIN_FEATURE_FLAGS.KM_2485_CLONED_PLUGINS, false)
+const usesFreeformLayout = ref(false)
+
+provide(PLUGIN_FORM_LAYOUT_STATE, usesFreeformLayout)
 
 const emit = defineEmits<{
   (e: 'cancel'): void

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -3,7 +3,7 @@
     :is="wrapperComponent"
     class="kong-ui-entity-base-form"
     :class="{
-      'new-form-layout': enabledNewPluginLayout && entityType === SupportedEntityType.Plugin,
+      'new-form-layout': pluginFormLayoutEnabled && entityType === SupportedEntityType.Plugin,
     }"
   >
     <!-- Loading -->
@@ -173,7 +173,7 @@ import TerraformCodeBlock from '../common/TerraformCodeBlock.vue'
 import DeckCodeBlock from '../common/DeckCodeBlock.vue'
 import { PLUGIN_FORM_LAYOUT_STATE } from '../../constants'
 
-const enabledNewPluginLayout = inject(PLUGIN_FORM_LAYOUT_STATE, computed(() => false))
+const pluginFormLayoutEnabled = inject(PLUGIN_FORM_LAYOUT_STATE, ref(false))
 
 const emit = defineEmits<{
   (e: 'loading', isLoading: boolean): void

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -171,9 +171,9 @@ import JsonCodeBlock from '../common/JsonCodeBlock.vue'
 import YamlCodeBlock from '../common/YamlCodeBlock.vue'
 import TerraformCodeBlock from '../common/TerraformCodeBlock.vue'
 import DeckCodeBlock from '../common/DeckCodeBlock.vue'
-import { FEATURE_FLAGS } from '../../constants'
+import { PLUGIN_FORM_LAYOUT_STATE } from '../../constants'
 
-const enabledNewPluginLayout = inject(FEATURE_FLAGS.KM_1948_PLUGIN_FORM_LAYOUT, computed(() => false))
+const enabledNewPluginLayout = inject(PLUGIN_FORM_LAYOUT_STATE, computed(() => false))
 
 const emit = defineEmits<{
   (e: 'loading', isLoading: boolean): void

--- a/packages/entities/entities-shared/src/constants.ts
+++ b/packages/entities/entities-shared/src/constants.ts
@@ -1,4 +1,3 @@
-export const FEATURE_FLAGS = {
-  /** Enable the new plugin form layout */
-  KM_1948_PLUGIN_FORM_LAYOUT: 'KM_1948_PLUGIN_FORM_LAYOUT',
-}
+import type { InjectionKey, Ref } from 'vue'
+
+export const PLUGIN_FORM_LAYOUT_STATE: InjectionKey<Ref<boolean>> = Symbol('PLUGIN_FORM_LAYOUT_STATE')


### PR DESCRIPTION
# Summary
This PR automated the new layout detection in `EntitiBaseForm.vue`, so consumers no longer need to provide `KM_1948_PLUGIN_FORM_LAYOUT`

Adoption PRs:
GM: https://github.com/kong-konnect/konnect-ui-apps/pull/11254
KM: https://github.com/Kong/kong-admin/pull/4353
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
