### PR TITLE
fix(entities-plugins): sanitize tooltip HTML to prevent XSS vulnerablities

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { useSchemaHelpers } from './schema'
+
+import type { FormSchema } from '../../../../types/plugins/form-schema'
+
+describe('useSchemaHelpers', () => {
+  describe('getLabelAttributes', () => {
+    it('sanitizes schema descriptions before exposing tooltip HTML', () => {
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            config: {
+              type: 'record',
+              fields: [
+                {
+                  description_xss: {
+                    type: 'string',
+                    description: 'Safe **markdown** <img src=x onerror="alert(\'xss\')">',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }
+
+      const { getLabelAttributes } = useSchemaHelpers(schema)
+      const labelAttributes = getLabelAttributes('config.description_xss')
+
+      expect(labelAttributes.info).toContain('<strong>markdown</strong>')
+      expect(labelAttributes.info).toContain('<img')
+      expect(labelAttributes.info).not.toContain('onerror')
+      expect(labelAttributes.info).not.toContain('alert(')
+    })
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.ts
@@ -1,6 +1,7 @@
 import { computed, toValue } from 'vue'
 import { marked } from 'marked'
 import * as utils from '../utils'
+import DOMPurify from 'dompurify'
 
 const SHARED_LABEL_ATTRIBUTES = {
   tooltipAttributes: {
@@ -238,7 +239,8 @@ export function useSchemaHelpers(schema: MaybeRefOrGetter<FormSchema | UnionFiel
 
   function getLabelAttributes(fieldPath: string): LabelAttributes {
     const schema = getSchema(fieldPath)
-    const info = schema?.description ? marked.parse(schema.description, { async: false }) : undefined
+    const info = schema?.description ? DOMPurify.sanitize(marked.parse(schema.description, { async: false })) : undefined
+
     return {
       ...SHARED_LABEL_ATTRIBUTES,
       'data-testid': `ff-label-${fieldPath}`,


### PR DESCRIPTION
# Summary

### Reproducing
Create a custom plugin using this `schema.lua`:
```lua
return {
  name = "xss-hack",
  fields = {
    {
      config = {
        type = "record",
        fields = {
          { description_xss = { type = "string", default = "foo", description = "<img src=x onerror=\"alert('xss-poc')\">" } }
        },
      },
    },
  },
}
```
<img width="2498" height="1914" alt="image" src="https://github.com/user-attachments/assets/49555f2d-c460-4634-bd87-e77c45b2f8e6" />

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
