### PR TITLE
fix(entities-shared): use unredacted command for decK customization editor

### DIFF
--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
@@ -90,7 +90,7 @@
     <component
       :is="DeckCommandEditor"
       v-else-if="props.entityRecord && props.isCustomizing && DeckCommandEditor"
-      v-model="deckCommand"
+      v-model="unredactedDeckCommand"
       :language="shell"
     />
 


### PR DESCRIPTION
Passing the unredacted `unredactedDeckCommand` to the decK customization editor instead.