### PR TITLE
feat(entities-plugins): make custom plugins cp-global

### DIFF
--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.cy.ts
@@ -667,7 +667,7 @@ describe('<CustomPluginForm />', () => {
     it('should submit streamed plugin via Kong Manager API', () => {
       cy.intercept(
         'POST',
-        `${kongManagerConfig.apiBaseUrl}/${kongManagerConfig.workspace}/custom-plugins`,
+        `${kongManagerConfig.apiBaseUrl}/custom-plugins`,
         {
           statusCode: 201,
           body: streamedPluginResponse,

--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
@@ -476,7 +476,6 @@ const props = defineProps({
     validator: (config: KonnectCustomPluginFormConfig | KongManagerCustomPluginFormConfig): boolean => {
       if (!config || !config.app) return false
       if (config.app === 'konnect' && !config.controlPlaneId) return false
-      if (config.app === 'kongManager' && !(config as KongManagerCustomPluginFormConfig).workspace) return false
       if (!config.cancelRoute) return false
       if (!config.successRoute) return false
       return true
@@ -517,7 +516,6 @@ const {
   apiBaseUrl: props.config.apiBaseUrl,
   controlPlaneId: (props.config as KonnectCustomPluginFormConfig).controlPlaneId,
   app: props.config.app,
-  workspace: (props.config as KongManagerCustomPluginFormConfig).workspace,
 })
 
 // Force-enable the new plugin form layout

--- a/packages/entities/entities-plugins/src/components/PluginCatalog.vue
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.vue
@@ -229,9 +229,9 @@ const availablePluginsUrl = computed((): string => {
 
 const streamingPluginsUrl = computed<string | null>(() => {
   if (props.config.app === 'konnect' && props.customPluginSupport === 'streaming') {
+    // Streamed custom plugins are CP-global, not workspace-scoped.
     return `${props.config.apiBaseUrl}${endpoints.select[props.config.app].streamingCustomPlugins}`
       .replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
-      .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
   }
   // Kong Manager and other support level does not support streaming custom plugins now
   return null

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -389,7 +389,6 @@ const { getClonedPlugin: fetchClonedPluginDetail } = composables.useCustomPlugin
   } as any).axiosInstance,
   apiBaseUrl: props.config.apiBaseUrl,
   app: props.config.app,
-  workspace: (props.config as KongManagerPluginFormConfig).workspace,
   controlPlaneId: (props.config as KonnectPluginFormConfig).controlPlaneId,
 })
 

--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -545,6 +545,7 @@ const availablePluginsUrl = computed((): string => {
   return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
 })
 
+// Streamed and cloned custom plugins are CP-global, not workspace-scoped.
 const streamingPluginsUrl = computed<string | null>(() => {
   if (isStreamingCustomPluginSupported.value) {
     let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].streamingCustomPlugins}`
@@ -553,7 +554,7 @@ const streamingPluginsUrl = computed<string | null>(() => {
       url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
     }
 
-    return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
+    return url
   }
 
   return null
@@ -565,8 +566,6 @@ const clonedPluginsUrl = computed<string | null>(() => {
 
     if (props.config.app === 'konnect') {
       url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
-    } else if (props.config.app === 'kongManager') {
-      url = url.replace(/{workspace}/gi, props.config.workspace || '')
     }
 
     return url

--- a/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
+++ b/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
@@ -94,6 +94,7 @@ const requestUrl = computed(() => {
   const pluginType = props.plugin.customPluginType
 
   if (props.config.app === 'konnect') {
+    // Installed / streamed / cloned custom plugins are all CP-global.
     const partialPluginURL = pluginType === 'streaming'
       ? endpoints.select[props.config.app].streamingCustomPluginItem
       : pluginType === 'cloned'
@@ -102,7 +103,6 @@ const requestUrl = computed(() => {
 
     return `${props.config.apiBaseUrl}${partialPluginURL}`
       .replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
-      .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
       .replace(/{pluginId}/gi, props.plugin.id)
   }
 

--- a/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
+++ b/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
@@ -107,14 +107,13 @@ const requestUrl = computed(() => {
   }
 
   if (props.config.app === 'kongManager' && pluginType && pluginType !== 'schema') {
+    // Streamed and cloned custom plugins are CP-global, not workspace-scoped.
     const partialPluginUrl = pluginType === 'cloned'
       ? endpoints.customPlugin[props.config.app].cloned.edit
       : endpoints.customPlugin[props.config.app].streamed.edit
 
-    let url = `${props.config.apiBaseUrl}${partialPluginUrl}`
-    url = url.replace(/{workspace}/gi, props.config.workspace || '')
-    url = url.replace(/{pluginId}/gi, props.plugin.id)
-    return url
+    return `${props.config.apiBaseUrl}${partialPluginUrl}`
+      .replace(/{pluginId}/gi, props.plugin.id)
   }
 
   return null

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.spec.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.spec.ts
@@ -45,7 +45,6 @@ describe('useCustomPluginApi', () => {
       axiosInstance: axiosInstance as AxiosInstance,
       apiBaseUrl: '/kong-manager',
       app: 'kongManager',
-      workspace: 'default',
     })
 
     await expect(api.getInstalledPlugin('my-plugin')).rejects.toThrow('Installed custom plugin APIs are only available for Konnect')

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
@@ -81,7 +81,11 @@ export const fetchAllPages = async <T>(
 
 interface UseKongManagerCustomPluginApiOptions {
   app: 'kongManager'
-  workspace: string
+  /**
+   * Only used by installed-plugin endpoints, which remain workspace-scoped.
+   * Streamed and cloned custom plugins are CP-global and ignore this value.
+   */
+  workspace?: string
 }
 
 type UseCustomPluginApiOptions = (

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
@@ -21,7 +21,6 @@ export type CustomPluginWithType =
 interface UseKonnectCustomPluginApiOptions {
   app: 'konnect'
   controlPlaneId: string
-  workspace?: string
 }
 
 interface PagedResponse<T> {
@@ -81,11 +80,6 @@ export const fetchAllPages = async <T>(
 
 interface UseKongManagerCustomPluginApiOptions {
   app: 'kongManager'
-  /**
-   * Only used by installed-plugin endpoints, which remain workspace-scoped.
-   * Streamed and cloned custom plugins are CP-global and ignore this value.
-   */
-  workspace?: string
 }
 
 type UseCustomPluginApiOptions = (
@@ -108,14 +102,11 @@ export function useCustomPluginApi(options: UseCustomPluginApiOptions) {
   const buildUrl = (endpointTemplate: string, pluginId?: string): string => {
     let url = `${apiBaseUrl}${endpointTemplate}`
 
-
     if (options.app === 'konnect') {
       url = url.replace(/{controlPlaneId}/gi, options.controlPlaneId)
     }
 
-    url = url
-      .replace(/{pluginId}/gi, pluginId ?? '')
-      .replace(/\/{workspace}/gi, options.workspace ? `/${options.workspace}` : '')
+    url = url.replace(/{pluginId}/gi, pluginId ?? '')
 
     return url
   }

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -1,6 +1,9 @@
 const konnectV1BaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/v1'
 const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
+// Custom plugins (streamed / cloned) are CP-global and never workspace-scoped.
+const konnectGlobalBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
 const KMBaseApiUrl = '/{workspace}'
+const KMGlobalBaseApiUrl = ''
 
 export default {
   list: {
@@ -16,16 +19,16 @@ export default {
   select: {
     konnect: {
       availablePlugins: `${konnectV1BaseApiUrl}/available-plugins`,
-      streamingCustomPlugins: `${konnectBaseApiUrl}/custom-plugins`,
-      clonedPlugins: `${konnectBaseApiUrl}/cloned-plugins`,
+      streamingCustomPlugins: `${konnectGlobalBaseApiUrl}/custom-plugins`,
+      clonedPlugins: `${konnectGlobalBaseApiUrl}/cloned-plugins`,
       schemaCustomPluginItem: `${konnectBaseApiUrl}/plugin-schemas/{pluginId}`,
-      streamingCustomPluginItem: `${konnectBaseApiUrl}/custom-plugins/{pluginId}`,
+      streamingCustomPluginItem: `${konnectGlobalBaseApiUrl}/custom-plugins/{pluginId}`,
     },
     kongManager: {
       availablePlugins: `${KMBaseApiUrl}/kong`,
       availablePluginsForOss: '/',
-      streamingCustomPlugins: `${KMBaseApiUrl}/custom-plugins`,
-      clonedPlugins: `${KMBaseApiUrl}/cloned-plugins`,
+      streamingCustomPlugins: `${KMGlobalBaseApiUrl}/custom-plugins`,
+      clonedPlugins: `${KMGlobalBaseApiUrl}/cloned-plugins`,
     },
   },
   form: {
@@ -76,22 +79,22 @@ export default {
         edit: `${konnectBaseApiUrl}/plugin-schemas/{pluginId}`,
       },
       streamed: {
-        create: `${konnectBaseApiUrl}/custom-plugins`,
-        edit: `${konnectBaseApiUrl}/custom-plugins/{pluginId}`,
+        create: `${konnectGlobalBaseApiUrl}/custom-plugins`,
+        edit: `${konnectGlobalBaseApiUrl}/custom-plugins/{pluginId}`,
       },
       cloned: {
-        create: `${konnectBaseApiUrl}/cloned-plugins/{pluginId}`,
-        edit: `${konnectBaseApiUrl}/cloned-plugins/{pluginId}`,
+        create: `${konnectGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
+        edit: `${konnectGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
       },
     },
     kongManager: {
       streamed: {
-        create: `${KMBaseApiUrl}/custom-plugins`,
-        edit: `${KMBaseApiUrl}/custom-plugins/{pluginId}`,
+        create: `${KMGlobalBaseApiUrl}/custom-plugins`,
+        edit: `${KMGlobalBaseApiUrl}/custom-plugins/{pluginId}`,
       },
       cloned: {
-        create: `${KMBaseApiUrl}/cloned-plugins/{pluginId}`,
-        edit: `${KMBaseApiUrl}/cloned-plugins/{pluginId}`,
+        create: `${KMGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
+        edit: `${KMGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
       },
     },
   },

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -1,6 +1,6 @@
 const konnectV1BaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/v1'
 const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
-// Custom plugins (streamed / cloned) are CP-global and never workspace-scoped.
+// Custom plugins (installed / streamed / cloned) are CP-global and never workspace-scoped.
 const konnectGlobalBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
 const KMBaseApiUrl = '/{workspace}'
 const KMGlobalBaseApiUrl = ''
@@ -21,7 +21,7 @@ export default {
       availablePlugins: `${konnectV1BaseApiUrl}/available-plugins`,
       streamingCustomPlugins: `${konnectGlobalBaseApiUrl}/custom-plugins`,
       clonedPlugins: `${konnectGlobalBaseApiUrl}/cloned-plugins`,
-      schemaCustomPluginItem: `${konnectBaseApiUrl}/plugin-schemas/{pluginId}`,
+      schemaCustomPluginItem: `${konnectGlobalBaseApiUrl}/plugin-schemas/{pluginId}`,
       streamingCustomPluginItem: `${konnectGlobalBaseApiUrl}/custom-plugins/{pluginId}`,
     },
     kongManager: {
@@ -75,8 +75,8 @@ export default {
   customPlugin: {
     konnect: {
       installed: {
-        create: `${konnectBaseApiUrl}/plugin-schemas`,
-        edit: `${konnectBaseApiUrl}/plugin-schemas/{pluginId}`,
+        create: `${konnectGlobalBaseApiUrl}/plugin-schemas`,
+        edit: `${konnectGlobalBaseApiUrl}/plugin-schemas/{pluginId}`,
       },
       streamed: {
         create: `${konnectGlobalBaseApiUrl}/custom-plugins`,


### PR DESCRIPTION
## Summary

Per product decision ([Slack thread](https://kongstrong.slack.com/archives/C0A1JBUT7A9/p1778738470694459)), **all three custom plugin types — installed, streamed, and cloned — are CP-global, not workspace-scoped**:

- Endpoint templates for `customPlugin.*.{installed,streamed,cloned}.{create,edit}`, `select.*.{streamingCustomPlugins,clonedPlugins,streamingCustomPluginItem,schemaCustomPluginItem}` drop the `/{workspace}` path segment.
- `PluginSelect` and `PluginCatalog` fetch streamed + cloned plugins without workspace, so users see them across all workspaces in the CP.
- `CustomPluginForm` no longer requires `workspace` in its validator and no longer forwards it to `useCustomPluginApi`.
- `PluginForm.vue` (used when editing a cloned plugin instance) likewise stops passing `workspace` to `useCustomPluginApi`.
- `useCustomPluginApi` options drop the `workspace` field entirely (both Konnect and Kong Manager variants) and `buildUrl` no longer performs `{workspace}` substitution.
- `DeleteCustomPluginSchemaModal` drops the same `{workspace}` replace in both Konnect and Kong Manager branches.

`installed` plugins were already global on the wire (existing Cypress fixtures never passed a `workspace`, so all `/plugin-schemas/...` intercepts already matched the global URL); this PR makes the source templates match that reality.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (119 / 119)
- [x] Updated Cypress intercept in `CustomPluginForm.cy.ts` for KM streamed plugin POST
- [x] Kong Manager: list / create / edit / delete streamed + cloned plugins; switching workspaces still re-fetches the regular plugin catalog