### PR TITLE
fix: use design token colors for status code colors

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/BarChartDemo.vue
@@ -213,9 +213,7 @@ import {
 } from '../../src'
 import type { AnalyticsExploreRecord, DimensionMap, ExploreResultV4, QueryResponseMeta } from '@kong-ui-public/analytics-utilities'
 import type { AnalyticsChartColors, AnalyticsChartOptions } from '../../src/types'
-import { isValidJson, rand } from '../utils/utils'
-import { lookupDatavisColor } from '../../src/utils'
-import { lookupStatusCodeColor } from '../../src/utils/customColors'
+import { getStatusCodeDatasetColor, isValidJson, rand } from '../utils/utils'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
 import { generateCrossSectionalData } from '@kong-ui-public/analytics-utilities'
 import CodeText from '../CodeText.vue'
@@ -277,7 +275,7 @@ const dimensionItems = [{
 
 // Short labels
 const statusCodeLabels = [
-  '500', '200', '300', '400', 'empty',
+  '500', '200', '300', '400', '____OTHER____', 'empty',
 ]
 
 const statusCodeDimensionValues = ref(new Set(statusCodeLabels))
@@ -336,7 +334,7 @@ const exploreResult = computed<ExploreResultV4>(() => {
   }
 })
 
-const colorPalette = ref<AnalyticsChartColors>([...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: lookupStatusCodeColor(dimension) || lookupDatavisColor(rand(0, 5)) }), {}))
+const colorPalette = ref<AnalyticsChartColors>([...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: getStatusCodeDatasetColor(dimension) }), {}))
 
 const updateSelectedColor = (event: Event, label: string) => {
   colorPalette.value[label] = (event.target as HTMLInputElement).value
@@ -354,7 +352,7 @@ const addDataset = () => {
   if (multiDimensionToggle.value) {
     const statusCode = `${rand(100, 599)}`
     statusCodeDimensionValues.value.add(statusCode)
-    colorPalette.value[statusCode] = lookupStatusCodeColor(statusCode)
+    colorPalette.value[statusCode] = getStatusCodeDatasetColor(statusCode)
 
     const service = `Service${rand(1, 100)}`
     serviceDimensionValues.value.add(service)
@@ -381,7 +379,7 @@ watch(multiDimensionToggle, () => {
   serviceDimensionValues.value = new Set(Array(1).fill(0).map(() => `Service${rand(1, 100)}`))
   statusCodeDimensionValues.value = new Set(statusCodeLabels)
 
-  colorPalette.value = [...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: lookupStatusCodeColor(dimension) || lookupDatavisColor(rand(0, 5)) }), {})
+  colorPalette.value = [...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: getStatusCodeDatasetColor(dimension) }), {})
 })
 </script>
 
@@ -398,7 +396,7 @@ watch(multiDimensionToggle, () => {
 }
 
 .data-container {
-  margin-top: $kui-space-100;
+  margin-top: var(--kui-space-100, $kui-space-100);
 }
 
 </style>

--- a/packages/analytics/analytics-chart/sandbox/pages/DonutChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/DonutChartDemo.vue
@@ -156,9 +156,7 @@ import {
 } from '../../src'
 import type { AnalyticsExploreV2Result } from '@kong-ui-public/analytics-utilities'
 import type { AnalyticsChartColors, AnalyticsChartOptions } from '../../src/types'
-import { isValidJson, rand } from '../utils/utils'
-import { lookupDatavisColor } from '../../src/utils'
-import { lookupStatusCodeColor } from '../../src/utils/customColors'
+import { getStatusCodeDatasetColor, isValidJson, rand } from '../utils/utils'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
 import { generateCrossSectionalData } from '@kong-ui-public/analytics-utilities'
 import CodeText from '../CodeText.vue'
@@ -206,7 +204,7 @@ const metricItems = [{
 
 // Short labels
 const statusCodeLabels = [
-  '200', '300', '400', '500',
+  '200', '300', '400', '500', '____OTHER____',
 ]
 
 const statusCodeDimensionValues = ref(new Set(statusCodeLabels))
@@ -243,7 +241,7 @@ const exploreResult = computed<AnalyticsExploreV2Result | null>(() => {
 
 })
 
-const colorPalette = ref<AnalyticsChartColors>([...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: lookupStatusCodeColor(dimension) || lookupDatavisColor(rand(0, 5)) }), {}))
+const colorPalette = ref<AnalyticsChartColors>([...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: getStatusCodeDatasetColor(dimension) }), {}))
 
 const updateSelectedColor = (event: Event, label: string) => {
   colorPalette.value[label] = (event.target as HTMLInputElement).value
@@ -258,7 +256,7 @@ const analyticsChartOptions = computed<AnalyticsChartOptions>(() => ({
 const addDataset = () => {
   const statusCode = `${rand(100, 599)}`
   statusCodeDimensionValues.value.add(statusCode)
-  colorPalette.value[statusCode] = lookupStatusCodeColor(statusCode)
+  colorPalette.value[statusCode] = getStatusCodeDatasetColor(statusCode)
 }
 const dataCode = computed(() => JSON.stringify(exploreResult.value, null, 2))
 const optionsCode = computed(() => JSON.stringify(analyticsChartOptions.value, null, 2))

--- a/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/TimeSeriesChartDemo.vue
@@ -171,9 +171,15 @@
           />
         </div>
         <div>
+          <KInputSwitch
+            v-model="thresholdToggle"
+            :label="thresholdToggle ? 'Threshold enabled' : 'Threshold disabled'"
+          />
+        </div>
+        <div v-if="thresholdToggle">
           <KInput
             v-model="thresholdValue"
-            label="Eror threshold"
+            label="Error threshold"
             type="number"
           />
         </div>
@@ -235,9 +241,7 @@ import {
 } from '../../src'
 import type { AnalyticsExploreRecord, ExploreExportState, ExploreAggregations, ExploreResultV4, QueryResponseMeta } from '@kong-ui-public/analytics-utilities'
 import type { AnalyticsChartColors, AnalyticsChartOptions, ChartType, Threshold } from '../../src/types'
-import { isValidJson, rand } from '../utils/utils'
-import { lookupDatavisColor } from '../../src/utils'
-import { lookupStatusCodeColor } from '../../src/utils/customColors'
+import { getStatusCodeDatasetColor, isValidJson, rand } from '../utils/utils'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
 import { generateMultipleMetricTimeSeriesData, generateSingleMetricTimeSeriesData } from '@kong-ui-public/analytics-utilities'
 import CodeText from '../CodeText.vue'
@@ -265,6 +269,7 @@ const multiDimensionToggle = ref(false)
 const showAnnotationsToggle = ref(true)
 const showLegendValuesToggle = ref(true)
 const emptyState = ref(false)
+const thresholdToggle = ref(false)
 const chartType = ref<ChartType>('timeseries_line')
 const legendPosition = ref(ChartLegendPosition.Bottom)
 const secondaryMetrics = ref([{ name: 'secondaryMetric', unit: 'count' }])
@@ -291,7 +296,7 @@ const metricItems = [{
 
 // Short labels
 const statusCodeLabels = [
-  '200', '300', '400', '500', '5XX', 'empty',
+  '200', '300', '400', '500', '5XX', '____OTHER____', 'empty',
 ]
 
 const statusCodeDimensionValues = ref(new Set(statusCodeLabels))
@@ -374,7 +379,7 @@ const exploreResult = computed<ExploreResultV4>(() => {
   return generateSingleMetricTimeSeriesData({ name: selectedMetric.value.name, unit: selectedMetric.value.unit }, undefined, metaOverrides)
 })
 
-const colorPalette = ref<AnalyticsChartColors>([...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: lookupStatusCodeColor(dimension) || lookupDatavisColor(rand(0, 5)) }), {}))
+const colorPalette = ref<AnalyticsChartColors>([...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: getStatusCodeDatasetColor(dimension) }), {}))
 
 const updateSelectedColor = (event: Event, label: string) => {
   colorPalette.value[label] = (event.target as HTMLInputElement).value
@@ -384,7 +389,7 @@ const analyticsChartOptions = computed<AnalyticsChartOptions>(() => {
   return {
     type: chartType.value,
     stacked: stackToggle.value,
-    threshold: threshold.value,
+    threshold: thresholdToggle.value ? threshold.value : undefined,
     // chartDatasetColors: colorPalette.value,
   }
 })
@@ -394,7 +399,7 @@ const addDataset = () => {
   if (multiDimensionToggle.value) {
     const statusCode = `${rand(100, 599)}`
     statusCodeDimensionValues.value.add(statusCode)
-    colorPalette.value[statusCode] = lookupStatusCodeColor(statusCode)
+    colorPalette.value[statusCode] = getStatusCodeDatasetColor(statusCode)
 
     const service = `Service${rand(1, 100)}`
     serviceDimensionValues.value.add(service)
@@ -424,7 +429,7 @@ watch(multiDimensionToggle, () => {
   serviceDimensionValues.value = new Set(Array(5).fill(0).map(() => `Service${rand(1, 100)}`))
   statusCodeDimensionValues.value = new Set(statusCodeLabels)
 
-  colorPalette.value = [...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: lookupStatusCodeColor(dimension) || lookupDatavisColor(rand(0, 5)) }), {})
+  colorPalette.value = [...statusCodeDimensionValues.value].reduce((obj, dimension) => ({ ...obj, [dimension]: getStatusCodeDatasetColor(dimension) }), {})
 })
 </script>
 

--- a/packages/analytics/analytics-chart/sandbox/utils/utils.ts
+++ b/packages/analytics/analytics-chart/sandbox/utils/utils.ts
@@ -1,4 +1,5 @@
 import type { AnalyticsExploreV2Result } from '@kong-ui-public/analytics-utilities'
+import { defaultStatusCodeColors, lookupStatusCodeColor } from '../../src/utils/customColors'
 
 export function generateRandomColor() {
   const letters = '0123456789ABCDEF'
@@ -15,6 +16,10 @@ export function rand(min: number, max: number): number {
   min = Math.ceil(min)
   max = Math.floor(max)
   return Math.floor(Math.random() * (max - min + 1) + min)
+}
+
+export function getStatusCodeDatasetColor(dimension: string): string {
+  return defaultStatusCodeColors[dimension] || lookupStatusCodeColor(dimension)
 }
 
 export function isValidJson(str: string): boolean {

--- a/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/DonutChart.vue
@@ -54,10 +54,10 @@ import ToolTip from '../chart-plugins/ChartTooltip.vue'
 import HtmlLegend from '../chart-plugins/ChartLegend.vue'
 import {
   datavisPalette,
-  darkenColor,
   isSummableMetricUnit,
 } from '../../utils'
 import { Doughnut } from 'vue-chartjs'
+import { color } from 'chart.js/helpers'
 import composables from '../../composables'
 import { unitFormatter } from '@kong-ui-public/analytics-utilities'
 import type { AnalyticsChartColors, KChartData, TooltipState } from '../../types'
@@ -136,7 +136,7 @@ const formattedDataset = computed<DonutChartData[]>(() => {
   const formatted = props.chartData.datasets.reduce((acc: any, current: ChartDataset) => {
     acc.labels.push(current.label)
     acc.backgroundColor.push(current.backgroundColor)
-    acc.hoverBorderColor.push(darkenColor(current.backgroundColor as string, 50))
+    acc.hoverBorderColor.push(color(current.backgroundColor as string).saturate(0.5).darken(0.15).hexString())
     acc.data.push(current.data.reduce((a, b) => (a as number) + (b as number), 0))
 
     return acc

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
@@ -2,6 +2,13 @@ import type { AnalyticsExploreRecord, DisplayBlob, ExploreResultV4, GroupByResul
 import { describe, it, expect } from 'vitest'
 import type { ComputedRef } from 'vue'
 import { computed } from 'vue'
+import {
+  KUI_STATUS_COLOR_100,
+  KUI_STATUS_COLOR_200,
+  KUI_STATUS_COLOR_300,
+  KUI_STATUS_COLOR_400,
+  KUI_STATUS_COLOR_500,
+} from '@kong/design-tokens'
 import useExploreResultToDatasets from './useExploreResultToDatasets'
 import { defaultStatusCodeColors } from '../utils'
 
@@ -462,11 +469,11 @@ describe('useVitalsExploreDatasets', () => {
       exploreResult,
     )
 
-    expect(result.value.datasets[0].backgroundColor).toEqual('#80bfff')
-    expect(result.value.datasets[1].backgroundColor).toEqual('#9edca6')
-    expect(result.value.datasets[2].backgroundColor).toEqual('#ffe9b8')
-    expect(result.value.datasets[3].backgroundColor).toEqual('#ffd5b1')
-    expect(result.value.datasets[4].backgroundColor).toEqual('#ffb6b6')
+    expect(result.value.datasets[0].backgroundColor).toEqual(KUI_STATUS_COLOR_100)
+    expect(result.value.datasets[1].backgroundColor).toEqual(KUI_STATUS_COLOR_200)
+    expect(result.value.datasets[2].backgroundColor).toEqual(KUI_STATUS_COLOR_300)
+    expect(result.value.datasets[3].backgroundColor).toEqual(KUI_STATUS_COLOR_400)
+    expect(result.value.datasets[4].backgroundColor).toEqual(KUI_STATUS_COLOR_500)
   })
 
 

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToTimedDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToTimedDatasets.spec.ts
@@ -2,11 +2,17 @@ import type { AnalyticsExploreRecord, DisplayBlob, ExploreAggregations, ExploreR
 import { describe, it, expect, vitest } from 'vitest'
 import type { ComputedRef } from 'vue'
 import { computed } from 'vue'
+import {
+  KUI_STATUS_COLOR_100,
+  KUI_STATUS_COLOR_200,
+  KUI_STATUS_COLOR_300,
+  KUI_STATUS_COLOR_400,
+  KUI_STATUS_COLOR_500,
+} from '@kong/design-tokens'
 import useExploreResultToTimeDataset from './useExploreResultToTimeDatasets'
 import { BORDER_WIDTH, NO_BORDER, defaultStatusCodeColors } from '../utils'
 import { addHours } from 'date-fns'
 import type { MockInstance } from 'vitest'
-import type { Threshold } from 'src/types'
 
 const START_FOR_DAILY_QUERY = new Date(1672560000000)
 const END_FOR_DAILY_QUERY = new Date(1672646400000)
@@ -893,11 +899,11 @@ describe('useVitalsExploreDatasets', () => {
       exploreResult,
     )
 
-    expect(result.value.datasets[0].backgroundColor).toEqual('#80bfff')
-    expect(result.value.datasets[1].backgroundColor).toEqual('#9edca6')
-    expect(result.value.datasets[2].backgroundColor).toEqual('#ffe9b8')
-    expect(result.value.datasets[3].backgroundColor).toEqual('#ffd5b1')
-    expect(result.value.datasets[4].backgroundColor).toEqual('#ffb6b6')
+    expect(result.value.datasets[0].backgroundColor).toEqual(KUI_STATUS_COLOR_100)
+    expect(result.value.datasets[1].backgroundColor).toEqual(KUI_STATUS_COLOR_200)
+    expect(result.value.datasets[2].backgroundColor).toEqual(KUI_STATUS_COLOR_300)
+    expect(result.value.datasets[3].backgroundColor).toEqual(KUI_STATUS_COLOR_400)
+    expect(result.value.datasets[4].backgroundColor).toEqual(KUI_STATUS_COLOR_500)
   })
 
   it('maps country_code values to full country names via getCountryName', () => {

--- a/packages/analytics/analytics-chart/src/index.ts
+++ b/packages/analytics/analytics-chart/src/index.ts
@@ -8,7 +8,7 @@ export { AnalyticsChart, SimpleChart, TopNTable, CsvExportModal, SparklineChart 
 
 export * from './types'
 export * from './enums'
-export * from './utils/colors'
-export * from './utils/customColors'
+export { statusCodeBadgeBackgroundColor } from './utils/colors'
+export { lookupStatusCodeColor } from './utils/customColors'
 export * from './utils/constants'
 export * from './utils/queryError'

--- a/packages/analytics/analytics-chart/src/utils/colors.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/colors.spec.ts
@@ -1,8 +1,19 @@
-import { lookupDatavisColor } from './colors'
+import { lookupDatavisColor, statusCodeBadgeBackgroundColor } from './colors'
 import { describe, it, expect } from 'vitest'
 
 describe('lookupDatavisColor', () => {
   it('handles large numbers of entities', () => {
     expect(lookupDatavisColor(5)).toBe('#a86cd5')
+  })
+})
+
+describe('statusCodeBadgeBackgroundColor', () => {
+  it('uses legacy API Requests colors by status code group', () => {
+    expect(statusCodeBadgeBackgroundColor('200')).toBe('#e5f7f4')
+    expect(statusCodeBadgeBackgroundColor('503')).toBe('#fedada')
+  })
+
+  it('falls back for invalid status codes', () => {
+    expect(statusCodeBadgeBackgroundColor('invalid')).toBe('#fafafa')
   })
 })

--- a/packages/analytics/analytics-chart/src/utils/colors.ts
+++ b/packages/analytics/analytics-chart/src/utils/colors.ts
@@ -1,4 +1,9 @@
-import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_COLOR_TEXT_DANGER, KUI_COLOR_TEXT_WARNING_WEAK } from '@kong/design-tokens'
+import {
+  KUI_COLOR_BACKGROUND_NEUTRAL,
+  KUI_COLOR_BACKGROUND_NEUTRAL_WEAK,
+  KUI_COLOR_TEXT_DANGER,
+  KUI_COLOR_TEXT_WARNING_WEAK,
+} from '@kong/design-tokens'
 import type { AnalyticsChartColors, ThresholdType } from '../../src/types'
 
 interface StatusCodeColor {
@@ -7,24 +12,6 @@ interface StatusCodeColor {
 }
 interface StatusCodeColors {
   [statusCode: number]: StatusCodeColor
-}
-
-// Collection of colors matching existing Kong Manager Status Code chart
-const kongManangerColorPalette = {
-  '1XXCount|1XX|1[0-9][0-9]': { solid: '#0072E5', light: '#4DA6FF', description: 'Informational' },
-  'SuccessfulRequests|2XXCount|2XX|2[0-9][0-9]|SUCCESS': { solid: '#0BB652', light: '#6FCC83', description: 'Success' },
-  '3XXCount|3XX|3[0-9][0-9]': { solid: '#FDC53B', light: '#FFD982', description: 'Redirection' },
-  '4XXCount|4XX|4[0-9][0-9]': { solid: '#FE9439', light: '#FFBA81', description: 'Client Errors' },
-  '5XXCount|5XX|5[0-9][0-9]': { solid: '#FF4545', light: '#FF8484', description: 'Server Errors' },
-  'errorCount|FailedRequests|FAILURE': { solid: '#FF4545', light: '#FF8484', description: 'Server Errors' },
-  nonStandard: { solid: '#6f7787', light: '#e7e7ec' }, // grey-500, grey-300
-  standard: { solid: '#1155cb', light: '#8ab3fa' }, // blue-500, blue-300,
-  p99: { solid: '#1356cb', light: '#1356cb' },
-  p95: { solid: '#1fbecd', light: '#1fbecd' },
-  p50: { solid: '#1df97d', light: '#1df97d' },
-  LatencyP99: { solid: '#1356cb', light: '#1356cb' },
-  LatencyP95: { solid: '#1fbecd', light: '#1fbecd' },
-  LatencyP50: { solid: '#1df97d', light: '#1df97d' },
 }
 
 export const datavisPalette = [
@@ -41,47 +28,11 @@ export const lookupDatavisColor = (idx: number, customPalette?: string[]) => {
   return colorLookup[idx % datavisPalette.length]
 }
 
-export const darkenColor = (hex: string, amt: number): string => {
-  if (hex[0] === '#') {
-    hex = hex.slice(1)
-  }
-
-  let R = parseInt(hex.substring(0, 2), 16)
-  let G = parseInt(hex.substring(2, 4), 16)
-  let B = parseInt(hex.substring(4, 6), 16)
-
-  R = R - amt
-  G = G - amt
-  B = B - amt
-
-  if (R > 255) {
-    R = 255
-  } else if (R < 0) {
-    R = 0
-  }
-
-  if (G > 255) {
-    G = 255
-  } else if (G < 0) {
-    G = 0
-  }
-
-  if (B > 255) {
-    B = 255
-  } else if (B < 0) {
-    B = 0
-  }
-
-  const RR = ((R.toString(16).length === 1) ? '0' + R.toString(16) : R.toString(16))
-  const GG = ((G.toString(16).length === 1) ? '0' + G.toString(16) : G.toString(16))
-  const BB = ((B.toString(16).length === 1) ? '0' + B.toString(16) : B.toString(16))
-
-  return `#${RR}${GG}${BB}`
-}
-
 export const accessibleGrey = '#6f7787' // grey-500
 
-export const apiRequestStatusCodeColors: StatusCodeColors = {
+// Deprecated: API Requests still depends on this legacy color map.
+// TODO: Remove once API Requests uses status-code variant KBadges instead.
+const apiRequestStatusCodeColors: StatusCodeColors = {
   100: { background: '#f0f5fd', text: '#10599e' },
   200: { background: '#e5f7f4', text: '#1b6955' },
   300: { background: '#fff1d5', text: '#a06027' },
@@ -95,33 +46,7 @@ export const statusCodeBadgeBackgroundColor = (statusCode: string) => {
   return apiRequestStatusCodeColors[keyIndex]?.background || '#fafafa'
 }
 
-export const trafficColors: AnalyticsChartColors = {
-  SUCCESS: '#6FCC83',
-  FAILURE: '#FF8484',
-}
-
-export const errorRateColors: AnalyticsChartColors = {
-  '4XX': '#FFBA81',
-  '5XX': '#FF8484',
-}
-
-export const latencyColors: AnalyticsChartColors = {
-  LatencyP99: '#1356cb',
-  LatencyP95: '#1fbecd',
-  LatencyP50: '#1df97d',
-}
-
-export const OTHERS_COLOR = '#dad4c7'
-export const EMPTY_COLOR = '#afb7c5'
-
-/**
- * Maps the first character of a dataset's label to a predefined list of colors
- */
-export const lookupColor = (label: string) => {
-  const found = Object.entries(kongManangerColorPalette).find(([key]) => (new RegExp(key).test(label)))
-
-  return (found && found[1]) || kongManangerColorPalette.standard
-}
+const EMPTY_COLOR = KUI_COLOR_BACKGROUND_NEUTRAL_WEAK
 
 export const determineBaseColor = (i: number, dimensionName: string, isEmpty: boolean, colorPalette: string[] | AnalyticsChartColors): string => {
   let baseColor

--- a/packages/analytics/analytics-chart/src/utils/customColors.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/customColors.spec.ts
@@ -1,29 +1,50 @@
-import { lookupStatusCodeCategoryColor, lookupStatusCodeColor, lightGrey } from './customColors'
+import {
+  KUI_COLOR_BACKGROUND_DISABLED,
+  KUI_STATUS_COLOR_100,
+  KUI_STATUS_COLOR_200,
+  KUI_STATUS_COLOR_2NA,
+  KUI_STATUS_COLOR_200S,
+  KUI_STATUS_COLOR_300S,
+  KUI_STATUS_COLOR_400S,
+  KUI_STATUS_COLOR_408,
+  KUI_STATUS_COLOR_409,
+  KUI_STATUS_COLOR_500S,
+  KUI_STATUS_COLOR_5NA,
+} from '@kong/design-tokens'
+import { defaultStatusCodeColors, lookupStatusCodeCategoryColor, lookupStatusCodeColor } from './customColors'
 import { describe, it, expect } from 'vitest'
 
 describe('lookupStatusCodeColor', () => {
-  it('correctly resolves specific colors', () => {
-    expect(lookupStatusCodeColor('100')).toBe('#80bfff')
-    expect(lookupStatusCodeColor('200')).toBe('#9edca6')
+  it('resolves official token colors for standard status codes', () => {
+    expect(lookupStatusCodeColor('100')).toBe(KUI_STATUS_COLOR_100)
+    expect(lookupStatusCodeColor('200')).toBe(KUI_STATUS_COLOR_200)
 
-    // Check that the loop-around works correctly.
-    expect(lookupStatusCodeColor('408')).toBe('#cc6100')
-    expect(lookupStatusCodeColor('409')).toBe('#ffd5b1')
+    expect(lookupStatusCodeColor('408')).toBe(KUI_STATUS_COLOR_408)
+    expect(lookupStatusCodeColor('409')).toBe(KUI_STATUS_COLOR_409)
   })
 
-  it('correctly handles out-of-spec codes', () => {
-    expect(lookupStatusCodeColor('210')).toBe('#ceedd2')
-    expect(lookupStatusCodeColor('512')).toBe('#ffd5d5')
+  it('uses official token fallback colors for unknown in-range codes', () => {
+    expect(lookupStatusCodeColor('210')).toBe(KUI_STATUS_COLOR_2NA)
+    expect(lookupStatusCodeColor('512')).toBe(KUI_STATUS_COLOR_5NA)
   })
 
   it('gracefully handles invalid codes', () => {
-    expect(lookupStatusCodeColor('600')).toBe(lightGrey)
-    expect(lookupStatusCodeColor('000')).toBe(lightGrey)
+    expect(lookupStatusCodeColor('600')).toBe(KUI_COLOR_BACKGROUND_DISABLED)
+    expect(lookupStatusCodeColor('000')).toBe(KUI_COLOR_BACKGROUND_DISABLED)
   })
 })
 
 describe('lookupStatusCodeCategoryColor', () => {
   it('creates the correct shape', () => {
-    expect(lookupStatusCodeCategoryColor('200')).toEqual({ solid: '#9edca6', light: '#9edca6' })
+    expect(lookupStatusCodeCategoryColor('200')).toEqual({ solid: KUI_STATUS_COLOR_200, light: KUI_STATUS_COLOR_200 })
+  })
+})
+
+describe('defaultStatusCodeColors', () => {
+  it('uses official token colors for grouped status codes', () => {
+    expect(defaultStatusCodeColors['2XX']).toBe(KUI_STATUS_COLOR_200S)
+    expect(defaultStatusCodeColors['3XX']).toBe(KUI_STATUS_COLOR_300S)
+    expect(defaultStatusCodeColors['4XX']).toBe(KUI_STATUS_COLOR_400S)
+    expect(defaultStatusCodeColors['5XX']).toBe(KUI_STATUS_COLOR_500S)
   })
 })

--- a/packages/analytics/analytics-chart/src/utils/customColors.ts
+++ b/packages/analytics/analytics-chart/src/utils/customColors.ts
@@ -1,67 +1,170 @@
 import type { AnalyticsChartColors } from 'src/types'
+import {
+  KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE_WEAKEST,
+  KUI_COLOR_BACKGROUND_DISABLED,
+  KUI_STATUS_COLOR_100,
+  KUI_STATUS_COLOR_100S,
+  KUI_STATUS_COLOR_101,
+  KUI_STATUS_COLOR_102,
+  KUI_STATUS_COLOR_103,
+  KUI_STATUS_COLOR_1NA,
+  KUI_STATUS_COLOR_200,
+  KUI_STATUS_COLOR_200S,
+  KUI_STATUS_COLOR_201,
+  KUI_STATUS_COLOR_202,
+  KUI_STATUS_COLOR_203,
+  KUI_STATUS_COLOR_204,
+  KUI_STATUS_COLOR_205,
+  KUI_STATUS_COLOR_206,
+  KUI_STATUS_COLOR_207,
+  KUI_STATUS_COLOR_208,
+  KUI_STATUS_COLOR_226,
+  KUI_STATUS_COLOR_2NA,
+  KUI_STATUS_COLOR_300,
+  KUI_STATUS_COLOR_300S,
+  KUI_STATUS_COLOR_301,
+  KUI_STATUS_COLOR_302,
+  KUI_STATUS_COLOR_303,
+  KUI_STATUS_COLOR_304,
+  KUI_STATUS_COLOR_305,
+  KUI_STATUS_COLOR_307,
+  KUI_STATUS_COLOR_308,
+  KUI_STATUS_COLOR_3NA,
+  KUI_STATUS_COLOR_400,
+  KUI_STATUS_COLOR_400S,
+  KUI_STATUS_COLOR_401,
+  KUI_STATUS_COLOR_402,
+  KUI_STATUS_COLOR_403,
+  KUI_STATUS_COLOR_404,
+  KUI_STATUS_COLOR_405,
+  KUI_STATUS_COLOR_406,
+  KUI_STATUS_COLOR_407,
+  KUI_STATUS_COLOR_408,
+  KUI_STATUS_COLOR_409,
+  KUI_STATUS_COLOR_410,
+  KUI_STATUS_COLOR_411,
+  KUI_STATUS_COLOR_412,
+  KUI_STATUS_COLOR_413,
+  KUI_STATUS_COLOR_414,
+  KUI_STATUS_COLOR_415,
+  KUI_STATUS_COLOR_416,
+  KUI_STATUS_COLOR_417,
+  KUI_STATUS_COLOR_418,
+  KUI_STATUS_COLOR_421,
+  KUI_STATUS_COLOR_422,
+  KUI_STATUS_COLOR_423,
+  KUI_STATUS_COLOR_424,
+  KUI_STATUS_COLOR_425,
+  KUI_STATUS_COLOR_426,
+  KUI_STATUS_COLOR_428,
+  KUI_STATUS_COLOR_429,
+  KUI_STATUS_COLOR_431,
+  KUI_STATUS_COLOR_451,
+  KUI_STATUS_COLOR_4NA,
+  KUI_STATUS_COLOR_500,
+  KUI_STATUS_COLOR_500S,
+  KUI_STATUS_COLOR_501,
+  KUI_STATUS_COLOR_502,
+  KUI_STATUS_COLOR_503,
+  KUI_STATUS_COLOR_504,
+  KUI_STATUS_COLOR_505,
+  KUI_STATUS_COLOR_506,
+  KUI_STATUS_COLOR_507,
+  KUI_STATUS_COLOR_508,
+  KUI_STATUS_COLOR_510,
+  KUI_STATUS_COLOR_511,
+  KUI_STATUS_COLOR_5NA,
+} from '@kong/design-tokens'
 
-export const lightGrey = '#e0e4ea' // kui-color-background-disabled
+const lightGrey = KUI_COLOR_BACKGROUND_DISABLED
 
-// Note: the first color of each palette is reserved for "out of spec" codes.  The remaining colors
-// are for in-spec codes.  For cases where there are more status codes than colors, the colors restart from
-// the beginning.
-// The algorithm assigns status codes consistent colors, regardless of which codes are present in a given
-// chart.  This is a tradeoff: in rare cases, it can lead to (for example) two codes with the same color
-// ending up next to each other.
-const statusCodePalette: { [label: string]: string[] } = {
-  100: ['#c8e2fd', '#80bfff', '#4da6ff', '#1a8cff', '#0072e5', '#0059b2'],
-  200: ['#ceedd2', '#9edca6', '#89d595', '#6fcc83', '#44c26b', '#0bb652', '#0ca84a', '#169643', '#196e33', '#1b572a'],
-  300: ['#fff4db', '#ffe9b8', '#ffe2a1', '#ffd982', '#ffd062', '#fdc53b', '#f4bb1e', '#e8b00b', '#d9a30f', '#c89407'],
-  400: ['#ffead8', '#ffd5b1', '#ffc899', '#ffba81', '#ffae6b', '#fe9439', '#f6871d', '#eb7c0c', '#da700c', '#cc6100'],
-  500: ['#ffd5d5', '#ffb6b6', '#ff9d9d', '#ff8484', '#ff6a6a', '#ff4545', '#fb1f1f', '#e90b0b', '#d40202', '#be0202'],
+const statusCodeColors: AnalyticsChartColors = {
+  100: KUI_STATUS_COLOR_100,
+  101: KUI_STATUS_COLOR_101,
+  102: KUI_STATUS_COLOR_102,
+  103: KUI_STATUS_COLOR_103,
+  200: KUI_STATUS_COLOR_200,
+  201: KUI_STATUS_COLOR_201,
+  202: KUI_STATUS_COLOR_202,
+  203: KUI_STATUS_COLOR_203,
+  204: KUI_STATUS_COLOR_204,
+  205: KUI_STATUS_COLOR_205,
+  206: KUI_STATUS_COLOR_206,
+  207: KUI_STATUS_COLOR_207,
+  208: KUI_STATUS_COLOR_208,
+  226: KUI_STATUS_COLOR_226,
+  300: KUI_STATUS_COLOR_300,
+  301: KUI_STATUS_COLOR_301,
+  302: KUI_STATUS_COLOR_302,
+  303: KUI_STATUS_COLOR_303,
+  304: KUI_STATUS_COLOR_304,
+  305: KUI_STATUS_COLOR_305,
+  307: KUI_STATUS_COLOR_307,
+  308: KUI_STATUS_COLOR_308,
+  400: KUI_STATUS_COLOR_400,
+  401: KUI_STATUS_COLOR_401,
+  402: KUI_STATUS_COLOR_402,
+  403: KUI_STATUS_COLOR_403,
+  404: KUI_STATUS_COLOR_404,
+  405: KUI_STATUS_COLOR_405,
+  406: KUI_STATUS_COLOR_406,
+  407: KUI_STATUS_COLOR_407,
+  408: KUI_STATUS_COLOR_408,
+  409: KUI_STATUS_COLOR_409,
+  410: KUI_STATUS_COLOR_410,
+  411: KUI_STATUS_COLOR_411,
+  412: KUI_STATUS_COLOR_412,
+  413: KUI_STATUS_COLOR_413,
+  414: KUI_STATUS_COLOR_414,
+  415: KUI_STATUS_COLOR_415,
+  416: KUI_STATUS_COLOR_416,
+  417: KUI_STATUS_COLOR_417,
+  418: KUI_STATUS_COLOR_418,
+  421: KUI_STATUS_COLOR_421,
+  422: KUI_STATUS_COLOR_422,
+  423: KUI_STATUS_COLOR_423,
+  424: KUI_STATUS_COLOR_424,
+  425: KUI_STATUS_COLOR_425,
+  426: KUI_STATUS_COLOR_426,
+  428: KUI_STATUS_COLOR_428,
+  429: KUI_STATUS_COLOR_429,
+  431: KUI_STATUS_COLOR_431,
+  451: KUI_STATUS_COLOR_451,
+  500: KUI_STATUS_COLOR_500,
+  501: KUI_STATUS_COLOR_501,
+  502: KUI_STATUS_COLOR_502,
+  503: KUI_STATUS_COLOR_503,
+  504: KUI_STATUS_COLOR_504,
+  505: KUI_STATUS_COLOR_505,
+  506: KUI_STATUS_COLOR_506,
+  507: KUI_STATUS_COLOR_507,
+  508: KUI_STATUS_COLOR_508,
+  510: KUI_STATUS_COLOR_510,
+  511: KUI_STATUS_COLOR_511,
 }
 
-const colorsForCodes = (codeClass: string, codes: number[]) => {
-  let i = 1
-  const palette = statusCodePalette[codeClass]
-
-  const ret: Map<number, string> = new Map()
-
-  // Assign each in-spec code a color.  Skip the first color (index 0) in the palette;
-  // it's reserved for out-of-spec codes.
-  for (const num of codes) {
-    ret.set(num, palette[i])
-    i = i % (palette.length - 1) + 1
-  }
-
-  // Assign the color for out-of-spec codes.
-  ret.set(-1, palette[0])
-
-  return ret
+const unknownStatusCodeColors: AnalyticsChartColors = {
+  100: KUI_STATUS_COLOR_1NA,
+  200: KUI_STATUS_COLOR_2NA,
+  300: KUI_STATUS_COLOR_3NA,
+  400: KUI_STATUS_COLOR_4NA,
+  500: KUI_STATUS_COLOR_5NA,
 }
 
-// Note: in addition to the colors, this map currently drives the available status codes
-// in the reports v2 filter list.  Eventually, hopefully, we'll have server-side search
-// and this won't be necessary.
-export const codesInSpec = new Map([
-  [100, colorsForCodes('100', [100, 101, 102, 103])],
-  [200, colorsForCodes('200', [200, 201, 202, 203, 204, 205, 206, 207, 208, 226])],
-  [300, colorsForCodes('300', [300, 301, 302, 303, 304, 305, 307, 308])],
-  [400, colorsForCodes('400', [
-    400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416,
-    417, 418, 421, 422, 423, 424, 425, 426, 428, 429, 431, 451,
-  ])],
-  [500, colorsForCodes('500', [500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511])],
-])
+const statusCodeGroupColors: AnalyticsChartColors = {
+  '1XX': KUI_STATUS_COLOR_100S,
+  '2XX': KUI_STATUS_COLOR_200S,
+  '3XX': KUI_STATUS_COLOR_300S,
+  '4XX': KUI_STATUS_COLOR_400S,
+  '5XX': KUI_STATUS_COLOR_500S,
+}
 
 export const lookupStatusCodeColor = (label: string) => {
   const code = parseInt(label, 10)
   const codeClass = Math.floor(code / 100) * 100
-  const palette = codesInSpec.get(codeClass)
+  const color = statusCodeColors[code] ?? unknownStatusCodeColors[codeClass]
 
-  if (palette === undefined) {
-    return lightGrey
-  }
-
-  // For in-spec codes, pick a color.  For out-of-spec codes, pick the fallback color.
-  const color = palette.get(code) ?? palette.get(-1) ?? lightGrey
-
-  return color
+  return color ?? lightGrey
 }
 
 export const lookupStatusCodeCategoryColor = (label: string) => {
@@ -79,10 +182,6 @@ export const defaultStatusCodeColors: AnalyticsChartColors = {
     return acc
 
   }, {} as AnalyticsChartColors),
-  ____OTHER____: '#DAD4C7',
-  '1XX': '#4DA6FF',
-  '2XX': '#6FCC83',
-  '3XX': '#FFD982',
-  '4XX': '#FFBA81',
-  '5XX': '#FF8484',
+  ____OTHER____: KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE_WEAKEST,
+  ...statusCodeGroupColors,
 }


### PR DESCRIPTION
# Summary

Use design token colors for status code colors + "others" color

https://konghq.atlassian.net/browse/MA-5007

<img width="809" height="571" alt="image" src="https://github.com/user-attachments/assets/c777d3a8-ed02-4580-8243-230ee9012c27" />


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
