### PR TITLE
feat(analytics): display tooltip numbers with better css [MA-4864]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
@@ -205,6 +205,7 @@ watch(tooltipEl, value => {
     }
 
     .display-value {
+      font-variant-numeric: tabular-nums;
       margin-left: var(--kui-space-auto, $kui-space-auto);
       padding-left: var(--kui-space-40, $kui-space-40);
       white-space: nowrap;


### PR DESCRIPTION
Satisfies [MA-4864](https://konghq.atlassian.net/browse/MA-4864)

# Summary

Make it so numbers are lined up nicely in the tooltip.

### Screenshots

**Before** - note how the numbers on the right side of the tooltip are different widths, despite being the same number of digits

<img width="443" height="319" alt="Screenshot 2026-05-11 at 11 58 35 AM" src="https://github.com/user-attachments/assets/7e4e797e-ae5b-4fc4-9f77-6a5e3de519d9" />

**After** - ayyy, the numbers line up

<img width="449" height="301" alt="Screenshot 2026-05-11 at 11 58 20 AM" src="https://github.com/user-attachments/assets/0e0b45dd-b1dc-46cb-a163-07fe1be7c83f" />

---

@kong-ui-public/analytics-chart@latest
@kong-ui-public/dashboard-renderer@latest

[MA-4864]: https://konghq.atlassian.net/browse/MA-4864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ