### PR TITLE
fix(entities-plugins): missing workspace param in fetch url for code mode

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/code-lens-providers.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/code-lens-providers.ts
@@ -178,11 +178,12 @@ function buildEntityUrl(config: PluginFormConfig, entity: `${EntityKind}s`, enti
 
   if (config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, config.controlPlaneId || '')
-  } else if (config.app === 'kongManager') {
-    url = url.replace(/\/{workspace}/gi, config.workspace ? `/${config.workspace}` : '')
   }
 
-  url = url.replace(/{entity}/gi, entity).replace(/{id}/gi, entityId)
+  url = url
+    .replace(/\/{workspace}/gi, config.workspace ? `/${config.workspace}` : '')
+    .replace(/{entity}/gi, entity)
+    .replace(/{id}/gi, entityId)
 
   return url
 }


### PR DESCRIPTION
Fixed an issue where the `{workspace}` URL param was not being correctly replaced, and caused fetch failures for Code Lens in the Plugin Code Mode.

KM-2583