### PR TITLE
feat(entities-consumer-groups): add a query when fetching consumer group detail

### DIFF
--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupConfigCard.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupConfigCard.vue
@@ -63,7 +63,7 @@ const props = defineProps({
 })
 
 const { i18n: { t } } = composables.useI18n()
-const fetchUrl = computed((): string => endpoints.form[props.config.app].edit)
+const fetchUrl = computed((): string => endpoints.item[props.config.app])
 
 const configSchema = ref<ConsumerGroupConfigurationSchema>({
   id: {},

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
@@ -182,7 +182,7 @@ const displayedConsumers = computed((): MultiselectItem[] => {
   }))
 })
 
-const fetchUrl = computed<string>(() => endpoints.form[props.config?.app]?.edit)
+const fetchUrl = computed<string>(() => endpoints.item[props.config?.app])
 
 const formType = computed((): EntityBaseFormType => props.consumerGroupId
   ? EntityBaseFormType.Edit

--- a/packages/entities/entities-consumer-groups/src/consumer-groups-endpoints.ts
+++ b/packages/entities/entities-consumer-groups/src/consumer-groups-endpoints.ts
@@ -34,4 +34,8 @@ export default {
       getConsumers: `${KMBaseApiUrl}/consumer_groups/{id}/consumers`,
     },
   },
+  item: {
+    konnect: `${konnectBaseApiUrl}/consumer_groups/{id}?list_consumers=false`,
+    kongManager: `${KMBaseApiUrl}/consumer_groups/{id}?list_consumers=false`,
+  },
 }


### PR DESCRIPTION
# Summary
Adding a query `list_consumers=false` when fetching the data of a consumer group. Context:
1. https://kongstrong.slack.com/archives/C03LRB400TC/p1777970723408319
2. https://github.com/Kong/kong-ee/pull/10467

KM-2552

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
