### PR TITLE
feat(analytics): dashboard filter type [ma-4978]

### DIFF
--- a/packages/analytics/analytics-utilities/src/types/explore/all.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/all.ts
@@ -31,6 +31,26 @@ export interface FilterTypeMap extends Record<QueryDatasource, AllFilters> {
   platform: PlatformExploreFilterAll
 }
 
+/**
+ * A collection of values that are used in the dashboard list filters
+ */
+export type DashboardListFilterValues = {
+  /**
+   * Distinct uuids of users who have created a dashboard. If not provided, none exist.
+   */
+  createdBy?: {
+    values: string[]
+    truncated: boolean
+  }
+  /**
+   * Distinct labels in use by any dashboard. If not provided, none exist.
+   */
+  labels?: {
+    values: string[]
+    truncated: boolean
+  }
+}
+
 export const datasourceToFilterableDimensions: Record<QueryDatasource, Set<string>> = {
   basic: new Set(filterableBasicExploreDimensions),
   api_usage: new Set(filterableExploreDimensions),


### PR DESCRIPTION
Types for [MA-4978](https://konghq.atlassian.net/browse/MA-4978)

# Summary

Adds a type that can be used by both the backend and the frontend for dashboard list filters.

[MA-4978]: https://konghq.atlassian.net/browse/MA-4978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ