### PR TITLE
feat(workspace): add workspace support to vault & upstream target entities

### DIFF
--- a/packages/entities/entities-upstreams-targets/docs/target-form.md
+++ b/packages/entities/entities-upstreams-targets/docs/target-form.md
@@ -51,10 +51,10 @@ A form component for targets. Comes with [`TargetsList` component](../src/compon
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-upstreams-targets/docs/targets-list.md
+++ b/packages/entities/entities-upstreams-targets/docs/targets-list.md
@@ -65,10 +65,10 @@ A table component for targets. Includes target create/edit form modal out of the
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-upstreams-targets/docs/upstreams-config-card.md
+++ b/packages/entities/entities-upstreams-targets/docs/upstreams-config-card.md
@@ -50,10 +50,10 @@ A config card component for Upstream.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-upstreams-targets/docs/upstreams-form.md
+++ b/packages/entities/entities-upstreams-targets/docs/upstreams-form.md
@@ -58,10 +58,10 @@ A form component to create/edit Upstreams.
     - If `true`, the sticky sessions algorithm is supported.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-upstreams-targets/docs/upstreams-list.md
+++ b/packages/entities/entities-upstreams-targets/docs/upstreams-list.md
@@ -75,10 +75,10 @@ A table component for upstreams.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-upstreams-targets/src/components/TargetForm.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetForm.cy.ts
@@ -346,4 +346,69 @@ describe('<TargetForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       cy.getTestId('info-slot').should('be.visible').should('contain', infoSlotContent)
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('includes workspace in GET URL when loading with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/upstreams/${upstreamId}/targets/${target.id}`,
+        },
+        { statusCode: 200, body: target },
+      ).as('getTargetWithWorkspace')
+
+      cy.mount(TargetForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          isVisible: true,
+          targetId: target.id,
+        },
+      })
+
+      cy.wait('@getTargetWithWorkspace')
+      cy.get('.kong-ui-entities-target-form').should('be.visible')
+    })
+
+    it('uses non-default workspace name in GET URL', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/upstreams/${upstreamId}/targets/${target.id}`,
+        },
+        { statusCode: 200, body: target },
+      ).as('getTargetWithMyWorkspace')
+
+      cy.mount(TargetForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'my-workspace' },
+          isVisible: true,
+          targetId: target.id,
+        },
+      })
+
+      cy.wait('@getTargetWithMyWorkspace')
+      cy.get('.kong-ui-entities-target-form').should('be.visible')
+    })
+
+    it('omits workspace segment in GET URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/upstreams/${upstreamId}/targets/${target.id}`,
+        },
+        { statusCode: 200, body: target },
+      ).as('getTargetNoWorkspace')
+
+      cy.mount(TargetForm, {
+        props: {
+          config: baseConfigKonnect,
+          isVisible: true,
+          targetId: target.id,
+        },
+      })
+
+      cy.wait('@getTargetNoWorkspace')
+      cy.get('.kong-ui-entities-target-form').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetForm.vue
@@ -140,13 +140,12 @@ const props = defineProps({
   isVisible: {
     type: Boolean,
     required: true,
-    default: false,
   },
   /** If a valid Target ID is provided, it will put the form in Edit mode instead of Create */
   targetId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
   failoverEnabled: {
     type: Boolean,
@@ -243,15 +242,13 @@ const submitUrl = computed((): string => {
   let url = `${props.config.apiBaseUrl}${endpoints.form[props.config.app][formType.value]}`
 
   if (props.config.app === 'konnect') {
-    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '').replace(/{upstreamId}/gi, props.config?.upstreamId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '').replace(/{upstreamId}/gi, props.config?.upstreamId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
-  // Replace the id when editing
-  url = url.replace(/{id}/gi, props.targetId)
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{upstreamId}/gi, props.config?.upstreamId || '')
+    .replace(/{id}/gi, props.targetId ?? '') // Replace the id when editing
 })
 
 const requestBody = computed((): Record<string, any> => {

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.cy.ts
@@ -829,4 +829,80 @@ describe('<TargetsList />', () => {
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/upstreams/${baseConfigKonnect.upstreamId}/targets*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(TargetsList, {
+        props: {
+          cacheIdentifier: `targets-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-targets-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/upstreams/${baseConfigKonnect.upstreamId}/targets*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(TargetsList, {
+        props: {
+          cacheIdentifier: `targets-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-targets-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/upstreams/${baseConfigKonnect.upstreamId}/targets*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(TargetsList, {
+        props: {
+          cacheIdentifier: `targets-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-targets-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.vue
@@ -269,16 +269,12 @@ const fetcherBaseUrl = computed((): string => {
   let url: string = `${props.config.apiBaseUrl}${endpoints.list[props.config.app]}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-      .replace(/{upstreamId}/gi, props.config?.upstreamId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
-      .replace(/{upstreamId}/gi, props.config?.upstreamId || '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{upstreamId}/gi, props.config?.upstreamId || '')
 })
 
 const {

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.cy.ts
@@ -902,4 +902,85 @@ describe('<UpstreamsForm/>', { viewportHeight: 700, viewportWidth: 700 }, () => 
       })
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('includes workspace in POST URL when creating with workspace config', () => {
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/services*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/certificates*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/upstreams`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createUpstreamWithWorkspace')
+
+      cy.mount(UpstreamsForm, {
+        props: { config: { ...konnectConfig, workspace: 'default' } },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createUpstreamWithWorkspace')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/services*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/certificates*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/upstreams/${upstreamsResponse.id}` },
+        { statusCode: 200, body: upstreamsResponse },
+      )
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/upstreams/${upstreamsResponse.id}`,
+        },
+        { statusCode: 200, body: upstreamsResponse },
+      ).as('updateUpstreamWithWorkspace')
+
+      cy.mount(UpstreamsForm, {
+        props: { config: { ...konnectConfig, workspace: 'default' }, upstreamId: upstreamsResponse.id },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@updateUpstreamWithWorkspace')
+    })
+
+    it('omits workspace segment in POST URL when workspace is not provided', () => {
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/services*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/certificates*` },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/upstreams`,
+        },
+        { statusCode: 201, body: {} },
+      ).as('createUpstreamNoWorkspace')
+
+      cy.mount(UpstreamsForm, {
+        props: { config: konnectConfig },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createUpstreamNoWorkspace')
+    })
+  })
 })

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsForm.vue
@@ -142,9 +142,9 @@ const props = defineProps({
   },
   /** If a valid upstreamId is provided, it will put the form in Edit mode instead of Create */
   upstreamId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
 })
 
@@ -480,13 +480,11 @@ const getUrl = (action: UpstreamsFormActions): string => {
 
   if (props.config?.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config?.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  url = url.replace(/{id}/gi, props.upstreamId)
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, props.upstreamId ?? '')
 }
 
 const submitData = async (): Promise<void> => {

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.cy.ts
@@ -764,4 +764,80 @@ describe('<UpstreamsList />', () => {
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/upstreams*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(UpstreamsList, {
+        props: {
+          cacheIdentifier: `upstreams-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-upstreams-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/upstreams*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(UpstreamsList, {
+        props: {
+          cacheIdentifier: `upstreams-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-upstreams-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/upstreams*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(UpstreamsList, {
+        props: {
+          cacheIdentifier: `upstreams-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-upstreams-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -293,14 +293,11 @@ const fetcherBaseUrl = computed((): string => {
   let url: string = `${props.config.apiBaseUrl}${endpoints.list[props.config.app]}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
 const filterQuery = ref<string>('')

--- a/packages/entities/entities-upstreams-targets/src/targets-endpoints.ts
+++ b/packages/entities/entities-upstreams-targets/src/targets-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {

--- a/packages/entities/entities-upstreams-targets/src/upstreams-endpoints.ts
+++ b/packages/entities/entities-upstreams-targets/src/upstreams-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {

--- a/packages/entities/entities-vaults/docs/vault-config-card.md
+++ b/packages/entities/entities-vaults/docs/vault-config-card.md
@@ -50,10 +50,10 @@ A config card component for Vaults.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-vaults/docs/vault-form.md
+++ b/packages/entities/entities-vaults/docs/vault-form.md
@@ -56,10 +56,10 @@ A form component for Vaults.
     - Route to return to when canceling creation of an Vault.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-vaults/docs/vault-list.md
+++ b/packages/entities/entities-vaults/docs/vault-list.md
@@ -72,10 +72,10 @@ A table component for vaults.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-vaults/src/components/SecretForm.cy.ts
+++ b/packages/entities/entities-vaults/src/components/SecretForm.cy.ts
@@ -178,4 +178,102 @@ describe('<SecretForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       cy.get('.kong-ui-entities-secret-form form').should('not.exist')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('includes workspace in vault and POST URLs when creating with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults/${vaultId}`,
+        },
+        { statusCode: 200, body: { config: { config_store_id: configStoreId } } },
+      ).as('getVaultWithWorkspace')
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/default/config-stores/${configStoreId}/secrets`,
+        },
+        { statusCode: 201, body: secret },
+      ).as('createSecretWithWorkspace')
+
+      cy.mount(SecretForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          vaultId,
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getVaultWithWorkspace').then(() => {
+        cy.get('@vueWrapper').then(wrapper => wrapper.findComponent({ name: 'EntityBaseForm' }).vm.$emit('submit'))
+        cy.wait('@createSecretWithWorkspace')
+      })
+    })
+
+    it('includes workspace in vault and GET/PUT URLs when editing with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults/${vaultId}`,
+        },
+        { statusCode: 200, body: { config: { config_store_id: configStoreId } } },
+      ).as('getVaultWithWorkspace')
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/default/config-stores/${configStoreId}/secrets/${secret.key}`,
+        },
+        { statusCode: 200, body: secret },
+      ).as('getSecretWithWorkspace')
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/default/config-stores/${configStoreId}/secrets/${secret.key}`,
+        },
+        { statusCode: 200, body: secret },
+      ).as('updateSecretWithWorkspace')
+
+      cy.mount(SecretForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          vaultId,
+          secretId: secret.key,
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getVaultWithWorkspace')
+      cy.wait('@getSecretWithWorkspace').then(() => {
+        cy.get('@vueWrapper').then(wrapper => wrapper.findComponent({ name: 'EntityBaseForm' }).vm.$emit('submit'))
+        cy.wait('@updateSecretWithWorkspace')
+      })
+    })
+
+    it('omits workspace segment in vault and POST URLs when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/vaults/${vaultId}`,
+        },
+        { statusCode: 200, body: { config: { config_store_id: configStoreId } } },
+      ).as('getVaultNoWorkspace')
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/config-stores/${configStoreId}/secrets`,
+        },
+        { statusCode: 201, body: secret },
+      ).as('createSecretNoWorkspace')
+
+      cy.mount(SecretForm, {
+        props: {
+          config: baseConfigKonnect,
+          vaultId,
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getVaultNoWorkspace').then(() => {
+        cy.get('@vueWrapper').then(wrapper => wrapper.findComponent({ name: 'EntityBaseForm' }).vm.$emit('submit'))
+        cy.wait('@createSecretNoWorkspace')
+      })
+    })
+  })
 })

--- a/packages/entities/entities-vaults/src/components/SecretForm.vue
+++ b/packages/entities/entities-vaults/src/components/SecretForm.vue
@@ -73,6 +73,7 @@ const configStoreId = ref<string>('')
 const fetchVaultUrl = computed<string>(() => {
   return `${props.config.apiBaseUrl}${endpoints.getVault[props.config.app]}`
     .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
     .replace(/{id}/gi, props.vaultId)
 })
 

--- a/packages/entities/entities-vaults/src/components/SecretFormInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretFormInner.vue
@@ -159,6 +159,7 @@ const formType = computed((): EntityBaseFormType => props.secretId
 const submitUrl = computed<string>(() => {
   return `${props.config.apiBaseUrl}${endpoints.form[props.config.app][formType.value]}`
     .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
     .replace(/{id}/gi, props.configStoreId)
     .replace(/{secretId}/gi, props.secretId)
 })

--- a/packages/entities/entities-vaults/src/components/SecretList.cy.ts
+++ b/packages/entities/entities-vaults/src/components/SecretList.cy.ts
@@ -426,4 +426,71 @@ describe('<SecretList />', () => {
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URLs for vault and secrets when workspace is provided', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults/${vaultId}`,
+        },
+        { statusCode: 200, body: { config: { config_store_id: configStoreId } } },
+      ).as('getVaultWithWorkspace')
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/default/config-stores/${configStoreId}/secrets*`,
+        },
+        { statusCode: 200, body: secrets },
+      ).as('getSecretsWithWorkspace')
+
+      cy.mount(SecretList, {
+        props: {
+          cacheIdentifier: `secret-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          vaultId,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+        },
+      })
+
+      cy.wait('@getVaultWithWorkspace')
+      cy.wait('@getSecretsWithWorkspace')
+      cy.get('.kong-ui-entities-secrets-list').should('be.visible')
+    })
+
+    it('omits workspace segment in both URLs when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/vaults/${vaultId}`,
+        },
+        { statusCode: 200, body: { config: { config_store_id: configStoreId } } },
+      ).as('getVaultNoWorkspace')
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/config-stores/${configStoreId}/secrets*`,
+        },
+        { statusCode: 200, body: secrets },
+      ).as('getSecretsNoWorkspace')
+
+      cy.mount(SecretList, {
+        props: {
+          cacheIdentifier: `secret-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          vaultId,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+        },
+      })
+
+      cy.wait('@getVaultNoWorkspace')
+      cy.wait('@getSecretsNoWorkspace')
+      cy.get('.kong-ui-entities-secrets-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-vaults/src/components/SecretList.vue
+++ b/packages/entities/entities-vaults/src/components/SecretList.vue
@@ -86,6 +86,7 @@ const configStoreId = ref<string>('')
 const fetchVaultUrl = computed<string>(() => {
   return `${props.config.apiBaseUrl}${endpoints.getVault[props.config.app]}`
     .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
     .replace(/{id}/gi, props.vaultId)
 })
 

--- a/packages/entities/entities-vaults/src/components/SecretListInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretListInner.vue
@@ -191,6 +191,7 @@ const rowAttrs = (row: Record<string, any>) => ({
 const fetcherBaseUrl = computed<string>(() => {
   return `${props.config.apiBaseUrl}${endpoints.list[props.config.app]}`
     .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
     .replace(/{id}/gi, props.configStoreId || '')
 })
 

--- a/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
+++ b/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
@@ -1099,4 +1099,75 @@ describe('<VaultForm />', () => {
       cy.get('@onUpdateSpy').should('have.been.calledOnce')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('includes workspace in GET URL when loading with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults/${vault.id}`,
+        },
+        { statusCode: 200, body: vault },
+      ).as('getVaultWithWorkspace')
+
+      cy.mount(VaultForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          vaultId: vault.id,
+        },
+      })
+
+      cy.wait('@getVaultWithWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults/${vault.id}`,
+        },
+        { statusCode: 200, body: vault },
+      ).as('getVaultWithWorkspace')
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults/${vault.id}`,
+        },
+        { statusCode: 200, body: vault },
+      ).as('updateVaultWithWorkspace')
+
+      cy.mount(VaultForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+          vaultId: vault.id,
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getVaultWithWorkspace').then(() => {
+        cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+        cy.wait('@updateVaultWithWorkspace')
+      })
+    })
+
+    it('omits workspace segment in GET URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/vaults/${vault.id}`,
+        },
+        { statusCode: 200, body: vault },
+      ).as('getVaultNoWorkspace')
+
+      cy.mount(VaultForm, {
+        props: {
+          config: baseConfigKonnect,
+          vaultId: vault.id,
+        },
+      })
+
+      cy.wait('@getVaultNoWorkspace')
+      cy.getTestId('form-fetch-error').should('not.exist')
+    })
+  })
 })

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -990,9 +990,9 @@ const props = defineProps({
   },
   /** If a valid vaultId is provided, it will put the form in Edit mode instead of Create */
   vaultId: {
-    type: String,
+    type: String as PropType<string | null>,
     required: false,
-    default: '',
+    default: null,
   },
 })
 
@@ -1483,14 +1483,11 @@ const submitUrl = computed<string>(() => {
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  // Always replace the id when editing
-  url = url.replace(/{id}/gi, props.vaultId)
-
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, props.vaultId ?? '') // Always replace the id when editing
 })
 
 const getPayload = computed((): Record<string, any> => {

--- a/packages/entities/entities-vaults/src/components/VaultList.cy.ts
+++ b/packages/entities/entities-vaults/src/components/VaultList.cy.ts
@@ -757,4 +757,80 @@ describe('<VaultList />', () => {
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(VaultList, {
+        props: {
+          cacheIdentifier: `vault-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+      cy.get('.kong-ui-entities-vaults-list').should('be.visible')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/vaults*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(VaultList, {
+        props: {
+          cacheIdentifier: `vault-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+      cy.get('.kong-ui-entities-vaults-list').should('be.visible')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/vaults*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(VaultList, {
+        props: {
+          cacheIdentifier: `vault-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+      cy.get('.kong-ui-entities-vaults-list').should('be.visible')
+    })
+  })
 })

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -306,14 +306,11 @@ const fetcherBaseUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app].getAll}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
 const filterQuery = ref<string>('')

--- a/packages/entities/entities-vaults/src/components/VaultSecretPicker.vue
+++ b/packages/entities/entities-vaults/src/components/VaultSecretPicker.vue
@@ -290,12 +290,11 @@ const buildVaultFetchUrl = (vaultPrefix: string) => {
 
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
   }
 
-  // Replacing {id} with the prefix because /vaults/:prefix is allowed
-  return url.replace(/{id}/gi, vaultPrefix)
+  return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    .replace(/{id}/gi, vaultPrefix) // Replacing {id} with the prefix because /vaults/:prefix is allowed
 }
 
 const buildSecretFetchUrl = (secretId: string, configStoreId: string) => {
@@ -306,6 +305,7 @@ const buildSecretFetchUrl = (secretId: string, configStoreId: string) => {
 
   return `${props.config.apiBaseUrl}${secretsEndpoints.form[props.config.app].edit}`
     .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
     .replace(/{id}/gi, configStoreId)
     .replace(/{secretId}/gi, secretId)
 }

--- a/packages/entities/entities-vaults/src/secrets-endpoints.ts
+++ b/packages/entities/entities-vaults/src/secrets-endpoints.ts
@@ -1,17 +1,18 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
+const konnectConfigStoreApiUrl = '/v2/control-planes/{controlPlaneId}/{workspace}/config-stores'
 
 // secrets are only available in Konnect config store
 export default {
   getVault: {
-    konnect: `${konnectBaseApiUrl}/core-entities/vaults/{id}`,
+    konnect: `${konnectBaseApiUrl}/vaults/{id}`,
   },
   list: {
-    konnect: `${konnectBaseApiUrl}/config-stores/{id}/secrets`,
+    konnect: `${konnectConfigStoreApiUrl}/{id}/secrets`,
   },
   form: {
     konnect: {
-      create: `${konnectBaseApiUrl}/config-stores/{id}/secrets`,
-      edit: `${konnectBaseApiUrl}/config-stores/{id}/secrets/{secretId}`,
+      create: `${konnectConfigStoreApiUrl}/{id}/secrets`,
+      edit: `${konnectConfigStoreApiUrl}/{id}/secrets/{secretId}`,
     },
   },
 }

--- a/packages/entities/entities-vaults/src/vaults-endpoints.ts
+++ b/packages/entities/entities-vaults/src/vaults-endpoints.ts
@@ -1,5 +1,5 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
-const konnectConfigStoreApiUrl = '/v2/control-planes/{controlPlaneId}/config-stores'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
+const konnectConfigStoreApiUrl = '/v2/control-planes/{controlPlaneId}/{workspace}/config-stores'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {


### PR DESCRIPTION
Expose the `workspace` prop to Konnect.

The `workspace` prop used to be available only in Kong Manager. We’re now introducing it to Konnect as well, so users can specify which (control plane, workspace) they want to work with when using Konnect.

In this commit, we are rolling it out in the `entities-vaults` and `entities-upstreams-targets` packages. It's safe because the `workspace` prop is still optional and will not take any effect when not specified.

Tests were added to cover the new `workspace` prop

JIRA: [KM-2445]


[KM-2445]: https://konghq.atlassian.net/browse/KM-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ