### PR TITLE
feat(entities-shared): add a secret advice to the decK customization editor

### DIFF
--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
@@ -87,23 +87,27 @@
       @code-block-render="highlightCodeBlock"
     />
 
-    <component
-      :is="DeckCommandEditor"
-      v-else-if="props.entityRecord && props.isCustomizing && DeckCommandEditor"
-      v-model="unredactedDeckCommand"
-      :language="shell"
-    />
+    <template v-else-if="props.entityRecord && props.isCustomizing && DeckCommandEditor">
+      <div class="customization-secret-advise">
+        {{ t('deckCodeBlock.customization.secret_advise') }}
+      </div>
 
-    <KAlert
-      v-if="props.isCustomizing"
-      class="customization-footer-reminder"
-    >
-      <template #icon>
-        <InfoIcon />
-      </template>
+      <component
+        :is="DeckCommandEditor"
+        v-model="unredactedDeckCommand"
+        :language="shell"
+      />
 
-      {{ t('deckCodeBlock.customization.footer_reminder') }}
-    </KAlert>
+      <KAlert
+        class="customization-footer-reminder"
+      >
+        <template #icon>
+          <InfoIcon />
+        </template>
+
+        {{ t('deckCodeBlock.customization.footer_reminder') }}
+      </KAlert>
+    </template>
   </div>
 
   <GeneratePatModal
@@ -305,6 +309,11 @@ ${unredactedCommand.value}
 
   .copy-konnect-pat-alert {
     margin-top: var(--kui-space-40, $kui-space-40);
+  }
+
+  .customization-secret-advise {
+    font-size: var(--kui-font-size-30, $kui-font-size-30);
+    opacity: 0.7;
   }
 
   .customization-footer-reminder {

--- a/packages/entities/entities-shared/src/locales/en.json
+++ b/packages/entities/entities-shared/src/locales/en.json
@@ -132,7 +132,8 @@
       "copy_pat": "Make sure to copy your personal access token now. You won't be able to see it again.",
       "reuse_pat": "Use an existing PAT if you've already generated one.",
       "generate_pat": "Generate PAT",
-      "footer_reminder": "Changes made here won't affect your configuration."
+      "footer_reminder": "Changes made here won't affect your configuration.",
+      "secret_advise": "Command may contain sensitive values. Treat it as a secret."
     },
     "copy_tooltip": "Copy"
   },


### PR DESCRIPTION
Adding a secret advice to the decK command editor, as it may contain sensitive fields:

<img width="682" height="845" alt="Screenshot 2026-05-11 at 14 55 25" src="https://github.com/user-attachments/assets/13d1fe35-d75f-4829-ac91-cec06ded50f6" />
