### PR TITLE
fix(analytics-chart): single value chart uses metric_units for bytes formatting

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
@@ -245,6 +245,12 @@ describe('<SingleValue />', () => {
     cy.get('.single-value-unit').should('not.exist')
   })
 
+  it('formats bytes values when metric_units is bytes', () => {
+    const exploreResult = buildExploreResult({ metricName: 'response_size_average', metricUnit: 'bytes', previous: 1500000, current: 1500000 })
+    cy.mount(SingleValue, { props: { data: exploreResult, showTrend: false } })
+    cy.getTestId('single-value-chart').should('contain.text', 'MB')
+    cy.get('.single-value-unit').should('not.exist')
+  })
 
   it('renders a non-empty trend range when trend is enabled', () => {
     const exploreResultWithMeta = {

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
@@ -192,8 +192,7 @@ const formattedValue = computed((): string => {
     return formatCost(value)
   }
 
-  // for response/request size metrics, display in bytes
-  if (metricName.value?.includes('_size_')) {
+  if (rawUnit === 'bytes') {
     return formatBytes(value)
   }
 


### PR DESCRIPTION
[KM-2582]

## Summary

- `SingleValue` chart was using `metricName.includes('_size_')` to detect bytes metrics, ignoring the `metric_units` field from the backend response
- Fixed by checking `rawUnit === 'bytes'` (read from `meta.metric_units`) instead, which is consistent with how `TopNTable` and `StackedBarChart` already handle bytes

[KM-2582]: https://konghq.atlassian.net/browse/KM-2582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ