### PR TITLE
fix(entities-plugins): cloned plugins now render source plugin's shared VFG form

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -472,7 +472,7 @@ const syncFormRenderingMode = (pluginName?: string) => {
   }
 
   // For cloned plugins, use the source plugin name for rendering decisions
-  const effectivePluginName = (props.schema as any)?._sourcePlugin || pluginName
+  const effectivePluginName = props.schema?._sourcePlugin || pluginName
   pluginConfig.value = getPluginConfig(effectivePluginName)
   freeformComponent.value = shouldUseFreeForm(effectivePluginName, props.engine)
     ? (getFreeFormComponent(effectivePluginName) ?? CommonForm)

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -471,11 +471,13 @@ const syncFormRenderingMode = (pluginName?: string) => {
     return
   }
 
-  pluginConfig.value = getPluginConfig(pluginName)
-  freeformComponent.value = shouldUseFreeForm(pluginName, props.engine)
-    ? (getFreeFormComponent(pluginName) ?? CommonForm)
+  // For cloned plugins, use the source plugin name for rendering decisions
+  const effectivePluginName = (props.schema as any)?._sourcePlugin || pluginName
+  pluginConfig.value = getPluginConfig(effectivePluginName)
+  freeformComponent.value = shouldUseFreeForm(effectivePluginName, props.engine)
+    ? (getFreeFormComponent(effectivePluginName) ?? CommonForm)
     : undefined
-  sharedFormName.value = getSharedFormName(pluginName)
+  sharedFormName.value = getSharedFormName(effectivePluginName)
 
   setPluginFormLayoutState(Boolean(freeformComponent.value))
 }

--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -2225,6 +2225,35 @@ describe('<PluginForm />', () => {
         cy.get('.vue-form-generator').should('exist')
         cy.get('[data-testid^="ff-"]').should('not.exist')
       })
+
+      it('renders OIDCForm for a cloned plugin when its source plugin is openid-connect', () => {
+        // openid-connect uses a shared custom form (OIDCForm) — a clone should inherit it.
+        const pluginType = 'oidc-clone'
+        interceptKonnectSchema({ mockData: schemaCors })
+        interceptClonedPlugin({ pluginName: pluginType, ref: 'openid-connect' })
+
+        cy.mount(PluginForm, {
+          props: {
+            config: baseConfigKonnect,
+            pluginType,
+          },
+          global: {
+            provide: {
+              [FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM]: true,
+              [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+            },
+          },
+          router,
+        })
+
+        cy.wait(['@getPluginSchema', '@getClonedPlugin'])
+        cy.get('.kong-ui-entities-plugin-form-container').should('be.visible')
+
+        // OIDCForm renders KTabs with these tab IDs — present only when OIDCForm is active.
+        cy.get('#advanced-tab').should('exist')
+        // Generic freeform layout must not be used.
+        cy.get('[data-testid^="ff-"]').should('not.exist')
+      })
     })
 
     describe('Condition field', () => {

--- a/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginForm.cy.ts
@@ -2229,7 +2229,8 @@ describe('<PluginForm />', () => {
       it('renders OIDCForm for a cloned plugin when its source plugin is openid-connect', () => {
         // openid-connect uses a shared custom form (OIDCForm) — a clone should inherit it.
         const pluginType = 'oidc-clone'
-        interceptKonnectSchema({ mockData: schemaCors })
+        // Use a minimal schema — OIDCForm renders its own fields regardless of schema content.
+        interceptKonnectSchema({ mockData: { fields: [] } })
         interceptClonedPlugin({ pluginName: pluginType, ref: 'openid-connect' })
 
         cy.mount(PluginForm, {

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -411,7 +411,7 @@ const clonedSourcePlugin = ref<string | null>(null)
 const isClonedPlugin = computed(() => clonedSourcePlugin.value !== null)
 
 const effectivePluginType = computed(() =>
-  (isClonedPlugin.value && clonedSourcePlugin.value) ? clonedSourcePlugin.value : props.pluginType
+  (isClonedPlugin.value && clonedSourcePlugin.value) ? clonedSourcePlugin.value : props.pluginType,
 )
 
 const realEngine = computed<'vfg' | 'freeform' | undefined>(() => {

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -686,7 +686,8 @@ const getArrayType = (list: unknown[]): string => {
 
 const buildFormSchema = (parentKey: string, response: Record<string, any>, initialFormSchema: Record<string, any>, arrayNested?: boolean) => {
   let schema = (response && response.fields) || []
-  const pluginSchema = customSchemas[props.pluginType as keyof CustomSchemas]
+  const effectivePluginType = (isClonedPlugin.value && clonedSourcePlugin.value) ? clonedSourcePlugin.value : props.pluginType
+  const pluginSchema = customSchemas[effectivePluginType as keyof CustomSchemas]
   const credentialSchema = CREDENTIAL_METADATA[props.pluginType]?.schema?.fields
 
   // schema can either be an object or an array of objects. If it's an array, convert it to an object
@@ -1363,6 +1364,9 @@ watch([entityMap, initialized], (newData, oldData) => {
     if (isCustomPlugin.value) {
       initialFormSchema._isCustomPlugin = true
     }
+    if (isClonedPlugin.value && clonedSourcePlugin.value) {
+      initialFormSchema._sourcePlugin = clonedSourcePlugin.value
+    }
     if (pluginPartialType.value) {
       initialFormSchema._supported_redis_partial_type = pluginPartialType.value
     }
@@ -1599,6 +1603,9 @@ onBeforeMount(async () => {
             }
             // pass whether the plugin is a custom plugin to the form schema
             if (isCustomPlugin.value) initialFormSchema._isCustomPlugin = true
+            if (isClonedPlugin.value && clonedSourcePlugin.value) {
+              initialFormSchema._sourcePlugin = clonedSourcePlugin.value
+            }
             finalSchema.value = initialFormSchema
           }
         }

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -410,6 +410,10 @@ const clonedSourcePlugin = ref<string | null>(null)
 
 const isClonedPlugin = computed(() => clonedSourcePlugin.value !== null)
 
+const effectivePluginType = computed(() =>
+  (isClonedPlugin.value && clonedSourcePlugin.value) ? clonedSourcePlugin.value : props.pluginType
+)
+
 const realEngine = computed<'vfg' | 'freeform' | undefined>(() => {
   if (props.engine) return props.engine
   if (!customPluginFreeform || !isCustomPlugin.value) return undefined
@@ -686,8 +690,7 @@ const getArrayType = (list: unknown[]): string => {
 
 const buildFormSchema = (parentKey: string, response: Record<string, any>, initialFormSchema: Record<string, any>, arrayNested?: boolean) => {
   let schema = (response && response.fields) || []
-  const effectivePluginType = (isClonedPlugin.value && clonedSourcePlugin.value) ? clonedSourcePlugin.value : props.pluginType
-  const pluginSchema = customSchemas[effectivePluginType as keyof CustomSchemas]
+  const pluginSchema = customSchemas[effectivePluginType.value as keyof CustomSchemas]
   const credentialSchema = CREDENTIAL_METADATA[props.pluginType]?.schema?.fields
 
   // schema can either be an object or an array of objects. If it's an array, convert it to an object
@@ -1276,9 +1279,9 @@ const initScopeFields = (): void => {
   }
 
   // apply custom front-end schema if overwriteDefault is true
-  if (customSchemas[props.pluginType as keyof CustomSchemas] && customSchemas[props.pluginType as keyof CustomSchemas].overwriteDefault) {
-    if (Object.hasOwnProperty.call(customSchemas[props.pluginType as keyof CustomSchemas], 'formSchema')) {
-      Object.assign(defaultFormSchema, customSchemas[props.pluginType as keyof CustomSchemas].formSchema)
+  if (customSchemas[effectivePluginType.value as keyof CustomSchemas] && customSchemas[effectivePluginType.value as keyof CustomSchemas].overwriteDefault) {
+    if (Object.hasOwnProperty.call(customSchemas[effectivePluginType.value as keyof CustomSchemas], 'formSchema')) {
+      Object.assign(defaultFormSchema, customSchemas[effectivePluginType.value as keyof CustomSchemas].formSchema)
     }
   }
 }
@@ -1476,7 +1479,7 @@ const saveFormData = async (): Promise<void> => {
     let response: AxiosResponse | undefined
 
     const payload = JSON.parse(JSON.stringify(getRequestBody.value))
-    const customSchema = customSchemas[props.pluginType as keyof CustomSchemas]
+    const customSchema = customSchemas[effectivePluginType.value as keyof CustomSchemas]
     if (typeof customSchema?.shamefullyTransformPayload === 'function') {
       customSchema.shamefullyTransformPayload({
         originalModel: formFieldsOriginal,

--- a/packages/entities/entities-plugins/src/composables/useSchemas.spec.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { useSchemas } from './useSchemas'
+
+describe('useSchemas', () => {
+  const { parseSchema } = useSchemas()
+
+  // Minimal schema that mimics the flat object produced by PluginForm.vue's buildFormSchema.
+  const makeSchema = (overrides: Record<string, any> = {}) => ({
+    name: { default: 'my-clone', type: 'input', inputType: 'hidden', styleClasses: 'd-none', pinned: true },
+    enabled: { type: 'switch', model: 'enabled', default: true, pinned: true },
+    ...overrides,
+  })
+
+  describe('parseSchema – _sourcePlugin handling', () => {
+    it('excludes _sourcePlugin from rendered form fields', () => {
+      const schema = makeSchema({ _sourcePlugin: 'openid-connect' })
+
+      const result = parseSchema(schema)
+      const fieldModels = result.schema.fields?.map((f: any) => f.model) ?? []
+
+      expect(fieldModels).not.toContain('_sourcePlugin')
+    })
+
+    it('generates flat fields schema when _sourcePlugin is a shared-form plugin (openid-connect)', () => {
+      // openid-connect → getSharedFormName returns 'OIDCForm' → parseSchema should produce flat fields
+      const schema = makeSchema({ _sourcePlugin: 'openid-connect' })
+
+      const result = parseSchema(schema)
+
+      expect(result.schema).toHaveProperty('fields')
+      expect(result.schema).not.toHaveProperty('groups')
+    })
+
+    it('generates grouped schema for a plain custom plugin without _sourcePlugin', () => {
+      // No _sourcePlugin, unknown plugin name → grouped schema (default VFG layout)
+      const schema = makeSchema()
+
+      const result = parseSchema(schema)
+
+      expect(result.schema).toHaveProperty('groups')
+      expect(result.schema).not.toHaveProperty('fields')
+    })
+  })
+})

--- a/packages/entities/entities-plugins/src/composables/useSchemas.spec.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.spec.ts
@@ -1,9 +1,22 @@
 import { describe, it, expect } from 'vitest'
+import { createApp, defineComponent, h } from 'vue'
 import { useSchemas } from './useSchemas'
 
-describe('useSchemas', () => {
-  const { parseSchema } = useSchemas()
+// useSchemas calls useExperimentalFreeForms which uses inject().
+// withSetup provides a valid Vue instance so inject() doesn't warn.
+function withSetup<T>(fn: () => T): T {
+  let result!: T
+  const app = createApp(defineComponent({
+    setup() {
+      result = fn()
+      return () => h('div')
+    },
+  }))
+  app.mount(document.createElement('div'))
+  return result
+}
 
+describe('useSchemas', () => {
   // Minimal schema that mimics the flat object produced by PluginForm.vue's buildFormSchema.
   const makeSchema = (overrides: Record<string, any> = {}) => ({
     name: { default: 'my-clone', type: 'input', inputType: 'hidden', styleClasses: 'd-none', pinned: true },
@@ -13,6 +26,7 @@ describe('useSchemas', () => {
 
   describe('parseSchema – _sourcePlugin handling', () => {
     it('excludes _sourcePlugin from rendered form fields', () => {
+      const { parseSchema } = withSetup(() => useSchemas())
       const schema = makeSchema({ _sourcePlugin: 'openid-connect' })
 
       const result = parseSchema(schema)
@@ -23,6 +37,7 @@ describe('useSchemas', () => {
 
     it('generates flat fields schema when _sourcePlugin is a shared-form plugin (openid-connect)', () => {
       // openid-connect → getSharedFormName returns 'OIDCForm' → parseSchema should produce flat fields
+      const { parseSchema } = withSetup(() => useSchemas())
       const schema = makeSchema({ _sourcePlugin: 'openid-connect' })
 
       const result = parseSchema(schema)
@@ -33,6 +48,7 @@ describe('useSchemas', () => {
 
     it('generates grouped schema for a plain custom plugin without _sourcePlugin', () => {
       // No _sourcePlugin, unknown plugin name → grouped schema (default VFG layout)
+      const { parseSchema } = withSetup(() => useSchemas())
       const schema = makeSchema()
 
       const result = parseSchema(schema)

--- a/packages/entities/entities-plugins/src/composables/useSchemas.ts
+++ b/packages/entities/entities-plugins/src/composables/useSchemas.ts
@@ -299,7 +299,7 @@ export const useSchemas = (options?: UseSchemasOptions) => {
    * @returns {Array} an array of form fields not to render across all entity forms
    */
   const getBlacklist = () => {
-    return ['created_at', 'updated_at', 'id', '_isCustomPlugin', '_supported_redis_partial_type', '_redis_partial_path']
+    return ['created_at', 'updated_at', 'id', '_isCustomPlugin', '_sourcePlugin', '_supported_redis_partial_type', '_redis_partial_path']
   }
 
   /**
@@ -333,7 +333,9 @@ export const useSchemas = (options?: UseSchemasOptions) => {
     })
 
     const pluginName = formModel.name
-    const metadata = PLUGIN_METADATA[pluginName]
+    // For cloned plugins, use the source plugin name for rendering decisions
+    const effectivePluginName = currentSchema._sourcePlugin || pluginName
+    const metadata = PLUGIN_METADATA[effectivePluginName]
 
 
     const redisFields = []
@@ -350,7 +352,7 @@ export const useSchemas = (options?: UseSchemasOptions) => {
     formSchema._supported_redis_partial_type = currentSchema._supported_redis_partial_type
     formSchema._redis_partial_path = currentSchema._redis_partial_path
 
-    if (getSharedFormName(pluginName) || shouldUseFreeForm(pluginName, experimentalFreeForms, engine) || metadata?.useLegacyForm || options?.credential) {
+    if (getSharedFormName(effectivePluginName) || shouldUseFreeForm(effectivePluginName, experimentalFreeForms, engine) || metadata?.useLegacyForm || options?.credential) {
       /**
        * Do not generate grouped schema when:
        * - The plugin has a custom layout


### PR DESCRIPTION
## Problem

When a plugin is a **cloned plugin** (created via the `KM_2485_CLONED_PLUGINS` feature), it has a custom name (e.g. `oidc-clone`) that is different from the built-in plugin it was cloned from (e.g. `openid-connect`). 

<img width="2276" height="1894" alt="image" src="https://github.com/user-attachments/assets/327f7095-a009-4218-a0f0-6825cabbac78" />


## Fix

Following the existing `_isCustomPlugin` pattern, propagate a `_sourcePlugin` metadata field through the flat form schema object. Then:

1. **`PluginForm.vue` (`buildFormSchema`)** — when building the schema, inject `_sourcePlugin = clonedSourcePlugin.value` and use the source plugin name when looking up `customSchemas`.

2. **`useSchemas.ts` (`parseSchema`)** — add `_sourcePlugin` to the field blacklist so it never renders as a form field; use `currentSchema._sourcePlugin || pluginName` as `effectivePluginName` for all layout decisions.

3. **`PluginEntityForm.vue` (`syncFormRenderingMode`)** — use `props.schema._sourcePlugin || pluginName` as `effectivePluginName` when calling `getSharedFormName`, `shouldUseFreeForm`, `getFreeFormComponent`, and `getPluginConfig`.

<img width="2812" height="1648" alt="image" src="https://github.com/user-attachments/assets/b77d5130-bc8b-4b7f-9bd0-8a973db8ad33" />

