### PR TITLE
chore(entities-plugins): add free-form plugin migration progress report script

### DIFF
--- a/packages/entities/entities-plugins/docs/ff-migration-report.md
+++ b/packages/entities/entities-plugins/docs/ff-migration-report.md
@@ -1,0 +1,139 @@
+# Free-form Plugin Migration Report
+
+> ⚠️ **Auto-generated — do not edit manually.**
+> To regenerate: `pnpm --filter @kong-ui-public/entities-plugins report:ff-migration`
+>
+> Generated: 2026-05-21T09:01:29.186Z
+
+## Summary
+
+`██████████░░░░░░░░░░░░░░░░░░░░` **33%**
+
+| Metric | Count |
+|--------|-------|
+| 📦 Total Kong Inc plugins | **113** |
+| ✅ Migrated | **37** |
+| ⏳ Pending | **76** |
+
+---
+
+## ✅ Migrated (37)
+
+- acl
+- ai-custom-guardrail
+- ai-mcp-proxy
+- aws-lambda
+- basic-auth
+- correlation-id
+- cors
+- datakit
+- exit-transformer
+- file-log
+- header-cert-auth
+- http-log
+- jwe-decrypt
+- jwt
+- jwt-signer
+- key-auth
+- metering-and-billing
+- mtls-auth
+- oauth2
+- opentelemetry
+- prometheus
+- proxy-cache
+- proxy-cache-advanced
+- rate-limiting
+- rate-limiting-advanced
+- request-callout
+- request-transformer
+- request-transformer-advanced
+- response-transformer
+- response-transformer-advanced
+- route-transformer-advanced
+- service-protection
+- session
+- solace-consume
+- solace-log
+- solace-upstream
+- upstream-oauth
+
+---
+
+## ⏳ Pending (76)
+
+- ace
+- acme
+- ai-a2a-proxy
+- ai-aws-guardrails
+- ai-azure-content-safety
+- ai-gcp-model-armor
+- ai-lakera-guard
+- ai-llm-as-judge
+- ai-mcp-oauth2
+- ai-prompt-compressor
+- ai-prompt-decorator
+- ai-prompt-guard
+- ai-prompt-template
+- ai-proxy
+- ai-proxy-advanced
+- ai-rag-injector
+- ai-rate-limiting-advanced
+- ai-request-transformer
+- ai-response-transformer
+- ai-sanitizer
+- ai-semantic-cache
+- ai-semantic-prompt-guard
+- ai-semantic-response-guard
+- app-dynamics
+- azure-functions
+- bot-detection
+- canary
+- confluent
+- confluent-consume
+- datadog
+- degraphql
+- forward-proxy
+- graphql-proxy-cache-advanced
+- graphql-rate-limiting-advanced
+- grpc-gateway
+- grpc-web
+- hmac-auth
+- injection-protection
+- ip-restriction
+- jq
+- json-threat-protection
+- kafka-consume
+- kafka-log
+- kafka-upstream
+- key-auth-enc
+- ldap-auth
+- ldap-auth-advanced
+- loggly
+- mocking
+- oas-validation
+- oauth2-introspection
+- opa
+- openid-connect
+- openwhisk
+- post-function
+- pre-function
+- redirect
+- request-size-limiting
+- request-termination
+- request-validator
+- response-ratelimiting
+- route-by-header
+- saml
+- standard-webhooks
+- statsd
+- syslog
+- tcp-log
+- tls-handshake-modifier
+- tls-metadata-headers
+- udp-log
+- upstream-timeout
+- vault-auth
+- websocket-size-limit
+- websocket-validator
+- xml-threat-protection
+- zipkin

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -112,7 +112,8 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui",
     "install:pw": "playwright install chromium",
     "test:pw": "cross-env FORCE_COLOR=1 playwright test -c playwright.config.ts",
-    "test:pw:open": "cross-env FORCE_COLOR=1 playwright test -c playwright.config.ts --ui"
+    "test:pw:open": "cross-env FORCE_COLOR=1 playwright test -c playwright.config.ts --ui",
+    "report:ff-migration": "node scripts/ff-migration-report.mjs"
   },
   "repository": {
     "type": "git",

--- a/packages/entities/entities-plugins/scripts/ff-migration-report.mjs
+++ b/packages/entities/entities-plugins/scripts/ff-migration-report.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { readdirSync, writeFileSync, mkdirSync } from 'fs'
+import { dirname, resolve, extname, basename } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PLUGINS_DIR = resolve(__dirname, '../src/components/free-form/plugins')
+const OUTPUT_PATH = resolve(__dirname, '../docs/ff-migration-report.md')
+const API_URL = 'https://developer.konghq.com/plugins/'
+
+// --- Fetch Kong Inc plugin slugs from developer.konghq.com ---
+async function fetchKongIncPlugins() {
+  const res = await fetch(API_URL)
+  if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${API_URL}`)
+  const html = await res.text()
+
+  const slugs = []
+  const cards = html.split(/(?=<div[^>]*data-card="plugin")/)
+  for (const card of cards) {
+    const support = card.match(/data-support="([^"]+)"/)
+    const slug = card.match(/href="\/plugins\/([^/"]+)\/?"/ )
+    if (support?.[1].includes('kong-inc') && slug?.[1]) {
+      slugs.push(slug[1])
+    }
+  }
+  return [...new Set(slugs)].sort()
+}
+
+// --- Read local free-form plugin implementations ---
+function readLocalPlugins() {
+  const entries = readdirSync(PLUGINS_DIR, { withFileTypes: true })
+  const localSlugs = new Set()
+
+  for (const entry of entries) {
+    if (entry.name === 'README.md') continue
+    if (entry.isDirectory()) {
+      localSlugs.add(entry.name)
+    } else if (entry.isFile() && extname(entry.name) === '.ts') {
+      localSlugs.add(basename(entry.name, '.ts'))
+    }
+  }
+  return localSlugs
+}
+
+// --- Generate Markdown report ---
+function buildReport(kongPlugins, localSlugs) {
+  const migrated = kongPlugins.filter(s => localSlugs.has(s))
+  const pending = kongPlugins.filter(s => !localSlugs.has(s))
+  const pct = Math.round((migrated.length / kongPlugins.length) * 100)
+
+  const BAR_WIDTH = 30
+  const filled = Math.round(pct / 100 * BAR_WIDTH)
+  const bar = '█'.repeat(filled) + '░'.repeat(BAR_WIDTH - filled)
+
+  const migratedList = migrated.map(s => `- ${s}`).join('\n')
+  const pendingList = pending.map(s => `- ${s}`).join('\n')
+
+  return `# Free-form Plugin Migration Report
+
+> ⚠️ **Auto-generated — do not edit manually.**
+> To regenerate: \`pnpm --filter @kong-ui-public/entities-plugins report:ff-migration\`
+>
+> Generated: ${new Date().toISOString()}
+
+## Summary
+
+\`${bar}\` **${pct}%**
+
+| Metric | Count |
+|--------|-------|
+| 📦 Total Kong Inc plugins | **${kongPlugins.length}** |
+| ✅ Migrated | **${migrated.length}** |
+| ⏳ Pending | **${pending.length}** |
+
+---
+
+## ✅ Migrated (${migrated.length})
+
+${migratedList}
+
+---
+
+## ⏳ Pending (${pending.length})
+
+${pendingList}
+`
+}
+
+// --- Main ---
+const kongPlugins = await fetchKongIncPlugins()
+const localSlugs = readLocalPlugins()
+const report = buildReport(kongPlugins, localSlugs)
+
+mkdirSync(dirname(OUTPUT_PATH), { recursive: true })
+writeFileSync(OUTPUT_PATH, report, 'utf-8')
+
+const migrated = kongPlugins.filter(s => localSlugs.has(s))
+console.log(`Report written to ${OUTPUT_PATH}`)
+console.log(`Progress: ${migrated.length}/${kongPlugins.length} (${Math.round(migrated.length / kongPlugins.length * 100)}%)`)


### PR DESCRIPTION
## Summary

Adds a Node.js script that generates a Markdown report tracking which Kong-Inc-supported plugins have been migrated to the free-form implementation.

The script scrapes `https://developer.konghq.com/plugins/` for all Kong Inc plugin slugs, compares them against local implementations in `src/components/free-form/plugins/`, and writes a report to `docs/ff-migration-report.md`.

## Usage

```bash
pnpm --filter @kong-ui-public/entities-plugins report:ff-migration
```

## Changes

- `scripts/ff-migration-report.mjs` — new script; uses only Node 24 built-ins (`fetch`, `fs`, `path`, `url`), no new dependencies
- `package.json` — adds `report:ff-migration` script
- `docs/ff-migration-report.md` — initial generated snapshot (37/113 migrated, 33%)
