### PR TITLE
fix(entities-shared): filter out date fields from code to copy

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -52,6 +52,7 @@ import { PluginForm, TOASTER_PROVIDER, useProvideExperimentalFreeForms } from '.
 import { FEATURE_FLAGS } from '../../src/constants'
 
 import { ToastManager } from '@kong/kongponents'
+import { provideDeckCommandEditor } from '@kong-ui-public/entities-shared/deck-editor'
 
 import type { KongManagerPluginFormConfig, KonnectPluginFormConfig } from '../../src'
 import type { GlobalAction } from '../../src/components/free-form/shared/types'
@@ -80,6 +81,8 @@ provide(FEATURE_FLAGS.KM_2306_CONDITION_FIELD_314, true)
 provide(FEATURE_FLAGS.KM_2446_DATAKIT_JWT_NODES, true)
 provide(FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM, true)
 provide(FEATURE_FLAGS.KM_2485_CLONED_PLUGINS, true)
+
+provideDeckCommandEditor()
 
 useProvideExperimentalFreeForms([
   'service-protection',

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.cy.ts
@@ -71,4 +71,97 @@ describe('<ConfigCardDisplay />', () => {
       cy.get('.deck-config').should('be.visible')
     })
   })
+
+  describe('Code block record processing:', () => {
+    const stubClipboard = () => cy.window().then((win) => {
+      cy.stub(win.navigator.clipboard, 'writeText').as('clipboardWriteText').resolves()
+    })
+
+    const formats: Array<{ format: 'json' | 'yaml' | 'deck', codeBlockId: string }> = [
+      { format: 'json', codeBlockId: 'json-codeblock' },
+      { format: 'yaml', codeBlockId: 'yaml-codeblock' },
+      { format: 'deck', codeBlockId: 'deck-codeblock' },
+    ]
+
+    const buildProps = (format: 'json' | 'yaml' | 'deck', extra: Record<string, any> = {}) => ({
+      format,
+      record,
+      ...(format === 'deck' ? { config: { app: 'konnect' } } : {}),
+      ...extra,
+    })
+
+    formats.forEach(({ format, codeBlockId }) => {
+      describe(`${format} format:`, () => {
+        it('strips created_at and updated_at from the displayed code by default', () => {
+          cy.mount(ConfigCardDisplay, { props: buildProps(format) })
+
+          cy.get(`#${codeBlockId}`).findTestId('highlighted-code-block').should('not.contain.text', 'created_at')
+          cy.get(`#${codeBlockId}`).findTestId('highlighted-code-block').should('not.contain.text', 'updated_at')
+        })
+
+        it('strips created_at and updated_at from the copied (unredacted) code', () => {
+          cy.mount(ConfigCardDisplay, { props: buildProps(format, { codeBlockRecord: record }) })
+
+          stubClipboard()
+          cy.getTestId(`code-block-copy-button-${codeBlockId}`).click()
+          cy.get('@clipboardWriteText').then((stub: any) => {
+            const copied = stub.firstCall.args[0] as string
+            expect(copied).to.not.include('created_at')
+            expect(copied).to.not.include('updated_at')
+          })
+        })
+
+        it('keeps timestamps when `preserveCodeBlockTimestamps` is true', () => {
+          cy.mount(ConfigCardDisplay, { props: buildProps(format, { preserveCodeBlockTimestamps: true }) })
+
+          cy.get(`#${codeBlockId}`).findTestId('highlighted-code-block').should('contain.text', 'created_at')
+          cy.get(`#${codeBlockId}`).findTestId('highlighted-code-block').should('contain.text', 'updated_at')
+        })
+
+        it('uses `codeBlockRecordRedacted` for display and `codeBlockRecord` for copy', () => {
+          const unredacted = { ...record, secret: 'plaintext-secret' }
+          const redacted = { ...record, secret: '********' }
+
+          cy.mount(ConfigCardDisplay, {
+            props: buildProps(format, {
+              codeBlockRecord: unredacted,
+              codeBlockRecordRedacted: redacted,
+            }),
+          })
+
+          cy.get(`#${codeBlockId}`).findTestId('highlighted-code-block').should('contain.text', '********')
+          cy.get(`#${codeBlockId}`).findTestId('highlighted-code-block').should('not.contain.text', 'plaintext-secret')
+
+          stubClipboard()
+          cy.getTestId(`code-block-copy-button-${codeBlockId}`).click()
+          cy.get('@clipboardWriteText').then((stub: any) => {
+            const copied = stub.firstCall.args[0] as string
+            expect(copied).to.include('plaintext-secret')
+            expect(copied).to.not.include('********')
+          })
+        })
+
+        it('applies `codeBlockRecordFormatter` to both displayed and copied content', () => {
+          const formatter = (r: Record<string, any>) => ({ ...r, formatted: 'YES' })
+
+          cy.mount(ConfigCardDisplay, {
+            props: buildProps(format, {
+              codeBlockRecord: record,
+              codeBlockRecordFormatter: formatter,
+            }),
+          })
+
+          cy.get(`#${codeBlockId}`).findTestId('highlighted-code-block').should('contain.text', 'formatted')
+
+          stubClipboard()
+          cy.getTestId(`code-block-copy-button-${codeBlockId}`).click()
+          cy.get('@clipboardWriteText').then((stub: any) => {
+            const copied = stub.firstCall.args[0] as string
+            expect(copied).to.include('formatted')
+            expect(copied).to.include('YES')
+          })
+        })
+      })
+    })
+  })
 })

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/ConfigCardDisplay.vue
@@ -58,13 +58,13 @@
     :entity-record="entityRecord"
     :fetcher-url="fetchUrlJsonBlock"
     request-method="get"
-    :unredacted-record="codeBlockRecord || record"
+    :unredacted-record="unredactedEntityRecord"
   />
   <YamlCodeBlock
     v-if="format === 'yaml' && entityRecord"
     :deck-callout-preference-key="isDeckEnabled ? deckCalloutPreferenceKey : undefined"
     :entity-record="entityRecord"
-    :unredacted-record="codeBlockRecord || record"
+    :unredacted-record="unredactedEntityRecord"
     @deck-callout:click-cta="$emit('request-deck-format')"
   />
   <TerraformCodeBlock
@@ -72,7 +72,7 @@
     :entity-record="entityRecord"
     :entity-type="props.entityType"
     :sub-entity-type="props.subEntityType"
-    :unredacted-record="codeBlockRecord || record"
+    :unredacted-record="unredactedEntityRecord"
   />
   <DeckCodeBlock
     v-if="format === 'deck' && entityRecord"
@@ -84,7 +84,7 @@
     :geo-api-server-url="config.app === 'konnect' ? config.geoApiServerUrl : undefined"
     :is-customization-modal-visible="isDeckCustomizationVisible"
     :kong-admin-api-url="config.app === 'kongManager' ? config.apiBaseUrl : undefined"
-    :unredacted-record="codeBlockRecord || record"
+    :unredacted-record="unredactedEntityRecord"
     :workspace="config.app === 'kongManager' ? config.workspace : undefined"
     @customization-close="$emit('deck-customization:close')"
   />
@@ -209,29 +209,35 @@ const { i18n: { t } } = composables.useI18n()
 
 const hasTooltip = (item: RecordItem): boolean => !!(item.tooltip || slots[`${item.key}-label-tooltip`])
 
-// Structured grid always uses `record`; code tabs uses `codeBlockRecordRedacted` or `codeBlockRecord` when the parent passes it
-const recordForCodeBlocks = computed((): Record<string, any> | undefined => props.codeBlockRecordRedacted || props.codeBlockRecord || props.record)
-
 // Deep clone + optional timestamp strip + per-format shaping (`codeBlockRecordFormatter`)
-const entityRecord = computed((): Record<string, any> | undefined => {
-  let record = recordForCodeBlocks.value
-
-  if (record == null) {
+const processForCodeBlock = (source: Record<string, any> | undefined): Record<string, any> | undefined => {
+  if (source == null) {
     return undefined
   }
 
+  // Clone first in case `codeBlockRecordFormatter` mutates the source (could be a prop field)
+  let record: Record<string, any> = JSON.parse(JSON.stringify(source))
   if (props.codeBlockRecordFormatter) {
     record = props.codeBlockRecordFormatter(record, props.format as ConfigCardCodeFormat)
   }
 
-  const processedRecord = JSON.parse(JSON.stringify(record))
   if (!props.preserveCodeBlockTimestamps) {
     // remove dates from JSON/YAML config [KHCP-9837]
-    delete processedRecord.created_at
-    delete processedRecord.updated_at
+    delete record.created_at
+    delete record.updated_at
   }
-  return processedRecord
-})
+  return record
+}
+
+// Structured grid always uses `record`; code tabs uses `codeBlockRecordRedacted` or `codeBlockRecord` when the parent passes it
+const entityRecord = computed((): Record<string, any> | undefined =>
+  processForCodeBlock(props.codeBlockRecordRedacted || props.codeBlockRecord || props.record),
+)
+
+// Unredacted record for code blocks, with date fields removed.
+const unredactedEntityRecord = computed((): Record<string, any> | undefined =>
+  processForCodeBlock(props.codeBlockRecord || props.record),
+)
 
 const fetchUrlJsonBlock = computed(() => {
   return props.fetcherUrl


### PR DESCRIPTION
Fixing a regression in ConfigCardDisplay where the code to copy (`:unredacted-record`) contains date fields like `updated_at` and `created_at`. Such fields will cause deck commands like `deck gateway apply` to fail to work. 

KM-2566