### PR TITLE
feat(workspace): add workspace support to cert-related entities

### DIFF
--- a/packages/entities/entities-certificates/docs/certificate-config-card.md
+++ b/packages/entities/entities-certificates/docs/certificate-config-card.md
@@ -50,10 +50,10 @@ A form component for Certificate.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-certificates/docs/certificate-form.md
+++ b/packages/entities/entities-certificates/docs/certificate-form.md
@@ -62,10 +62,10 @@ A form component for Certificates.
     - Route of listing SNIs.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-certificates/docs/certificate-list.md
+++ b/packages/entities/entities-certificates/docs/certificate-list.md
@@ -80,10 +80,10 @@ A table component for certificates.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-certificates/src/certificates-endpoints.ts
+++ b/packages/entities/entities-certificates/src/certificates-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {

--- a/packages/entities/entities-certificates/src/components/CertificateForm.cy.ts
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.cy.ts
@@ -636,4 +636,98 @@ describe('<CertificateForm />', () => {
       cy.wait('@createCertificate').its('response.statusCode').should('eq', 200)
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    const configWithWorkspace: KonnectCertificateFormConfig = {
+      ...baseConfigKonnect,
+      workspace: 'default',
+    }
+
+    const interceptGetWithWorkspace = (params?: { alias?: string }) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${configWithWorkspace.apiBaseUrl}/v2/control-planes/${configWithWorkspace.controlPlaneId}/core-entities/default/certificates/*`,
+        },
+        { statusCode: 200, body: certificate1 },
+      ).as(params?.alias ?? 'getCertificate')
+    }
+
+    it('uses workspace-scoped URL for certificate creation in Konnect', () => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${configWithWorkspace.apiBaseUrl}/v2/control-planes/${configWithWorkspace.controlPlaneId}/core-entities/default/certificates`,
+        },
+        handleCertificateCreateUpdate((request) => {
+          request.reply({ statusCode: 200, body: request.body })
+        }),
+      ).as('createCertificateWithWorkspace')
+
+      cy.mount(CertificateForm, {
+        props: { config: configWithWorkspace },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.getTestId('certificate-form-cert').type(certificate1.cert, { delay: 0 })
+      cy.getTestId('certificate-form-key').type(certificate1.key, { delay: 0 })
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+
+      cy.wait('@createCertificateWithWorkspace').its('response.statusCode').should('eq', 200)
+    })
+
+    it('uses workspace-scoped URL when updating a certificate in Konnect', () => {
+      interceptGetWithWorkspace()
+
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${configWithWorkspace.apiBaseUrl}/v2/control-planes/${configWithWorkspace.controlPlaneId}/core-entities/default/certificates/*`,
+        },
+        handleCertificateCreateUpdate((request) => {
+          request.reply({ statusCode: 200, body: request.body })
+        }),
+      ).as('updateCertificateWithWorkspace')
+
+      cy.mount(CertificateForm, {
+        props: {
+          config: configWithWorkspace,
+          certificateId: certificate1.id,
+          onUpdate: cy.spy().as('onUpdateSpy'),
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getCertificate')
+      cy.getTestId('certificate-form-tags').clear()
+      cy.getTestId('certificate-form-tags').type('workspace-tag')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+
+      cy.wait('@updateCertificateWithWorkspace').its('response.statusCode').should('eq', 200)
+      cy.get('@onUpdateSpy').should('have.been.calledOnce')
+    })
+
+    it('omits workspace segment in submit URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/certificates`,
+        },
+        handleCertificateCreateUpdate((request) => {
+          request.reply({ statusCode: 200, body: request.body })
+        }),
+      ).as('createCertificateNoWorkspace')
+
+      cy.mount(CertificateForm, {
+        props: { config: baseConfigKonnect },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.getTestId('certificate-form-cert').type(certificate1.cert, { delay: 0 })
+      cy.getTestId('certificate-form-key').type(certificate1.key, { delay: 0 })
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+
+      cy.wait('@createCertificateNoWorkspace').its('response.statusCode').should('eq', 200)
+    })
+  })
 })

--- a/packages/entities/entities-certificates/src/components/CertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.vue
@@ -184,9 +184,9 @@ const props = defineProps({
   },
   /** If a valid certificate ID is provided, it will put the form in Edit mode instead of Create */
   certificateId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
   /** If true, the SNI field will be shown */
   showSnisField: {
@@ -269,14 +269,11 @@ const submitUrl = computed<string>(() => {
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  // Always replace the id when editing
-  url = url.replace(/{id}/gi, props.certificateId)
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, props.certificateId ?? '') // Always replace the id when editing
 })
 
 const requestBody = computed((): Record<string, any> => {

--- a/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
+++ b/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
@@ -817,4 +817,88 @@ describe('<CertificateList />', () => {
       cy.get(rowWithVaultRef).find('[data-testid="cert"]').should('contain.text', certificateVaultRef)
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching certificates in Konnect', () => {
+      const configWithWorkspace: KonnectCertificateListConfig = {
+        ...baseConfigKonnect,
+        workspace: 'default',
+      }
+
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${configWithWorkspace.apiBaseUrl}/v2/control-planes/${configWithWorkspace.controlPlaneId}/core-entities/default/certificates*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getCertificatesWithWorkspace')
+
+      cy.mount(CertificateList, {
+        props: {
+          cacheIdentifier: `certificate-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getCertificatesWithWorkspace')
+      cy.get('.kong-ui-entities-certificates-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithMyWorkspace: KonnectCertificateListConfig = {
+        ...baseConfigKonnect,
+        workspace: 'my-workspace',
+      }
+
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${configWithMyWorkspace.apiBaseUrl}/v2/control-planes/${configWithMyWorkspace.controlPlaneId}/core-entities/my-workspace/certificates*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getCertificatesMyWorkspace')
+
+      cy.mount(CertificateList, {
+        props: {
+          cacheIdentifier: `certificate-list-${uuidv4()}`,
+          config: configWithMyWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getCertificatesMyWorkspace')
+      cy.get('.kong-ui-entities-certificates-list').should('be.visible')
+    })
+
+    it('omits workspace segment in fetch URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/certificates*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getCertificatesNoWorkspace')
+
+      cy.mount(CertificateList, {
+        props: {
+          cacheIdentifier: `certificate-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getCertificatesNoWorkspace')
+      cy.get('.kong-ui-entities-certificates-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -361,14 +361,11 @@ const fetcherBaseUrl = computed((): string => {
   let url: string = `${props.config.apiBaseUrl}${endpoints.list[props.config.app]}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
 const filterQuery = ref<string>('')

--- a/packages/entities/entities-snis/docs/sni-form.md
+++ b/packages/entities/entities-snis/docs/sni-form.md
@@ -56,10 +56,10 @@ A form component for SNIs.
     - Route to return to when canceling creation of an SNI.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-snis/docs/sni-list.md
+++ b/packages/entities/entities-snis/docs/sni-list.md
@@ -74,10 +74,10 @@ A table component for SNIs.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-snis/src/components/SniForm.cy.ts
+++ b/packages/entities/entities-snis/src/components/SniForm.cy.ts
@@ -651,4 +651,96 @@ describe('<SniForm />', {
       cy.get('@onUpdateSpy').should('have.been.calledOnce')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('includes workspace in GET URL when loading with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/certificates*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/snis/${sni1.id}`,
+        },
+        { statusCode: 200, body: sni1 },
+      ).as('getSniWithWorkspace')
+
+      cy.mount(SniForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          sniId: sni1.id,
+        },
+      })
+
+      cy.wait('@getSniWithWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/certificates*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/snis/${sni1.id}`,
+        },
+        { statusCode: 200, body: sni1 },
+      ).as('getSniWithWorkspace')
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/snis/${sni1.id}`,
+        },
+        { statusCode: 200, body: sni1 },
+      ).as('updateSniWithWorkspace')
+
+      cy.mount(SniForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          sniId: sni1.id,
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getSniWithWorkspace').then(() => {
+        cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+        cy.wait('@updateSniWithWorkspace')
+      })
+    })
+
+    it('omits workspace segment in GET URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/certificates*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/snis/${sni1.id}`,
+        },
+        { statusCode: 200, body: sni1 },
+      ).as('getSniNoWorkspace')
+
+      cy.mount(SniForm, {
+        props: {
+          config: baseConfigKonnect,
+          sniId: sni1.id,
+        },
+      })
+
+      cy.wait('@getSniNoWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+  })
 })

--- a/packages/entities/entities-snis/src/components/SniForm.vue
+++ b/packages/entities/entities-snis/src/components/SniForm.vue
@@ -145,9 +145,9 @@ const props = defineProps({
   },
   /** If a valid SNI ID is provided, it will put the form in Edit mode instead of Create */
   sniId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
 })
 
@@ -209,14 +209,11 @@ const submitUrl = computed<string>(() => {
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  // Always replace the id when editing
-  url = url.replace(/{id}/gi, props.sniId)
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, props.sniId ?? '') // Always replace the id when editing
 })
 
 const requestBody = computed((): Record<string, any> => {

--- a/packages/entities/entities-snis/src/components/SniList.cy.ts
+++ b/packages/entities/entities-snis/src/components/SniList.cy.ts
@@ -819,4 +819,80 @@ describe('<SniList />', () => {
       cy.wait('@getSnisRefetch')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/snis*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(SniList, {
+        props: {
+          cacheIdentifier: `sni-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-snis-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/snis*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(SniList, {
+        props: {
+          cacheIdentifier: `sni-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-snis-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/snis*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(SniList, {
+        props: {
+          cacheIdentifier: `sni-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-snis-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -329,14 +329,11 @@ const fetcherBaseUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app].all}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
 const filterQuery = ref<string>('')

--- a/packages/entities/entities-snis/src/snis-endpoints.ts
+++ b/packages/entities/entities-snis/src/snis-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {


### PR DESCRIPTION
Expose the `workspace` prop to Konnect.

The `workspace` prop used to be available only in Kong Manager. We’re now introducing it to Konnect as well, so users can specify which (control plane, workspace) they want to work with when using Konnect.

In this commit, we are rolling it out in the `entities-snis` and `entities-certificates` packages. It's safe because the `workspace` prop is still optional and will not take any effect when not specified.

CA certificates are not workspace-scoped, so we are not modifying related components.

Tests were added to cover the new `workspace` prop

JIRA: [KM-2445]


[KM-2445]: https://konghq.atlassian.net/browse/KM-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ