### PR TITLE
chore(deps): bump `ajv` to `8.20.0`

### DIFF
--- a/packages/analytics/analytics-utilities/package.json
+++ b/packages/analytics/analytics-utilities/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
-    "ajv": "^8.18.0",
+    "ajv": "^8.20.0",
     "json-schema-to-ts": "^3.1.1",
     "vue": "^3.5.33"
   }

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -50,7 +50,7 @@
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.52.0",
     "@kong/kongponents": "9.53.2",
-    "ajv": "^8.18.0",
+    "ajv": "^8.20.0",
     "cypress-real-events": "^1.15.0",
     "pinia": ">= 3.0.4 < 4",
     "swrv": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,8 +375,8 @@ importers:
         specifier: 1.20.1
         version: 1.20.1
       ajv:
-        specifier: ^8.18.0
-        version: 8.18.0
+        specifier: ^8.20.0
+        version: 8.20.0
       json-schema-to-ts:
         specifier: ^3.1.1
         version: 3.1.1
@@ -430,8 +430,8 @@ importers:
         specifier: 9.53.2
         version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       ajv:
-        specifier: ^8.18.0
-        version: 8.18.0
+        specifier: ^8.20.0
+        version: 8.20.0
       cypress-real-events:
         specifier: ^1.15.0
         version: 1.15.0(cypress@13.17.0)
@@ -621,10 +621,10 @@ importers:
         version: 1.1.0(monaco-editor@0.55.1)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 1.6.0(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 3.6.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -1087,7 +1087,7 @@ importers:
         version: 2.0.0
       '@playwright/experimental-ct-vue':
         specifier: ^1.59.1
-        version: 1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)
+        version: 1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -1388,7 +1388,7 @@ importers:
         version: 1.26.6
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.2.0
-        version: 4.2.0(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))
+        version: 4.2.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
       vue:
         specifier: 3.5.33
         version: 3.5.33(typescript@5.9.3)
@@ -1419,7 +1419,7 @@ importers:
         version: 9.53.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.6(@vue/compiler-sfc@3.5.33)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.1
-        version: 1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 1.1.1(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -4332,8 +4332,8 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   alien-signals@3.1.2:
     resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
@@ -6080,8 +6080,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.0.1:
-    resolution: {integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -11285,13 +11285,13 @@ snapshots:
   '@commitlint/config-validator@19.8.1':
     dependencies:
       '@commitlint/types': 19.8.1
-      ajv: 8.18.0
+      ajv: 8.20.0
     optional: true
 
   '@commitlint/config-validator@20.5.0':
     dependencies:
       '@commitlint/types': 20.5.0
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   '@commitlint/ensure@20.5.0':
     dependencies:
@@ -12295,12 +12295,12 @@ snapshots:
     dependencies:
       langium: 4.2.2
 
-  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))':
+  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.59.0)
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
-      vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
 
@@ -12769,10 +12769,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-vue@1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)':
+  '@playwright/experimental-ct-vue@1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
       '@playwright/experimental-ct-core': 1.59.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13896,9 +13896,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
+      '@rolldown/pluginutils': 1.0.0-beta.32
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.0)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
+      vue: 3.5.33(typescript@5.9.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vue: 3.5.33(typescript@5.9.3)
+
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
       vue: 3.5.33(typescript@5.9.3)
 
   '@vitest/expect@3.2.4':
@@ -14379,17 +14395,17 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1(ajv@8.18.0):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-keywords@3.5.2(ajv@6.14.0):
     dependencies:
       ajv: 6.14.0
 
-  ajv-keywords@5.1.0(ajv@8.18.0):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
 
   ajv@6.14.0:
@@ -14399,10 +14415,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.18.0:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.1
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -16403,7 +16419,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.0.1: {}
+  fast-uri@3.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -20056,9 +20072,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.18.0
-      ajv-formats: 2.1.1(ajv@8.18.0)
-      ajv-keywords: 5.1.0(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   scule@1.3.0: {}
 
@@ -20727,7 +20743,7 @@ snapshots:
 
   table@6.9.0:
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3
@@ -21342,13 +21358,13 @@ snapshots:
     dependencies:
       monaco-editor: 0.55.1
 
-  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)):
+  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
       '@swc/core': 1.15.7
       '@swc/wasm': 1.15.7
       uuid: 10.0.0
-      vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
@@ -21384,9 +21400,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-wasm@3.6.0(vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)):
+  vite-plugin-wasm@3.6.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)):
     dependencies:
-      vite: 5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.8.3)
 
   vite@5.4.21(@types/node@24.12.2)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1):
     dependencies:


### PR DESCRIPTION
Bumps `ajv` from `8.18.0` to `8.20.0`, which indirectly updates the vulnerable dependency `fast-uri` to version `3.1.2`

https://github.com/advisories/GHSA-v39h-62p7-jpjc
