### PR TITLE
fix(entities-plugins): preserve request callout ids

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/request-callout/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/request-callout/types.ts
@@ -88,7 +88,7 @@ export interface RedisClusterNode {
  *                    Callout                   *
  ************************************************/
 
-export const CalloutId: unique symbol = Symbol()
+export const CalloutId = '_callout_id' as const
 
 export interface Callout {
   [CalloutId]?: string // used as key, will be removed from final data


### PR DESCRIPTION
## Summary
- switch the temporary request-callout id key from a symbol to a string so it survives MapField serialization
- before this change, RequestCallout stored a temporary per-callout id on a symbol key for depends_on name/id remapping
- after introducing MapField serialization, that symbol key was dropped during serialization/deserialization, so the temporary id was lost and the remapping logic could no longer rely on it

