### PR TITLE
fix(entities-plugins): prevent showing create custom plugin card when query is present

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -361,7 +361,7 @@ const filteredPlugins = computed((): PluginCardList => {
     }
   }
 
-  if (shouldShowCreateCustomPluginCard.value) {
+  if (shouldShowCreateCustomPluginCard.value && !query) {
     const customPlugins = (results[PluginGroup.CUSTOM_PLUGINS] || []).filter((plugin: PluginType) => plugin.id !== createCustomPluginCard.value.id)
     results[PluginGroup.CUSTOM_PLUGINS] = [createCustomPluginCard.value, ...customPlugins]
   }


### PR DESCRIPTION
# Summary

### Before
<img width="3168" height="1012" alt="image" src="https://github.com/user-attachments/assets/d993fcfb-6e69-4b83-8bdf-260a4f5c81c4" />

### After
<img width="3486" height="666" alt="image" src="https://github.com/user-attachments/assets/ad7cceb0-d2fd-4c59-ab02-1c0d86b3db94" />

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
