### PR TITLE
fix(entities-shared): deck customization tweaks

### DIFF
--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
@@ -64,6 +64,7 @@
     >
       <KButton
         appearance="secondary"
+        data-testid="generate-konnect-pat-button"
         @click="isGeneratePatModalVisible = true"
       >
         {{ t('deckCodeBlock.customization.generate_pat') }}

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -29,15 +29,6 @@
           :label="t('baseConfigCard.actions.sensitive_fields')"
         />
 
-        <KButton
-          v-if="configFormat === 'deck' && Boolean(deckCustomizationOptions)"
-          appearance="secondary"
-          class="button-customize-deck"
-          @click="isDeckCustomizationVisible = true"
-        >
-          {{ t('baseConfigCard.actions.deck_customize') }}
-        </KButton>
-
         <div class="row">
           <KLabel
             class="config-format-select-label"
@@ -52,6 +43,16 @@
             @change="handleChange"
           />
         </div>
+
+        <KButton
+          v-if="configFormat === 'deck' && Boolean(deckCustomizationOptions)"
+          appearance="secondary"
+          class="button-customize-deck"
+          data-testid="config-deck-customize-button"
+          @click="isDeckCustomizationVisible = true"
+        >
+          {{ t('baseConfigCard.actions.deck_customize') }}
+        </KButton>
 
         <KButton
           v-if="configCardDoc"

--- a/packages/entities/entities-shared/src/locales/en.json
+++ b/packages/entities/entities-shared/src/locales/en.json
@@ -132,7 +132,7 @@
       "copy_pat": "Make sure to copy your personal access token now. You won't be able to see it again.",
       "reuse_pat": "Use an existing PAT if you've already generated one.",
       "generate_pat": "Generate PAT",
-      "footer_reminder": "Changes made here won't affect your configuration.",
+      "footer_reminder": "Changes you make here won't affect your configuration. After you apply changes with decK in the CLI, refresh the page to view them.",
       "secret_advise": "Command may contain sensitive values. Treat it as a secret."
     },
     "copy_tooltip": "Copy"


### PR DESCRIPTION
1. "Customize before copying to CLI" button now appears on the right of the format dropdown:
   <img width="1320" height="646" alt="Screenshot 2026-05-12 at 18 23 45" src="https://github.com/user-attachments/assets/afa801ed-1b2d-489b-ad19-df8717e8f666" />
2. Copy edited the footer reminder:
   <img width="663" height="838" alt="Screenshot 2026-05-12 at 18 23 56" src="https://github.com/user-attachments/assets/86f9784c-2829-4e3b-80c1-40334b83befe" />
3. Added more `data-testid` for better observability.
