### PR TITLE
feat(entities-certificates): add vault reference tab for azure-certs vault integration [KM-2543]

### DIFF
--- a/packages/entities/entities-certificates/docs/certificate-form.md
+++ b/packages/entities/entities-certificates/docs/certificate-form.md
@@ -55,6 +55,12 @@ A form component for Certificates.
     - default: `undefined`
     - Route to return to when canceling creation of an Certificate.
 
+  - `azureCertsVaultAvailable`:
+    - type: `boolean`
+    - required: `false`
+    - default: `undefined`
+    - Show/hide the Azure Key Vault Certificates source type option in the certificate form.
+
   - `sniListRoute`:
     - type: `RouteLocationRaw`
     - required: `false`

--- a/packages/entities/entities-certificates/fixtures/mockData.ts
+++ b/packages/entities/entities-certificates/fixtures/mockData.ts
@@ -6,6 +6,8 @@ export interface FetcherRawResponse {
 }
 
 export const certificateVaultRef = '{vault://some-vault/cert-1}'
+export const certificateVaultRefCert = '{vault://some-vault/cert-1/cert}'
+export const certificateVaultRefKey = '{vault://some-vault/cert-1/key}'
 
 export const certificate1 = {
   id: '1',
@@ -22,7 +24,8 @@ export const certificate1 = {
 
 export const certificate3 = {
   id: '3',
-  cert: certificateVaultRef,
+  cert: certificateVaultRefCert,
+  key: certificateVaultRefKey,
   name: 'certificate-3',
   tags: ['test', 'prod', 'vault'],
 }

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -22,6 +22,7 @@
   },
   "peerDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
+    "@kong-ui-public/entities-vaults": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/icons": "^1.52.0",
     "@kong/kongponents": "^9.53.2",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@kong-ui-public/entities-shared": "workspace:^",
+    "@kong-ui-public/entities-vaults": "workspace:^",
     "@kong-ui-public/i18n": "workspace:^",
     "@kong/design-tokens": "1.20.1",
     "@kong/icons": "^1.55.0",

--- a/packages/entities/entities-certificates/sandbox/index.html
+++ b/packages/entities/entities-certificates/sandbox/index.html
@@ -16,6 +16,17 @@
         padding: 0;
       }
 
+      html,
+      body {
+        font-family: sans-serif;
+        margin: 0;
+        padding: 0;
+      }
+
+      *, *::before, *::after {
+        box-sizing: border-box;
+      }
+
     </style>
   </head>
 

--- a/packages/entities/entities-certificates/sandbox/pages/CertificateFormPage.vue
+++ b/packages/entities/entities-certificates/sandbox/pages/CertificateFormPage.vue
@@ -42,6 +42,7 @@ const konnectConfig = ref<KonnectCertificateFormConfig>({
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   cancelRoute: { name: 'certificate-list' },
+  azureCertsVaultAvailable: true,
 })
 
 const kongManagerConfig = ref<KongManagerCertificateFormConfig>({
@@ -50,6 +51,7 @@ const kongManagerConfig = ref<KongManagerCertificateFormConfig>({
   apiBaseUrl: '/kong-manager', // For local dev server proxy
   cancelRoute: { name: 'certificate-list' },
   sniListRoute: { name: 'sni-list' },
+  azureCertsVaultAvailable: true,
 })
 
 const onError = (error: AxiosError) => {

--- a/packages/entities/entities-certificates/src/components/CertificateForm.cy.ts
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.cy.ts
@@ -1,7 +1,7 @@
 // Cypress component test spec file
 import { EntityBaseForm } from '@kong-ui-public/entities-shared'
 import type { CyHttpMessages, RouteHandler } from 'cypress/types/net-stubbing'
-import { certificate1, secp384r1CertKeyPair } from '../../fixtures/mockData'
+import { certificate1, certificate3, certificateVaultRef, secp384r1CertKeyPair } from '../../fixtures/mockData'
 import type { KongManagerCertificateFormConfig, KonnectCertificateFormConfig } from '../types'
 import CertificateForm from './CertificateForm.vue'
 
@@ -728,6 +728,134 @@ describe('<CertificateForm />', () => {
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
 
       cy.wait('@createCertificateNoWorkspace').its('response.statusCode').should('eq', 200)
+    })
+  })
+
+  describe('source type selector (azureCertsVaultAvailable)', () => {
+    const configWithVault: KongManagerCertificateFormConfig = {
+      ...baseConfigKM,
+      azureCertsVaultAvailable: true,
+    }
+
+    const interceptKMGet = (mockData: object = certificate1) => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/certificates/*`,
+        },
+        { statusCode: 200, body: mockData },
+      ).as('getCertificate')
+    }
+
+    const interceptKMCreate = () => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}/certificates`,
+        },
+        (request) => {
+          request.reply({ statusCode: 200, body: request.body })
+        },
+      ).as('createCertificate')
+    }
+
+    it('should not show source type selector when azureCertsVaultAvailable is not set', () => {
+      cy.mount(CertificateForm, {
+        props: { config: baseConfigKM },
+      })
+
+      cy.get('.kong-ui-entities-certificates-form').should('be.visible')
+      cy.getTestId('certificate-form-cert').should('be.visible')
+      cy.getTestId('certificate-form-vault').should('not.exist')
+      cy.getTestId('certificate-source-type-azure').should('not.exist')
+    })
+
+    it('should show ssl and azure source type options when azureCertsVaultAvailable is true', () => {
+      cy.mount(CertificateForm, {
+        props: { config: configWithVault },
+      })
+
+      cy.get('.kong-ui-entities-certificates-form').should('be.visible')
+      cy.getTestId('certificate-source-type-ssl').should('exist')
+      cy.getTestId('certificate-source-type-azure').should('exist')
+      // ssl is selected by default — PEM fields visible, vault input not rendered
+      cy.getTestId('certificate-form-cert').should('be.visible')
+      cy.getTestId('certificate-form-vault').should('not.exist')
+    })
+
+    it('should show vault input and hide PEM fields when azure source type is selected', () => {
+      cy.mount(CertificateForm, {
+        props: { config: configWithVault },
+      })
+
+      cy.getTestId('certificate-source-type-azure').click()
+      cy.getTestId('certificate-form-vault').should('be.visible')
+      cy.getTestId('certificate-form-cert').should('not.exist')
+    })
+
+    it('should disable submit when azure source type is selected until vault field is filled', () => {
+      cy.mount(CertificateForm, {
+        props: { config: configWithVault },
+      })
+
+      cy.getTestId('certificate-source-type-azure').click()
+      cy.getTestId('certificate-create-form-submit').should('be.disabled')
+      cy.getTestId('certificate-form-vault').type(certificateVaultRef, { delay: 0, parseSpecialCharSequences: false })
+      cy.getTestId('certificate-create-form-submit').should('be.enabled')
+      cy.getTestId('certificate-form-vault').clear()
+      cy.getTestId('certificate-create-form-submit').should('be.disabled')
+    })
+
+    it('should send vault field in the payload when azure source type is selected', () => {
+      interceptKMCreate()
+
+      cy.mount(CertificateForm, {
+        props: { config: configWithVault },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.getTestId('certificate-source-type-azure').click()
+      cy.getTestId('certificate-form-vault').type(certificateVaultRef, { delay: 0, parseSpecialCharSequences: false })
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+
+      cy.wait('@createCertificate').then((interception) => {
+        expect(interception.request.body.vault).to.equal(certificateVaultRef)
+      })
+    })
+
+    it('should auto-select azure source type on edit when cert is a vault reference', () => {
+      interceptKMGet(certificate3)
+
+      cy.mount(CertificateForm, {
+        props: {
+          config: configWithVault,
+          certificateId: certificate3.id,
+        },
+      })
+
+      cy.wait('@getCertificate')
+      // azure source type should be automatically selected
+      cy.getTestId('certificate-form-vault').should('be.visible')
+      cy.getTestId('certificate-form-vault').should('have.value', certificateVaultRef)
+      // PEM fields should not be rendered
+      cy.getTestId('certificate-form-cert').should('not.exist')
+    })
+
+    it('should auto-select ssl source type on edit when cert is not a vault reference', () => {
+      interceptKMGet(certificate1)
+
+      cy.mount(CertificateForm, {
+        props: {
+          config: configWithVault,
+          certificateId: certificate1.id,
+        },
+      })
+
+      cy.wait('@getCertificate')
+      // ssl source type should be active
+      cy.getTestId('certificate-form-cert').should('be.visible')
+      cy.getTestId('certificate-form-cert').should('have.value', certificate1.cert)
+      cy.getTestId('certificate-form-vault').should('not.exist')
     })
   })
 })

--- a/packages/entities/entities-certificates/src/components/CertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="kong-ui-entities-certificates-form">
     <EntityBaseForm
+      :align-action-button-to-left="config.azureCertsVaultAvailable"
       :can-submit="canSubmit"
       :config="config"
       :edit-id="certificateId"
@@ -15,132 +16,345 @@
       @loading="(val: boolean) => $emit('loading', val)"
       @submit="saveFormData"
     >
-      <EntityFormSection
-        :description="t('certificates.form.sections.ssl.description')"
-        :title="t('certificates.form.sections.ssl.title')"
-      >
-        <KTextArea
-          v-model.trim="form.fields.cert"
-          :character-limit="false"
-          class="certificate-form-textarea"
-          data-testid="certificate-form-cert"
-          :label="t('certificates.form.fields.cert.label')"
-          :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
-          :readonly="form.isReadonly"
-          required
+      <!-- Multi-step layout (vault available) -->
+      <template v-if="config.azureCertsVaultAvailable">
+        <EntityFormBlock
+          :step="1"
+          :title="t('certificates.form.sections.certificate_config.title')"
         >
-          <template #label-tooltip>
-            <i18nT
-              keypath="certificates.form.fields.cert.tooltip"
-              scope="global"
-            >
-              <template #emphasis>
-                <em>{{ t('certificates.form.fields.cert.emphasis') }}</em>
-              </template>
-            </i18nT>
-          </template>
-        </KTextArea>
+          <div class="certificate-source-selector">
+            <KLabel>{{ t('certificates.form.source_type.question') }}</KLabel>
+            <div class="certificate-source-options">
+              <KRadio
+                v-model="sourceType"
+                card
+                card-orientation="vertical"
+                data-testid="certificate-source-type-azure"
+                :description="t('certificates.form.source_type.azure.description')"
+                :label="t('certificates.form.source_type.azure.label')"
+                :readonly="form.isReadonly"
+                selected-value="azure"
+              >
+                <AzureIcon />
+              </KRadio>
+              <KRadio
+                v-model="sourceType"
+                card
+                card-orientation="vertical"
+                data-testid="certificate-source-type-ssl"
+                :description="t('certificates.form.source_type.ssl.description')"
+                :label="t('certificates.form.source_type.ssl.label')"
+                :readonly="form.isReadonly"
+                selected-value="ssl"
+              >
+                <KongIcon />
+              </KRadio>
+            </div>
+          </div>
 
-        <KTextArea
-          v-model.trim="form.fields.key"
-          :character-limit="false"
-          class="certificate-form-textarea"
-          data-testid="certificate-form-key"
-          :label="t('certificates.form.fields.key.label')"
-          :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
-          :readonly="form.isReadonly"
-          required
+          <template v-if="sourceType === 'ssl'">
+            <KTextArea
+              v-model.trim="form.fields.cert"
+              :character-limit="false"
+              class="certificate-form-textarea"
+              data-testid="certificate-form-cert"
+              :label="t('certificates.form.fields.cert.label')"
+              :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
+              :readonly="form.isReadonly"
+              required
+            >
+              <template #label-tooltip>
+                <i18nT
+                  keypath="certificates.form.fields.cert.tooltip"
+                  scope="global"
+                >
+                  <template #emphasis>
+                    <em>{{ t('certificates.form.fields.cert.emphasis') }}</em>
+                  </template>
+                </i18nT>
+              </template>
+            </KTextArea>
+
+            <KTextArea
+              v-model.trim="form.fields.key"
+              :character-limit="false"
+              class="certificate-form-textarea"
+              data-testid="certificate-form-key"
+              :label="t('certificates.form.fields.key.label')"
+              :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
+              :readonly="form.isReadonly"
+              required
+            >
+              <template #label-tooltip>
+                <i18nT
+                  keypath="certificates.form.fields.key.tooltip"
+                  scope="global"
+                >
+                  <template #emphasis>
+                    <em>{{ t('certificates.form.fields.key.emphasis') }}</em>
+                  </template>
+                </i18nT>
+              </template>
+            </KTextArea>
+
+            <KTextArea
+              v-model.trim="form.fields.certAlt"
+              :character-limit="false"
+              class="certificate-form-textarea"
+              data-testid="certificate-form-cert-alt"
+              :label="t('certificates.form.fields.cert_alt.label')"
+              :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
+              :readonly="form.isReadonly"
+            >
+              <template #label-tooltip>
+                <i18nT
+                  keypath="certificates.form.fields.cert_alt.tooltip"
+                  scope="global"
+                >
+                  <template #emphasis>
+                    <em>{{ t('certificates.form.fields.cert_alt.emphasis') }}</em>
+                  </template>
+                </i18nT>
+              </template>
+            </KTextArea>
+
+            <KTextArea
+              v-model.trim="form.fields.keyAlt"
+              :character-limit="false"
+              class="certificate-form-textarea"
+              data-testid="certificate-form-key-alt"
+              :label="t('certificates.form.fields.key_alt.label')"
+              :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
+              :readonly="form.isReadonly"
+            >
+              <template #label-tooltip>
+                <i18nT
+                  keypath="certificates.form.fields.key_alt.tooltip"
+                  scope="global"
+                >
+                  <template #emphasis>
+                    <em>{{ t('certificates.form.fields.key_alt.emphasis') }}</em>
+                  </template>
+                </i18nT>
+              </template>
+            </KTextArea>
+          </template>
+
+          <template v-else>
+            <div>
+              <KInput
+                v-model.trim="form.fields.vault"
+                autocomplete="off"
+                class="certificate-form-vault-input"
+                data-testid="certificate-form-vault"
+                :label="t('certificates.form.fields.vault.label')"
+                :placeholder="t('certificates.form.fields.vault.placeholder')"
+                :readonly="form.isReadonly"
+                required
+              />
+              <VaultSecretPickerProvider
+                :disabled="form.isReadonly"
+                :update="(v: string) => form.fields.vault = v"
+                :value="form.fields.vault"
+                @open="(value, update) => setUpVaultSecretPicker(value, update)"
+              />
+            </div>
+
+            <div>
+              <KInput
+                v-model.trim="form.fields.vaultAlt"
+                autocomplete="off"
+                class="certificate-form-vault-input"
+                data-testid="certificate-form-vault-alt"
+                :label="t('certificates.form.fields.vault_alt.label')"
+                :placeholder="t('certificates.form.fields.vault_alt.placeholder')"
+                :readonly="form.isReadonly"
+              />
+              <VaultSecretPickerProvider
+                :disabled="form.isReadonly"
+                :update="(v: string) => form.fields.vaultAlt = v"
+                :value="form.fields.vaultAlt"
+                @open="(value, update) => setUpVaultSecretPicker(value, update)"
+              />
+            </div>
+          </template>
+
+          <CertificateFormSniField
+            v-if="showSnisField && config.sniListRoute"
+            v-model="form.fields.snis"
+            :is-editing="formType === EntityBaseFormType.Edit"
+            :sni-list-route="config.sniListRoute"
+            @add="handleAddSni"
+            @remove="(index: number) => handleRemoveSni(index)"
+          />
+        </EntityFormBlock>
+
+        <EntityFormBlock
+          :description="t('certificates.form.sections.general.description')"
+          :step="2"
+          :title="t('certificates.form.sections.general.title')"
         >
-          <template #label-tooltip>
-            <i18nT
-              keypath="certificates.form.fields.key.tooltip"
-              scope="global"
-            >
-              <template #emphasis>
-                <em>{{ t('certificates.form.fields.key.emphasis') }}</em>
-              </template>
-            </i18nT>
-          </template>
-        </KTextArea>
+          <KCollapse
+            v-model="tagsCollapseOpen"
+            :trigger-label="t('certificates.form.fields.tags.show_label')"
+          >
+            <KInput
+              v-model.trim="form.fields.tags"
+              autocomplete="off"
+              data-testid="certificate-form-tags"
+              :help="t('certificates.form.fields.tags.help')"
+              :label="t('certificates.form.fields.tags.label')"
+              :label-attributes="{
+                info: t('certificates.form.fields.tags.tooltip'),
+                tooltipAttributes: { maxWidth: '400' },
+              }"
+              :placeholder="t('certificates.form.fields.tags.placeholder')"
+              :readonly="form.isReadonly"
+              type="text"
+            />
+          </KCollapse>
+        </EntityFormBlock>
+      </template>
 
-        <KTextArea
-          v-model.trim="form.fields.certAlt"
-          :character-limit="false"
-          class="certificate-form-textarea"
-          data-testid="certificate-form-cert-alt"
-          :label="t('certificates.form.fields.cert_alt.label')"
-          :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
-          :readonly="form.isReadonly"
+      <!-- Single-section layout (vault not available) -->
+      <template v-else>
+        <EntityFormSection
+          :description="t('certificates.form.sections.ssl.description')"
+          :title="t('certificates.form.sections.ssl.title')"
         >
-          <template #label-tooltip>
-            <i18nT
-              keypath="certificates.form.fields.cert_alt.tooltip"
-              scope="global"
-            >
-              <template #emphasis>
-                <em>{{ t('certificates.form.fields.cert_alt.emphasis') }}</em>
-              </template>
-            </i18nT>
-          </template>
-        </KTextArea>
+          <KTextArea
+            v-model.trim="form.fields.cert"
+            :character-limit="false"
+            class="certificate-form-textarea"
+            data-testid="certificate-form-cert"
+            :label="t('certificates.form.fields.cert.label')"
+            :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
+            :readonly="form.isReadonly"
+            required
+          >
+            <template #label-tooltip>
+              <i18nT
+                keypath="certificates.form.fields.cert.tooltip"
+                scope="global"
+              >
+                <template #emphasis>
+                  <em>{{ t('certificates.form.fields.cert.emphasis') }}</em>
+                </template>
+              </i18nT>
+            </template>
+          </KTextArea>
 
-        <KTextArea
-          v-model.trim="form.fields.keyAlt"
-          :character-limit="false"
-          class="certificate-form-textarea"
-          data-testid="certificate-form-key-alt"
-          :label="t('certificates.form.fields.key_alt.label')"
-          :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
-          :readonly="form.isReadonly"
+          <KTextArea
+            v-model.trim="form.fields.key"
+            :character-limit="false"
+            class="certificate-form-textarea"
+            data-testid="certificate-form-key"
+            :label="t('certificates.form.fields.key.label')"
+            :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
+            :readonly="form.isReadonly"
+            required
+          >
+            <template #label-tooltip>
+              <i18nT
+                keypath="certificates.form.fields.key.tooltip"
+                scope="global"
+              >
+                <template #emphasis>
+                  <em>{{ t('certificates.form.fields.key.emphasis') }}</em>
+                </template>
+              </i18nT>
+            </template>
+          </KTextArea>
+
+          <KTextArea
+            v-model.trim="form.fields.certAlt"
+            :character-limit="false"
+            class="certificate-form-textarea"
+            data-testid="certificate-form-cert-alt"
+            :label="t('certificates.form.fields.cert_alt.label')"
+            :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
+            :readonly="form.isReadonly"
+          >
+            <template #label-tooltip>
+              <i18nT
+                keypath="certificates.form.fields.cert_alt.tooltip"
+                scope="global"
+              >
+                <template #emphasis>
+                  <em>{{ t('certificates.form.fields.cert_alt.emphasis') }}</em>
+                </template>
+              </i18nT>
+            </template>
+          </KTextArea>
+
+          <KTextArea
+            v-model.trim="form.fields.keyAlt"
+            :character-limit="false"
+            class="certificate-form-textarea"
+            data-testid="certificate-form-key-alt"
+            :label="t('certificates.form.fields.key_alt.label')"
+            :label-attributes="{ tooltipAttributes: { maxWidth: '400' } }"
+            :readonly="form.isReadonly"
+          >
+            <template #label-tooltip>
+              <i18nT
+                keypath="certificates.form.fields.key_alt.tooltip"
+                scope="global"
+              >
+                <template #emphasis>
+                  <em>{{ t('certificates.form.fields.key_alt.emphasis') }}</em>
+                </template>
+              </i18nT>
+            </template>
+          </KTextArea>
+
+          <CertificateFormSniField
+            v-if="showSnisField && config.sniListRoute"
+            v-model="form.fields.snis"
+            :is-editing="formType === EntityBaseFormType.Edit"
+            :sni-list-route="config.sniListRoute"
+            @add="handleAddSni"
+            @remove="(index: number) => handleRemoveSni(index)"
+          />
+        </EntityFormSection>
+
+        <EntityFormSection
+          :description="t('certificates.form.sections.general.description')"
+          :title="t('certificates.form.sections.general.title')"
         >
-          <template #label-tooltip>
-            <i18nT
-              keypath="certificates.form.fields.key_alt.tooltip"
-              scope="global"
-            >
-              <template #emphasis>
-                <em>{{ t('certificates.form.fields.key_alt.emphasis') }}</em>
-              </template>
-            </i18nT>
-          </template>
-        </KTextArea>
-
-        <CertificateFormSniField
-          v-if="showSnisField && config.sniListRoute"
-          v-model="form.fields.snis"
-          :is-editing="formType === EntityBaseFormType.Edit"
-          :sni-list-route="config.sniListRoute"
-          @add="handleAddSni"
-          @remove="(index: number) => handleRemoveSni(index)"
-        />
-      </EntityFormSection>
-
-      <EntityFormSection
-        :description="t('certificates.form.sections.general.description')"
-        :title="t('certificates.form.sections.general.title')"
-      >
-        <KInput
-          v-model.trim="form.fields.tags"
-          autocomplete="off"
-          data-testid="certificate-form-tags"
-          :help="t('certificates.form.fields.tags.help')"
-          :label="t('certificates.form.fields.tags.label')"
-          :label-attributes="{
-            info: t('certificates.form.fields.tags.tooltip'),
-            tooltipAttributes: { maxWidth: '400' },
-          }"
-          :placeholder="t('certificates.form.fields.tags.placeholder')"
-          :readonly="form.isReadonly"
-          type="text"
-        />
-      </EntityFormSection>
+          <KInput
+            v-model.trim="form.fields.tags"
+            autocomplete="off"
+            data-testid="certificate-form-tags"
+            :help="t('certificates.form.fields.tags.help')"
+            :label="t('certificates.form.fields.tags.label')"
+            :label-attributes="{
+              info: t('certificates.form.fields.tags.tooltip'),
+              tooltipAttributes: { maxWidth: '400' },
+            }"
+            :placeholder="t('certificates.form.fields.tags.placeholder')"
+            :readonly="form.isReadonly"
+            type="text"
+          />
+        </EntityFormSection>
+      </template>
     </EntityBaseForm>
+
+    <VaultSecretPicker
+      v-if="config.azureCertsVaultAvailable"
+      :allowed-providers="[VaultProviders.AZURE_CERTS]"
+      :config="config"
+      :setup="vaultSecretPickerSetup"
+      :show-secret-key="false"
+      @cancel="() => vaultSecretPickerSetup = false"
+      @proceed="handleVaultSecretPickerAutofill"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed, reactive } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import type { AxiosError, AxiosResponse } from 'axios'
 import type {
@@ -156,11 +370,15 @@ import {
   useAxios,
   useErrors,
   EntityFormSection,
+  EntityFormBlock,
   EntityBaseForm,
   EntityBaseFormType,
   SupportedEntityType,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
+import { VaultSecretPicker, VaultSecretPickerProvider, VaultProviders } from '@kong-ui-public/entities-vaults'
+import '@kong-ui-public/entities-vaults/dist/style.css'
+import { AzureIcon, KongIcon } from '@kong/icons'
 
 const emit = defineEmits<{
   (e: 'update', data: Record<string, any>): void
@@ -205,12 +423,62 @@ const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 const fetchUrl = computed<string>(() => endpoints.form[props.config.app].edit)
 const formType = computed((): EntityBaseFormType => props.certificateId ? EntityBaseFormType.Edit : EntityBaseFormType.Create)
 
+// Vault secret picker state (inlined from useVaultSecretPicker)
+const vaultSecretPickerSetup = ref<string | false>(false)
+const vaultSecretPickerAutofillAction = ref<((secretRef: string) => void) | undefined>()
+
+const setUpVaultSecretPicker = (setupValue: string, autofillAction: (secretRef: string) => void): void => {
+  vaultSecretPickerSetup.value = setupValue ?? ''
+  vaultSecretPickerAutofillAction.value = autofillAction
+}
+
+const handleVaultSecretPickerAutofill = (secretRef: string): void => {
+  vaultSecretPickerAutofillAction.value?.(secretRef)
+  vaultSecretPickerSetup.value = false
+}
+
+// Source type for the multi-step layout ('ssl' = direct cert/key, 'azure' = vault reference)
+const sourceType = ref<'ssl' | 'azure'>('ssl')
+
+// Collapse state for the tags section in the multi-step layout
+const tagsCollapseOpen = ref(false)
+
+// Strip the trailing key segment: {vault://prefix/name/cert} → {vault://prefix/name}
+const stripKeySegment = (vaultRef: string): string =>
+  vaultRef.replace(/^(\{vault:\/\/[^/]+\/[^/}]+)(?:\/[^}]*)?\}$/, '$1}')
+
+// Append a key segment: {vault://prefix/name} → {vault://prefix/name/cert}
+const withKeySeg = (vaultRef: string, seg: string): string =>
+  `${stripKeySegment(vaultRef).slice(0, -1)}/${seg}}`
+
+
+// Returns true only when cert+key are both azure-managed vault refs pointing to the same resource,
+// and alt fields (if present) satisfy the same condition.
+const isAzureManagedCert = (cert: string, key: string, certAlt?: string, keyAlt?: string): boolean => {
+  const certPattern = /^\{vault:\/\/([^/]+\/[^/]+)\/cert\}$/
+  const keyPattern = /^\{vault:\/\/([^/]+\/[^/]+)\/key\}$/
+
+  const certMatch = cert.match(certPattern)
+  const keyMatch = key.match(keyPattern)
+  if (!certMatch || !keyMatch || certMatch[1] !== keyMatch[1]) return false
+
+  if (certAlt || keyAlt) {
+    const certAltMatch = certAlt?.match(certPattern)
+    const keyAltMatch = keyAlt?.match(keyPattern)
+    if (!certAltMatch || !keyAltMatch || certAltMatch[1] !== keyAltMatch[1]) return false
+  }
+
+  return true
+}
+
 const form = reactive<CertificateFormState>({
   fields: {
     cert: '',
     key: '',
     certAlt: '',
     keyAlt: '',
+    vault: '',
+    vaultAlt: '',
     snis: [''],
     tags: '',
   },
@@ -223,6 +491,8 @@ const formFieldsOriginal = reactive<CertificateFormFields>({
   key: '',
   certAlt: '',
   keyAlt: '',
+  vault: '',
+  vaultAlt: '',
   snis: [''],
   tags: '',
 })
@@ -231,7 +501,13 @@ const formFieldsOriginal = reactive<CertificateFormFields>({
  * Is the form submit button enabled?
  * If the form.fields and formFieldsOriginal are equal, always return false
  */
-const canSubmit = computed((): boolean => (formType.value === EntityBaseFormType.Create || JSON.stringify(form.fields) !== JSON.stringify(formFieldsOriginal)) && !!form.fields.cert && !!form.fields.key)
+const canSubmit = computed((): boolean => {
+  const changed = formType.value === EntityBaseFormType.Create || JSON.stringify(form.fields) !== JSON.stringify(formFieldsOriginal)
+  if (props.config.azureCertsVaultAvailable && sourceType.value === 'azure') {
+    return changed && !!form.fields.vault
+  }
+  return changed && !!form.fields.cert && !!form.fields.key
+})
 
 const initForm = (data: Record<string, any>): void => {
   form.fields.cert = data?.cert || ''
@@ -241,7 +517,20 @@ const initForm = (data: Record<string, any>): void => {
   form.fields.snis = data?.snis?.length ? data.snis : ['']
   form.fields.tags = data?.tags?.join(', ') || ''
 
-  // Set initial state of `formFieldsOriginal` to these values in order to detect changes
+  if (props.config.azureCertsVaultAvailable && isAzureManagedCert(form.fields.cert, form.fields.key, form.fields.certAlt, form.fields.keyAlt)) {
+    sourceType.value = 'azure'
+    form.fields.vault = stripKeySegment(form.fields.cert)
+    form.fields.vaultAlt = form.fields.certAlt ? stripKeySegment(form.fields.certAlt) : ''
+    form.fields.cert = ''
+    form.fields.key = ''
+    form.fields.certAlt = ''
+    form.fields.keyAlt = ''
+  } else {
+    sourceType.value = 'ssl'
+    form.fields.vault = ''
+    form.fields.vaultAlt = ''
+  }
+
   Object.assign(formFieldsOriginal, form.fields)
 }
 
@@ -277,6 +566,16 @@ const submitUrl = computed<string>(() => {
 })
 
 const requestBody = computed((): Record<string, any> => {
+  if (props.config.azureCertsVaultAvailable && sourceType.value === 'azure') {
+    return {
+      cert: withKeySeg(form.fields.vault, 'cert'),
+      key: withKeySeg(form.fields.vault, 'key'),
+      cert_alt: form.fields.vaultAlt ? withKeySeg(form.fields.vaultAlt, 'cert') : null,
+      key_alt: form.fields.vaultAlt ? withKeySeg(form.fields.vaultAlt, 'key') : null,
+      ...(props.showSnisField ? { snis: form.fields.snis.filter(Boolean) } : {}),
+      tags: form.fields.tags.split(',')?.map((tag: string) => String(tag || '').trim())?.filter((tag: string) => tag !== ''),
+    }
+  }
   return {
     cert: form.fields.cert,
     key: form.fields.key,
@@ -293,20 +592,41 @@ const saveFormData = async (): Promise<void> => {
 
     let response: AxiosResponse | undefined
 
+    // For azure mode, submit the vault shorthand so the backend validates the ref and expands it.
+    // requestBody uses cert/key expansion for the view-config codeblock display.
+    const submitPayload = (props.config.azureCertsVaultAvailable && sourceType.value === 'azure')
+      ? {
+        ...requestBody.value,
+        vault: form.fields.vault || null,
+        vault_alt: form.fields.vaultAlt || null,
+      }
+      : requestBody.value
+
     if (formType.value === 'create') {
-      response = await axiosInstance.post(submitUrl.value, requestBody.value)
+      response = await axiosInstance.post(submitUrl.value, submitPayload)
     } else if (formType.value === 'edit') {
       response = props.config?.app === 'konnect'
         // Note: Konnect currently uses PUT because PATCH is not fully supported in Koko
         //       If this changes, the `edit` form methods should be re-evaluated/updated accordingly
-        ? await axiosInstance.put(submitUrl.value, requestBody.value)
-        : await axiosInstance.patch(submitUrl.value, requestBody.value)
+        ? await axiosInstance.put(submitUrl.value, submitPayload)
+        : await axiosInstance.patch(submitUrl.value, submitPayload)
     }
 
-    form.fields.cert = response?.data?.cert || ''
-    form.fields.key = response?.data?.key || ''
-    form.fields.certAlt = response?.data?.cert_alt || ''
-    form.fields.keyAlt = response?.data?.key_alt || ''
+    if (props.config.azureCertsVaultAvailable && sourceType.value === 'azure') {
+      form.fields.vault = response?.data?.cert ? stripKeySegment(response.data.cert) : ''
+      form.fields.vaultAlt = response?.data?.cert_alt ? stripKeySegment(response.data.cert_alt) : ''
+      form.fields.cert = ''
+      form.fields.key = ''
+      form.fields.certAlt = ''
+      form.fields.keyAlt = ''
+    } else {
+      form.fields.cert = response?.data?.cert || ''
+      form.fields.key = response?.data?.key || ''
+      form.fields.certAlt = response?.data?.cert_alt || ''
+      form.fields.keyAlt = response?.data?.key_alt || ''
+      form.fields.vault = ''
+      form.fields.vaultAlt = ''
+    }
     form.fields.snis = response?.data?.snis?.length ? response.data.snis : ['']
     form.fields.tags = response?.data?.tags?.join(', ') || ''
 
@@ -334,6 +654,21 @@ const saveFormData = async (): Promise<void> => {
 
     :deep(.k-tooltip) {
       max-width: 300px;
+    }
+  }
+
+  .certificate-form-vault-input {
+    width: 100%;
+  }
+
+  :deep(.kong-ui-entity-form-block:not(:last-child)) {
+    margin-bottom: var(--kui-space-70, $kui-space-70);
+  }
+
+  .certificate-source-selector {
+    .certificate-source-options {
+      display: flex;
+      gap: var(--kui-space-70, $kui-space-70);
     }
   }
 }

--- a/packages/entities/entities-certificates/src/components/CertificateFormSniField.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateFormSniField.vue
@@ -3,63 +3,61 @@
     <KLabel :info="t('certificates.form.fields.snis.tooltip')">
       {{ t('certificates.form.fields.snis.label') }}
     </KLabel>
-    <div
-      v-for="_, index in fieldsValue"
-      :key="index"
-      class="sni-field-input"
-    >
-      <KInput
-        v-if="!isEditing || fieldsValue[index]"
-        v-model.trim="fieldsValue[index]"
-        :data-testid="`sni-field-input-${index + 1}`"
-        :disabled="isEditing"
-        :placeholder="t('certificates.form.fields.snis.placeholder')"
-      />
-      <div
-        v-if="!isEditing"
-        class="sni-field-controls-container"
+
+    <template v-if="isEditing">
+      <template
+        v-for="_, index in fieldsValue"
+        :key="index"
       >
+        <KInput
+          v-if="fieldsValue[index]"
+          v-model.trim="fieldsValue[index]"
+          :data-testid="`sni-field-input-${index + 1}`"
+          disabled
+          :placeholder="t('certificates.form.fields.snis.placeholder')"
+        />
+      </template>
+      <i18nT keypath="certificates.form.fields.snis.editingTip">
+        <template #link>
+          <router-link :to="sniListRoute">
+            {{ t('certificates.form.fields.snis.editingTipLink') }}
+          </router-link>
+        </template>
+      </i18nT>
+    </template>
+
+    <template v-else>
+      <div
+        v-for="_, index in fieldsValue"
+        :key="index"
+        class="sni-field-row"
+      >
+        <KInput
+          v-model.trim="fieldsValue[index]"
+          :data-testid="`sni-field-input-${index + 1}`"
+          :placeholder="t('certificates.form.fields.snis.placeholder')"
+        />
         <KButton
           appearance="tertiary"
-          class="remove-button"
-          data-testid="remove-sni"
+          class="sni-remove-button"
+          :data-testid="`remove-sni-${index + 1}`"
           icon
           @click="$emit('remove', index)"
         >
-          <TrashIcon
-            :color="KUI_COLOR_TEXT_DANGER"
-          />
-        </KButton>
-        <KButton
-          appearance="tertiary"
-          data-testid="add-sni"
-          :disabled="index !== fieldsValue.length - 1"
-          icon
-          @click="$emit('add')"
-        >
-          <AddIcon />
+          <CloseIcon />
         </KButton>
       </div>
-    </div>
-    <div
-      v-if="fieldsValue.length === 0"
-    >
+
       <KButton
+        appearance="tertiary"
+        class="sni-add-button"
+        data-testid="add-sni"
         @click="$emit('add')"
       >
+        <AddIcon />
         {{ t('certificates.form.fields.snis.add') }}
       </KButton>
-    </div>
-    <i18nT
-      v-if="isEditing"
-      keypath="certificates.form.fields.snis.editingTip"
-    >
-      <template #link>
-        <router-link :to="sniListRoute">
-          {{ t('certificates.form.fields.snis.editingTipLink') }}
-        </router-link>
-      </template>
-    </i18nT>
+    </template>
   </div>
 </template>
 
@@ -67,8 +65,7 @@
 import type { PropType } from 'vue'
 import { ref, watch } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
-import { KUI_COLOR_TEXT_DANGER } from '@kong/design-tokens'
-import { TrashIcon, AddIcon } from '@kong/icons'
+import { CloseIcon, AddIcon } from '@kong/icons'
 import composables from '../composables'
 
 type FieldsValue = string[]
@@ -109,19 +106,26 @@ watch(fieldsValue, (value) => {
 
 <style lang="scss" scoped>
 .sni-field-container {
-  .sni-field-input {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-40, $kui-space-40);
+
+  .sni-field-row {
     align-items: center;
     display: flex;
-    gap: var(--kui-space-80, $kui-space-80);
+    gap: var(--kui-space-40, $kui-space-40);
 
-    &:not(:last-child) {
-      margin-bottom: var(--kui-space-60, $kui-space-60);
+    .sni-remove-button {
+      flex-shrink: 0;
+    }
+
+    :deep(.k-input) {
+      flex: 1;
     }
   }
 
-  .sni-field-controls-container {
-    display: flex;
-    gap: var(--kui-space-20, $kui-space-20);
+  .sni-add-button {
+    align-self: flex-start;
   }
 }
 </style>

--- a/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
+++ b/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
@@ -6,7 +6,7 @@ import {
   paginate,
   certificate,
   certificate100,
-  certificateVaultRef,
+  certificateVaultRefCert,
 } from '../../fixtures/mockData'
 import type { FetcherResponse } from '@kong-ui-public/entities-shared'
 import type { Router } from 'vue-router'
@@ -507,7 +507,7 @@ describe('<CertificateList />', () => {
       cy.get(rowWithVaultRef).find('[data-testid="subject"] .content-wrapper').should('contain.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="expiry"]').should('have.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="san"]').should('have.text', '-')
-      cy.get(rowWithVaultRef).find('[data-testid="cert"]').should('contain.text', certificateVaultRef)
+      cy.get(rowWithVaultRef).find('[data-testid="cert"]').should('contain.text', certificateVaultRefCert)
     })
   })
 
@@ -814,7 +814,7 @@ describe('<CertificateList />', () => {
       cy.get(rowWithVaultRef).find('[data-testid="subject"] .content-wrapper').should('contain.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="expiry"]').should('have.text', '-')
       cy.get(rowWithVaultRef).find('[data-testid="san"]').should('have.text', '-')
-      cy.get(rowWithVaultRef).find('[data-testid="cert"]').should('contain.text', certificateVaultRef)
+      cy.get(rowWithVaultRef).find('[data-testid="cert"]').should('contain.text', certificateVaultRefCert)
     })
   })
 

--- a/packages/entities/entities-certificates/src/locales/en.json
+++ b/packages/entities/entities-certificates/src/locales/en.json
@@ -32,9 +32,23 @@
           "title": "SSL key pair",
           "description": "The PEM-encoded public certificate chain and private key of the SSL key pair and the alternate."
         },
+        "certificate_config": {
+          "title": "Certificate configuration"
+        },
         "general": {
           "title": "General information",
-          "description": "General information will help identify and manage this key."
+          "description": "General information will help identify and manage this certificate."
+        }
+      },
+      "source_type": {
+        "question": "Which certificate source would you like to use?",
+        "ssl": {
+          "label": "SSL key pair",
+          "description": "Use self-managed certificates when you need full control over certificate lifecycle management."
+        },
+        "azure": {
+          "label": "Azure Key Vault Certificates",
+          "description": "Automatically provision and renew TLS certificates through Azure Certificate Management."
         }
       },
       "fields": {
@@ -70,7 +84,16 @@
           "label": "Tags",
           "placeholder": "Enter a list of tags separated by comma",
           "help": "e.g. tag1, tag2, tag3",
-          "tooltip": "An optional set of strings for grouping and filtering, separated by commas."
+          "tooltip": "An optional set of strings for grouping and filtering, separated by commas.",
+          "show_label": "Show labels and tags"
+        },
+        "vault": {
+          "label": "Managed certificate",
+          "placeholder": "e.g. {vault://azure-certs-prefix/my-cert}"
+        },
+        "vault_alt": {
+          "label": "Managed certificate alt",
+          "placeholder": "e.g. {vault://azure-certs-prefix/my-cert-alt}"
         }
       }
     },

--- a/packages/entities/entities-certificates/src/types/certificate-form.ts
+++ b/packages/entities/entities-certificates/src/types/certificate-form.ts
@@ -7,6 +7,8 @@ export interface KonnectCertificateFormConfig extends KonnectBaseFormConfig {
   cancelRoute: RouteLocationRaw
   /** Route of listing SNIs */
   sniListRoute?: RouteLocationRaw
+  /** Show vault reference tab for cert/key fields (azure-certs vault integration) */
+  azureCertsVaultAvailable?: boolean
 }
 
 /** Kong Manager certificate form config */
@@ -15,6 +17,8 @@ export interface KongManagerCertificateFormConfig extends KongManagerBaseFormCon
   cancelRoute: RouteLocationRaw
   /** Route of listing SNIs */
   sniListRoute?: RouteLocationRaw
+  /** Show vault reference tab for cert/key fields (azure-certs vault integration) */
+  azureCertsVaultAvailable?: boolean
 }
 
 export interface CertificateFormFields {
@@ -22,6 +26,8 @@ export interface CertificateFormFields {
   key: string
   certAlt: string
   keyAlt: string
+  vault: string
+  vaultAlt: string
   snis: string[]
   tags: string
 }

--- a/packages/entities/entities-certificates/vite.config.ts
+++ b/packages/entities/entities-certificates/vite.config.ts
@@ -16,6 +16,17 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
       entry: resolve(__dirname, './src/index.ts'),
       fileName: (format) => `${sanitizedPackageName}.${format}.js`,
     },
+    rollupOptions: {
+      external: [
+        '@kong-ui-public/entities-vaults/dist/style.css',
+        '@kong-ui-public/entities-vaults',
+      ],
+      output: {
+        globals: {
+          '@kong-ui-public/entities-vaults': 'kong-ui-public-entities-vaults',
+        },
+      },
+    },
   },
   server: {
     proxy: {

--- a/packages/entities/entities-vaults/README.md
+++ b/packages/entities/entities-vaults/README.md
@@ -21,6 +21,7 @@ Vault entity components.
 - `VaultList`
 - `VaultForm`
 - `VaultConfigCard`
+- `VaultSecretPicker`
 
 Reference the [individual component docs](#individual-component-documentation) for more info.
 
@@ -48,3 +49,4 @@ import '@kong-ui-public/entities-vaults/dist/style.css'
 - [`<VaultList.vue />`](docs/vault-list.md)
 - [`<VaultForm.vue />`](docs/vault-form.md)
 - [`<VaultConfigCard.vue />`](docs/vault-config-card.md)
+- [`<VaultSecretPicker.vue />`](docs/vault-secret-picker.md)

--- a/packages/entities/entities-vaults/docs/vault-form.md
+++ b/packages/entities/entities-vaults/docs/vault-form.md
@@ -74,6 +74,12 @@ A form component for Vaults.
     - *Specific to Konnect*. Show/hide Azure option.
     - **Note:** This is experimental and not supported by the backend right now
 
+  - `azureCertsVaultProviderAvailable`
+    - type: `boolean`
+    - required: `false`
+    - default: `undefined`
+    - Show/hide the Azure Key Vault Certificates provider option.
+
   - `fsVaultProviderAvailable`
     - type: `boolean`
     - required: `false`

--- a/packages/entities/entities-vaults/docs/vault-secret-picker.md
+++ b/packages/entities/entities-vaults/docs/vault-secret-picker.md
@@ -1,0 +1,106 @@
+# VaultSecretPicker.vue
+
+A picker component for selecting a vault secret reference.
+
+- [Requirements](#requirements)
+- [Usage](#usage)
+  - [Install](#install)
+  - [Props](#props)
+  - [Events](#events)
+  - [Usage example](#usage-example)
+- [TypeScript interfaces](#typescript-interfaces)
+
+## Requirements
+
+- `vue` and `vue-router` must be initialized in the host application
+- `@kong/kongponents` must be added as a dependency in the host application, globally available via the Vue Plugin installation, and the package's style imports must be added in the app entry file. [See here for instructions on installing Kongponents](https://kongponents.konghq.com/#globally-install-all-kongponents).
+- `@kong-ui-public/i18n` must be available as a `dependency` in the host application.
+- `axios` must be installed as a dependency in the host application
+
+## Usage
+
+### Install
+
+[See instructions for installing the `@kong-ui-public/entities-vaults` package.](../README.md#install)
+
+### Props
+
+#### `config`
+
+- type: `Object as PropType<KonnectBaseFormConfig | KongManagerBaseFormConfig>`
+- required: `true`
+- default: `undefined`
+
+The base Konnect or Kong Manager config object.
+
+#### `setup`
+
+- type: `string | false`
+- required: `false`
+- default: `false`
+
+Pre-selected vault prefix. When set to a non-empty string, the picker skips the vault selection step and uses this value as the vault prefix.
+
+#### `title`
+
+- type: `string`
+- required: `false`
+- default: `undefined`
+
+Custom title displayed in the picker modal header.
+
+#### `proceedButtonText`
+
+- type: `string`
+- required: `false`
+- default: `undefined`
+
+Custom label for the confirm/proceed button.
+
+#### `additionalDisabled`
+
+- type: `boolean`
+- required: `false`
+- default: `false`
+
+When `true`, the proceed button is disabled regardless of the current selection state.
+
+#### `allowedProviders`
+
+- type: `VaultProviders[]`
+- required: `false`
+- default: `undefined`
+
+Restricts the vault list to only the specified providers. When `undefined`, all providers except `azure-certs` are shown.
+
+#### `showSecretKey`
+
+- type: `boolean`
+- required: `false`
+- default: `true`
+
+Whether to show the optional secret key input field. Set to `false` when the consumer only needs a vault-level reference (e.g. Azure Key Vault Certificates, where the key segment is determined server-side).
+
+### Events
+
+#### proceed
+
+A `@proceed` event is emitted when the user confirms their selection. The event payload is the resulting vault secret reference string (e.g. `{vault://my-vault/my-secret/my-key}`).
+
+#### cancel
+
+A `@cancel` event is emitted when the user dismisses the picker without making a selection.
+
+### Usage example
+
+Please refer to the [sandbox](../sandbox/pages/VaultSecretPickerPage.vue).
+
+## TypeScript interfaces
+
+TypeScript interfaces [are available here](../src/types/vault-form.ts) and can be directly imported into your host application. The following type interfaces are available for import:
+
+```ts
+import type {
+  VaultProviders,
+} from '@kong-ui-public/entities-vaults'
+```

--- a/packages/entities/entities-vaults/sandbox/pages/VaultFormPage.vue
+++ b/packages/entities/entities-vaults/sandbox/pages/VaultFormPage.vue
@@ -36,6 +36,7 @@ const konnectConfig = ref<KonnectVaultFormConfig>({
   controlPlaneId,
   cancelRoute: { name: 'vault-list' },
   azureVaultProviderAvailable: true,
+  azureCertsVaultProviderAvailable: true,
   ttl: true,
   hcvAppRoleMethodAvailable: true,
   hcvCspAuthMethodsAvailable: true,
@@ -55,6 +56,7 @@ const kongManagerConfig = ref<KongManagerVaultFormConfig>({
   apiBaseUrl: '/kong-manager', // For local dev server proxy
   cancelRoute: { name: 'vault-list' },
   azureVaultProviderAvailable: false,
+  azureCertsVaultProviderAvailable: true,
   ttl: true,
   hcvAppRoleMethodAvailable: true,
   hcvCspAuthMethodsAvailable: true,

--- a/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
+++ b/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
@@ -489,6 +489,50 @@ describe('<VaultForm />', () => {
       cy.getTestId('vault-create-form-submit').should('be.disabled')
     })
 
+    it('should show azure-certs fields and validate required fields', () => {
+      cy.mount(VaultForm, {
+        props: {
+          config: {
+            ...baseConfigKM,
+            azureCertsVaultProviderAvailable: true,
+          },
+        },
+      })
+
+      cy.get('.kong-ui-entities-vault-form').should('be.visible')
+      cy.getTestId('vault-form-prefix').type(vault.prefix)
+
+      // switch to azure-certs provider
+      cy.getTestId('provider-select').click({ force: true })
+      cy.getTestId('vault-form-provider-azure-certs').click({ force: true })
+
+      // required fields are visible
+      cy.getTestId('vault-form-config-azure-certs-vault-uri').should('be.visible')
+      cy.getTestId('vault-form-config-azure-certs-credentials-prefix').should('be.visible')
+
+      // optional fields are visible
+      cy.getTestId('vault-form-config-azure-certs-client-id').should('be.visible')
+      cy.getTestId('vault-form-config-azure-certs-tenant-id').should('be.visible')
+
+      // ttl advanced section is visible
+      cy.getTestId('advanced-fields-collapse').should('be.visible')
+
+      // credentials_prefix has default value AZURE
+      cy.getTestId('vault-form-config-azure-certs-credentials-prefix').should('have.value', 'AZURE')
+
+      // ttl has default value 3600
+      cy.getTestId('vault-ttl-input').should('have.value', '3600')
+
+      // submit disabled until vault_uri is filled
+      cy.getTestId('vault-create-form-submit').should('be.disabled')
+      cy.getTestId('vault-form-config-azure-certs-vault-uri').type('https://my-vault.vault.azure.net')
+      cy.getTestId('vault-create-form-submit').should('be.enabled')
+
+      // clears vault_uri → submit disabled again
+      cy.getTestId('vault-form-config-azure-certs-vault-uri').clear()
+      cy.getTestId('vault-create-form-submit').should('be.disabled')
+    })
+
     it('should show edit form', () => {
       interceptKM()
 
@@ -963,6 +1007,50 @@ describe('<VaultForm />', () => {
 
       // disables save when required field is cleared - general
       cy.getTestId('vault-form-prefix').clear()
+      cy.getTestId('vault-create-form-submit').should('be.disabled')
+    })
+
+    it('should show azure-certs fields and validate required fields', () => {
+      cy.mount(VaultForm, {
+        props: {
+          config: {
+            ...baseConfigKonnect,
+            azureCertsVaultProviderAvailable: true,
+          },
+        },
+      })
+
+      cy.get('.kong-ui-entities-vault-form').should('be.visible')
+      cy.getTestId('vault-form-prefix').type(vault.prefix)
+
+      // switch to azure-certs provider
+      cy.getTestId('provider-select').click({ force: true })
+      cy.getTestId('vault-form-provider-azure-certs').click({ force: true })
+
+      // required fields are visible
+      cy.getTestId('vault-form-config-azure-certs-vault-uri').should('be.visible')
+      cy.getTestId('vault-form-config-azure-certs-credentials-prefix').should('be.visible')
+
+      // optional fields are visible
+      cy.getTestId('vault-form-config-azure-certs-client-id').should('be.visible')
+      cy.getTestId('vault-form-config-azure-certs-tenant-id').should('be.visible')
+
+      // ttl advanced section is visible
+      cy.getTestId('advanced-fields-collapse').should('be.visible')
+
+      // credentials_prefix has default value AZURE
+      cy.getTestId('vault-form-config-azure-certs-credentials-prefix').should('have.value', 'AZURE')
+
+      // ttl has default value 3600
+      cy.getTestId('vault-ttl-input').should('have.value', '3600')
+
+      // submit disabled until vault_uri is filled
+      cy.getTestId('vault-create-form-submit').should('be.disabled')
+      cy.getTestId('vault-form-config-azure-certs-vault-uri').type('https://my-vault.vault.azure.net')
+      cy.getTestId('vault-create-form-submit').should('be.enabled')
+
+      // clears vault_uri → submit disabled again
+      cy.getTestId('vault-form-config-azure-certs-vault-uri').clear()
       cy.getTestId('vault-create-form-submit').should('be.disabled')
     })
 

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -748,6 +748,48 @@
             />
           </div>
 
+          <!-- Azure Key Vault Certificates fields -->
+          <div
+            v-if="vaultProvider === VaultProviders.AZURE_CERTS"
+            :key="`${VaultProviders.AZURE_CERTS}-vault-config-fields`"
+            class="vault-form-config-fields-container"
+          >
+            <KInput
+              v-model.trim="configFields[VaultProviders.AZURE_CERTS].vault_uri"
+              autocomplete="off"
+              data-testid="vault-form-config-azure-certs-vault-uri"
+              :label="t('form.config.azure-certs.fields.vault_uri.label')"
+              :readonly="form.isReadonly"
+              required
+              type="text"
+            />
+            <KInput
+              v-model.trim="configFields[VaultProviders.AZURE_CERTS].credentials_prefix"
+              autocomplete="off"
+              data-testid="vault-form-config-azure-certs-credentials-prefix"
+              :label="t('form.config.azure-certs.fields.credential_prefix.label')"
+              :readonly="form.isReadonly"
+              required
+              type="text"
+            />
+            <KInput
+              v-model.trim="configFields[VaultProviders.AZURE_CERTS].client_id"
+              autocomplete="off"
+              data-testid="vault-form-config-azure-certs-client-id"
+              :label="t('form.config.azure-certs.fields.client_id.label')"
+              :readonly="form.isReadonly"
+              type="text"
+            />
+            <KInput
+              v-model.trim="configFields[VaultProviders.AZURE_CERTS].tenant_id"
+              autocomplete="off"
+              data-testid="vault-form-config-azure-certs-tenant-id"
+              :label="t('form.config.azure-certs.fields.tenant_id.label')"
+              :readonly="form.isReadonly"
+              type="text"
+            />
+          </div>
+
           <!-- Conjur fields -->
           <div
             v-if="vaultProvider === VaultProviders.CONJUR"
@@ -863,7 +905,7 @@
               <div class="wrapper">
                 <div class="item-50">
                   <KInput
-                    v-model="configFields[vaultProvider as VaultProviders.HCV | VaultProviders.GCP | VaultProviders.AWS | VaultProviders.AZURE | VaultProviders.CONJUR | VaultProviders.FS].ttl"
+                    v-model="configFields[vaultProvider as VaultProviders.HCV | VaultProviders.GCP | VaultProviders.AWS | VaultProviders.AZURE | VaultProviders.CONJUR | VaultProviders.FS | VaultProviders.AZURE_CERTS].ttl"
                     data-testid="vault-ttl-input"
                     :label="t('form.config.advancedFields.ttl')"
                     :label-attributes="{
@@ -876,7 +918,7 @@
 
                 <div class="item-50">
                   <KInput
-                    v-model="configFields[vaultProvider as VaultProviders.HCV | VaultProviders.GCP | VaultProviders.AWS | VaultProviders.AZURE | VaultProviders.CONJUR | VaultProviders.FS].neg_ttl"
+                    v-model="configFields[vaultProvider as VaultProviders.HCV | VaultProviders.GCP | VaultProviders.AWS | VaultProviders.AZURE | VaultProviders.CONJUR | VaultProviders.FS | VaultProviders.AZURE_CERTS].neg_ttl"
                     data-testid="vault-neg-ttl-input"
                     :label="t('form.config.advancedFields.negTtl')"
                     :label-attributes="{
@@ -891,7 +933,7 @@
               <div class="wrapper">
                 <div class="item-100">
                   <KInput
-                    v-model="configFields[vaultProvider as VaultProviders.HCV | VaultProviders.GCP | VaultProviders.AWS | VaultProviders.AZURE | VaultProviders.CONJUR | VaultProviders.FS].resurrect_ttl"
+                    v-model="configFields[vaultProvider as VaultProviders.HCV | VaultProviders.GCP | VaultProviders.AWS | VaultProviders.AZURE | VaultProviders.CONJUR | VaultProviders.FS | VaultProviders.AZURE_CERTS].resurrect_ttl"
                     data-testid="vault-resurrect-ttl-input"
                     :label="t('form.config.advancedFields.resurrectTtl')"
                     :label-attributes="{
@@ -971,6 +1013,7 @@ import type {
   GCPVaultConfig,
   HCVVaultConfig,
   AzureVaultConfig,
+  AzureCertsVaultConfig,
   VaultState,
   VaultStateFields,
   KongManagerVaultFormConfig,
@@ -1004,6 +1047,7 @@ interface ConfigFields {
   [VaultProviders.GCP]: GCPVaultConfig
   [VaultProviders.HCV]: HCVVaultConfig
   [VaultProviders.AZURE]: AzureVaultConfig
+  [VaultProviders.AZURE_CERTS]: AzureCertsVaultConfig
   [VaultProviders.KONNECT]: ConfigStoreConfig
   [VaultProviders.CONJUR]: ConjurVaultConfig
   [VaultProviders.FS]: FSVaultConfig
@@ -1063,7 +1107,7 @@ const originalVaultProvider = ref<VaultProviders | null>(null)
 const configStoreId = ref<string>()
 
 const isAvailableTTLConfig = computed(() => {
-  return [VaultProviders.AWS, VaultProviders.GCP, VaultProviders.HCV, VaultProviders.AZURE, VaultProviders.CONJUR, VaultProviders.FS].includes(vaultProvider.value)
+  return [VaultProviders.AWS, VaultProviders.GCP, VaultProviders.HCV, VaultProviders.AZURE, VaultProviders.CONJUR, VaultProviders.FS, VaultProviders.AZURE_CERTS].includes(vaultProvider.value)
 })
 
 const providers = computed<Array<{ label: string, value: VaultProviders }>>(() => {
@@ -1118,6 +1162,15 @@ const providers = computed<Array<{ label: string, value: VaultProviders }>>(() =
         ? [{
           label: t('form.config.fs.label'),
           value: VaultProviders.FS,
+          disabled: !isOtherProvidersSupported.value,
+        }]
+        : []
+    ),
+    ...(
+      props.config.azureCertsVaultProviderAvailable
+        ? [{
+          label: t('form.config.azure-certs.label'),
+          value: VaultProviders.AZURE_CERTS,
           disabled: !isOtherProvidersSupported.value,
         }]
         : []
@@ -1196,6 +1249,13 @@ const configFields = reactive<ConfigFields>({
     tenant_id: '',
     ...base64FieldConfig,
   } as AzureVaultConfig,
+  [VaultProviders.AZURE_CERTS]: {
+    vault_uri: '',
+    credentials_prefix: 'AZURE',
+    client_id: '',
+    tenant_id: '',
+    ttl: 3600,
+  } as AzureCertsVaultConfig,
   [VaultProviders.CONJUR]: {
     endpoint_url: '',
     auth_method: 'api_key',
@@ -1276,6 +1336,13 @@ const originalConfigFields = reactive<ConfigFields>({
     tenant_id: '',
     ...base64FieldConfig,
   } as AzureVaultConfig,
+  [VaultProviders.AZURE_CERTS]: {
+    vault_uri: '',
+    credentials_prefix: 'AZURE',
+    client_id: '',
+    tenant_id: '',
+    ttl: 3600,
+  } as AzureCertsVaultConfig,
   [VaultProviders.CONJUR]: {
     endpoint_url: '',
     auth_method: 'api_key',
@@ -1361,6 +1428,8 @@ const getProviderIcon = (providerName: VaultProviders) => {
       return HashicorpIcon
     case VaultProviders.AZURE:
       return AzureIcon
+    case VaultProviders.AZURE_CERTS:
+      return AzureIcon
     case VaultProviders.CONJUR:
       return ConjourIcon
     case VaultProviders.FS:
@@ -1382,6 +1451,8 @@ const getProviderDescription = (providerName: VaultProviders) => {
       return t('form.config.hcv.description')
     case VaultProviders.AZURE:
       return t('form.config.azure.description')
+    case VaultProviders.AZURE_CERTS:
+      return t('form.config.azure-certs.description')
     case VaultProviders.CONJUR:
       return t('form.config.conjur.description')
     case VaultProviders.FS:
@@ -1504,6 +1575,17 @@ const isVaultConfigValid = computed((): boolean => {
     }).length
   }
 
+  // Azure Key Vault Certificates fields logic
+  if (vaultProvider.value === VaultProviders.AZURE_CERTS) {
+    return !Object.keys(configFields[VaultProviders.AZURE_CERTS]).filter(key => {
+      // client_id, tenant_id and ttl fields are optional
+      if (['client_id', 'tenant_id', 'ttl', 'neg_ttl', 'resurrect_ttl'].includes(key)) {
+        return false
+      }
+      return isEmpty((configFields[vaultProvider.value] as AzureCertsVaultConfig)[key as keyof AzureCertsVaultConfig])
+    }).length
+  }
+
   // AWS Vault fields logic
   if (vaultProvider.value === VaultProviders.AWS) {
     return !Object.keys(configFields[VaultProviders.AWS]).filter(key => {
@@ -1623,6 +1705,12 @@ const getPayload = computed((): Record<string, any> => {
     tenant_id: (configFields[vaultProvider.value] as AzureVaultConfig).tenant_id || null,
   }
 
+  const azureCertsConfig = {
+    ...configFields[vaultProvider.value],
+    client_id: (configFields[vaultProvider.value] as AzureCertsVaultConfig).client_id || null,
+    tenant_id: (configFields[vaultProvider.value] as AzureCertsVaultConfig).tenant_id || null,
+  }
+
   const awsConfig = {
     ...configFields[vaultProvider.value],
     endpoint_url: (configFields[vaultProvider.value] as AWSVaultConfig).endpoint_url || null,
@@ -1635,13 +1723,15 @@ const getPayload = computed((): Record<string, any> => {
     config = hcvConfig
   } else if (vaultProvider.value === VaultProviders.AZURE) {
     config = azureConfig
+  } else if (vaultProvider.value === VaultProviders.AZURE_CERTS) {
+    config = azureCertsConfig
   } else if (vaultProvider.value === VaultProviders.AWS) {
     config = awsConfig
   }
 
   let ttlFields = {}
   if (![VaultProviders.KONNECT, VaultProviders.ENV].includes(vaultProvider.value)) {
-    const fields = configFields[vaultProvider.value as VaultProviders.HCV | VaultProviders.GCP | VaultProviders.AWS | VaultProviders.AZURE | VaultProviders.CONJUR | VaultProviders.FS]
+    const fields = configFields[vaultProvider.value as VaultProviders.HCV | VaultProviders.GCP | VaultProviders.AWS | VaultProviders.AZURE | VaultProviders.CONJUR | VaultProviders.FS | VaultProviders.AZURE_CERTS]
     const ttl = fields.ttl
     const negTtl = fields.neg_ttl
     const resurrectTtl = fields.resurrect_ttl

--- a/packages/entities/entities-vaults/src/components/VaultSecretPicker.vue
+++ b/packages/entities/entities-vaults/src/components/VaultSecretPicker.vue
@@ -102,6 +102,7 @@
       />
 
       <KInput
+        v-if="showSecretKey"
         v-model.trim="optionalSecretKey"
         autocomplete="off"
         data-testid="vault-secret-picker-secret-key-input"
@@ -118,6 +119,7 @@
 <script lang="ts">
 import { useAxios, useDebouncedFilter, type KongManagerBaseFormConfig, type KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
 import type { SecretEntityRow as SecretEntity, EntityRow as VaultEntity } from '../types'
+import { VaultProviders } from '../types'
 import vaultsEndpoints from '../vaults-endpoints'
 import secretsEndpoints from '../secrets-endpoints'
 import type { SelectItem } from '@kong/kongponents'
@@ -163,6 +165,16 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+  allowedProviders: {
+    type: Array as PropType<VaultProviders[]>,
+    required: false,
+    default: undefined,
+  },
+  showSecretKey: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
 })
 
@@ -236,17 +248,24 @@ const {
   exactMatchKey: 'key',
 })
 
+const isProviderAllowed = (vaultName: string): boolean => {
+  if (props.allowedProviders?.length) {
+    return props.allowedProviders.includes(vaultName as VaultProviders)
+  }
+  return vaultName !== VaultProviders.AZURE_CERTS
+}
+
 const availableVaults = computed<SelectVaultItem[]>(() => {
   let hasSelectedVault = false
 
-  const items = vaultsResults.value?.map((v) => {
-    if (v.prefix === selectedVaultPrefix.value) {
-      hasSelectedVault = true
-    }
-
-    return { label: v.prefix, value: v.prefix, vault: v as VaultEntity }
-  }) ?? []
-
+  const items = (vaultsResults.value ?? [])
+    .filter((v) => isProviderAllowed(v.name))
+    .map((v) => {
+      if (v.prefix === selectedVaultPrefix.value) {
+        hasSelectedVault = true
+      }
+      return { label: v.prefix, value: v.prefix, vault: v as VaultEntity }
+    })
 
   if (!hasSelectedVault && selectedVault.value) {
     items.push({

--- a/packages/entities/entities-vaults/src/locales/en.json
+++ b/packages/entities/entities-vaults/src/locales/en.json
@@ -404,6 +404,24 @@
           }
         }
       },
+      "azure-certs": {
+        "label": "Azure Key Vault (Certificates)",
+        "description": "Access certificates stored in Azure Key Vault for Kong Gateway TLS termination.",
+        "fields": {
+          "vault_uri": {
+            "label": "Vault URI"
+          },
+          "credential_prefix": {
+            "label": "Credential prefix"
+          },
+          "client_id": {
+            "label": "Client ID"
+          },
+          "tenant_id": {
+            "label": "Tenant ID"
+          }
+        }
+      },
       "conjur": {
         "label": "CyberArk Secrets Manager (Conjur)",
         "description": "Access secrets stored in CyberArk Secrets Manager (Conjur) for Kong Gateway configuration.",

--- a/packages/entities/entities-vaults/src/types/vault-form.ts
+++ b/packages/entities/entities-vaults/src/types/vault-form.ts
@@ -57,6 +57,11 @@ export interface BaseVaultFormConfig extends Omit<BaseFormConfig, 'cancelRoute'>
   fsVaultProviderAvailable?: boolean
 
   /**
+   * Show/hide Azure Key Vault Certificates option
+   */
+  azureCertsVaultProviderAvailable?: boolean
+
+  /**
    * Show/hide Base64 field (added since 3.11)
    */
   base64FieldAvailable?: boolean
@@ -74,6 +79,7 @@ export enum VaultProviders {
   HCV = 'hcv',
   ENV = 'env',
   AZURE = 'azure',
+  AZURE_CERTS = 'azure-certs',
   KONNECT = 'konnect',
   CONJUR = 'conjur',
   FS = 'fs',
@@ -180,6 +186,16 @@ export interface AzureVaultConfig {
   base64_decode?: boolean
 }
 
+export interface AzureCertsVaultConfig {
+  vault_uri: string
+  credentials_prefix: string
+  client_id?: string
+  tenant_id?: string
+  ttl?: number
+  neg_ttl?: number
+  resurrect_ttl?: number
+}
+
 export interface ConjurVaultConfig {
   endpoint_url: string
   auth_method: 'api_key'
@@ -216,6 +232,13 @@ export interface AzureVaultConfigPayload extends Omit<AzureVaultConfig, 'client_
 
 // allow for nullish values in payload because Kong Admin API treats null as an empty value
 // in case it's an empty string, it will be treated as a value and must have length > 0
+export interface AzureCertsVaultConfigPayload extends Omit<AzureCertsVaultConfig, 'client_id' | 'tenant_id'> {
+  client_id?: string | null
+  tenant_id?: string | null
+}
+
+// allow for nullish values in payload because Kong Admin API treats null as an empty value
+// in case it's an empty string, it will be treated as a value and must have length > 0
 export interface AWSVaultConfigPayload extends Omit<AWSVaultConfig, 'endpoint_url' | 'assume_role_arn'> {
   endpoint_url?: string | null
   assume_role_arn?: string | null
@@ -226,7 +249,7 @@ export interface VaultPayload {
   prefix: string
   description: string | null
   tags: string[]
-  config: ConfigStoreConfig | KongVaultConfig | GCPVaultConfig | HCVVaultConfigPayload | AzureVaultConfigPayload | AWSVaultConfigPayload | ConjurVaultConfig | FSVaultConfig
+  config: ConfigStoreConfig | KongVaultConfig | GCPVaultConfig | HCVVaultConfigPayload | AzureVaultConfigPayload | AWSVaultConfigPayload | ConjurVaultConfig | FSVaultConfig | AzureCertsVaultConfigPayload
 }
 
 export interface VaultStateFields {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -817,6 +817,9 @@ importers:
       '@kong-ui-public/entities-shared':
         specifier: workspace:^
         version: link:../entities-shared
+      '@kong-ui-public/entities-vaults':
+        specifier: workspace:^
+        version: link:../entities-vaults
       '@kong-ui-public/i18n':
         specifier: workspace:^
         version: link:../../core/i18n


### PR DESCRIPTION
[KM-2543]

Adds support for Azure Certificates vault (`azure-certs`) as a certificate source in `entities-certificates`, and extends `entities-vaults` with the new vault provider.

## Changes

**`entities-vaults`**
- Add `azure-certs` vault provider to `VaultForm` (new provider type, config fields, i18n)
- Add `allowedProviders` and `showSecretKey` props to `VaultSecretPicker`; default behavior excludes `azure-certs` from all existing pickers to avoid breaking consumers
- Add `azureCertsVaultProviderAvailable` feature flag to vault form config types

**`entities-certificates`**
- Add a "Source" radio selector to `CertificateForm`: **SSL** (existing PEM flow) vs **Azure Vault** (new vault ref flow)
- Azure mode stores a vault reference (`{vault://<prefix>/<resource>}`) and expands it to `cert`/`key` fields on submit (`{vault://…/cert}` and `{vault://…/key}`) — compatible with decK and direct API usage
- On edit, auto-detect azure-managed certificates from the `cert`/`key` field patterns and switch to Azure mode
- Add `azureCertsVaultAvailable` flag to certificate form config types

[KM-2543]: https://konghq.atlassian.net/browse/KM-2543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ