### PR TITLE
feat(workspace): add workspace support to config store

### DIFF
--- a/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
+++ b/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
@@ -1169,5 +1169,61 @@ describe('<VaultForm />', () => {
       cy.wait('@getVaultNoWorkspace')
       cy.getTestId('form-fetch-error').should('not.exist')
     })
+
+    it('includes workspace in config-store POST and vault POST URLs when creating a Konnect vault', () => {
+      const configStoreId = 'new-config-store-id'
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/default/config-stores`,
+        },
+        { statusCode: 201, body: { id: configStoreId } },
+      ).as('createConfigStoreWithWorkspace')
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults`,
+        },
+        { statusCode: 201, body: vault },
+      ).as('createVaultWithWorkspace')
+
+      cy.mount(VaultForm, {
+        props: {
+          config: { ...baseConfigKonnect, workspace: 'default' },
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createConfigStoreWithWorkspace')
+      cy.wait('@createVaultWithWorkspace')
+    })
+
+    it('omits workspace in config-store POST and vault POST URLs when workspace is not provided', () => {
+      const configStoreId = 'new-config-store-id'
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/config-stores`,
+        },
+        { statusCode: 201, body: { id: configStoreId } },
+      ).as('createConfigStoreNoWorkspace')
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/vaults`,
+        },
+        { statusCode: 201, body: vault },
+      ).as('createVaultNoWorkspace')
+
+      cy.mount(VaultForm, {
+        props: {
+          config: baseConfigKonnect,
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+      cy.wait('@createConfigStoreNoWorkspace')
+      cy.wait('@createVaultNoWorkspace')
+    })
   })
 })

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -1627,6 +1627,7 @@ const createConfigStore = async (): Promise<string | undefined> => {
 
     const requestUrl = `${props.config.apiBaseUrl}${endpoints.form.konnect.createConfigStore}`
       .replace(/{controlPlaneId}/gi, (props.config as KonnectVaultFormConfig)?.controlPlaneId || '')
+      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 
     const response = await axiosInstance.post<KonnectConfigStore>(requestUrl)
 

--- a/packages/entities/entities-vaults/src/components/VaultList.cy.ts
+++ b/packages/entities/entities-vaults/src/components/VaultList.cy.ts
@@ -832,5 +832,116 @@ describe('<VaultList />', () => {
       cy.wait('@getNoWorkspace')
       cy.get('.kong-ui-entities-vaults-list').should('be.visible')
     })
+
+    it('includes workspace in config-store DELETE URL when deleting a Konnect vault', () => {
+      const konnectConfigStoreId = 'test-config-store-id'
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults*`,
+        },
+        {
+          statusCode: 200,
+          body: {
+            data: [{
+              id: '1',
+              name: 'konnect',
+              prefix: 'konnect-vault',
+              config: { config_store_id: konnectConfigStoreId },
+            }],
+            total: 1,
+          },
+        },
+      ).as('getVaultsWithWorkspace')
+      cy.intercept(
+        {
+          method: 'DELETE',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/vaults/1`,
+        },
+        { statusCode: 204 },
+      ).as('deleteVaultWithWorkspace')
+      cy.intercept(
+        {
+          method: 'DELETE',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/default/config-stores/${konnectConfigStoreId}*`,
+        },
+        { statusCode: 204 },
+      ).as('deleteConfigStoreWithWorkspace')
+
+      cy.mount(VaultList, {
+        props: {
+          cacheIdentifier: `vault-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => true,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getVaultsWithWorkspace')
+      cy.getTestId('row-actions-dropdown-trigger').eq(0).click()
+      cy.getTestId('action-entity-delete').click()
+      cy.getTestId('confirmation-input').type('konnect-vault')
+      cy.getTestId('modal-action-button').click()
+      cy.wait('@deleteVaultWithWorkspace')
+      cy.wait('@deleteConfigStoreWithWorkspace')
+    })
+
+    it('omits workspace in config-store DELETE URL when workspace is not provided', () => {
+      const konnectConfigStoreId = 'test-config-store-id'
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/vaults*`,
+        },
+        {
+          statusCode: 200,
+          body: {
+            data: [{
+              id: '1',
+              name: 'konnect',
+              prefix: 'konnect-vault',
+              config: { config_store_id: konnectConfigStoreId },
+            }],
+            total: 1,
+          },
+        },
+      ).as('getVaultsNoWorkspace')
+      cy.intercept(
+        {
+          method: 'DELETE',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/vaults/1`,
+        },
+        { statusCode: 204 },
+      ).as('deleteVaultNoWorkspace')
+      cy.intercept(
+        {
+          method: 'DELETE',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/config-stores/${konnectConfigStoreId}*`,
+        },
+        { statusCode: 204 },
+      ).as('deleteConfigStoreNoWorkspace')
+
+      cy.mount(VaultList, {
+        props: {
+          cacheIdentifier: `vault-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => true,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@getVaultsNoWorkspace')
+      cy.getTestId('row-actions-dropdown-trigger').eq(0).click()
+      cy.getTestId('action-entity-delete').click()
+      cy.getTestId('confirmation-input').type('konnect-vault')
+      cy.getTestId('modal-action-button').click()
+      cy.wait('@deleteVaultNoWorkspace')
+      cy.wait('@deleteConfigStoreNoWorkspace')
+    })
   })
 })

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -457,6 +457,7 @@ const deleteAssociatedConfigStore = async (configStoreId: string): Promise<void>
   const { apiBaseUrl, app, controlPlaneId } = (props.config as KonnectVaultListConfig)
   const url = `${apiBaseUrl}${endpoints.list[app].deleteConfigStore}`
     .replace(/{controlPlaneId}/gi, controlPlaneId || '')
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
     .replace(/{id}/gi, configStoreId)
   try {
     await axiosInstance.delete(url)


### PR DESCRIPTION
Although the config store is konnect only and not a core entity, we still need to add workspace support to it, as the vault relies on the config store.

Tests were added accordingly

JIRA: [KM-2445]


[KM-2445]: https://konghq.atlassian.net/browse/KM-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ