### PR TITLE
feat(entities-shared): support enableItemCreation in EntityFilter select fields

### DIFF
--- a/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
+++ b/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
@@ -79,11 +79,11 @@
             <KSelect
               v-if="config.schema?.[field.value]?.type === 'select'"
               :id="getFieldId(field.value)"
-              :model-value="searchParams[field.value]"
               :enable-filtering="enableFiltering(field.value)"
               :enable-item-creation="config.schema?.[field.value]?.enableItemCreation"
               :filter-function="(params: SelectFilterFunctionParams<string | number>) => handleFilter(field.value, params)"
               :items="getFieldOptions(field.value)"
+              :model-value="searchParams[field.value]"
               :placeholder="t('filter.selectPlaceholder')"
               @change="(item) => handleSelectChange(field.value, item)"
             />

--- a/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
+++ b/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
@@ -81,6 +81,7 @@
               :id="getFieldId(field.value)"
               v-model="searchParams[field.value]"
               :enable-filtering="enableFiltering(field.value)"
+              :enable-item-creation="config.schema?.[field.value]?.enableItemCreation"
               :filter-function="(params: SelectFilterFunctionParams<string | number>) => handleFilter(field.value, params)"
               :items="getFieldOptions(field.value)"
               :placeholder="t('filter.selectPlaceholder')"

--- a/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
+++ b/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
@@ -79,12 +79,13 @@
             <KSelect
               v-if="config.schema?.[field.value]?.type === 'select'"
               :id="getFieldId(field.value)"
-              v-model="searchParams[field.value]"
+              :model-value="searchParams[field.value]"
               :enable-filtering="enableFiltering(field.value)"
               :enable-item-creation="config.schema?.[field.value]?.enableItemCreation"
               :filter-function="(params: SelectFilterFunctionParams<string | number>) => handleFilter(field.value, params)"
               :items="getFieldOptions(field.value)"
               :placeholder="t('filter.selectPlaceholder')"
+              @change="(item) => handleSelectChange(field.value, item)"
             />
             <KInput
               v-else
@@ -272,6 +273,12 @@ const handleFilter = (
     return true
   }
   return fieldSchema.filterFunction(params)
+}
+
+const handleSelectChange = (field: string, item: (SelectItem & { custom?: boolean }) | null) => {
+  searchParams.value[field] = item
+    ? item.custom ? String(item.label) : String(item.value)
+    : ''
 }
 </script>
 

--- a/packages/entities/entities-shared/src/types/entity-filter.ts
+++ b/packages/entities/entities-shared/src/types/entity-filter.ts
@@ -32,6 +32,8 @@ export interface FilterSchema {
     filterFunction?: (params: SelectFilterFunctionParams<string | number>) => SelectItem[]
     /** Options for the select input, only used if type is 'select' */
     values?: string[] | SelectItem[]
+    /** Allow users to create custom items in the select input, only used if type is 'select' */
+    enableItemCreation?: boolean
   }
 }
 


### PR DESCRIPTION
## Summary

- Add optional `enableItemCreation` to `FilterSchema` field config (type definition)
- Pass `:enable-item-creation` through to `KSelect` in `EntityFilter.vue`

Consumers can now set `enableItemCreation: true` on any `select`-type filter field to allow users to type and create custom filter items not present in the predefined list.
