### PR TITLE
feat(workspace): add workspace support to redis configuration

### DIFF
--- a/packages/core/forms/src/components/RedisConfigSelect.vue
+++ b/packages/core/forms/src/components/RedisConfigSelect.vue
@@ -121,8 +121,8 @@ const redisPartialFetcherKey: Ref<number, number> | undefined = inject(REDIS_PAR
 
 const endpoints = {
   konnect: {
-    getOne: '/v2/control-planes/{controlPlaneId}/core-entities/partials/{id}',
-    getAll: '/v2/control-planes/{controlPlaneId}/core-entities/partials',
+    getOne: '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}/partials/{id}',
+    getAll: '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}/partials',
   },
   kongManager: {
     getOne: '/{workspace}/partials/{id}',
@@ -213,11 +213,12 @@ const getOnePartialUrl = (partialId: string | number): string => {
 
   if (formConfig.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, formConfig?.controlPlaneId || '')
-  } else if (formConfig.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, formConfig?.workspace ? `/${formConfig.workspace}` : '')
   }
-  // Always replace the id when editing
-  url = url.replace(/{id}/gi, String(partialId))
+
+  url = url
+    .replace(/\/{workspace}/gi, formConfig?.workspace ? `/${formConfig.workspace}` : '')
+    .replace(/{id}/gi, String(partialId)) // Always replace the id when editing
+
   return url
 }
 

--- a/packages/entities/entities-redis-configurations/docs/redis-configuration-config-card.md
+++ b/packages/entities/entities-redis-configurations/docs/redis-configuration-config-card.md
@@ -50,10 +50,10 @@ A config card component for Redis Configurations.
     - An optional configuration object for the underlying Axios request.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-redis-configurations/docs/redis-configuration-form.md
+++ b/packages/entities/entities-redis-configurations/docs/redis-configuration-form.md
@@ -58,10 +58,10 @@ A form component for Redis Configurations.
     - Route to return to when canceling creation of a redis configuration.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `controlPlaneId`:
     - type: `string`

--- a/packages/entities/entities-redis-configurations/docs/redis-configuration-list.md
+++ b/packages/entities/entities-redis-configurations/docs/redis-configuration-list.md
@@ -74,10 +74,10 @@ A table component for Redis Configurations.
     - Additional message to show when there are no records.
 
   - `workspace`:
-    - type: `string`
-    - required: `true`
+    - type: `string` for Kong Manager, `string | null` for Konnect
+    - required: `true` for Kong Manager, `false` for Konnect
     - default: `undefined`
-    - *Specific to Kong Manager*. Name of the current workspace.
+    - Name of the current workspace.
 
   - `isExactMatch`:
     - type: `boolean`

--- a/packages/entities/entities-redis-configurations/src/components/LinkedPluginListModal.vue
+++ b/packages/entities/entities-redis-configurations/src/components/LinkedPluginListModal.vue
@@ -46,7 +46,6 @@ defineProps({
   visible: {
     type: Boolean,
     required: true,
-    default: false,
   },
 })
 

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.cy.ts
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationForm.cy.ts
@@ -1202,4 +1202,75 @@ describe('<RedisConfigurationForm />', {
     })
 
   }
+
+  describe('Konnect - workspace URL building', () => {
+    const partialId = 'workspace-test-partial-id'
+
+    it('includes workspace in POST URL when creating with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/partials`,
+        },
+        { statusCode: 201, body: { id: partialId } },
+      ).as('createPartialWithWorkspace')
+
+      cy.mount(RedisConfigurationForm, {
+        props: { config: { ...baseConfigKonnect, workspace: 'default' } },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent({ name: 'EntityBaseForm' }).vm.$emit('submit'))
+      cy.wait('@createPartialWithWorkspace')
+    })
+
+    it('includes workspace in PUT URL when editing with workspace config', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/partials/${partialId}`,
+        },
+        { statusCode: 200, body: redisConfigurationCE },
+      ).as('getPartialWithWorkspace')
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/partials/${partialId}/links*`,
+        },
+        { statusCode: 200, body: { data: [], next: null, count: 0 } },
+      )
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/partials/${partialId}`,
+        },
+        { statusCode: 200, body: redisConfigurationCE },
+      ).as('updatePartialWithWorkspace')
+
+      cy.mount(RedisConfigurationForm, {
+        props: { config: { ...baseConfigKonnect, workspace: 'default' }, partialId },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.wait('@getPartialWithWorkspace').then(() => {
+        cy.get('@vueWrapper').then(wrapper => wrapper.findComponent({ name: 'EntityBaseForm' }).vm.$emit('submit'))
+        cy.wait('@updatePartialWithWorkspace')
+      })
+    })
+
+    it('omits workspace segment in POST URL when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/partials`,
+        },
+        { statusCode: 201, body: { id: partialId } },
+      ).as('createPartialNoWorkspace')
+
+      cy.mount(RedisConfigurationForm, {
+        props: { config: baseConfigKonnect },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent({ name: 'EntityBaseForm' }).vm.$emit('submit'))
+      cy.wait('@createPartialNoWorkspace')
+    })
+  })
 })

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.cy.ts
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.cy.ts
@@ -631,4 +631,77 @@ describe('<RedisConfigurationList />', () => {
       cy.get('tr [data-testid="self-managed-config"]').should('not.exist')
     })
   })
+
+  describe('Konnect - workspace URL building', () => {
+    it('uses workspace-scoped URL when fetching with workspace', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/partials*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithWorkspace')
+
+      cy.mount(RedisConfigurationList, {
+        props: {
+          cacheIdentifier: `redis-configuration-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithWorkspace')
+    })
+
+    it('uses non-default workspace name in fetch URL', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'my-workspace' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/my-workspace/partials*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getWithMyWorkspace')
+
+      cy.mount(RedisConfigurationList, {
+        props: {
+          cacheIdentifier: `redis-configuration-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getWithMyWorkspace')
+    })
+
+    it('omits workspace segment when workspace is not provided', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/partials*`,
+        },
+        { statusCode: 200, body: { data: [], total: 0 } },
+      ).as('getNoWorkspace')
+
+      cy.mount(RedisConfigurationList, {
+        props: {
+          cacheIdentifier: `redis-configuration-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getNoWorkspace')
+    })
+  })
 })

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.vue
@@ -363,14 +363,11 @@ const fetcherBaseUrl = computed<string>(() => {
   let url = `${props.config.apiBaseUrl}${endpoints.list[props.config.app]}`
 
   if (props.config.app === 'konnect') {
-    url = url
-      .replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
-  } else if (props.config.app === 'kongManager') {
-    url = url
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+    url = url.replace(/{controlPlaneId}/gi, props.config?.controlPlaneId || '')
   }
 
   return url
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
 const linkedPluginsModalVisible = ref<boolean>(false)

--- a/packages/entities/entities-redis-configurations/src/composables/useLinkedPlugins.ts
+++ b/packages/entities/entities-redis-configurations/src/composables/useLinkedPlugins.ts
@@ -27,12 +27,11 @@ export const useLinkedPluginsFetcher = (config: KonnectConfig | KongManagerConfi
 
       if (config.app === 'konnect') {
         url = url.replace(/{controlPlaneId}/gi, config?.controlPlaneId || '')
-      } else if (config.app === 'kongManager') {
-        url = url.replace(/\/{workspace}/gi, config?.workspace ? `/${config.workspace}` : '')
       }
 
-      // Always replace the id when editing
-      url = url.replace(/{id}/gi, partialId || '')
+      url = url
+        .replace(/\/{workspace}/gi, config?.workspace ? `/${config.workspace}` : '')
+        .replace(/{id}/gi, partialId || '') // Always replace the id when editing
 
       if (query) {
         url = `${url}?${query}`

--- a/packages/entities/entities-redis-configurations/src/composables/useRedisConfigurationForm.ts
+++ b/packages/entities/entities-redis-configurations/src/composables/useRedisConfigurationForm.ts
@@ -242,12 +242,11 @@ export const useRedisConfigurationForm = (options: Options) => {
 
     if (config.app === 'konnect') {
       url = url.replace(/{controlPlaneId}/gi, config?.controlPlaneId || '')
-    } else if (config.app === 'kongManager') {
-      url = url.replace(/\/{workspace}/gi, config?.workspace ? `/${config.workspace}` : '')
     }
 
-    // Always replace the id when editing
-    url = url.replace(/{id}/gi, partialId || '')
+    url = url
+      .replace(/\/{workspace}/gi, config?.workspace ? `/${config.workspace}` : '')
+      .replace(/{id}/gi, partialId || '') // Always replace the id when editing
 
     return url
   })

--- a/packages/entities/entities-redis-configurations/src/partials-endpoints.ts
+++ b/packages/entities/entities-redis-configurations/src/partials-endpoints.ts
@@ -1,4 +1,4 @@
-const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
+const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {


### PR DESCRIPTION
Expose the `workspace` prop to Konnect.

The `workspace` prop used to be available only in Kong Manager. We’re now introducing it to Konnect as well, so users can specify which (control plane, workspace) they want to work with when using Konnect.

In this commit, we are rolling it out in the `@kong-ui-public/forms` and `entities-redis-configurations` packages. It's safe because the `workspace` prop is still optional and will not take any effect when not specified.

Tests were added to cover the new `workspace` prop

JIRA: [KM-2445]


[KM-2445]: https://konghq.atlassian.net/browse/KM-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ