### PR TITLE
feat(workspace): allow `workspace` and `editId` to be `null` and workspace-scoped route support

### DIFF
--- a/packages/entities/entities-gateway-services/docs/gateway-service-config-card.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-config-card.md
@@ -50,8 +50,8 @@ A config card component for gateway services.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
     - Name of the current workspace.
 

--- a/packages/entities/entities-gateway-services/docs/gateway-service-form.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-form.md
@@ -57,8 +57,8 @@ A form component for gateway services.
     - Route to return to when canceling creation of a gateway service.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
     - Name of the current workspace.
 

--- a/packages/entities/entities-gateway-services/docs/gateway-service-list.md
+++ b/packages/entities/entities-gateway-services/docs/gateway-service-list.md
@@ -80,8 +80,8 @@ A table component for gateway services.
     - *Specific to Konnect*. A function that returns the route for the belonged control plane.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
     - Name of the current workspace.
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceForm.vue
@@ -525,9 +525,9 @@ const props = defineProps({
   },
   /** If a valid Gateway Service ID is provided, it will put the form in Edit mode instead of Create */
   gatewayServiceId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
   /** Whether show or hide EntityFormSection info column */
   hideSectionsInfo: {
@@ -992,7 +992,7 @@ const submitUrl = computed<string>(() => {
 
   return url
     .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-    .replace(/{id}/gi, props.gatewayServiceId) // Always replace the id when editing
+    .replace(/{id}/gi, props.gatewayServiceId ?? '') // Always replace the id when editing
 })
 
 const tlsSansPayload = computed(() => {

--- a/packages/entities/entities-routes/docs/route-config-card.md
+++ b/packages/entities/entities-routes/docs/route-config-card.md
@@ -50,10 +50,10 @@ A config card component for routes.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-routes/docs/route-form.md
+++ b/packages/entities/entities-routes/docs/route-form.md
@@ -57,10 +57,10 @@ A form component for Routes.
     - Route to return to when canceling creation of a Route.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-routes/docs/route-list.md
+++ b/packages/entities/entities-routes/docs/route-list.md
@@ -78,10 +78,10 @@ A table component for routes.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-routes/src/components/RouteConfigCard.vue
+++ b/packages/entities/entities-routes/src/components/RouteConfigCard.vue
@@ -95,9 +95,9 @@ const props = defineProps({
   },
   /** The id of the service with which the route is associated */
   serviceId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
 })
 
@@ -108,7 +108,7 @@ const serviceName = ref('')
 const isServiceNameLoading = ref(false)
 const fetchUrl = computed<string>(
   () => endpoints.item[props.config?.app]?.[props.serviceId ? 'forGatewayService' : 'all']
-    .replace(/{serviceId}/gi, props.serviceId),
+    .replace(/{serviceId}/gi, props.serviceId ?? ''),
 )
 
 const fetchServiceName = computed<string>(() => endpoints.item[props.config.app]?.getService)
@@ -123,14 +123,12 @@ const handleSuccess = async (entity: any) => {
 
   let url = `${props.config.apiBaseUrl}${fetchServiceName.value}`
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{serviceId}/gi, internalServiceId.value || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{serviceId}/gi, internalServiceId.value || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
+
+  url = url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{serviceId}/gi, internalServiceId.value || '')
 
   try {
     isServiceNameLoading.value = true

--- a/packages/entities/entities-routes/src/components/RouteForm.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteForm.cy.ts
@@ -1977,4 +1977,73 @@ describe('<RouteForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       })
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('includes workspace in POST URL when creating with workspace config', () => {
+      cy.intercept(
+        { method: 'GET', url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/services*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/routes`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createRouteWithWorkspace')
+
+      cy.mount(RouteForm, {
+        props: { config: { ...baseConfigKonnect, workspace: 'default' } },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createRouteWithWorkspace')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        { method: 'GET', url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/services*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        { method: 'GET', url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/routes/${route.id}` },
+        { statusCode: 200, body: route },
+      )
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/routes/${route.id}`,
+        },
+        { statusCode: 200, body: route },
+      ).as('updateRouteWithWorkspace')
+
+      cy.mount(RouteForm, {
+        props: { config: { ...baseConfigKonnect, workspace: 'default' }, routeId: route.id },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@updateRouteWithWorkspace')
+    })
+
+    it('omits workspace segment in POST URL when workspace is not provided', () => {
+      cy.intercept(
+        { method: 'GET', url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/services*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/routes`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createRouteNoWorkspace')
+
+      cy.mount(RouteForm, {
+        props: { config: baseConfigKonnect },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createRouteNoWorkspace')
+    })
+  })
 })

--- a/packages/entities/entities-routes/src/components/RouteForm.vue
+++ b/packages/entities/entities-routes/src/components/RouteForm.vue
@@ -178,15 +178,15 @@ const props = defineProps({
   },
   /** If a valid routeId is provided, it will put the form in Edit mode instead of Create */
   routeId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
   /** If valid serviceId is provided, disable the service select field */
   serviceId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
   /** Whether show or hide EntityFormSection info column */
   hideSectionsInfo: {
@@ -515,19 +515,13 @@ const submitUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.form[props.config.app][formType.value][props.serviceId ? 'forGatewayService' : 'all']}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{serviceId}/gi, props.serviceId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{serviceId}/gi, props.serviceId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
-  // Always replace the id when editing
-  url = url.replace(/{id}/gi, props.routeId)
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{serviceId}/gi, props.serviceId || '')
+    .replace(/{id}/gi, props.routeId ?? '') // Always replace the id when editing
 })
 
 watch(() => state.fields, () => {

--- a/packages/entities/entities-routes/src/components/RouteList.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteList.cy.ts
@@ -925,4 +925,80 @@ describe('<RouteList />', () => {
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/routes*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(RouteList, {
+        props: {
+          cacheIdentifier: `route-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-routes-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/routes*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(RouteList, {
+        props: {
+          cacheIdentifier: `route-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-routes-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/routes*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(RouteList, {
+        props: {
+          cacheIdentifier: `route-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-routes-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -422,16 +422,12 @@ const fetcherBaseUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app][props.config.serviceId ? 'forGatewayService' : 'all']}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{serviceId}/gi, props.config?.serviceId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{serviceId}/gi, props.config?.serviceId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{serviceId}/gi, props.config?.serviceId || '')
 })
 
 const filterQuery = ref<string>('')

--- a/packages/entities/entities-routes/src/routes-endpoints.ts
+++ b/packages/entities/entities-routes/src/routes-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {

--- a/packages/entities/entities-shared/docs/entity-base-config-card.md
+++ b/packages/entities/entities-shared/docs/entity-base-config-card.md
@@ -57,8 +57,8 @@ A base display component for an entity's record data.
     - Route to return to when canceling creation of an entity.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
     - Name of the current workspace.
 

--- a/packages/entities/entities-shared/docs/entity-base-form.md
+++ b/packages/entities/entities-shared/docs/entity-base-form.md
@@ -56,8 +56,8 @@ A base form component for entity create/edit views.
     - Route to return to when canceling creation of an entity.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
     - Name of the current workspace.
 
@@ -71,9 +71,9 @@ The base konnect or kongManger config.
 
 #### `editId`
 
-- type: `String`
+- type: `string | null`
 - required: `false`
-- default: `''`
+- default: `null`
 
 If showing the `Edit` type form, the ID of the entity to edit.
 

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -199,9 +199,9 @@ const props = defineProps({
   },
   /** If a valid edit ID is provided, it will put the form in Edit mode instead of Create */
   editId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
   /**
    * Entity type, required to generate terraform code

--- a/packages/entities/entities-shared/src/types/app-config.ts
+++ b/packages/entities/entities-shared/src/types/app-config.ts
@@ -17,7 +17,7 @@ export interface KonnectConfig extends BaseAppConfig {
   /** The control plane id */
   controlPlaneId: string
   /** Optional workspace name or identifier */
-  workspace?: string
+  workspace?: string | null
   /** Identifies whether the Control Plane type is a Control Plane Group or not */
   isControlPlaneGroup?: boolean
   /** Identifies whether the control plane is a member of a control plane group (not the group itself) */


### PR DESCRIPTION
We usually use `null` to explicitly express “this entity doesn’t exist”, rather than `undefined`. The current `string | undefined` type isn’t compatible with `null`, which means we have to keep forcing a cast like `:edit-id="routeId ?? undefined"` when using it.

Allowing `null` would avoid this repeated boilerplate.

JIRA: KM-2242
