### PR TITLE
fix(entities-plugins): custom plugin endpoints

### DIFF
--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.cy.ts
@@ -669,7 +669,7 @@ describe('<CustomPluginForm />', () => {
     it('should submit streamed plugin via Kong Manager API', () => {
       cy.intercept(
         'POST',
-        `${kongManagerConfig.apiBaseUrl}/custom-plugins`,
+        `${kongManagerConfig.apiBaseUrl}/${kongManagerConfig.workspace}/custom-plugins`,
         {
           statusCode: 201,
           body: streamedPluginResponse,

--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
@@ -477,6 +477,7 @@ const props = defineProps({
     validator: (config: KonnectCustomPluginFormConfig | KongManagerCustomPluginFormConfig): boolean => {
       if (!config || !config.app) return false
       if (config.app === 'konnect' && !config.controlPlaneId) return false
+      if (config.app === 'kongManager' && !(config as KongManagerCustomPluginFormConfig).workspace) return false
       if (!config.cancelRoute) return false
       if (!config.successRoute) return false
       return true
@@ -517,6 +518,7 @@ const {
   apiBaseUrl: props.config.apiBaseUrl,
   controlPlaneId: (props.config as KonnectCustomPluginFormConfig).controlPlaneId,
   app: props.config.app,
+  workspace: (props.config as KongManagerCustomPluginFormConfig).workspace,
 })
 
 // Force-enable the new plugin form layout

--- a/packages/entities/entities-plugins/src/components/PluginCatalog.vue
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.vue
@@ -229,9 +229,9 @@ const availablePluginsUrl = computed((): string => {
 
 const streamingPluginsUrl = computed<string | null>(() => {
   if (props.config.app === 'konnect' && props.customPluginSupport === 'streaming') {
-    // Streamed custom plugins are CP-global, not workspace-scoped.
     return `${props.config.apiBaseUrl}${endpoints.select[props.config.app].streamingCustomPlugins}`
       .replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+      .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
   }
   // Kong Manager and other support level does not support streaming custom plugins now
   return null

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -389,6 +389,7 @@ const { getClonedPlugin: fetchClonedPluginDetail } = composables.useCustomPlugin
   } as any).axiosInstance,
   apiBaseUrl: props.config.apiBaseUrl,
   app: props.config.app,
+  workspace: (props.config as KongManagerPluginFormConfig).workspace,
   controlPlaneId: (props.config as KonnectPluginFormConfig).controlPlaneId,
 })
 

--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -175,6 +175,12 @@ const props = defineProps({
     required: true,
     validator: (config: KonnectPluginSelectConfig | KongManagerPluginSelectConfig): boolean => {
       if (!config || !['konnect', 'kongManager'].includes(config?.app)) return false
+      if (config.app === 'kongManager' && !config.workspace) return false
+      if (config.app === 'konnect') {
+        if (!config.controlPlaneId || config.workspace) { // controlPlaneId is required and workspace should not be provided for konnect
+          return false
+        }
+      }
       if (!config.getCreateRoute) return false
       return true
     },
@@ -565,11 +571,9 @@ const clonedPluginsUrl = computed<string | null>(() => {
 
     if (props.config.app === 'konnect') {
       url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
-    } else if (props.config.app === 'kongManager') {
-      url = url.replace(/{workspace}/gi, props.config.workspace || '')
     }
 
-    return url
+    return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
   }
 
   return null

--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -545,7 +545,6 @@ const availablePluginsUrl = computed((): string => {
   return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
 })
 
-// Streamed and cloned custom plugins are CP-global, not workspace-scoped.
 const streamingPluginsUrl = computed<string | null>(() => {
   if (isStreamingCustomPluginSupported.value) {
     let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].streamingCustomPlugins}`
@@ -554,7 +553,7 @@ const streamingPluginsUrl = computed<string | null>(() => {
       url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
     }
 
-    return url
+    return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
   }
 
   return null
@@ -566,6 +565,8 @@ const clonedPluginsUrl = computed<string | null>(() => {
 
     if (props.config.app === 'konnect') {
       url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+    } else if (props.config.app === 'kongManager') {
+      url = url.replace(/{workspace}/gi, props.config.workspace || '')
     }
 
     return url

--- a/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
+++ b/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
@@ -94,7 +94,6 @@ const requestUrl = computed(() => {
   const pluginType = props.plugin.customPluginType
 
   if (props.config.app === 'konnect') {
-    // Installed / streamed / cloned custom plugins are all CP-global.
     const partialPluginURL = pluginType === 'streaming'
       ? endpoints.select[props.config.app].streamingCustomPluginItem
       : pluginType === 'cloned'
@@ -103,17 +102,19 @@ const requestUrl = computed(() => {
 
     return `${props.config.apiBaseUrl}${partialPluginURL}`
       .replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+      .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
       .replace(/{pluginId}/gi, props.plugin.id)
   }
 
   if (props.config.app === 'kongManager' && pluginType && pluginType !== 'schema') {
-    // Streamed and cloned custom plugins are CP-global, not workspace-scoped.
     const partialPluginUrl = pluginType === 'cloned'
       ? endpoints.customPlugin[props.config.app].cloned.edit
       : endpoints.customPlugin[props.config.app].streamed.edit
 
-    return `${props.config.apiBaseUrl}${partialPluginUrl}`
-      .replace(/{pluginId}/gi, props.plugin.id)
+    let url = `${props.config.apiBaseUrl}${partialPluginUrl}`
+    url = url.replace(/{workspace}/gi, props.config.workspace || '')
+    url = url.replace(/{pluginId}/gi, props.plugin.id)
+    return url
   }
 
   return null

--- a/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
+++ b/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
@@ -111,10 +111,9 @@ const requestUrl = computed(() => {
       ? endpoints.customPlugin[props.config.app].cloned.edit
       : endpoints.customPlugin[props.config.app].streamed.edit
 
-    let url = `${props.config.apiBaseUrl}${partialPluginUrl}`
-    url = url.replace(/{workspace}/gi, props.config.workspace || '')
-    url = url.replace(/{pluginId}/gi, props.plugin.id)
-    return url
+    return `${props.config.apiBaseUrl}${partialPluginUrl}`
+      .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
+      .replace(/{pluginId}/gi, props.plugin.id)
   }
 
   return null

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.spec.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.spec.ts
@@ -45,6 +45,7 @@ describe('useCustomPluginApi', () => {
       axiosInstance: axiosInstance as AxiosInstance,
       apiBaseUrl: '/kong-manager',
       app: 'kongManager',
+      workspace: 'default',
     })
 
     await expect(api.getInstalledPlugin('my-plugin')).rejects.toThrow('Installed custom plugin APIs are only available for Konnect')

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.spec.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.spec.ts
@@ -34,7 +34,7 @@ describe('useCustomPluginApi', () => {
 
     await expect(api.updateInstalledPlugin('my-plugin', { lua_schema: 'return {}' })).resolves.toEqual(response)
     expect(axiosInstance.put).toHaveBeenCalledWith(
-      '/us/kong-api/v2/control-planes/test-cp-id/core-entities/plugin-schemas/my-plugin',
+      '/us/kong-api/v2/control-planes/test-cp-id/core-entities/{workspace}/plugin-schemas/my-plugin',
       { lua_schema: 'return {}' },
     )
     expect(axiosInstance.patch).not.toHaveBeenCalled()

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.spec.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.spec.ts
@@ -34,7 +34,7 @@ describe('useCustomPluginApi', () => {
 
     await expect(api.updateInstalledPlugin('my-plugin', { lua_schema: 'return {}' })).resolves.toEqual(response)
     expect(axiosInstance.put).toHaveBeenCalledWith(
-      '/us/kong-api/v2/control-planes/test-cp-id/core-entities/{workspace}/plugin-schemas/my-plugin',
+      '/us/kong-api/v2/control-planes/test-cp-id/core-entities/plugin-schemas/my-plugin',
       { lua_schema: 'return {}' },
     )
     expect(axiosInstance.patch).not.toHaveBeenCalled()

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
@@ -114,6 +114,9 @@ export function useCustomPluginApi(options: UseCustomPluginApiOptions) {
     // For Kong Manager, even resources are none-workspace, the endpoint still include /{workspace}
     if (options.app === 'kongManager') {
       url = url.replace(/\/{workspace}/gi, options.workspace ? `/${options.workspace}` : '')
+    } else {
+      // For Konnect, the endpoint should not include /{workspace} at all
+      url = url.replace(/\/{workspace}/gi, '')
     }
 
     return url

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
@@ -21,7 +21,6 @@ export type CustomPluginWithType =
 interface UseKonnectCustomPluginApiOptions {
   app: 'konnect'
   controlPlaneId: string
-  workspace?: string
 }
 
 interface PagedResponse<T> {
@@ -111,7 +110,11 @@ export function useCustomPluginApi(options: UseCustomPluginApiOptions) {
 
     url = url
       .replace(/{pluginId}/gi, pluginId ?? '')
-      .replace(/\/{workspace}/gi, options.workspace ? `/${options.workspace}` : '')
+
+    // For Kong Manager, even resources are none-workspace, the endpoint still include /{workspace}
+    if (options.app === 'kongManager') {
+      url = url.replace(/\/{workspace}/gi, options.workspace ? `/${options.workspace}` : '')
+    }
 
     return url
   }

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
@@ -21,6 +21,8 @@ export type CustomPluginWithType =
 interface UseKonnectCustomPluginApiOptions {
   app: 'konnect'
   controlPlaneId: string
+  // Workspace is supported in this composable, but the entry in Konnect will not include workspace for now.
+  workspace?: string
 }
 
 interface PagedResponse<T> {
@@ -103,21 +105,13 @@ export function useCustomPluginApi(options: UseCustomPluginApiOptions) {
   const buildUrl = (endpointTemplate: string, pluginId?: string): string => {
     let url = `${apiBaseUrl}${endpointTemplate}`
 
-
     if (options.app === 'konnect') {
       url = url.replace(/{controlPlaneId}/gi, options.controlPlaneId)
     }
 
     url = url
       .replace(/{pluginId}/gi, pluginId ?? '')
-
-    // For Kong Manager, even resources are none-workspace, the endpoint still include /{workspace}
-    if (options.app === 'kongManager') {
-      url = url.replace(/\/{workspace}/gi, options.workspace ? `/${options.workspace}` : '')
-    } else {
-      // For Konnect, the endpoint should not include /{workspace} at all
-      url = url.replace(/\/{workspace}/gi, '')
-    }
+      .replace(/\/{workspace}/gi, options.workspace ? `/${options.workspace}` : '')
 
     return url
   }

--- a/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
+++ b/packages/entities/entities-plugins/src/composables/useCustomPluginApi.ts
@@ -21,6 +21,7 @@ export type CustomPluginWithType =
 interface UseKonnectCustomPluginApiOptions {
   app: 'konnect'
   controlPlaneId: string
+  workspace?: string
 }
 
 interface PagedResponse<T> {
@@ -80,6 +81,7 @@ export const fetchAllPages = async <T>(
 
 interface UseKongManagerCustomPluginApiOptions {
   app: 'kongManager'
+  workspace: string
 }
 
 type UseCustomPluginApiOptions = (
@@ -102,11 +104,14 @@ export function useCustomPluginApi(options: UseCustomPluginApiOptions) {
   const buildUrl = (endpointTemplate: string, pluginId?: string): string => {
     let url = `${apiBaseUrl}${endpointTemplate}`
 
+
     if (options.app === 'konnect') {
       url = url.replace(/{controlPlaneId}/gi, options.controlPlaneId)
     }
 
-    url = url.replace(/{pluginId}/gi, pluginId ?? '')
+    url = url
+      .replace(/{pluginId}/gi, pluginId ?? '')
+      .replace(/\/{workspace}/gi, options.workspace ? `/${options.workspace}` : '')
 
     return url
   }

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -1,9 +1,6 @@
 const konnectV1BaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/v1'
 const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
-// Custom plugins (installed / streamed / cloned) are CP-global and never workspace-scoped.
-const konnectGlobalBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
 const KMBaseApiUrl = '/{workspace}'
-const KMGlobalBaseApiUrl = ''
 
 export default {
   list: {
@@ -19,16 +16,16 @@ export default {
   select: {
     konnect: {
       availablePlugins: `${konnectV1BaseApiUrl}/available-plugins`,
-      streamingCustomPlugins: `${konnectGlobalBaseApiUrl}/custom-plugins`,
-      clonedPlugins: `${konnectGlobalBaseApiUrl}/cloned-plugins`,
-      schemaCustomPluginItem: `${konnectGlobalBaseApiUrl}/plugin-schemas/{pluginId}`,
-      streamingCustomPluginItem: `${konnectGlobalBaseApiUrl}/custom-plugins/{pluginId}`,
+      streamingCustomPlugins: `${konnectBaseApiUrl}/custom-plugins`,
+      clonedPlugins: `${konnectBaseApiUrl}/cloned-plugins`,
+      schemaCustomPluginItem: `${konnectBaseApiUrl}/plugin-schemas/{pluginId}`,
+      streamingCustomPluginItem: `${konnectBaseApiUrl}/custom-plugins/{pluginId}`,
     },
     kongManager: {
       availablePlugins: `${KMBaseApiUrl}/kong`,
       availablePluginsForOss: '/',
-      streamingCustomPlugins: `${KMGlobalBaseApiUrl}/custom-plugins`,
-      clonedPlugins: `${KMGlobalBaseApiUrl}/cloned-plugins`,
+      streamingCustomPlugins: `${KMBaseApiUrl}/custom-plugins`,
+      clonedPlugins: `${KMBaseApiUrl}/cloned-plugins`,
     },
   },
   form: {
@@ -75,26 +72,26 @@ export default {
   customPlugin: {
     konnect: {
       installed: {
-        create: `${konnectGlobalBaseApiUrl}/plugin-schemas`,
-        edit: `${konnectGlobalBaseApiUrl}/plugin-schemas/{pluginId}`,
+        create: `${konnectBaseApiUrl}/plugin-schemas`,
+        edit: `${konnectBaseApiUrl}/plugin-schemas/{pluginId}`,
       },
       streamed: {
-        create: `${konnectGlobalBaseApiUrl}/custom-plugins`,
-        edit: `${konnectGlobalBaseApiUrl}/custom-plugins/{pluginId}`,
+        create: `${konnectBaseApiUrl}/custom-plugins`,
+        edit: `${konnectBaseApiUrl}/custom-plugins/{pluginId}`,
       },
       cloned: {
-        create: `${konnectGlobalBaseApiUrl}/cloned-plugins`,
-        edit: `${konnectGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
+        create: `${konnectBaseApiUrl}/cloned-plugins/{pluginId}`,
+        edit: `${konnectBaseApiUrl}/cloned-plugins/{pluginId}`,
       },
     },
     kongManager: {
       streamed: {
-        create: `${KMGlobalBaseApiUrl}/custom-plugins`,
-        edit: `${KMGlobalBaseApiUrl}/custom-plugins/{pluginId}`,
+        create: `${KMBaseApiUrl}/custom-plugins`,
+        edit: `${KMBaseApiUrl}/custom-plugins/{pluginId}`,
       },
       cloned: {
-        create: `${KMGlobalBaseApiUrl}/cloned-plugins`,
-        edit: `${KMGlobalBaseApiUrl}/cloned-plugins/{pluginId}`,
+        create: `${KMBaseApiUrl}/cloned-plugins/{pluginId}`,
+        edit: `${KMBaseApiUrl}/cloned-plugins/{pluginId}`,
       },
     },
   },

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -80,7 +80,7 @@ export default {
         edit: `${konnectBaseApiUrl}/custom-plugins/{pluginId}`,
       },
       cloned: {
-        create: `${konnectBaseApiUrl}/cloned-plugins/{pluginId}`,
+        create: `${konnectBaseApiUrl}/cloned-plugins`,
         edit: `${konnectBaseApiUrl}/cloned-plugins/{pluginId}`,
       },
     },
@@ -90,7 +90,7 @@ export default {
         edit: `${KMBaseApiUrl}/custom-plugins/{pluginId}`,
       },
       cloned: {
-        create: `${KMBaseApiUrl}/cloned-plugins/{pluginId}`,
+        create: `${KMBaseApiUrl}/cloned-plugins`,
         edit: `${KMBaseApiUrl}/cloned-plugins/{pluginId}`,
       },
     },

--- a/packages/entities/entities-plugins/src/types/custom-plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/custom-plugin-form.ts
@@ -11,7 +11,7 @@ export interface CustomPluginFormConfig {
   /** Available plugins for cloning (only needed for Cloned type) */
   clonablePlugins?: string[]
 }
-export type KonnectCustomPluginFormConfig = KonnectBaseFormConfig & CustomPluginFormConfig
+export type KonnectCustomPluginFormConfig = Omit<KonnectBaseFormConfig & CustomPluginFormConfig, 'workspace'>
 
 export type KongManagerCustomPluginFormConfig = KongManagerBaseFormConfig & CustomPluginFormConfig
 


### PR DESCRIPTION
# Summary

The Admin API requires `workspace` in endpoints, even when managing non-workspace resources.

This PR reverts #3260 and removes `workspace` of the Konnect config interface.
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
