### PR TITLE
feat(entities-plugins): reset cleared array enums to null

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/node-forms/NodeFormBranch.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/node-forms/NodeFormBranch.vue
@@ -19,7 +19,7 @@
       :items="branchOptions"
       multiple
       name="then"
-      @update="(value) => onBranchChange('then', value)"
+      @update="(value) => onBranchChange('then', value as string | string[] | null)"
     >
       <template #item-label="item">
         <SourceItem :item="item" />
@@ -31,7 +31,7 @@
       :items="branchOptions"
       multiple
       name="else"
-      @update="(value) => onBranchChange('else', value)"
+      @update="(value) => onBranchChange('else', value as string | string[] | null)"
     >
       <template #item-label="item">
         <SourceItem :item="item" />

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RateLimitingAdvancedForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RateLimitingAdvancedForm.vue
@@ -32,13 +32,6 @@ function handleFormChange(value: Partial<FreeFormPluginData>, fields?: string[])
   if (value.config?.namespace === null) {
     delete value.config.namespace
   }
-
-  /**
-   * `compound_identifier` should be null when empty, not an empty array.
-   */
-  if (Array.isArray(value.config?.compound_identifier) && value.config.compound_identifier.length === 0) {
-    value.config.compound_identifier = null
-  }
   props.onFormChange(value, fields)
 }
 </script>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
@@ -285,8 +285,8 @@ const removeItem = async (index: number) => {
   if (Array.isArray(fieldValue!.value)) {
     fieldValue!.value.splice(index, 1)
 
-    if (fieldValue!.value.length === 0 && !field.schema?.value?.required) {
-      fieldValue!.value = null as any
+    if (fieldValue!.value.length === 0 && !fieldAttrs.value.required) {
+      fieldValue!.value = null
     }
   }
   emit('remove', index)

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
@@ -284,6 +284,10 @@ const addItem = async () => {
 const removeItem = async (index: number) => {
   if (Array.isArray(fieldValue!.value)) {
     fieldValue!.value.splice(index, 1)
+
+    if (fieldValue!.value.length === 0 && !field.schema?.value?.required) {
+      fieldValue!.value = null as any
+    }
   }
   emit('remove', index)
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
@@ -83,6 +83,11 @@ const fieldModel = defineModel({
   // If multiple and value is null/undefined, return empty array for v-model
   get: () => isMultiple.value && fieldValue?.value == null ? [] : fieldValue!.value,
   set: (val) => {
+    if (isMultiple.value && Array.isArray(val) && val.length === 0 && !field.schema?.value?.required) {
+      fieldValue!.value = null as any
+      return
+    }
+
     fieldValue!.value = val as any
   },
 })

--- a/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
@@ -17,7 +17,7 @@
     :data-testid="`ff-${field.path.value}`"
     :items="realItems"
     :kpop-attributes="{ 'data-testid': `ff-enum-${field.path.value}-items` }"
-    @update:model-value="(value: string | string[] | null) => emit('update', value)"
+    @update:model-value="(value: string | string[] | null) => emit('update', normalizeValue(value))"
   >
     <template
       v-if="'tooltip' in $slots || fieldAttrs.labelAttributes?.info"
@@ -75,24 +75,26 @@ const {
   ...props
 } = defineProps<EnumFieldProps>()
 const { getSelectItems } = useFormShared()
-const { value: fieldValue, hide, ...field } = useField<number | string | string[]>(
+const { value: fieldValue, hide, ...field } = useField<number | string | string[] | null>(
   toRef(() => name),
 )
+const fieldAttrs = useFieldAttrs(field.path!, props)
+
+function normalizeValue(value: number | string | string[] | null) {
+  if (isMultiple.value && Array.isArray(value) && value.length === 0 && !fieldAttrs.value.required) {
+    return null
+  }
+
+  return value
+}
 
 const fieldModel = defineModel({
   // If multiple and value is null/undefined, return empty array for v-model
   get: () => isMultiple.value && fieldValue?.value == null ? [] : fieldValue!.value,
   set: (val) => {
-    if (isMultiple.value && Array.isArray(val) && val.length === 0 && !field.schema?.value?.required) {
-      fieldValue!.value = null as any
-      return
-    }
-
-    fieldValue!.value = val as any
+    fieldValue!.value = normalizeValue(val as number | string | string[] | null)
   },
 })
-
-const fieldAttrs = useFieldAttrs(field.path!, props)
 
 const realItems = computed<SelectItem[]>(() => {
   if (items) return items

--- a/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
@@ -17,7 +17,7 @@
     :data-testid="`ff-${field.path.value}`"
     :items="realItems"
     :kpop-attributes="{ 'data-testid': `ff-enum-${field.path.value}-items` }"
-    @update:model-value="(value: string | string[] | null) => emit('update', normalizeValue(value))"
+    @update:model-value="(value: EnumValue) => emit('update', normalizeValue(value))"
   >
     <template
       v-if="'tooltip' in $slots || fieldAttrs.labelAttributes?.info"
@@ -56,6 +56,7 @@ import type { BaseFieldProps } from './types'
 
 type MultipleSelectProps = { multiple: true } & MultiselectProps<string, false>
 type SingleSelectProps = { multiple?: false } & SelectProps<string, false>
+type EnumValue = number | string | string[] | null
 
 type EnumFieldProps = {
   labelAttributes?: LabelAttributes
@@ -64,7 +65,7 @@ type EnumFieldProps = {
 } & (MultipleSelectProps | SingleSelectProps) & BaseFieldProps
 
 const emit = defineEmits<{
-  update: [string | string[] | null]
+  update: [EnumValue]
 }>()
 
 const {
@@ -75,12 +76,12 @@ const {
   ...props
 } = defineProps<EnumFieldProps>()
 const { getSelectItems } = useFormShared()
-const { value: fieldValue, hide, ...field } = useField<number | string | string[] | null>(
+const { value: fieldValue, hide, ...field } = useField<EnumValue>(
   toRef(() => name),
 )
 const fieldAttrs = useFieldAttrs(field.path!, props)
 
-function normalizeValue(value: number | string | string[] | null) {
+function normalizeValue(value: EnumValue): EnumValue {
   if (isMultiple.value && Array.isArray(value) && value.length === 0 && !fieldAttrs.value.required) {
     return null
   }
@@ -92,7 +93,7 @@ const fieldModel = defineModel({
   // If multiple and value is null/undefined, return empty array for v-model
   get: () => isMultiple.value && fieldValue?.value == null ? [] : fieldValue!.value,
   set: (val) => {
-    fieldValue!.value = normalizeValue(val as number | string | string[] | null)
+    fieldValue!.value = normalizeValue(val as EnumValue)
   },
 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/test/array-field.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/test/array-field.cy.ts
@@ -1,4 +1,6 @@
+import { h } from 'vue'
 import Form from '../shared/Form.vue'
+import ArrayField from '../shared/ArrayField.vue'
 import type { FormSchema } from 'src/types/plugins/form-schema'
 
 const FIELD_NAME = 'list'
@@ -23,13 +25,24 @@ function createArraySchema(options: {
 function mountArrayForm(options: {
   schema?: FormSchema
   data?: Record<string, unknown>
+  requiredOverride?: boolean
 }) {
+  const props = {
+    schema: options.schema ?? createArraySchema(),
+    data: options.data,
+    onChange: cy.spy().as('onChangeSpy'),
+  }
+
+  if (options.requiredOverride) {
+    cy.mount(() => h(Form, props, {
+      default: () => h(ArrayField, { name: FIELD_NAME, required: true }),
+    }))
+
+    return
+  }
+
   cy.mount(Form, {
-    props: {
-      schema: options.schema ?? createArraySchema(),
-      data: options.data,
-      onChange: cy.spy().as('onChangeSpy'),
-    },
+    props,
   })
 }
 
@@ -89,5 +102,16 @@ describe('ArrayField', () => {
     cy.getTestId(`ff-array-remove-item-btn-${FIELD_NAME}.1`).click()
 
     assertLastChange({ [FIELD_NAME]: ['alpha'] })
+  })
+
+  it('should emit [] when removing the last item from an array marked required via prop override', () => {
+    mountArrayForm({
+      data: { [FIELD_NAME]: ['alpha'] },
+      requiredOverride: true,
+    })
+
+    cy.getTestId(`ff-array-remove-item-btn-${FIELD_NAME}.0`).click()
+
+    assertLastChange({ [FIELD_NAME]: [] })
   })
 })

--- a/packages/entities/entities-plugins/src/components/free-form/test/array-field.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/test/array-field.cy.ts
@@ -1,0 +1,93 @@
+import Form from '../shared/Form.vue'
+import type { FormSchema } from 'src/types/plugins/form-schema'
+
+const FIELD_NAME = 'list'
+
+function createArraySchema(options: {
+  required?: boolean
+  defaultValue?: string[]
+} = {}): FormSchema {
+  return {
+    type: 'record',
+    fields: [{
+      [FIELD_NAME]: {
+        type: 'array',
+        elements: { type: 'string' },
+        ...(options.required ? { required: true } : {}),
+        ...(options.defaultValue !== undefined ? { default: options.defaultValue } : {}),
+      },
+    }],
+  }
+}
+
+function mountArrayForm(options: {
+  schema?: FormSchema
+  data?: Record<string, unknown>
+}) {
+  cy.mount(Form, {
+    props: {
+      schema: options.schema ?? createArraySchema(),
+      data: options.data,
+      onChange: cy.spy().as('onChangeSpy'),
+    },
+  })
+}
+
+function assertLastChange(expected: Record<string, unknown>) {
+  cy.get('@onChangeSpy').should((spy: any) => {
+    expect(spy.lastCall?.args[0]).to.deep.equal(expected)
+  })
+}
+
+describe('ArrayField', () => {
+  it('should emit [] when removing last item from required array', () => {
+    mountArrayForm({
+      schema: createArraySchema({ required: true }),
+      data: { [FIELD_NAME]: ['alpha'] },
+    })
+
+    cy.getTestId(`ff-array-remove-item-btn-${FIELD_NAME}.0`).click()
+
+    assertLastChange({ [FIELD_NAME]: [] })
+  })
+
+  it('should emit null when removing last item from optional array', () => {
+    mountArrayForm({
+      data: { [FIELD_NAME]: ['alpha'] },
+    })
+
+    cy.getTestId(`ff-array-remove-item-btn-${FIELD_NAME}.0`).click()
+
+    assertLastChange({ [FIELD_NAME]: null })
+  })
+
+  it('should emit null instead of the default when removing last item from optional array with default', () => {
+    mountArrayForm({
+      schema: createArraySchema({ defaultValue: ['alpha'] }),
+    })
+
+    cy.getTestId(`ff-array-remove-item-btn-${FIELD_NAME}.0`).click()
+
+    assertLastChange({ [FIELD_NAME]: null })
+  })
+
+  it('should emit [] instead of the default when removing last item from required array with default', () => {
+    mountArrayForm({
+      schema: createArraySchema({ required: true, defaultValue: ['alpha'] }),
+    })
+
+    cy.getTestId(`ff-array-remove-item-btn-${FIELD_NAME}.0`).click()
+
+    assertLastChange({ [FIELD_NAME]: [] })
+  })
+
+  it('should emit the remaining items when removing one of two entries', () => {
+    mountArrayForm({
+      data: { [FIELD_NAME]: ['alpha', 'beta'] },
+    })
+
+    cy.getTestId(`ff-array-remove-item-btn-${FIELD_NAME}.1`).click()
+
+    assertLastChange({ [FIELD_NAME]: ['alpha'] })
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/test/enum-field.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/test/enum-field.cy.ts
@@ -1,0 +1,83 @@
+import Form from '../shared/Form.vue'
+import type { FormSchema } from 'src/types/plugins/form-schema'
+
+const FIELD_NAME = 'protocols'
+
+function getMultiEnumSchema(required = false): FormSchema {
+  return {
+    type: 'record',
+    fields: [
+      {
+        [FIELD_NAME]: {
+          type: 'set',
+          elements: {
+            type: 'string',
+            one_of: ['http', 'https', 'grpc'],
+          },
+          ...(required ? { required: true } : {}),
+        },
+      },
+    ],
+  }
+}
+
+function mountEnumForm(options: {
+  required?: boolean
+  data: Record<string, unknown>
+}) {
+  cy.mount(Form, {
+    props: {
+      schema: getMultiEnumSchema(options.required),
+      data: options.data,
+      onChange: cy.spy().as('onChangeSpy'),
+    },
+  })
+}
+
+function assertLastChange(expected: Record<string, unknown>) {
+  cy.get('@onChangeSpy').should((spy: any) => {
+    expect(spy.lastCall?.args[0]).to.deep.equal(expected)
+  })
+}
+
+function removeSelectedValue(value: string) {
+  cy.getTestId(`ff-${FIELD_NAME}`)
+    .contains('.multiselect-selection-badge', new RegExp(value, 'i'))
+    .findTestId('badge-dismiss-button')
+    .click()
+}
+
+describe('EnumField', () => {
+  it('should emit [] when clearing all selections from required multiselect', () => {
+    mountEnumForm({
+      required: true,
+      data: { [FIELD_NAME]: ['http', 'grpc'] },
+    })
+
+    removeSelectedValue('http')
+    removeSelectedValue('grpc')
+
+    assertLastChange({ [FIELD_NAME]: [] })
+  })
+
+  it('should emit null when clearing all selections from optional multiselect', () => {
+    mountEnumForm({
+      data: { [FIELD_NAME]: ['http', 'grpc'] },
+    })
+
+    removeSelectedValue('http')
+    removeSelectedValue('grpc')
+
+    assertLastChange({ [FIELD_NAME]: null })
+  })
+
+  it('should emit the remaining selections after a partial deselect', () => {
+    mountEnumForm({
+      data: { [FIELD_NAME]: ['http', 'grpc'] },
+    })
+
+    removeSelectedValue('grpc')
+
+    assertLastChange({ [FIELD_NAME]: ['http'] })
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/test/enum-field.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/test/enum-field.cy.ts
@@ -1,4 +1,6 @@
+import { h } from 'vue'
 import Form from '../shared/Form.vue'
+import EnumField from '../shared/EnumField.vue'
 import type { FormSchema } from 'src/types/plugins/form-schema'
 
 const FIELD_NAME = 'protocols'
@@ -24,13 +26,28 @@ function getMultiEnumSchema(required = false): FormSchema {
 function mountEnumForm(options: {
   required?: boolean
   data: Record<string, unknown>
+  onUpdate?: (value: string | string[] | null) => void
 }) {
+  const props = {
+    schema: getMultiEnumSchema(options.required),
+    data: options.data,
+    onChange: cy.spy().as('onChangeSpy'),
+  }
+
+  if (options.onUpdate) {
+    cy.mount(() => h(Form, props, {
+      default: () => h(EnumField, {
+        name: FIELD_NAME,
+        multiple: true,
+        onUpdate: options.onUpdate,
+      }),
+    }))
+
+    return
+  }
+
   cy.mount(Form, {
-    props: {
-      schema: getMultiEnumSchema(options.required),
-      data: options.data,
-      onChange: cy.spy().as('onChangeSpy'),
-    },
+    props,
   })
 }
 
@@ -79,5 +96,21 @@ describe('EnumField', () => {
     removeSelectedValue('grpc')
 
     assertLastChange({ [FIELD_NAME]: ['http'] })
+  })
+
+  it('should emit null from @update when clearing all selections from optional multiselect', () => {
+    const onUpdateSpy = cy.spy().as('onUpdateSpy')
+
+    mountEnumForm({
+      data: { [FIELD_NAME]: ['http', 'grpc'] },
+      onUpdate: onUpdateSpy,
+    })
+
+    removeSelectedValue('http')
+    removeSelectedValue('grpc')
+
+    cy.get('@onUpdateSpy').should((spy: any) => {
+      expect(spy.lastCall?.args[0]).to.equal(null)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- reset optional ArrayField values to null when the last item is removed
- reset optional multiselect EnumField values to null when cleared
- remove the now-obsolete rate-limiting-advanced workaround and add focused field specs
