### PR TITLE
feat(entities-shared): provide/inject DeckCommandEditor to split monaco-editor and shiki

### DIFF
--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -12,7 +12,12 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/entities-shared.es.js",
-      "require": "./dist/entities-shared.umd.js"
+      "require": "./dist/entities-shared.cjs.js"
+    },
+    "./deck-editor": {
+      "types": "./dist/types/deck-editor.d.ts",
+      "import": "./dist/deck-editor.es.js",
+      "require": "./dist/deck-editor.cjs.js"
     },
     "./package.json": "./package.json",
     "./dist/*": "./dist/*"

--- a/packages/entities/entities-shared/sandbox/pages/EntityBaseConfigCardPage.vue
+++ b/packages/entities/entities-shared/sandbox/pages/EntityBaseConfigCardPage.vue
@@ -76,6 +76,7 @@ import {
   ConfigCardItem,
   SupportedEntityType,
 } from '../../src'
+import { provideDeckCommandEditor } from '../../src/deck-editor'
 import composables from '../../src/composables'
 
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
@@ -91,6 +92,8 @@ const { convertKeyToTitle } = composables.useStringHelpers()
 
 const enableDeckConfigCustomization = ref(false)
 const enableDeckCallout = ref(false)
+
+provideDeckCommandEditor()
 
 const konnectConfig = computed<KonnectBaseEntityConfig>(() => ({
   app: 'konnect',

--- a/packages/entities/entities-shared/sandbox/tsconfig.json
+++ b/packages/entities/entities-shared/sandbox/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "rootDir": ".."
   },
   "include": [
     "**/*.ts",
-    "**/*.vue"
+    "**/*.vue",
+    "../src/**/*"
   ],
   "exclude": [
     "node_modules"

--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
@@ -85,8 +85,9 @@
       @code-block-render="highlightCodeBlock"
     />
 
-    <DeckCommandEditor
-      v-else-if="props.entityRecord && props.isCustomizing"
+    <component
+      :is="DeckCommandEditor"
+      v-else-if="props.entityRecord && props.isCustomizing && DeckCommandEditor"
       v-model="deckCommand"
       :language="shell"
     />
@@ -116,24 +117,17 @@
 import { InfoIcon, LanguageBashIcon, LanguageShellIcon } from '@kong/icons'
 import { KExternalLink } from '@kong/kongponents'
 import yaml from 'js-yaml'
-import { computed, defineAsyncComponent, ref, watchEffect } from 'vue'
+import { computed, inject, ref, watchEffect } from 'vue'
 
 import composables from '../../composables'
+import { DECK_COMMAND_EDITOR_KEY, DECK_COMMAND_EDITOR_MISSING_WARNING } from '../../constants'
 import { SupportedEntityType } from '../../types'
 import { highlightCodeBlock } from '../../utils/code-block'
-import DeckCommandEditorLoading from './DeckCommandEditorLoading.vue'
 import GeneratePatModal from './GeneratePatModal.vue'
 
 import type { DeckCodeBlockProps } from '../../types'
 
-/**
- * Lazy load the Monaco Editor inside when customization mode is enabled.
- */
-const DeckCommandEditor = defineAsyncComponent({
-  loader: () => import('./DeckCommandEditor.vue'),
-  loadingComponent: DeckCommandEditorLoading,
-  delay: 200,
-})
+const DeckCommandEditor = inject(DECK_COMMAND_EDITOR_KEY, null)
 
 const props = defineProps<DeckCodeBlockProps & {
   isCustomizing?: boolean
@@ -143,6 +137,10 @@ const props = defineProps<DeckCodeBlockProps & {
    */
   generateKonnectPat?: (name: string, expiresAt: Date) => string | Promise<string>
 }>()
+
+if (props.isCustomizing && !DeckCommandEditor) {
+  console.warn(DECK_COMMAND_EDITOR_MISSING_WARNING)
+}
 
 const { i18n, i18nT } = composables.useI18n()
 const { t } = i18n

--- a/packages/entities/entities-shared/src/composables/tests/useDeckOptions.spec.ts
+++ b/packages/entities/entities-shared/src/composables/tests/useDeckOptions.spec.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+/* eslint-disable vue/one-component-per-file */
 
-import { useBaseEntityDeckOptions, useBaseFormDeckOptions } from '../useDeckOptions'
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, ref } from 'vue'
+
+import { DECK_COMMAND_EDITOR_KEY } from '../../constants'
 import { SupportedEntityType } from '../../types'
+import { useBaseEntityDeckOptions, useBaseFormDeckOptions } from '../useDeckOptions'
 
+import type { DeckCommandEditor } from '../../deck-editor'
 import type {
   DeckConfigOptions,
   KongManagerBaseEntityConfig,
@@ -11,6 +15,23 @@ import type {
   KonnectBaseEntityConfig,
   KonnectBaseFormConfig,
 } from '../../types'
+
+function withSetup<T>(fn: () => T, providedEditor?: typeof DeckCommandEditor): T {
+  let result!: T
+  const app = createApp(defineComponent({
+    setup() {
+      result = fn()
+      return () => h('div')
+    },
+  }))
+  if (providedEditor) {
+    app.provide(DECK_COMMAND_EDITOR_KEY, providedEditor)
+  }
+  app.mount(document.createElement('div'))
+  return result
+}
+
+const STUB_EDITOR: typeof DeckCommandEditor = defineComponent({ render: () => null })
 
 const konnectEntityBase = {
   app: 'konnect',
@@ -41,46 +62,46 @@ const kongManagerFormBase = {
 describe('useBaseEntityDeckOptions()', () => {
   describe('isDeckEnabled', () => {
     it('returns false when the entity type is not supported by decK', () => {
-      const { isDeckEnabled } = useBaseEntityDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseEntityDeckOptions(
         { ...kongManagerEntityBase },
         SupportedEntityType.Other,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(false)
     })
 
     it('is enabled for Kong Manager on a supported entity', () => {
-      const { isDeckEnabled } = useBaseEntityDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseEntityDeckOptions(
         { ...kongManagerEntityBase },
         SupportedEntityType.GatewayService,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(true)
     })
 
     it('is disabled for Konnect without `enableDeckConfig`', () => {
-      const { isDeckEnabled } = useBaseEntityDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseEntityDeckOptions(
         { ...konnectEntityBase },
         SupportedEntityType.GatewayService,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(false)
     })
 
     it('is enabled for Konnect with `enableDeckConfig: true`', () => {
-      const { isDeckEnabled } = useBaseEntityDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseEntityDeckOptions(
         { ...konnectEntityBase, enableDeckConfig: true },
         SupportedEntityType.GatewayService,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(true)
     })
 
     it('is enabled for Konnect with an `enableDeckConfig` object', () => {
-      const { isDeckEnabled } = useBaseEntityDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseEntityDeckOptions(
         { ...konnectEntityBase, enableDeckConfig: {} },
         SupportedEntityType.GatewayService,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(true)
     })
@@ -88,58 +109,74 @@ describe('useBaseEntityDeckOptions()', () => {
 
   describe('deckCustomizationOptions', () => {
     it('is undefined for Kong Manager', () => {
-      const { deckCustomizationOptions } = useBaseEntityDeckOptions(
+      const { deckCustomizationOptions } = withSetup(() => useBaseEntityDeckOptions(
         { ...kongManagerEntityBase },
         SupportedEntityType.GatewayService,
-      )
+      ))
 
       expect(deckCustomizationOptions.value).toBeUndefined()
     })
 
     it('is undefined when `enableDeckConfig` is a boolean', () => {
-      const { deckCustomizationOptions } = useBaseEntityDeckOptions(
+      const { deckCustomizationOptions } = withSetup(() => useBaseEntityDeckOptions(
         { ...konnectEntityBase, enableDeckConfig: true },
         SupportedEntityType.GatewayService,
-      )
+      ))
 
       expect(deckCustomizationOptions.value).toBeUndefined()
     })
 
-    it('returns the nested `customization` field', () => {
+    it('returns the nested `customization` field when a `DeckCommandEditor` is provided', () => {
       const customization = { generateKonnectPat: async () => 'pat' }
-      const { deckCustomizationOptions } = useBaseEntityDeckOptions(
-        { ...konnectEntityBase, enableDeckConfig: { customization } },
-        SupportedEntityType.GatewayService,
+      const { deckCustomizationOptions } = withSetup(
+        () => useBaseEntityDeckOptions(
+          { ...konnectEntityBase, enableDeckConfig: { customization } },
+          SupportedEntityType.GatewayService,
+        ),
+        STUB_EDITOR,
       )
 
       expect(deckCustomizationOptions.value).toBe(customization)
+    })
+
+    it('returns undefined and warns when customization is configured but no `DeckCommandEditor` is provided', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const customization = { generateKonnectPat: async () => 'pat' }
+      const { deckCustomizationOptions } = withSetup(() => useBaseEntityDeckOptions(
+        { ...konnectEntityBase, enableDeckConfig: { customization } },
+        SupportedEntityType.GatewayService,
+      ))
+
+      expect(deckCustomizationOptions.value).toBeUndefined()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('DeckCommandEditor'))
+      warnSpy.mockRestore()
     })
   })
 
   describe('deckCalloutPreferenceKey', () => {
     it('returns `deckCalloutPreferenceKey` for Kong Manager configs', () => {
-      const { deckCalloutPreferenceKey } = useBaseEntityDeckOptions(
+      const { deckCalloutPreferenceKey } = withSetup(() => useBaseEntityDeckOptions(
         { ...kongManagerEntityBase, deckCalloutPreferenceKey: 'km-key' },
         SupportedEntityType.GatewayService,
-      )
+      ))
 
       expect(deckCalloutPreferenceKey.value).toBe('km-key')
     })
 
     it('returns the nested `calloutPreferenceKey` for Konnect configs', () => {
-      const { deckCalloutPreferenceKey } = useBaseEntityDeckOptions(
+      const { deckCalloutPreferenceKey } = withSetup(() => useBaseEntityDeckOptions(
         { ...konnectEntityBase, enableDeckConfig: { calloutPreferenceKey: 'konnect-key' } },
         SupportedEntityType.GatewayService,
-      )
+      ))
 
       expect(deckCalloutPreferenceKey.value).toBe('konnect-key')
     })
 
     it('is undefined when Konnect `enableDeckConfig` is a boolean', () => {
-      const { deckCalloutPreferenceKey } = useBaseEntityDeckOptions(
+      const { deckCalloutPreferenceKey } = withSetup(() => useBaseEntityDeckOptions(
         { ...konnectEntityBase, enableDeckConfig: true },
         SupportedEntityType.GatewayService,
-      )
+      ))
 
       expect(deckCalloutPreferenceKey.value).toBeUndefined()
     })
@@ -149,7 +186,7 @@ describe('useBaseEntityDeckOptions()', () => {
     const config = ref<KonnectBaseEntityConfig | KongManagerBaseEntityConfig>({ ...konnectEntityBase })
     const entityType = ref(SupportedEntityType.Other)
 
-    const { isDeckEnabled, deckCalloutPreferenceKey } = useBaseEntityDeckOptions(config, entityType)
+    const { isDeckEnabled, deckCalloutPreferenceKey } = withSetup(() => useBaseEntityDeckOptions(config, entityType))
 
     expect(isDeckEnabled.value).toBe(false)
 
@@ -169,47 +206,47 @@ describe('useBaseEntityDeckOptions()', () => {
 describe('useBaseFormDeckOptions()', () => {
   describe('isDeckEnabled', () => {
     it('returns false when the entity type is not supported by decK', () => {
-      const { isDeckEnabled } = useBaseFormDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseFormDeckOptions(
         { ...kongManagerFormBase },
         SupportedEntityType.Other,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(false)
     })
 
     it('is enabled for Kong Manager on a supported entity', () => {
-      const { isDeckEnabled } = useBaseFormDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseFormDeckOptions(
         { ...kongManagerFormBase },
         SupportedEntityType.Plugin,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(true)
     })
 
     it('is disabled for Konnect without `enableDeckTab`', () => {
-      const { isDeckEnabled } = useBaseFormDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseFormDeckOptions(
         { ...konnectFormBase },
         SupportedEntityType.Plugin,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(false)
     })
 
     it('is enabled for Konnect with `enableDeckTab: true`', () => {
-      const { isDeckEnabled } = useBaseFormDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseFormDeckOptions(
         { ...konnectFormBase, enableDeckTab: true },
         SupportedEntityType.Plugin,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(true)
     })
 
     it('is enabled for Konnect with an `enableDeckTab` object', () => {
       const options: DeckConfigOptions = {}
-      const { isDeckEnabled } = useBaseFormDeckOptions(
+      const { isDeckEnabled } = withSetup(() => useBaseFormDeckOptions(
         { ...konnectFormBase, enableDeckTab: options },
         SupportedEntityType.Plugin,
-      )
+      ))
 
       expect(isDeckEnabled.value).toBe(true)
     })
@@ -217,58 +254,74 @@ describe('useBaseFormDeckOptions()', () => {
 
   describe('deckCustomizationOptions', () => {
     it('is undefined for Kong Manager', () => {
-      const { deckCustomizationOptions } = useBaseFormDeckOptions(
+      const { deckCustomizationOptions } = withSetup(() => useBaseFormDeckOptions(
         { ...kongManagerFormBase },
         SupportedEntityType.Plugin,
-      )
+      ))
 
       expect(deckCustomizationOptions.value).toBeUndefined()
     })
 
     it('is undefined when `enableDeckTab` is a boolean', () => {
-      const { deckCustomizationOptions } = useBaseFormDeckOptions(
+      const { deckCustomizationOptions } = withSetup(() => useBaseFormDeckOptions(
         { ...konnectFormBase, enableDeckTab: true },
         SupportedEntityType.Plugin,
-      )
+      ))
 
       expect(deckCustomizationOptions.value).toBeUndefined()
     })
 
-    it('returns the nested `customization` field', () => {
+    it('returns the nested `customization` field when a `DeckCommandEditor` is provided', () => {
       const customization = { generateKonnectPat: async () => 'pat' }
-      const { deckCustomizationOptions } = useBaseFormDeckOptions(
-        { ...konnectFormBase, enableDeckTab: { customization } },
-        SupportedEntityType.Plugin,
+      const { deckCustomizationOptions } = withSetup(
+        () => useBaseFormDeckOptions(
+          { ...konnectFormBase, enableDeckTab: { customization } },
+          SupportedEntityType.Plugin,
+        ),
+        STUB_EDITOR,
       )
 
       expect(deckCustomizationOptions.value).toBe(customization)
+    })
+
+    it('returns undefined and warns when customization is configured but no `DeckCommandEditor` is provided', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const customization = { generateKonnectPat: async () => 'pat' }
+      const { deckCustomizationOptions } = withSetup(() => useBaseFormDeckOptions(
+        { ...konnectFormBase, enableDeckTab: { customization } },
+        SupportedEntityType.Plugin,
+      ))
+
+      expect(deckCustomizationOptions.value).toBeUndefined()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('DeckCommandEditor'))
+      warnSpy.mockRestore()
     })
   })
 
   describe('deckCalloutPreferenceKey', () => {
     it('returns `deckCalloutPreferenceKey` for Kong Manager configs', () => {
-      const { deckCalloutPreferenceKey } = useBaseFormDeckOptions(
+      const { deckCalloutPreferenceKey } = withSetup(() => useBaseFormDeckOptions(
         { ...kongManagerFormBase, deckCalloutPreferenceKey: 'km-key' },
         SupportedEntityType.Plugin,
-      )
+      ))
 
       expect(deckCalloutPreferenceKey.value).toBe('km-key')
     })
 
     it('returns the nested `calloutPreferenceKey` for Konnect configs', () => {
-      const { deckCalloutPreferenceKey } = useBaseFormDeckOptions(
+      const { deckCalloutPreferenceKey } = withSetup(() => useBaseFormDeckOptions(
         { ...konnectFormBase, enableDeckTab: { calloutPreferenceKey: 'konnect-key' } },
         SupportedEntityType.Plugin,
-      )
+      ))
 
       expect(deckCalloutPreferenceKey.value).toBe('konnect-key')
     })
 
     it('is undefined when Konnect `enableDeckTab` is a boolean', () => {
-      const { deckCalloutPreferenceKey } = useBaseFormDeckOptions(
+      const { deckCalloutPreferenceKey } = withSetup(() => useBaseFormDeckOptions(
         { ...konnectFormBase, enableDeckTab: true },
         SupportedEntityType.Plugin,
-      )
+      ))
 
       expect(deckCalloutPreferenceKey.value).toBeUndefined()
     })

--- a/packages/entities/entities-shared/src/composables/useDeckOptions.ts
+++ b/packages/entities/entities-shared/src/composables/useDeckOptions.ts
@@ -1,5 +1,6 @@
-import { computed, toValue } from 'vue'
+import { computed, inject, toValue } from 'vue'
 
+import { DECK_COMMAND_EDITOR_KEY, DECK_COMMAND_EDITOR_MISSING_WARNING } from '../constants'
 import { isSupportedDeckEntityType } from '../types'
 
 import type { MaybeRefOrGetter } from 'vue'
@@ -16,6 +17,8 @@ export function useBaseEntityDeckOptions(
   config: MaybeRefOrGetter<KonnectBaseEntityConfig | KongManagerBaseEntityConfig>,
   entityType: MaybeRefOrGetter<SupportedEntityType>,
 ) {
+  const deckCommandEditor = inject(DECK_COMMAND_EDITOR_KEY, null)
+
   const isDeckEnabled = computed(() => {
     const c = toValue(config)
     const enabled = c.app === 'kongManager' || Boolean(c.app === 'konnect' && c.enableDeckConfig)
@@ -24,9 +27,14 @@ export function useBaseEntityDeckOptions(
 
   const deckCustomizationOptions = computed(() => {
     const c = toValue(config)
-    return c.app === 'konnect' && c.enableDeckConfig && typeof c.enableDeckConfig !== 'boolean'
+    const configured = c.app === 'konnect' && c.enableDeckConfig && typeof c.enableDeckConfig !== 'boolean'
       ? c.enableDeckConfig.customization
       : undefined
+    if (configured && !deckCommandEditor) {
+      console.warn(DECK_COMMAND_EDITOR_MISSING_WARNING)
+      return undefined
+    }
+    return configured
   })
 
   const deckCalloutPreferenceKey = computed(() => {
@@ -49,6 +57,8 @@ export function useBaseFormDeckOptions(
   config: MaybeRefOrGetter<KonnectBaseFormConfig | KongManagerBaseFormConfig>,
   entityType: MaybeRefOrGetter<SupportedEntityType>,
 ) {
+  const deckCommandEditor = inject(DECK_COMMAND_EDITOR_KEY, null)
+
   const isDeckEnabled = computed(() => {
     const c = toValue(config)
     const enabled = c.app === 'kongManager' || Boolean(c.app === 'konnect' && c.enableDeckTab)
@@ -57,9 +67,14 @@ export function useBaseFormDeckOptions(
 
   const deckCustomizationOptions = computed(() => {
     const c = toValue(config)
-    return c.app === 'konnect' && c.enableDeckTab && typeof c.enableDeckTab !== 'boolean'
+    const configured = c.app === 'konnect' && c.enableDeckTab && typeof c.enableDeckTab !== 'boolean'
       ? c.enableDeckTab.customization
       : undefined
+    if (configured && !deckCommandEditor) {
+      console.warn(DECK_COMMAND_EDITOR_MISSING_WARNING)
+      return undefined
+    }
+    return configured
   })
 
   const deckCalloutPreferenceKey = computed(() => {

--- a/packages/entities/entities-shared/src/constants.ts
+++ b/packages/entities/entities-shared/src/constants.ts
@@ -1,3 +1,27 @@
 import type { InjectionKey, Ref } from 'vue'
 
+import type DeckCommandEditor from './components/common/DeckCommandEditor.vue'
+
 export const PLUGIN_FORM_LAYOUT_STATE: InjectionKey<Ref<boolean>> = Symbol('PLUGIN_FORM_LAYOUT_STATE')
+
+/**
+ * The injection key for providing the `DeckCommandEditor` component.
+ *
+ * For:
+ * - decK command customization
+ *
+ * Usage:
+ * ```ts
+ * // In the host app
+ * import { provide } from 'vue'
+ * import { DECK_COMMAND_EDITOR_KEY } from '@kong-ui-public/entities-shared'
+ * import { DeckCommandEditor } from '@kong-ui-public/entities-shared/deck-editor'
+ * provide(DECK_COMMAND_EDITOR_KEY, DeckCommandEditor)
+ * ```
+ *
+ * See `provideDeckCommandEditor` from `@kong-ui-public/entities-shared/deck-editor`
+ * for the convenient helper.
+ */
+export const DECK_COMMAND_EDITOR_KEY: InjectionKey<typeof DeckCommandEditor> = Symbol('DECK_COMMAND_EDITOR')
+
+export const DECK_COMMAND_EDITOR_MISSING_WARNING = '[entities-shared] DeckCommandEditor was not provided. Provide it via the `DECK_COMMAND_EDITOR_KEY` injection key or the `provideDeckCommandEditor` helper (see @kong-ui-public/entities-shared/deck-editor).'

--- a/packages/entities/entities-shared/src/deck-editor.ts
+++ b/packages/entities/entities-shared/src/deck-editor.ts
@@ -1,0 +1,24 @@
+import { provide } from 'vue'
+
+import { DECK_COMMAND_EDITOR_KEY } from './constants'
+import DeckCommandEditor from './components/common/DeckCommandEditor.vue'
+import DeckCommandEditorLoading from './components/common/DeckCommandEditorLoading.vue'
+
+export { DeckCommandEditor, DeckCommandEditorLoading }
+
+/**
+ * Provides the `DeckCommandEditor` component via the `DECK_COMMAND_EDITOR_KEY` injection key.
+ *
+ * For:
+ * - decK command customization
+ *
+ * Usage:
+ * ```ts
+ * // In the host app
+ * import { provideDeckCommandEditor } from '@kong-ui-public/entities-shared/deck-editor'
+ * provideDeckCommandEditor()
+ * ```
+ */
+export function provideDeckCommandEditor() {
+  provide(DECK_COMMAND_EDITOR_KEY, DeckCommandEditor)
+}

--- a/packages/entities/entities-shared/src/types/deck.ts
+++ b/packages/entities/entities-shared/src/types/deck.ts
@@ -24,6 +24,13 @@ export interface DeckCustomizationOptions {
 export interface DeckConfigOptions {
   /**
    * This option enables the "Customize before copying" feature on the decK config.
+   *
+   * Requires the host app to provide `DeckCommandEditor` via the
+   * `DECK_COMMAND_EDITOR_KEY` injection key — typically through the
+   * `provideDeckCommandEditor` helper from `@kong-ui-public/entities-shared/deck-editor`.
+   * If the editor is not provided, the customize button is hidden and a
+   * `console.warn` is emitted at runtime.
+   *
    * See {@link DeckCustomizationOptions} for extra options.
    */
   customization?: boolean | DeckCustomizationOptions

--- a/packages/entities/entities-shared/vite.config.ts
+++ b/packages/entities/entities-shared/vite.config.ts
@@ -17,8 +17,14 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       // The kebab-case name of the exposed global variable. MUST be in the format `kong-ui-public-{package-name}`
       // Example: name: 'kong-ui-public-demo-component'
       name: `kong-ui-public-${sanitizedPackageName}`,
-      entry: resolve(__dirname, './src/index.ts'),
-      fileName: (format) => `${sanitizedPackageName}.${format}.js`,
+      entry: {
+        index: resolve(__dirname, './src/index.ts'),
+        'deck-editor': resolve(__dirname, './src/deck-editor.ts'),
+      },
+      fileName: (format, entryName) =>
+        entryName === 'index'
+          ? `${sanitizedPackageName}.${format}.js`
+          : `${entryName}.${format}.js`,
     },
     rollupOptions: {
       external: [


### PR DESCRIPTION
- Split DeckCommandEditor to `@kong-ui-public/entities-shared/deck-editor` so that the `monaco-editor` and `shiki` dependencies won't be imported by the default package export.
- Provided a `provideDeckCommandEditor` helper to provide the editor with only one call.
- The "Customize before copying to CLI" button will not be shown when DeckCommandEditor is not provided. 
- Fixed `require` export entry from `.umd.js` to `.cjs.js` as the actual build artifact is in the `.cjs.js` extension.

KM-2548