### PR TITLE
fix(page-layout): always pass path on entity page visit

### DIFF
--- a/packages/core/page-layout/src/components/PageLayout.cy.ts
+++ b/packages/core/page-layout/src/components/PageLayout.cy.ts
@@ -1,4 +1,6 @@
 import { defineComponent, inject, h, reactive, ref } from 'vue'
+import { createRouter, createMemoryHistory, type Router } from 'vue-router'
+import type { OptionsParam } from '../../../../../cypress/types'
 import PageLayout from './PageLayout.vue'
 import { nestedPageLayoutInjectionKey } from '../symbols'
 import type { PageShortcutData } from '../types'
@@ -9,7 +11,23 @@ const validShortcutData: PageShortcutData = {
   entityType: 'gateway-service',
 }
 
+const createTestRouter = () => createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
+})
+
 describe('<PageLayout />', () => {
+  let router: Router
+
+  beforeEach(() => {
+    router = createTestRouter()
+    cy.wrap(router.push('/services/my-service').then(() => router.isReady()))
+  })
+
+  const mountWithRouter = (
+    component: Parameters<typeof cy.mount>[0],
+    options: OptionsParam = {},
+  ) => cy.mount(component, { ...options, router } as OptionsParam)
   it('renders breadcrumbs, title and tabs when breadcrumbs and tabs are passed', () => {
     const title = 'Test Page Title'
 
@@ -22,7 +40,7 @@ describe('<PageLayout />', () => {
       { key: 'settings', label: 'Settings', to: '/settings' },
     ]
 
-    cy.mount(PageLayout, {
+    mountWithRouter(PageLayout, {
       props: {
         title,
         breadcrumbs,
@@ -39,7 +57,7 @@ describe('<PageLayout />', () => {
   it('renders the back button when the backTo prop is passed', () => {
     const backTo = '/'
 
-    cy.mount(PageLayout, {
+    mountWithRouter(PageLayout, {
       props: {
         title: 'Test Page Title',
         backTo,
@@ -52,7 +70,7 @@ describe('<PageLayout />', () => {
   it('renders only the title when neither breadcrumbs nor tabs are passed', () => {
     const title = 'Test Page Title'
 
-    cy.mount(PageLayout, {
+    mountWithRouter(PageLayout, {
       props: {
         title,
       },
@@ -67,7 +85,7 @@ describe('<PageLayout />', () => {
     const actionsTestId = 'page-layout-slotted-actions'
     const actionsText = 'Actions'
 
-    cy.mount(PageLayout, {
+    mountWithRouter(PageLayout, {
       props: { title: 'Test Page Title' },
       slots: { actions: () => h('div', { 'data-testid': actionsTestId }, actionsText) },
     })
@@ -79,7 +97,7 @@ describe('<PageLayout />', () => {
     const titleAfterTestId = 'page-layout-slotted-title-after'
     const titleAfterText = 'Title after'
 
-    cy.mount(PageLayout, {
+    mountWithRouter(PageLayout, {
       props: { title: 'Test Page Title' },
       slots: { 'title-after': () => h('span', { 'data-testid': titleAfterTestId }, titleAfterText) },
     })
@@ -99,7 +117,7 @@ describe('<PageLayout />', () => {
         },
       })
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: parentTitle },
         slots: { default: () => h(ChildNotifier) },
       })
@@ -113,7 +131,7 @@ describe('<PageLayout />', () => {
       const childTitle = 'Child Title'
       let notified = false
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: childTitle },
         global: {
           provide: {
@@ -145,7 +163,7 @@ describe('<PageLayout />', () => {
         },
       })
 
-      cy.mount(Wrapper)
+      mountWithRouter(Wrapper)
 
       // Child is mounted — parent header should be hidden, child header visible
       cy.getTestId('page-layout-title').should('have.length', 1).and('contain.text', childTitle)
@@ -167,7 +185,7 @@ describe('<PageLayout />', () => {
         onEntityPageVisit,
       })
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Parent Title', pageShortcutData: validShortcutData },
         global: { provide: { 'app:pageShortcutsContext': ctx } },
         slots: {
@@ -184,7 +202,7 @@ describe('<PageLayout />', () => {
       const parentTitle = 'Parent Title'
       const childTitle = 'Child Title'
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: parentTitle },
         slots: { default: () => h(PageLayout, { title: childTitle }) },
       })
@@ -197,7 +215,7 @@ describe('<PageLayout />', () => {
 
   describe('page shortcuts', () => {
     it('does not render the favorite button when neither pageShortcutData nor pageShortcutsContext are provided', () => {
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Test Page Title' },
       })
 
@@ -205,7 +223,7 @@ describe('<PageLayout />', () => {
     })
 
     it('does not render the favorite button when only pageShortcutData is provided', () => {
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Test Page Title', pageShortcutData: validShortcutData },
       })
 
@@ -219,7 +237,7 @@ describe('<PageLayout />', () => {
         onEntityPageVisit: () => { },
       })
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Test Page Title' },
         global: { provide: { 'app:pageShortcutsContext': ctx } },
       })
@@ -234,7 +252,7 @@ describe('<PageLayout />', () => {
         onEntityPageVisit: () => { },
       })
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         // @ts-expect-error testing invalid shape
         props: { title: 'Test Page Title', pageShortcutData: { label: 'X' } },
         global: { provide: { 'app:pageShortcutsContext': ctx } },
@@ -249,7 +267,7 @@ describe('<PageLayout />', () => {
         onEntityPageVisit: () => { },
       })
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Test Page Title', pageShortcutData: validShortcutData },
         global: { provide: { 'app:pageShortcutsContext': ctx } },
       })
@@ -264,7 +282,7 @@ describe('<PageLayout />', () => {
         onEntityPageVisit: () => { },
       })
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Test Page Title', pageShortcutData: validShortcutData },
         global: { provide: { 'app:pageShortcutsContext': ctx } },
       })
@@ -283,7 +301,7 @@ describe('<PageLayout />', () => {
         onEntityPageVisit: () => { },
       })
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Test Page Title', pageShortcutData: validShortcutData },
         global: { provide: { 'app:pageShortcutsContext': ctx } },
       })
@@ -299,7 +317,7 @@ describe('<PageLayout />', () => {
         onEntityPageVisit: () => { },
       })
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Test Page Title', pageShortcutData: validShortcutData },
         global: { provide: { 'app:pageShortcutsContext': ctx } },
       })
@@ -316,7 +334,7 @@ describe('<PageLayout />', () => {
         onEntityPageVisit,
       })
 
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Test Page Title', pageShortcutData: validShortcutData },
         global: { provide: { 'app:pageShortcutsContext': ctx } },
       })
@@ -340,7 +358,7 @@ describe('<PageLayout />', () => {
         },
       })
 
-      cy.mount(Wrapper, {
+      mountWithRouter(Wrapper, {
         global: { provide: { 'app:pageShortcutsContext': ctx } },
       })
 
@@ -361,7 +379,7 @@ describe('<PageLayout />', () => {
       })
 
       // Should not throw despite the missing callback
-      cy.mount(PageLayout, {
+      mountWithRouter(PageLayout, {
         props: { title: 'Test Page Title', pageShortcutData: validShortcutData },
         global: { provide: { 'app:pageShortcutsContext': ctx } },
       })

--- a/packages/core/page-layout/src/components/PageLayout.cy.ts
+++ b/packages/core/page-layout/src/components/PageLayout.cy.ts
@@ -324,6 +324,7 @@ describe('<PageLayout />', () => {
 
       cy.getTestId('page-layout-favorite-button').click()
       cy.get('@onFavoriteToggle').should('have.been.calledOnce')
+      cy.get('@onFavoriteToggle').should('have.been.calledWith', validShortcutData)
     })
 
     it('calls onEntityPageVisit on mount with the provided pageShortcutData', () => {

--- a/packages/core/page-layout/src/components/PageLayout.vue
+++ b/packages/core/page-layout/src/components/PageLayout.vue
@@ -47,7 +47,6 @@
               class="favorite-button-container"
             >
               <button
-                :key="favoriteButtonKey"
                 :aria-label="isFavorite ? t('favorite_button.remove_shortcut') : t('favorite_button.save_shortcut')"
                 class="favorite-button"
                 :class="{ 'active': isFavorite }"
@@ -188,7 +187,6 @@ if (typeof registerNestedPageLayout === 'function') {
   unregisterNestedPageLayout.value = registerNestedPageLayout()
 }
 
-const favoriteButtonKey = ref<number>(0)
 const onFavoriteButtonClick = () => {
   // Cast to the expected type -- we already checked for the function in the computed property
   (pageShortcutsContext as { onFavoriteToggle: () => void }).onFavoriteToggle()
@@ -206,7 +204,6 @@ watch([() => pageShortcutData, () => route.fullPath], async () => {
   await nextTick()
   if (!hasNestedPageLayout.value && isEntityPage.value && pageShortcutsContext && 'onEntityPageVisit' in pageShortcutsContext && typeof pageShortcutsContext.onEntityPageVisit === 'function') {
     pageShortcutsContext.onEntityPageVisit({ ...pageShortcutData, path: pageShortcutData?.path || route.fullPath })
-    favoriteButtonKey.value++
   }
 }, { immediate: true, deep: true })
 </script>

--- a/packages/core/page-layout/src/components/PageLayout.vue
+++ b/packages/core/page-layout/src/components/PageLayout.vue
@@ -104,7 +104,7 @@ import PageLayoutTabs from './PageLayoutTabs.vue'
 import { nestedPageLayoutInjectionKey } from '../symbols'
 import { ArrowTopLeftIcon, StarIcon, StarFillIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import composables from '../composables'
 
 const {
@@ -123,6 +123,7 @@ const pageShortcutsContext = inject<DeepReadonly<Reactive<unknown>> | null>('app
 const { i18n: { t } } = composables.useI18n()
 
 const router = useRouter()
+const route = useRoute()
 
 const hasTabs = computed((): boolean => !!(tabs && tabs.length))
 
@@ -195,14 +196,14 @@ onUnmounted(() => {
   unregisterNestedPageLayout.value?.()
 })
 
-watch(() => pageShortcutData, async (newPageShortcutData) => {
+watch([() => pageShortcutData, () => route.fullPath], async () => {
   /**
    * Wait for the next tick to ensure any nested PageLayouts have mounted to make sure shortcut logic handling is deferred to the most nested PageLayout.
    * The reason why it has to be a watcher is because sometimes it takes time for the host app router to update the route and set the path properly.
    */
   await nextTick()
   if (!hasNestedPageLayout.value && isEntityPage.value && pageShortcutsContext && 'onEntityPageVisit' in pageShortcutsContext && typeof pageShortcutsContext.onEntityPageVisit === 'function') {
-    pageShortcutsContext.onEntityPageVisit(newPageShortcutData)
+    pageShortcutsContext.onEntityPageVisit({ ...pageShortcutData, path: pageShortcutData?.path || route.fullPath })
   }
 }, { immediate: true, deep: true })
 </script>

--- a/packages/core/page-layout/src/components/PageLayout.vue
+++ b/packages/core/page-layout/src/components/PageLayout.vue
@@ -47,6 +47,7 @@
               class="favorite-button-container"
             >
               <button
+                :key="favoriteButtonKey"
                 :aria-label="isFavorite ? t('favorite_button.remove_shortcut') : t('favorite_button.save_shortcut')"
                 class="favorite-button"
                 :class="{ 'active': isFavorite }"
@@ -187,6 +188,7 @@ if (typeof registerNestedPageLayout === 'function') {
   unregisterNestedPageLayout.value = registerNestedPageLayout()
 }
 
+const favoriteButtonKey = ref<number>(0)
 const onFavoriteButtonClick = () => {
   // Cast to the expected type -- we already checked for the function in the computed property
   (pageShortcutsContext as { onFavoriteToggle: () => void }).onFavoriteToggle()
@@ -204,6 +206,7 @@ watch([() => pageShortcutData, () => route.fullPath], async () => {
   await nextTick()
   if (!hasNestedPageLayout.value && isEntityPage.value && pageShortcutsContext && 'onEntityPageVisit' in pageShortcutsContext && typeof pageShortcutsContext.onEntityPageVisit === 'function') {
     pageShortcutsContext.onEntityPageVisit({ ...pageShortcutData, path: pageShortcutData?.path || route.fullPath })
+    favoriteButtonKey.value++
   }
 }, { immediate: true, deep: true })
 </script>

--- a/packages/core/page-layout/src/components/PageLayout.vue
+++ b/packages/core/page-layout/src/components/PageLayout.vue
@@ -99,7 +99,7 @@
 <script setup lang="ts">
 import { computed, ref, provide, inject, onUnmounted, nextTick, watch } from 'vue'
 import type { DeepReadonly, Reactive } from 'vue'
-import type { PageLayoutProps, PageLayoutSlots } from '../types'
+import type { PageLayoutProps, PageLayoutSlots, PageShortcutData } from '../types'
 import PageLayoutTabs from './PageLayoutTabs.vue'
 import { nestedPageLayoutInjectionKey } from '../symbols'
 import { ArrowTopLeftIcon, StarIcon, StarFillIcon } from '@kong/icons'
@@ -189,7 +189,7 @@ if (typeof registerNestedPageLayout === 'function') {
 
 const onFavoriteButtonClick = () => {
   // Cast to the expected type -- we already checked for the function in the computed property
-  (pageShortcutsContext as { onFavoriteToggle: () => void }).onFavoriteToggle()
+  (pageShortcutsContext as { onFavoriteToggle: (pageShortcutData: PageShortcutData) => void }).onFavoriteToggle(pageShortcutData!)
 }
 
 onUnmounted(() => {

--- a/packages/core/page-layout/src/components/PageLayout.vue
+++ b/packages/core/page-layout/src/components/PageLayout.vue
@@ -189,7 +189,7 @@ if (typeof registerNestedPageLayout === 'function') {
 
 const onFavoriteButtonClick = () => {
   // Cast to the expected type -- we already checked for the function in the computed property
-  (pageShortcutsContext as { onFavoriteToggle: (pageShortcutData: PageShortcutData) => void }).onFavoriteToggle(pageShortcutData!)
+  (pageShortcutsContext as { onFavoriteToggle: (pageShortcutData: PageShortcutData) => void }).onFavoriteToggle({ ...pageShortcutData!, path: pageShortcutData?.path || route.fullPath })
 }
 
 onUnmounted(() => {


### PR DESCRIPTION
# Summary

Provide path to shortcut context calls (both on entity page load and favorite toggle) at all times - if not provided through `pageShortcutData` prop provide `route.fullPath`.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
