### PR TITLE
fix(app-layout): tweak app page header title in next navigation

### DIFF
--- a/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
+++ b/packages/core/app-layout/src/components/pageHeader/AppPageHeader.vue
@@ -160,8 +160,9 @@ const breadcrumbIconSlots = computed((): string[] => {
   &.konnect-navigation-next {
     .page-header-title-section {
       .page-header-title {
-        font-size: var(--kui-font-size-50, $kui-font-size-50);
-        line-height: var(--kui-line-height-40, $kui-line-height-40);
+        font-size: var(--kui-font-size-40, $kui-font-size-40);
+        font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+        line-height: var(--kui-line-height-30, $kui-line-height-30);
       }
     }
 


### PR DESCRIPTION
# Summary

Tweak AppPageHeader title styles in next navigation

Before
<img width="490" height="282" alt="Screenshot 2026-05-01 at 12 34 36 PM" src="https://github.com/user-attachments/assets/334a1fa8-f30e-4d4a-81f9-2ce3c0a26cc3" />

After
<img width="516" height="286" alt="Screenshot 2026-05-01 at 12 35 09 PM" src="https://github.com/user-attachments/assets/db864430-c6ca-4f1a-845a-37207e657af5" />

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
