### PR TITLE
feat(dashboard-renderer): add configurable cols to DashboardConfig

### DIFF
--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -692,6 +692,10 @@ export const dashboardConfigSchema = {
       type: 'number',
       description: 'Height of each tile in pixels.',
     },
+    cols: {
+      type: 'number',
+      description: 'Number of columns in the dashboard grid.',
+    },
     preset_filters: filtersFn([
       ...new Set([
         ...filterableExploreDimensions,

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -692,7 +692,7 @@ export const dashboardConfigSchema = {
       type: 'number',
       description: 'Height of each tile in pixels.',
     },
-    cols: {
+    columns: {
       type: 'number',
       description: 'Number of columns in the dashboard grid.',
     },

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -418,7 +418,7 @@ The root configuration type for a dashboard.
 interface DashboardConfig {
   tiles: TileConfig[]         // Array of tile configurations
   tile_height?: number         // Optional height of each tile in pixels
-  cols?: number                // Optional number of grid columns (default: 6)
+  columns?: number             // Optional number of grid columns (default: 6)
 }
 ```
 

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -418,6 +418,7 @@ The root configuration type for a dashboard.
 interface DashboardConfig {
   tiles: TileConfig[]         // Array of tile configurations
   tile_height?: number         // Optional height of each tile in pixels
+  cols?: number                // Optional number of grid columns (default: 6)
 }
 ```
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -25,7 +25,7 @@
         :is="internalContext.editable && !isFullscreen ? DraggableGridLayout : GridLayout"
         v-else
         ref="gridLayoutRef"
-        :cols="model.cols"
+        :columns="model.columns"
         :tile-height="model.tile_height"
         :tiles="gridTiles"
         @update-tiles="handleUpdateTiles"

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -25,6 +25,7 @@
         :is="internalContext.editable && !isFullscreen ? DraggableGridLayout : GridLayout"
         v-else
         ref="gridLayoutRef"
+        :cols="model.cols"
         :tile-height="model.tile_height"
         :tiles="gridTiles"
         @update-tiles="handleUpdateTiles"

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.cy.ts
@@ -84,6 +84,27 @@ describe('<DraggableGridLayout />', () => {
     })
   })
 
+  it('should initialize GridStack with the cols prop', () => {
+    cy.mount(DraggableGridLayout, {
+      props: {
+        tiles: mockTiles,
+        cols: 12,
+      },
+    })
+
+    cy.get('.grid-stack').should('have.class', 'grid-stack-12')
+  })
+
+  it('should default to 6 columns when cols prop is not set', () => {
+    cy.mount(DraggableGridLayout, {
+      props: {
+        tiles: mockTiles,
+      },
+    })
+
+    cy.get('.grid-stack').should('have.class', 'grid-stack-6')
+  })
+
   it('should add new tile when tiles prop length increases', () => {
 
     const tilesRef = ref(mockTiles)

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.cy.ts
@@ -92,7 +92,7 @@ describe('<DraggableGridLayout />', () => {
       },
     })
 
-    cy.get('.grid-stack').should('have.class', 'grid-stack-12')
+    cy.get('.grid-stack').should('have.class', 'gs-12')
   })
 
   it('should default to 6 columns when cols prop is not set', () => {
@@ -102,7 +102,7 @@ describe('<DraggableGridLayout />', () => {
       },
     })
 
-    cy.get('.grid-stack').should('have.class', 'grid-stack-6')
+    cy.get('.grid-stack').should('have.class', 'gs-6')
   })
 
   it('should add new tile when tiles prop length increases', () => {

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.cy.ts
@@ -84,18 +84,18 @@ describe('<DraggableGridLayout />', () => {
     })
   })
 
-  it('should initialize GridStack with the cols prop', () => {
+  it('should initialize GridStack with the columns prop', () => {
     cy.mount(DraggableGridLayout, {
       props: {
         tiles: mockTiles,
-        cols: 12,
+        columns: 12,
       },
     })
 
     cy.get('.grid-stack').should('have.class', 'gs-12')
   })
 
-  it('should default to 6 columns when cols prop is not set', () => {
+  it('should default to 6 columns when columns prop is not set', () => {
     cy.mount(DraggableGridLayout, {
       props: {
         tiles: mockTiles,

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -42,10 +42,10 @@ export type DraggableGridLayoutExpose<T> = {
 const props = withDefaults(defineProps<{
   tiles: Array<GridTile<T>>
   tileHeight?: number
-  cols?: number
+  columns?: number
 }>(), {
   tileHeight: DEFAULT_TILE_HEIGHT,
-  cols: DASHBOARD_COLS,
+  columns: DASHBOARD_COLS,
 })
 const emit = defineEmits<{
   (e: 'update-tiles', tiles: Array<GridTile<T>>): void
@@ -97,7 +97,7 @@ onMounted(() => {
   if (gridContainer.value) {
     grid = GridStack.init({
       margin: 10,
-      column: props.cols,
+      column: props.columns,
       cellHeight: props.tileHeight,
       resizable: { handles: 'se, sw' },
       handle: '.tile-header',

--- a/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/DraggableGridLayout.vue
@@ -42,8 +42,10 @@ export type DraggableGridLayoutExpose<T> = {
 const props = withDefaults(defineProps<{
   tiles: Array<GridTile<T>>
   tileHeight?: number
+  cols?: number
 }>(), {
   tileHeight: DEFAULT_TILE_HEIGHT,
+  cols: DASHBOARD_COLS,
 })
 const emit = defineEmits<{
   (e: 'update-tiles', tiles: Array<GridTile<T>>): void
@@ -95,7 +97,7 @@ onMounted(() => {
   if (gridContainer.value) {
     grid = GridStack.init({
       margin: 10,
-      column: DASHBOARD_COLS,
+      column: props.cols,
       cellHeight: props.tileHeight,
       resizable: { handles: 'se, sw' },
       handle: '.tile-header',

--- a/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
@@ -33,7 +33,7 @@ const props = defineProps({
     required: false,
     default: () => DEFAULT_TILE_HEIGHT,
   },
-  cols: {
+  columns: {
     type: Number,
     required: false,
     default: () => DASHBOARD_COLS,
@@ -99,7 +99,7 @@ const gridCells = computed<Array<Cell<T>>>(() => {
 .kong-ui-public-grid-layout {
   display: grid;
   gap: var(--kui-space-70, $kui-space-70);
-  grid-template-columns: repeat(v-bind('props.cols'), 1fr);
+  grid-template-columns: repeat(v-bind('props.columns'), 1fr);
   grid-template-rows: v-bind('rowDefinition');
   width: 100%;
 }

--- a/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
+++ b/packages/analytics/dashboard-renderer/src/components/layout/GridLayout.vue
@@ -33,6 +33,11 @@ const props = defineProps({
     required: false,
     default: () => DEFAULT_TILE_HEIGHT,
   },
+  cols: {
+    type: Number,
+    required: false,
+    default: () => DASHBOARD_COLS,
+  },
   tiles: {
     type: Array as PropType<Array<GridTile<T>>>,
     required: true,
@@ -94,7 +99,7 @@ const gridCells = computed<Array<Cell<T>>>(() => {
 .kong-ui-public-grid-layout {
   display: grid;
   gap: var(--kui-space-70, $kui-space-70);
-  grid-template-columns: repeat(v-bind('DASHBOARD_COLS'), 1fr);
+  grid-template-columns: repeat(v-bind('props.cols'), 1fr);
   grid-template-rows: v-bind('rowDefinition');
   width: 100%;
 }

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
@@ -369,7 +369,7 @@ describe('configureAllowedDefinition', () => {
     })
   })
 
-  describe('cols config', () => {
+  describe('columns config', () => {
     const halfWidthTile = (id: string, col: number): TileConfig => ({
       ...mockBasicTile,
       id,
@@ -387,9 +387,9 @@ describe('configureAllowedDefinition', () => {
       expect(result.tiles[1].layout?.position).toEqual({ col: 0, row: 1 })
     })
 
-    it('keeps both tiles on the same row when cols is 12', () => {
+    it('keeps both tiles on the same row when columns is 12', () => {
       const config: DashboardConfig = {
-        cols: 12,
+        columns: 12,
         tiles: [halfWidthTile('t1', 0), halfWidthTile('t2', 6)],
       }
 

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
@@ -369,6 +369,37 @@ describe('configureAllowedDefinition', () => {
     })
   })
 
+  describe('cols config', () => {
+    const halfWidthTile = (id: string, col: number): TileConfig => ({
+      ...mockBasicTile,
+      id,
+      layout: { size: { cols: 6, rows: 1 }, position: { col, row: 0 } },
+    })
+
+    it('wraps second tile to next row with default 6-column grid', () => {
+      const config: DashboardConfig = {
+        tiles: [halfWidthTile('t1', 0), halfWidthTile('t2', 6)],
+      }
+
+      const result = configureAllowedDefinition(config, false)
+
+      expect(result.tiles[0].layout?.position).toEqual({ col: 0, row: 0 })
+      expect(result.tiles[1].layout?.position).toEqual({ col: 0, row: 1 })
+    })
+
+    it('keeps both tiles on the same row when cols is 12', () => {
+      const config: DashboardConfig = {
+        cols: 12,
+        tiles: [halfWidthTile('t1', 0), halfWidthTile('t2', 6)],
+      }
+
+      const result = configureAllowedDefinition(config, false)
+
+      expect(result.tiles[0].layout?.position).toEqual({ col: 0, row: 0 })
+      expect(result.tiles[1].layout?.position).toEqual({ col: 6, row: 0 })
+    })
+  })
+
   describe('Dashboard Example', () => {
     it('should correctly process dashboard for advanced tier', () => {
       const runtimeInstancesConfig: DashboardConfig = {

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
@@ -59,6 +59,7 @@ const processTileForAdvancedTier = (tile: TileConfig): TileConfig => {
  * The algorithm lays out tiles row by row based on their widths (cols) and heights (rows).
  *
  * @param tiles - The array of tile configuration objects.
+ * @param cols - The number of grid columns (default: DASHBOARD_COLS).
  * @returns The updated array of tile configuration objects.
  */
 const repositionTiles = (tiles: TileConfig[], cols: number = DASHBOARD_COLS): TileConfig[] => {

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
@@ -59,10 +59,10 @@ const processTileForAdvancedTier = (tile: TileConfig): TileConfig => {
  * The algorithm lays out tiles row by row based on their widths (cols) and heights (rows).
  *
  * @param tiles - The array of tile configuration objects.
- * @param cols - The number of grid columns (default: DASHBOARD_COLS).
+ * @param columns - The number of grid columns (default: DASHBOARD_COLS).
  * @returns The updated array of tile configuration objects.
  */
-const repositionTiles = (tiles: TileConfig[], cols: number = DASHBOARD_COLS): TileConfig[] => {
+const repositionTiles = (tiles: TileConfig[], columns: number = DASHBOARD_COLS): TileConfig[] => {
   if (!tiles.length) {
     return []
   }
@@ -79,7 +79,7 @@ const repositionTiles = (tiles: TileConfig[], cols: number = DASHBOARD_COLS): Ti
     const rowSpan = tile.layout?.size?.rows ?? 1
 
     // If the tile won't fit on the current row, move to next row
-    if (currentCol + colSpan > cols) {
+    if (currentCol + colSpan > columns) {
       currentRow += rowHeight
       currentCol = 0
       rowHeight = 0
@@ -131,7 +131,7 @@ export const configureAllowedDefinition = (
     .map(processTileForBasicTier)
     .filter((tile) => tile !== undefined)
 
-  const repositionedTiles = repositionTiles(processedTiles, config.cols)
+  const repositionedTiles = repositionTiles(processedTiles, config.columns)
 
   return {
     ...config,

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
@@ -61,7 +61,7 @@ const processTileForAdvancedTier = (tile: TileConfig): TileConfig => {
  * @param tiles - The array of tile configuration objects.
  * @returns The updated array of tile configuration objects.
  */
-const repositionTiles = (tiles: TileConfig[]): TileConfig[] => {
+const repositionTiles = (tiles: TileConfig[], cols: number = DASHBOARD_COLS): TileConfig[] => {
   if (!tiles.length) {
     return []
   }
@@ -78,7 +78,7 @@ const repositionTiles = (tiles: TileConfig[]): TileConfig[] => {
     const rowSpan = tile.layout?.size?.rows ?? 1
 
     // If the tile won't fit on the current row, move to next row
-    if (currentCol + colSpan > DASHBOARD_COLS) {
+    if (currentCol + colSpan > cols) {
       currentRow += rowHeight
       currentCol = 0
       rowHeight = 0
@@ -130,7 +130,7 @@ export const configureAllowedDefinition = (
     .map(processTileForBasicTier)
     .filter((tile) => tile !== undefined)
 
-  const repositionedTiles = repositionTiles(processedTiles)
+  const repositionedTiles = repositionTiles(processedTiles, config.cols)
 
   return {
     ...config,


### PR DESCRIPTION
[KM-2570]

## Summary

- Adds optional `cols` field to `DashboardConfig` schema (alongside existing `tile_height`) so the grid column count can be persisted and configured per dashboard
- Defaults to `6` (existing behavior), fully backward-compatible
- Threads the value through `GridLayout`, `DraggableGridLayout`, and the `repositionTiles` utility so the full layout stack respects the setting

## Preview

https://github.com/kong-konnect/konnect-ui-apps/pull/10981

<img width="2173" height="1409" alt="image" src="https://github.com/user-attachments/assets/108efd15-2aa7-4c77-80b5-71c350391565" />

[KM-2570]: https://konghq.atlassian.net/browse/KM-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ