### PR TITLE
feat(workspace): add workspace support to key-related entities

### DIFF
--- a/packages/entities/entities-key-sets/docs/key-set-config-card.md
+++ b/packages/entities/entities-key-sets/docs/key-set-config-card.md
@@ -50,10 +50,10 @@ A config card component for Key Sets.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-key-sets/docs/key-set-form.md
+++ b/packages/entities/entities-key-sets/docs/key-set-form.md
@@ -56,10 +56,10 @@ A form component for Key Sets.
     - Route to return to when canceling creation of a Key Set.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-key-sets/docs/key-set-list.md
+++ b/packages/entities/entities-key-sets/docs/key-set-list.md
@@ -68,10 +68,10 @@ A table component for key sets.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-key-sets/src/components/KeySetForm.cy.ts
+++ b/packages/entities/entities-key-sets/src/components/KeySetForm.cy.ts
@@ -374,4 +374,75 @@ describe('<KeySetForm />', () => {
       cy.get('@onUpdateSpy').should('have.been.calledOnce')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('includes workspace in GET URL when loading with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/key-sets/${keySet1.id}`,
+        },
+        { statusCode: 200, body: keySet1 },
+      ).as('getKeySetWithWorkspace')
+
+      cy.mount(KeySetForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          keySetId: keySet1.id,
+        },
+      })
+
+      cy.wait('@getKeySetWithWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/key-sets/${keySet1.id}`,
+        },
+        { statusCode: 200, body: keySet1 },
+      ).as('getKeySetWithWorkspace')
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/key-sets/${keySet1.id}`,
+        },
+        { statusCode: 200, body: keySet1 },
+      ).as('updateKeySetWithWorkspace')
+
+      cy.mount(KeySetForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          keySetId: keySet1.id,
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getKeySetWithWorkspace').then(() => {
+        cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+        cy.wait('@updateKeySetWithWorkspace')
+      })
+    })
+
+    it('omits workspace segment in GET URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/key-sets/${keySet1.id}`,
+        },
+        { statusCode: 200, body: keySet1 },
+      ).as('getKeySetNoWorkspace')
+
+      cy.mount(KeySetForm, {
+        props: {
+          config: baseConfigKonnect,
+          keySetId: keySet1.id,
+        },
+      })
+
+      cy.wait('@getKeySetNoWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+  })
 })

--- a/packages/entities/entities-key-sets/src/components/KeySetForm.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetForm.vue
@@ -96,9 +96,9 @@ const props = defineProps({
   },
   /** If a valid Key Set ID is provided, it will put the form in Edit mode instead of Create */
   keySetId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
 })
 
@@ -156,14 +156,11 @@ const submitUrl = computed<string>(() => {
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  // Always replace the id when editing
-  url = url.replace(/{id}/gi, props.keySetId)
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, props.keySetId ?? '') // Always replace the id when editing
 })
 
 const requestBody = computed((): Record<string, any> => {

--- a/packages/entities/entities-key-sets/src/components/KeySetList.cy.ts
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.cy.ts
@@ -761,4 +761,80 @@ describe('<KeySetList />', () => {
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/key-sets*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(KeySetList, {
+        props: {
+          cacheIdentifier: `key-set-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-key-sets-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/key-sets*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(KeySetList, {
+        props: {
+          cacheIdentifier: `key-set-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-key-sets-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/key-sets*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(KeySetList, {
+        props: {
+          cacheIdentifier: `key-set-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-key-sets-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -295,14 +295,11 @@ const fetcherBaseUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app]}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
 const filterQuery = ref<string>('')

--- a/packages/entities/entities-key-sets/src/key-sets-endpoints.ts
+++ b/packages/entities/entities-key-sets/src/key-sets-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {

--- a/packages/entities/entities-keys/docs/key-config-card.md
+++ b/packages/entities/entities-keys/docs/key-config-card.md
@@ -50,10 +50,10 @@ A config card component for Keys.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-keys/docs/key-form.md
+++ b/packages/entities/entities-keys/docs/key-form.md
@@ -56,10 +56,10 @@ A form component for Keys.
     - Route to return to when canceling creation of a Key.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-keys/docs/key-list.md
+++ b/packages/entities/entities-keys/docs/key-list.md
@@ -74,10 +74,10 @@ A table component for keys.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-keys/src/components/KeyConfigCard.vue
+++ b/packages/entities/entities-keys/src/components/KeyConfigCard.vue
@@ -191,14 +191,12 @@ watch(entityKeySetId, async () => {
 
   let url = `${props.config.apiBaseUrl}${fetchKeySetNameUrl.value}`
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{keySetId}/gi, entityKeySetId.value || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{keySetId}/gi, entityKeySetId.value || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
+
+  url = url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{keySetId}/gi, entityKeySetId.value || '')
 
   try {
     isKeySetNameLoading.value = true

--- a/packages/entities/entities-keys/src/components/KeyForm.cy.ts
+++ b/packages/entities/entities-keys/src/components/KeyForm.cy.ts
@@ -1119,4 +1119,73 @@ describe('<KeyForm />', () => {
       cy.get('@onUpdateSpy').should('have.been.calledOnce')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('includes workspace in POST URL when creating with workspace config', () => {
+      cy.intercept(
+        { method: 'GET', url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/key-sets*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/keys`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createKeyWithWorkspace')
+
+      cy.mount(KeyForm, {
+        props: { config: { ...baseConfigKonnect, workspace: 'default' } },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createKeyWithWorkspace')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        { method: 'GET', url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/key-sets*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        { method: 'GET', url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/keys/${key1.id}` },
+        { statusCode: 200, body: key1 },
+      )
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/keys/${key1.id}`,
+        },
+        { statusCode: 200, body: key1 },
+      ).as('updateKeyWithWorkspace')
+
+      cy.mount(KeyForm, {
+        props: { config: { ...baseConfigKonnect, workspace: 'default' }, keyId: key1.id },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@updateKeyWithWorkspace')
+    })
+
+    it('omits workspace segment in POST URL when workspace is not provided', () => {
+      cy.intercept(
+        { method: 'GET', url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/key-sets*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/keys`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createKeyNoWorkspace')
+
+      cy.mount(KeyForm, {
+        props: { config: baseConfigKonnect },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createKeyNoWorkspace')
+    })
+  })
 })

--- a/packages/entities/entities-keys/src/components/KeyForm.vue
+++ b/packages/entities/entities-keys/src/components/KeyForm.vue
@@ -232,9 +232,9 @@ const props = defineProps({
   },
   /** If a valid Key ID is provided, it will put the form in Edit mode instead of Create */
   keyId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
   /** Specific the keyset Id if the key entity is a scoped entity [both create and edit form] */
   keySetId: {
@@ -244,9 +244,9 @@ const props = defineProps({
   },
   /** Pre-select the Key Set field and mark it as read-only [create form only] */
   fixedKeySetId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
   /** Whether to provide x5t field in key form */
   showx5t: {
@@ -325,7 +325,7 @@ const isKeySetFieldClearable = computed<boolean>(() => !isKeySetFieldReadonly.va
 // In create form, set new props.fixedKeySetId to form.fields.key_set to apply the change and mark the field as read-only
 watch(() => props.fixedKeySetId, (newVal) => {
   if (formType.value === EntityBaseFormType.Create) {
-    form.fields.key_set = newVal
+    form.fields.key_set = newVal ?? ''
   }
 }, { immediate: true })
 
@@ -370,15 +370,12 @@ const submitUrl = computed<string>(() => {
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  // Always replace the id when editing
-  url = url.replace(/{id}/gi, props.keyId)
-    .replace(/{keySetId}/gi, props.keySetId || '')
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, props.keyId ?? '') // Always replace the id when editing
+    .replace(/{keySetId}/gi, props.keySetId || '') // Always replace the id when editing
 })
 
 const requestBody = computed((): Record<string, any> => {

--- a/packages/entities/entities-keys/src/components/KeyList.cy.ts
+++ b/packages/entities/entities-keys/src/components/KeyList.cy.ts
@@ -765,4 +765,80 @@ describe('<KeyList />', () => {
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/keys*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(KeyList, {
+        props: {
+          cacheIdentifier: `key-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-keys-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/keys*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(KeyList, {
+        props: {
+          cacheIdentifier: `key-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-keys-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/keys*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(KeyList, {
+        props: {
+          cacheIdentifier: `key-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-keys-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -301,16 +301,12 @@ const fetcherBaseUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app][props.config.keySetId ? 'forKeySet' : 'all']}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{keySetId}/gi, props.config?.keySetId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{keySetId}/gi, props.config?.keySetId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{keySetId}/gi, props.config?.keySetId || '')
 })
 
 const filterQuery = ref<string>('')

--- a/packages/entities/entities-keys/src/keys-endpoints.ts
+++ b/packages/entities/entities-keys/src/keys-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {


### PR DESCRIPTION
Expose the `workspace` prop to Konnect.

The `workspace` prop used to be available only in Kong Manager. We’re now introducing it to Konnect as well, so users can specify which (control plane, workspace) they want to work with when using Konnect.

In this commit, we are rolling it out in the `entities-keys` and `entities-key-sets` packages. It's safe because the `workspace` prop is still optional and will not take any effect when not specified.

Tests were added to cover the new `workspace` prop

JIRA: [KM-2445]


[KM-2445]: https://konghq.atlassian.net/browse/KM-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ