### PR TITLE
Feat/donut chart center metric default

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
@@ -161,13 +161,13 @@ describe('<AnalyticsChart />', () => {
     cy.get('[data-testid="time-series-line-chart"]').should('be.visible')
     cy.get('[data-testid="legend"]').children().should('have.length', 5)
     cy.get('.label').eq(0).should('include.text', '200')
-    cy.get('.sub-label').eq(0).should('include.text', '1.2M requests')
+    cy.get('.sub-label').eq(0).should('include.text', '1.2M')
     cy.get('.label').eq(1).should('include.text', '201')
-    cy.get('.sub-label').eq(1).should('include.text', '907K requests')
+    cy.get('.sub-label').eq(1).should('include.text', '907K')
     cy.get('.label').eq(2).should('include.text', '202')
-    cy.get('.sub-label').eq(2).should('include.text', '910K requests')
+    cy.get('.sub-label').eq(2).should('include.text', '910K')
     cy.get('.label').eq(3).should('include.text', '300')
-    cy.get('.sub-label').eq(3).should('include.text', '378K requests')
+    cy.get('.sub-label').eq(3).should('include.text', '378K')
   })
 
   it('shows the empty state with no data', () => {
@@ -195,7 +195,7 @@ describe('<AnalyticsChart />', () => {
     cy.get('[data-testid="time-series-bar-chart"]').should('be.visible')
     cy.get('[data-testid="legend"]').should('have.length', 1)
     cy.get(':nth-child(1) > .label-container > .label').should('include.text', '200')
-    cy.get(':nth-child(1) > .label-container > .sub-label').should('include.text', '1.2M requests')
+    cy.get(':nth-child(1) > .label-container > .sub-label').should('include.text', '1.2M')
     cy.get("[role='tooltip']").should(
       'include.text',
       'Grouped value limit exceeded, showing the top 50',
@@ -243,13 +243,13 @@ describe('<AnalyticsChart />', () => {
     cy.get('[data-testid="bar-chart-container"]').should('be.visible')
     cy.get('[data-testid="legend"]').children().should('have.length', 20)
     cy.get('.label').eq(0).should('include.text', '200')
-    cy.get('.sub-label').eq(0).should('include.text', '1.2M requests')
+    cy.get('.sub-label').eq(0).should('include.text', '1.2M')
     cy.get('.label').eq(1).should('include.text', '201')
-    cy.get('.sub-label').eq(1).should('include.text', '882K requests')
+    cy.get('.sub-label').eq(1).should('include.text', '882K')
     cy.get('.label').eq(2).should('include.text', '202')
-    cy.get('.sub-label').eq(2).should('include.text', '885K requests')
+    cy.get('.sub-label').eq(2).should('include.text', '885K')
     cy.get('.label').eq(3).should('include.text', '300')
-    cy.get('.sub-label').eq(3).should('include.text', '367K requests')
+    cy.get('.sub-label').eq(3).should('include.text', '367K')
   })
 
   it('renders a donut chart with multi dimension data', () => {
@@ -283,13 +283,13 @@ describe('<AnalyticsChart />', () => {
     cy.get('[data-testid="donut-chart-parent"]').should('be.visible')
     cy.get('[data-testid="legend"]').children().should('have.length', 5)
     cy.get('.label').eq(0).should('include.text', '200')
-    cy.get('.sub-label').eq(0).should('include.text', '42K requests')
+    cy.get('.sub-label').eq(0).should('include.text', '42K')
     cy.get('.label').eq(1).should('include.text', '201')
-    cy.get('.sub-label').eq(1).should('include.text', '31K requests')
+    cy.get('.sub-label').eq(1).should('include.text', '31K')
     cy.get('.label').eq(2).should('include.text', '202')
-    cy.get('.sub-label').eq(2).should('include.text', '30K requests')
+    cy.get('.sub-label').eq(2).should('include.text', '30K')
     cy.get('.label').eq(3).should('include.text', '300')
-    cy.get('.sub-label').eq(3).should('include.text', '12K requests')
+    cy.get('.sub-label').eq(3).should('include.text', '12K')
   })
 
   it('renders an empty state with default title and description text', () => {

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -110,7 +110,7 @@ import DonutChart from './chart-types/DonutChart.vue'
 import { computed, provide, toRef } from 'vue'
 import { msToGranularity } from '@kong-ui-public/analytics-utilities'
 import type { AbsoluteTimeRangeV4, ExploreAggregations, ExploreResultV4, GranularityValues } from '@kong-ui-public/analytics-utilities'
-import { hasMillisecondTimestamps, defaultStatusCodeColors, isUnitlessMetricUnit } from '../utils'
+import { hasMillisecondTimestamps, defaultStatusCodeColors, isNoSuffixMetric } from '../utils'
 import TimeSeriesChart from './chart-types/TimeSeriesChart.vue'
 import { KUI_COLOR_TEXT_WARNING, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 import { WarningIcon } from '@kong/icons'
@@ -248,7 +248,7 @@ const tooltipMetricDisplay = computed<string | undefined>(() => {
   }
 
   // @ts-ignore - dynamic i18n key
-  if (isUnitlessMetricUnit(metricUnit) && i18n.te(`metricAxisTitles.${metricName}`)) {
+  if (isNoSuffixMetric(metricUnit) && i18n.te(`metricAxisTitles.${metricName}`)) {
     // @ts-ignore - dynamic i18n key
     return i18n.t(`metricAxisTitles.${metricName}`) || undefined
   }
@@ -281,8 +281,8 @@ const metricAxesTitle = computed<string | undefined>(() => {
   }
 
   // @ts-ignore - dynamic i18n key
-  if (i18n.te(`metricAxisTitles.${metricName}`) && (isUnitlessMetricUnit(metricUnit) || i18n.te(`chartUnits.${metricUnit}`))) {
-    if (isUnitlessMetricUnit(metricUnit)) {
+  if (i18n.te(`metricAxisTitles.${metricName}`) && (isNoSuffixMetric(metricUnit) || i18n.te(`chartUnits.${metricUnit}`))) {
+    if (isNoSuffixMetric(metricUnit)) {
       // @ts-ignore - dynamic i18n key
       return i18n.t(`metricAxisTitles.${metricName}`) || undefined
     }

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -89,6 +89,7 @@
         :dataset-colors="chartOptions.chartDatasetColors || defaultStatusCodeColors"
         :legend-position="legendPosition"
         :legend-values="legendValues"
+        :metric-name="computedMetricName"
         :metric-unit="computedMetricUnit"
         :show-center-metric="chartOptions.showCenterMetric"
         :synthetics-data-key="syntheticsDataKey"
@@ -191,6 +192,14 @@ const computedMetricUnit = computed<string>(() => {
   }
 
   return Object.values(props.chartData.meta.metric_units)[0]
+})
+
+const computedMetricName = computed<string>(() => {
+  if (!props.chartData.meta?.metric_units) {
+    return ''
+  }
+
+  return Object.keys(props.chartData.meta.metric_units)[0] ?? ''
 })
 
 const showLegendValues = computed(() => props.showLegendValues && props.legendPosition !== ChartLegendPosition.Hidden)

--- a/packages/analytics/analytics-chart/src/components/TopNTable.vue
+++ b/packages/analytics/analytics-chart/src/components/TopNTable.vue
@@ -141,7 +141,7 @@ import type {
 import { computed } from 'vue'
 import { unitFormatter } from '@kong-ui-public/analytics-utilities'
 import composables from '../composables'
-import { isUnitlessMetricUnit } from '../utils'
+import { isNoSuffixMetric } from '../utils'
 
 type TableHeader = {
   key: string
@@ -396,7 +396,7 @@ const getRowMetricDisplayValue = (row: TopNRow, key: string): string => {
 }
 
 const translateChartUnit = (unit: string, value: number): string => {
-  if (isUnitlessMetricUnit(unit) || unit === 'count' || unit === 'requests') {
+  if (isNoSuffixMetric(unit) || unit === 'count' || unit === 'requests') {
     return ''
   }
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.cy.ts
@@ -41,32 +41,32 @@ describe('<DonutChart />', () => {
     })
 
     it('does not show center metric when showCenterMetric is true but unit is non-summable', () => {
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'ms' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'ms', metricName: 'response_latency_p99' })
       cy.get('.chart-center-metric').should('not.exist')
     })
 
     it('does not show center metric for bytes unit', () => {
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'bytes' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'bytes', metricName: 'response_size_average' })
       cy.get('.chart-center-metric').should('not.exist')
     })
 
     it('shows center metric when showCenterMetric is true and unit is count', () => {
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'count' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'count', metricName: 'request_count' })
       cy.get('.chart-center-metric').should('be.visible')
     })
 
     it('shows center metric for requests unit', () => {
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'requests' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'count', metricName: 'request_count' })
       cy.get('.chart-center-metric').should('be.visible')
     })
 
     it('shows center metric for usd unit', () => {
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'usd' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'usd', metricName: 'llm_embeddings_cost' })
       cy.get('.chart-center-metric').should('be.visible')
     })
 
     it('shows center metric for token count unit', () => {
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'token count' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'token count', metricName: 'total_tokens' })
       cy.get('.chart-center-metric').should('be.visible')
     })
   })
@@ -74,22 +74,22 @@ describe('<DonutChart />', () => {
   describe('grand total value', () => {
     it('sums all dataset values', () => {
       // datasets: [52428 + 38020] + [12897 + 9100] = 112445 → approx "112K"
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'count' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'count', metricName: 'request_count' })
       cy.get('.chart-center-total').should('be.visible').and('contain', 'K')
     })
 
     it('formats usd values with currency symbol', () => {
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'usd' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'usd', metricName: 'llm_embeddings_cost' })
       cy.get('.chart-center-total').should('contain', '$')
     })
 
     it('does not include unit text in the number for count', () => {
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'count' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'count', metricName: 'request_count' })
       cy.get('.chart-center-total').invoke('text').should('not.match', /requests/i)
     })
 
     it('does not include unit text in the number for token count', () => {
-      mountDonutChart({ showCenterMetric: true, metricUnit: 'token count' })
+      mountDonutChart({ showCenterMetric: true, metricUnit: 'token count', metricName: 'total_tokens' })
       cy.get('.chart-center-total').invoke('text').should('not.match', /token/i)
     })
   })
@@ -99,6 +99,7 @@ describe('<DonutChart />', () => {
       mountDonutChart({
         showCenterMetric: true,
         metricUnit: 'count',
+        metricName: 'request_count',
         tooltipMetricDisplay: 'Request count',
       })
       cy.get('.chart-center-unit').should('contain', 'Request count')
@@ -108,6 +109,7 @@ describe('<DonutChart />', () => {
       mountDonutChart({
         showCenterMetric: true,
         metricUnit: 'usd',
+        metricName: 'llm_embeddings_cost',
         tooltipMetricDisplay: 'Costs',
       })
       cy.get('.chart-center-unit').should('contain', 'Costs')
@@ -117,6 +119,7 @@ describe('<DonutChart />', () => {
       mountDonutChart({
         showCenterMetric: true,
         metricUnit: 'count',
+        metricName: 'request_count',
         tooltipMetricDisplay: '',
       })
       cy.get('.chart-center-unit').should('not.exist')

--- a/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
@@ -56,6 +56,7 @@ import {
   datavisPalette,
   darkenColor,
   isSummableMetricUnit,
+  isSummableMetricName,
 } from '../../utils'
 import { Doughnut } from 'vue-chartjs'
 import composables from '../../composables'
@@ -69,6 +70,7 @@ const props = withDefaults(defineProps<{
   chartData: KChartData
   tooltipTitle: string
   metricUnit?: string
+  metricName?: string
   legendPosition?: `${ChartLegendPosition}`
   legendValues?: LegendValues
   syntheticsDataKey?: string
@@ -78,13 +80,14 @@ const props = withDefaults(defineProps<{
   showCenterMetric?: boolean
 }>(), {
   metricUnit: '',
+  metricName: '',
   legendPosition: ChartLegendPosition.Bottom,
   legendValues: undefined,
   syntheticsDataKey: '',
   datasetColors: () => datavisPalette,
   tooltipDimensionDisplay: '',
   tooltipMetricDisplay: '',
-  showCenterMetric: false,
+  showCenterMetric: true,
 })
 
 const { translateUnit } = composables.useTranslatedUnits()
@@ -156,7 +159,7 @@ const formattedDataset = computed<DonutChartData[]>(() => {
 
 const { formatUnit } = unitFormatter({ i18n })
 
-const isSummable = computed(() => isSummableMetricUnit(props.metricUnit))
+const isSummable = computed(() => isSummableMetricUnit(props.metricUnit) || isSummableMetricName(props.metricName ?? ''))
 
 const grandTotal = computed(() => {
   const sum = formattedDataset.value[0]?.data.reduce((a, b) => a + b, 0) ?? 0

--- a/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
@@ -54,7 +54,6 @@ import ToolTip from '../chart-plugins/ChartTooltip.vue'
 import HtmlLegend from '../chart-plugins/ChartLegend.vue'
 import {
   datavisPalette,
-  darkenColor,
   isSummableMetric,
 } from '../../utils'
 import { Doughnut } from 'vue-chartjs'

--- a/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
@@ -146,9 +146,9 @@ const formattedDataset = computed<DonutChartData[]>(() => {
     labels: [],
     backgroundColor: [],
     borderColor: '#ffffff',
-    borderWidth: 3,
+    borderWidth: 1,
     hoverBorderColor: [],
-    hoverBorderWidth: 3,
+    hoverBorderWidth: 1,
     data: [],
     hoverOffset: 10,
   })

--- a/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
@@ -55,8 +55,7 @@ import HtmlLegend from '../chart-plugins/ChartLegend.vue'
 import {
   datavisPalette,
   darkenColor,
-  isSummableMetricUnit,
-  isSummableMetricName,
+  isSummableMetric,
 } from '../../utils'
 import { Doughnut } from 'vue-chartjs'
 import composables from '../../composables'
@@ -159,13 +158,13 @@ const formattedDataset = computed<DonutChartData[]>(() => {
 
 const { formatUnit } = unitFormatter({ i18n })
 
-const isSummable = computed(() => isSummableMetricUnit(props.metricUnit) || isSummableMetricName(props.metricName ?? ''))
+const isSummable = computed(() => isSummableMetric(props.metricName ?? ''))
 
 const grandTotal = computed(() => {
   const sum = formattedDataset.value[0]?.data.reduce((a, b) => a + b, 0) ?? 0
   return formatUnit(sum, props.metricUnit, {
     approximate: true,
-    translateUnit: (unit, value) => isSummableMetricUnit(unit) && unit !== 'usd' ? '' : translateUnit(unit, value),
+    translateUnit: (unit, value) => translateUnit(unit, value),
   }).trim()
 })
 

--- a/packages/analytics/analytics-chart/src/composables/useTranslatedUnits.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useTranslatedUnits.spec.ts
@@ -3,12 +3,12 @@ import useTranslatedUnits from './useTranslatedUnits'
 
 describe('useTranslatedUnits', () => {
 
-  it('pluralizes properly', () => {
+  it('suppresses unit text for count', () => {
     const { translateUnit } = useTranslatedUnits()
 
-    expect(translateUnit('count', 0)).toBe('requests')
-    expect(translateUnit('count', 1)).toBe('request')
-    expect(translateUnit('count', 2)).toBe('requests')
+    expect(translateUnit('count', 0)).toBe('')
+    expect(translateUnit('count', 1)).toBe('')
+    expect(translateUnit('count', 2)).toBe('')
   })
 
   it('suppresses unit text for unitless metrics', () => {

--- a/packages/analytics/analytics-chart/src/composables/useTranslatedUnits.ts
+++ b/packages/analytics/analytics-chart/src/composables/useTranslatedUnits.ts
@@ -1,5 +1,5 @@
 import composables from '../composables'
-import { isUnitlessMetricUnit } from '../utils'
+import { isNoSuffixMetric } from '../utils'
 
 export default function useTranslatedUnits() {
   const { i18n } = composables.useI18n()
@@ -9,7 +9,7 @@ export default function useTranslatedUnits() {
 
     const translationKey = `chartUnits.${unit}`
 
-    if (isUnitlessMetricUnit(unit)) {
+    if (isNoSuffixMetric(unit)) {
       return ''
     }
     // @ts-ignore - dynamic i18n key

--- a/packages/analytics/analytics-chart/src/utils/metric-units.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/metric-units.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isUnitlessMetricUnit, isSummableMetricUnit } from './metric-units'
+import { isUnitlessMetricUnit, isSummableMetricUnit, isSummableMetricName } from './metric-units'
 
 describe('metric-units', () => {
   describe('isUnitlessMetricUnit', () => {
@@ -26,9 +26,14 @@ describe('metric-units', () => {
   describe('isSummableMetricUnit', () => {
     it.each([
       'count',
-      'requests',
       'usd',
       'token count',
+      'control_plane_count',
+      'service_count',
+      'route_count',
+      'consumer_count',
+      'plugin_count',
+      'node_count',
     ])('identifies %s as a summable metric unit', (unit) => {
       expect(isSummableMetricUnit(unit)).toBe(true)
     })
@@ -38,8 +43,31 @@ describe('metric-units', () => {
       'bytes',
       '%',
       'count/minute',
+      'requests',
     ])('does not identify %s as a summable metric unit', (unit) => {
       expect(isSummableMetricUnit(unit)).toBe(false)
+    })
+  })
+
+  describe('isSummableMetricName', () => {
+    it.each([
+      'request_size_sum',
+      'response_size_sum',
+      'a2a_response_size_sum',
+      'mcp_response_size_sum',
+      'mcp_response_body_size_sum',
+      'record_bytes:sum',
+    ])('identifies %s as a summable metric name', (name) => {
+      expect(isSummableMetricName(name)).toBe(true)
+    })
+
+    it.each([
+      'request_size_p99',
+      'request_size_average',
+      'response_size_p50',
+      'request_count',
+    ])('does not identify %s as a summable metric name', (name) => {
+      expect(isSummableMetricName(name)).toBe(false)
     })
   })
 })

--- a/packages/analytics/analytics-chart/src/utils/metric-units.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/metric-units.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { isUnitlessMetricUnit, isSummableMetricUnit, isSummableMetricName } from './metric-units'
+import { isNoSuffixMetric, isSummableMetricUnit, isSummableMetricName } from './metric-units'
 
 describe('metric-units', () => {
-  describe('isUnitlessMetricUnit', () => {
+  describe('isNoSuffixMetric', () => {
     it.each([
       'control_plane_count',
       'service_count',
@@ -12,14 +12,14 @@ describe('metric-units', () => {
       'node_count',
       'usd',
     ])('identifies %s as a unitless metric unit', (unit) => {
-      expect(isUnitlessMetricUnit(unit)).toBe(true)
+      expect(isNoSuffixMetric(unit)).toBe(true)
     })
 
     it.each([
       'count',
       'bytes',
     ])('does not identify %s as a unitless metric unit', (unit) => {
-      expect(isUnitlessMetricUnit(unit)).toBe(false)
+      expect(isNoSuffixMetric(unit)).toBe(false)
     })
   })
 

--- a/packages/analytics/analytics-chart/src/utils/metric-units.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/metric-units.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isNoSuffixMetric, isSummableMetricUnit, isSummableMetricName } from './metric-units'
+import { isNoSuffixMetric, isSummableMetric } from './metric-units'
 
 describe('metric-units', () => {
   describe('isNoSuffixMetric', () => {
@@ -10,64 +10,105 @@ describe('metric-units', () => {
       'consumer_count',
       'plugin_count',
       'node_count',
-      'usd',
-    ])('identifies %s as a unitless metric unit', (unit) => {
+      'count',
+      'token count',
+    ])('identifies %s as a no-suffix metric unit', (unit) => {
       expect(isNoSuffixMetric(unit)).toBe(true)
     })
 
     it.each([
-      'count',
       'bytes',
-    ])('does not identify %s as a unitless metric unit', (unit) => {
+      'ms',
+      'usd',
+      '%',
+      'count/minute',
+    ])('does not identify %s as a no-suffix metric unit', (unit) => {
       expect(isNoSuffixMetric(unit)).toBe(false)
     })
   })
 
-  describe('isSummableMetricUnit', () => {
-    it.each([
-      'count',
-      'usd',
-      'token count',
-      'control_plane_count',
-      'service_count',
-      'route_count',
-      'consumer_count',
-      'plugin_count',
-      'node_count',
-    ])('identifies %s as a summable metric unit', (unit) => {
-      expect(isSummableMetricUnit(unit)).toBe(true)
+  describe('isSummableMetric', () => {
+    describe('request and entity counts', () => {
+      it.each([
+        'request_count',
+        'ai_request_count',
+        'service_count',
+        'node_count',
+        'control_plane_count',
+        'route_count',
+        'consumer_count',
+        'plugin_count',
+      ])('identifies %s as summable', (name) => {
+        expect(isSummableMetric(name)).toBe(true)
+      })
     })
 
-    it.each([
-      'ms',
-      'bytes',
-      '%',
-      'count/minute',
-      'requests',
-    ])('does not identify %s as a summable metric unit', (unit) => {
-      expect(isSummableMetricUnit(unit)).toBe(false)
-    })
-  })
-
-  describe('isSummableMetricName', () => {
-    it.each([
-      'request_size_sum',
-      'response_size_sum',
-      'a2a_response_size_sum',
-      'mcp_response_size_sum',
-      'mcp_response_body_size_sum',
-      'record_bytes:sum',
-    ])('identifies %s as a summable metric name', (name) => {
-      expect(isSummableMetricName(name)).toBe(true)
+    describe('token counts', () => {
+      it.each([
+        'total_tokens',
+        'prompt_tokens',
+        'completion_tokens',
+        'llm_embeddings_tokens',
+      ])('identifies %s as summable', (name) => {
+        expect(isSummableMetric(name)).toBe(true)
+      })
     })
 
-    it.each([
-      'request_size_p99',
-      'request_size_average',
-      'response_size_p50',
-      'request_count',
-    ])('does not identify %s as a summable metric name', (name) => {
-      expect(isSummableMetricName(name)).toBe(false)
+    describe('cost', () => {
+      it.each([
+        'cost',
+        'llm_embeddings_cost',
+      ])('identifies %s as summable', (name) => {
+        expect(isSummableMetric(name)).toBe(true)
+      })
+    })
+
+    describe('size sum metrics', () => {
+      it.each([
+        'request_size_sum',
+        'response_size_sum',
+        'a2a_response_size_sum',
+        'mcp_response_size_sum',
+        'mcp_response_body_size_sum',
+        'record_bytes:sum',
+      ])('identifies %s as summable', (name) => {
+        expect(isSummableMetric(name)).toBe(true)
+      })
+    })
+
+    describe('latency metrics', () => {
+      it.each([
+        'response_latency_p99',
+        'response_latency_p95',
+        'response_latency_p50',
+        'response_latency_average',
+        'upstream_latency_p99',
+        'kong_latency_average',
+      ])('does not identify %s as summable', (name) => {
+        expect(isSummableMetric(name)).toBe(false)
+      })
+    })
+
+    describe('size percentile and average metrics', () => {
+      it.each([
+        'response_size_p99',
+        'response_size_p50',
+        'response_size_average',
+        'request_size_p99',
+        'request_size_average',
+      ])('does not identify %s as summable', (name) => {
+        expect(isSummableMetric(name)).toBe(false)
+      })
+    })
+
+    describe('other non-summable metrics', () => {
+      it.each([
+        'error_rate',
+        'request_per_minute',
+        'active_services',
+      ])('does not identify %s as summable', (name) => {
+        expect(isSummableMetric(name)).toBe(false)
+      })
     })
   })
 })

--- a/packages/analytics/analytics-chart/src/utils/metric-units.ts
+++ b/packages/analytics/analytics-chart/src/utils/metric-units.ts
@@ -1,6 +1,6 @@
 
 export const isNoSuffixMetric = (unit: string): boolean => {
-  return unit.toLocaleLowerCase().includes('count')
+  return unit.toLocaleLowerCase().endsWith('count')
 }
 
 // Unit-based checks don't work for size metrics since all aggregations (sum, avg, percentiles) share

--- a/packages/analytics/analytics-chart/src/utils/metric-units.ts
+++ b/packages/analytics/analytics-chart/src/utils/metric-units.ts
@@ -1,35 +1,13 @@
-export const UNITLESS_METRICS = new Set([
-  'control_plane_count',
-  'service_count',
-  'route_count',
-  'consumer_count',
-  'plugin_count',
-  'node_count',
-  'usd',
-])
 
-export const isUnitlessMetricUnit = (unit: string): boolean => {
-  return UNITLESS_METRICS.has(unit)
-}
-
-export const SUMMABLE_METRIC_UNITS = new Set([
-  'count',
-  'usd',
-  'token count',
-  'control_plane_count',
-  'service_count',
-  'route_count',
-  'consumer_count',
-  'plugin_count',
-  'node_count',
-])
-
-export const isSummableMetricUnit = (unit: string): boolean => {
-  return SUMMABLE_METRIC_UNITS.has(unit)
+export const isNoSuffixMetric = (unit: string): boolean => {
+  return unit.toLocaleLowerCase().includes('count')
 }
 
 // Unit-based checks don't work for size metrics since all aggregations (sum, avg, percentiles) share
 // the same 'bytes' unit. Check the metric name instead — both _sum (Druid) and :sum (GOAP) notations.
-export const isSummableMetricName = (name: string): boolean => {
-  return name.endsWith('_sum') || name.endsWith(':sum')
+export const isSummableMetric = (name: string): boolean => {
+  const lowerName = name.toLocaleLowerCase()
+  return [
+    'sum', 'count', 'cost', 'tokens',
+  ].some(summableSuffix => lowerName.endsWith(summableSuffix))
 }

--- a/packages/analytics/analytics-chart/src/utils/metric-units.ts
+++ b/packages/analytics/analytics-chart/src/utils/metric-units.ts
@@ -14,11 +14,20 @@ export const isUnitlessMetricUnit = (unit: string): boolean => {
 
 export const SUMMABLE_METRIC_UNITS = new Set([
   'count',
-  'requests',
   'usd',
   'token count',
+  'control_plane_count',
+  'service_count',
+  'route_count',
+  'consumer_count',
+  'plugin_count',
+  'node_count',
 ])
 
 export const isSummableMetricUnit = (unit: string): boolean => {
   return SUMMABLE_METRIC_UNITS.has(unit)
+}
+
+export const isSummableMetricName = (name: string): boolean => {
+  return name.endsWith('_sum') || name.endsWith(':sum')
 }

--- a/packages/analytics/analytics-chart/src/utils/metric-units.ts
+++ b/packages/analytics/analytics-chart/src/utils/metric-units.ts
@@ -28,6 +28,8 @@ export const isSummableMetricUnit = (unit: string): boolean => {
   return SUMMABLE_METRIC_UNITS.has(unit)
 }
 
+// Unit-based checks don't work for size metrics since all aggregations (sum, avg, percentiles) share
+// the same 'bytes' unit. Check the metric name instead — both _sum (Druid) and :sum (GOAP) notations.
 export const isSummableMetricName = (name: string): boolean => {
   return name.endsWith('_sum') || name.endsWith(':sum')
 }


### PR DESCRIPTION
# Summary

The donut chart's center metric was previously hidden by default and only          supported a limited set of unit-based checks to determine whether a total could be displayed. 

This PR addresses both issues.

Changes:
  - showCenterMetric now defaults to true                                            
  - Adds isSummableMetricName to handle metrics where the unit alone isn't
  sufficient to determine summability — specifically size metrics (request_size_sum, response_size_sum, etc.) where all aggregations (sum, avg, percentiles) share the same bytes unit. Supports both _sum (Druid) and :sum (GOAP) naming conventions
  - Expands SUMMABLE_METRIC_UNITS with platform entity count units (service_count, route_count, etc.) which use their metric name as the unit string
  - Removes the dead requests entry from SUMMABLE_METRIC_UNITS — the API never returns this string as a unit; it was an i18n display artifact from old mock data
  - Passes the metric name alongside the metric unit from AnalyticsChart down to DonutChart to enable the name-based summability check

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
