### PR TITLE
feat(workspace): add workspace support to consumer-related entities

### DIFF
--- a/packages/entities/entities-consumer-credentials/docs/consumer-credential-list.md
+++ b/packages/entities/entities-consumer-credentials/docs/consumer-credential-list.md
@@ -74,10 +74,10 @@ A table component for consumer credentials.
     - Current credential plugin name.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.cy.ts
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.cy.ts
@@ -829,4 +829,80 @@ describe('<ConsumerCredentialList />', () => {
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/consumers/${baseConfigKonnect.consumerId}/${baseConfigKonnect.plugin}*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/consumers/${baseConfigKonnect.consumerId}/${baseConfigKonnect.plugin}*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/consumers/${baseConfigKonnect.consumerId}/${baseConfigKonnect.plugin}*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(ConsumerCredentialList, {
+        props: {
+          cacheIdentifier: `consumer-credential-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-consumer-credentials-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.vue
@@ -313,18 +313,13 @@ const fetcherBaseUrl = computed((): string => {
   let url: string = `${props.config.apiBaseUrl}${endpoints.list[props.config.app]}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
-      .replace(/{consumerId}/gi, props.config.consumerId || '')
-      .replace(/{plugin}/gi, props.config.plugin || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{consumerId}/gi, props.config.consumerId || '')
-      .replace(/{plugin}/gi, props.config.plugin || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{consumerId}/gi, props.config.consumerId || '')
+    .replace(/{plugin}/gi, props.config.plugin || '')
 })
 
 const {

--- a/packages/entities/entities-consumer-credentials/src/consumer-credentials-endpoints.ts
+++ b/packages/entities/entities-consumer-credentials/src/consumer-credentials-endpoints.ts
@@ -1,6 +1,6 @@
 export default {
   list: {
-    konnect: '/v2/control-planes/{controlPlaneId}/core-entities/consumers/{consumerId}/{plugin}',
+    konnect: '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}/consumers/{consumerId}/{plugin}',
     kongManager: '/{workspace}/consumers/{consumerId}/{plugin}',
   },
 }

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-config-card.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-config-card.md
@@ -50,10 +50,10 @@ A config card component for consumer groups.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-form.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-form.md
@@ -53,10 +53,10 @@ A form component to create/edit Consumer Group.
     - Route to return to when canceling creation of a Consumer.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
+++ b/packages/entities/entities-consumer-groups/docs/consumer-group-list.md
@@ -92,10 +92,10 @@ A table component for consumer groups.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-consumer-groups/src/components/AddToGroupModal.vue
+++ b/packages/entities/entities-consumer-groups/src/components/AddToGroupModal.vue
@@ -81,7 +81,6 @@ const props = defineProps({
   visible: {
     type: Boolean,
     required: true,
-    default: false,
   },
 })
 
@@ -209,16 +208,12 @@ const submitUrl = computed((): string => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app].forConsumer}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{consumerId}/gi, props.config?.consumerId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{consumerId}/gi, props.config?.consumerId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{consumerId}/gi, props.config?.consumerId || '')
 })
 
 const addConsumerToGroup = async (consumerGroupId: string): Promise<any> => {

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.cy.ts
@@ -851,4 +851,82 @@ describe('<ConsumerGroupForm />', () => {
       cy.get('@onUpdateSpy').should('have.been.calledWith', expectedOutput)
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    const groupId = '973ed6f2-3da6-4dfb-8bd5-e4235b726bd5'
+
+    it('includes workspace in POST URL when creating with workspace config', () => {
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumers*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumer_groups`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createGroupWithWorkspace')
+
+      cy.mount(ConsumerGroupForm, {
+        props: { config: { ...konnectConfig, workspace: 'default' } },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createGroupWithWorkspace')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumers*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumer_groups/${groupId}?list_consumers=false` },
+        { statusCode: 200, body: { item: { id: groupId, name: 'test', tags: [] } } },
+      ).as('getGroupWithWorkspace')
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumer_groups/${groupId}/consumers*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getConsumersWithWorkspace')
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumer_groups/${groupId}`,
+        },
+        { statusCode: 200, body: {} },
+      ).as('updateGroupWithWorkspace')
+
+      cy.mount(ConsumerGroupForm, {
+        props: { config: { ...konnectConfig, workspace: 'default' }, consumerGroupId: groupId },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getGroupWithWorkspace')
+      cy.wait('@getConsumersWithWorkspace')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@updateGroupWithWorkspace')
+    })
+
+    it('omits workspace segment in POST URL when workspace is not provided', () => {
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/consumers*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/consumer_groups`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createGroupNoWorkspace')
+
+      cy.mount(ConsumerGroupForm, {
+        props: { config: konnectConfig },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createGroupNoWorkspace')
+    })
+  })
 })

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
@@ -123,9 +123,9 @@ const props = defineProps({
   },
   /** If a valid consumerGroupId is provided, it will put the form in Edit mode instead of Create */
   consumerGroupId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
   hideConsumers: {
     type: Boolean,
@@ -196,11 +196,11 @@ const getUrl = (action: ConsumerGroupActions, groupId = '', consumerId = ''): st
 
   if (props.config?.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config?.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  url = url.replace(/{id}/gi, groupId || props.consumerGroupId)
+  url = url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, (groupId || props.consumerGroupId) ?? '')
 
   if (action === 'addConsumer' || action === 'removeConsumer') {
     url = url.replace(/{consumerId}/gi, consumerId)
@@ -267,13 +267,13 @@ const emitError = (e: AxiosError): void => {
   emit('error', e as AxiosError)
 }
 
-const emitUpdate = (id = props.consumerGroupId): void => {
+const emitUpdate = (id = props.consumerGroupId ?? ''): void => {
   Object.assign(originalFields, state.fields)
 
   emit('update', { ...state.fields, id })
 }
 
-const handleConsumers = (results: any[] | undefined, message: string, groupId = props.consumerGroupId): void => {
+const handleConsumers = (results: any[] | undefined, message: string, groupId = props.consumerGroupId ?? ''): void => {
   const failed = results?.find(result => result.status !== 'fulfilled')
   if (failed) {
     emitError({

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -1229,4 +1229,90 @@ describe('<ConsumerGroupList />', () => {
         cy.getTestId(confirmationModalQuery).should('exist')
       })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    const wsConfig: KonnectConsumerGroupListConfig = {
+      app: 'konnect',
+      controlPlaneId: '1234-abcd-ilove-cats',
+      apiBaseUrl: '/us/kong-api',
+      isExactMatch: false,
+      createRoute: 'create-consumer-group',
+      getViewRoute: () => 'view-consumer-group',
+      getEditRoute: () => 'edit-consumer-group',
+    }
+
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...wsConfig, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsConfig.apiBaseUrl}/v2/control-planes/${wsConfig.controlPlaneId}/core-entities/default/consumer_groups*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...wsConfig, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsConfig.apiBaseUrl}/v2/control-planes/${wsConfig.controlPlaneId}/core-entities/my-workspace/consumer_groups*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsConfig.apiBaseUrl}/v2/control-planes/${wsConfig.controlPlaneId}/core-entities/consumer_groups*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(ConsumerGroupList, {
+        props: {
+          cacheIdentifier: `consumer-group-list-${uuidv4()}`,
+          config: wsConfig,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-consumer-groups-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -356,16 +356,12 @@ const fetcherBaseUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app][isConsumerPage.value ? 'forConsumer' : 'all']}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{consumerId}/gi, props.config?.consumerId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{consumerId}/gi, props.config?.consumerId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{consumerId}/gi, props.config?.consumerId || '')
 })
 
 const filterQuery = ref<string>('')
@@ -599,15 +595,12 @@ const hideExitGroupModal = (): void => {
 const removeUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app].oneForConsumer}`
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{consumerId}/gi, props.config?.consumerId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{consumerId}/gi, props.config?.consumerId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
+
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{consumerId}/gi, props.config?.consumerId || '')
 })
 const isRemovePending = ref(false)
 const exitGroups = async (): Promise<void> => {

--- a/packages/entities/entities-consumer-groups/src/consumer-groups-endpoints.ts
+++ b/packages/entities/entities-consumer-groups/src/consumer-groups-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {

--- a/packages/entities/entities-consumers/docs/consumer-config-card.md
+++ b/packages/entities/entities-consumers/docs/consumer-config-card.md
@@ -50,10 +50,10 @@ A form component for consumer.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-consumers/docs/consumer-form.md
+++ b/packages/entities/entities-consumers/docs/consumer-form.md
@@ -53,10 +53,10 @@ A form component to create/edit Consumer.
     - Route to return to when canceling creation of a Consumer.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-consumers/docs/consumer-list.md
+++ b/packages/entities/entities-consumers/docs/consumer-list.md
@@ -93,10 +93,10 @@ A table component for consumers.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-consumers/src/components/AddConsumerModal.vue
+++ b/packages/entities/entities-consumers/src/components/AddConsumerModal.vue
@@ -93,7 +93,6 @@ const props = defineProps({
   visible: {
     type: Boolean,
     required: true,
-    default: false,
   },
 })
 
@@ -210,7 +209,7 @@ const addConsumers = async (): Promise<void> => {
       selectedConsumers.value = []
       handleBulkError(results)
     }
-  } catch (_err: any) {
+  } catch {
     error.value = t('consumers.errors.add')
 
     // Emit the error event for the host app
@@ -223,16 +222,12 @@ const addConsumers = async (): Promise<void> => {
 const submitUrl = computed((): string => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app].forConsumerGroup}`
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{consumerGroupId}/gi, props.config?.consumerGroupId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{consumerGroupId}/gi, props.config?.consumerGroupId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{consumerGroupId}/gi, props.config?.consumerGroupId || '')
 })
 
 const addConsumerToGroup = async (consumerId: string): Promise<any> => {

--- a/packages/entities/entities-consumers/src/components/ConsumerForm.cy.ts
+++ b/packages/entities/entities-consumers/src/components/ConsumerForm.cy.ts
@@ -393,4 +393,66 @@ describe('<ConsumerForm/>', () => {
       })
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    const consumerId = '1234-1234-asdf-asdf'
+
+    it('includes workspace in POST URL when creating with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumers`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createConsumerWithWorkspace')
+
+      cy.mount(ConsumerForm, {
+        props: { config: { ...konnectConfig, workspace: 'default' } },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createConsumerWithWorkspace')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumers/${consumerId}`,
+        },
+        { statusCode: 200, body: {} },
+      )
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumers/${consumerId}`,
+        },
+        { statusCode: 200, body: {} },
+      ).as('updateConsumerWithWorkspace')
+
+      cy.mount(ConsumerForm, {
+        props: { config: { ...konnectConfig, workspace: 'default' }, consumerId },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@updateConsumerWithWorkspace')
+    })
+
+    it('omits workspace segment in POST URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/consumers`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createConsumerNoWorkspace')
+
+      cy.mount(ConsumerForm, {
+        props: { config: konnectConfig },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createConsumerNoWorkspace')
+    })
+  })
 })

--- a/packages/entities/entities-consumers/src/components/ConsumerForm.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerForm.vue
@@ -142,9 +142,9 @@ const props = defineProps({
   },
   /** If a valid consumerId is provided, it will put the form in Edit mode instead of Create */
   consumerId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
 })
 
@@ -209,13 +209,11 @@ const getUrl = (action: 'create' | 'edit'): string => {
 
   if (props.config?.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config?.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  url = url.replace(/{id}/gi, props.consumerId)
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, props.consumerId ?? '')
 }
 
 const isFormValid = computed((): boolean => !!state.fields.username || !!state.fields.customId)

--- a/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
@@ -1261,4 +1261,90 @@ describe('<ConsumerList />', () => {
         cy.getTestId(confirmationModalQuery).should('exist')
       })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    const wsConfig: KonnectConsumerListConfig = {
+      app: 'konnect',
+      controlPlaneId: '1234-abcd-ilove-cats',
+      apiBaseUrl: '/us/kong-api',
+      isExactMatch: false,
+      createRoute: 'create-consumer',
+      getViewRoute: () => 'view-consumer',
+      getEditRoute: () => 'edit-consumer',
+    }
+
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...wsConfig, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsConfig.apiBaseUrl}/v2/control-planes/${wsConfig.controlPlaneId}/core-entities/default/consumers*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(ConsumerList, {
+        props: {
+          cacheIdentifier: `consumer-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-consumers-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...wsConfig, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsConfig.apiBaseUrl}/v2/control-planes/${wsConfig.controlPlaneId}/core-entities/my-workspace/consumers*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(ConsumerList, {
+        props: {
+          cacheIdentifier: `consumer-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-consumers-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${wsConfig.apiBaseUrl}/v2/control-planes/${wsConfig.controlPlaneId}/core-entities/consumers*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(ConsumerList, {
+        props: {
+          cacheIdentifier: `consumer-list-${uuidv4()}`,
+          config: wsConfig,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-consumers-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -358,16 +358,12 @@ const fetcherBaseUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app][isConsumerGroupPage.value ? 'forConsumerGroup' : 'all']}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{consumerGroupId}/gi, props.config?.consumerGroupId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{consumerGroupId}/gi, props.config?.consumerGroupId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{consumerGroupId}/gi, props.config?.consumerGroupId || '')
 })
 
 const filterQuery = ref<string>('')
@@ -602,16 +598,12 @@ const removeUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app].oneForConsumerGroup}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{consumerGroupId}/gi, props.config?.consumerGroupId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{consumerGroupId}/gi, props.config?.consumerGroupId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{consumerGroupId}/gi, props.config?.consumerGroupId || '')
 })
 
 const isRemovePending = ref(false)

--- a/packages/entities/entities-consumers/src/consumers-endpoints.ts
+++ b/packages/entities/entities-consumers/src/consumers-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {


### PR DESCRIPTION
Expose the `workspace` prop to Konnect.

The `workspace` prop used to be available only in Kong Manager. We’re now introducing it to Konnect as well, so users can specify which (control plane, workspace) they want to work with when using Konnect.

In this commit, we are rolling it out in the `entities-consumers`, `entities-consumer-groups` and `entities-consumer-credentials` packages. It's safe because the `workspace` prop is still optional and will not take any effect when not specified.

Test were added to cover the new workspace prop

JIRA: [KM-2445]



[KM-2445]: https://konghq.atlassian.net/browse/KM-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ