### PR TITLE
fix(entities-plugins): use POST to create cloned plugin to reject duplicate names [KM-2579]

### DIFF
--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.cy.ts
@@ -268,8 +268,8 @@ describe('<CustomPluginForm />', () => {
       const aliasName = 'my-created-cloned-plugin'
 
       cy.intercept(
-        'PUT',
-        `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/cloned-plugins/${aliasName}`,
+        'POST',
+        `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/cloned-plugins`,
         {
           statusCode: 201,
           body: {
@@ -295,8 +295,9 @@ describe('<CustomPluginForm />', () => {
       cy.getTestId('custom-plugin-form-submit').should('be.enabled').click()
 
       cy.wait('@createClonedPlugin').then((interception) => {
-        expect(interception.request.method).to.equal('PUT')
+        expect(interception.request.method).to.equal('POST')
         expect(interception.request.body).to.deep.equal({
+          name: aliasName,
           ref: 'acl',
         })
       })
@@ -306,8 +307,8 @@ describe('<CustomPluginForm />', () => {
       const aliasName = 'my-created-cloned-plugin-zero'
 
       cy.intercept(
-        'PUT',
-        `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/cloned-plugins/${aliasName}`,
+        'POST',
+        `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/cloned-plugins`,
         {
           statusCode: 201,
           body: {
@@ -334,8 +335,9 @@ describe('<CustomPluginForm />', () => {
       cy.getTestId('custom-plugin-form-submit').should('be.enabled').click()
 
       cy.wait('@createClonedPluginWithPriority').then((interception) => {
-        expect(interception.request.method).to.equal('PUT')
+        expect(interception.request.method).to.equal('POST')
         expect(interception.request.body).to.deep.equal({
+          name: aliasName,
           ref: 'acl',
           priority: 0,
         })

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
@@ -159,8 +159,9 @@ export function useCustomPluginApi(options: UseCustomPluginApiOptions) {
 
   const createClonedPlugin = async (body: ClonedPluginRequestBody): Promise<ClonedPluginResponse> => {
     const { aliasName: alias, priority, sourcePlugin: ref } = body
-    const url = buildUrl(endpoints.customPlugin[options.app].cloned.create, alias)
-    const { data } = await axiosInstance.put<ClonedPluginResponse>(url, {
+    const url = buildUrl(endpoints.customPlugin[options.app].cloned.create)
+    const { data } = await axiosInstance.post<ClonedPluginResponse>(url, {
+      name: alias,
       ref,
       priority,
     })

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -83,7 +83,7 @@ export default {
         edit: `${konnectGlobalBaseApiUrl}/custom-plugins/{pluginId}`,
       },
       cloned: {
-        create: `${konnectGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
+        create: `${konnectGlobalBaseApiUrl}/cloned-plugins`,
         edit: `${konnectGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
       },
     },
@@ -93,7 +93,7 @@ export default {
         edit: `${KMGlobalBaseApiUrl}/custom-plugins/{pluginId}`,
       },
       cloned: {
-        create: `${KMGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
+        create: `${KMGlobalBaseApiUrl}/cloned-plugins`,
         edit: `${KMGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
       },
     },


### PR DESCRIPTION
## Summary

Fixes [KM-2579](https://konghq.atlassian.net/browse/KM-2579).

Creating a cloned plugin currently uses `PUT /cloned-plugins/<name>`, which Kong treats as an upsert. So submitting the create form with an alias that already exists silently overwrites the existing plugin instead of reporting a name conflict.

Switch the create call to `POST /cloned-plugins` (with `name` in the body) so the backend rejects duplicates. `updateClonedPlugin` keeps using `PATCH /cloned-plugins/<name>`.


[KM-2579]: https://konghq.atlassian.net/browse/KM-2579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ