### PR TITLE
fix(ci): block merge when component tests timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -383,7 +383,6 @@ jobs:
     name: Collect Test Results And Publish
     needs: [build, component-tests]
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 20
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -394,10 +393,10 @@ jobs:
 
     steps:
       - name: Successful tests
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: exit 0
       - name: Failing tests
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
 
       - name: Checkout Source Code


### PR DESCRIPTION
## Problem
I recently found a bug that PR can not be blocked when the test is timed out.
- The problem PR: https://github.com/Kong/public-ui-components/pull/3241
- The action logs: https://github.com/Kong/public-ui-components/actions/runs/25655877320/job/75304758976?pr=3241

Root cause:

1. `finish-test-and-publish` had `continue-on-error: true` — GitHub marks the job as succeeded even when it runs `exit 1`, so branch protection rules are never triggered.
2. The failure gate only checked for `'failure'`, but a job that hits `timeout-minutes` gets status `'cancelled'` — so the gate ran `exit 0` and the workflow passed.

## Fix

- Remove `continue-on-error: true` from `finish-test-and-publish`
- Add `|| contains(needs.*.result, 'cancelled')` to the failure condition