### PR TITLE
feat(entities-plugins): add warnings for keyset fields in jwt-signer

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer.ts
@@ -1,3 +1,0 @@
-import { definePluginConfig } from '../shared/define-plugin-config'
-
-export default definePluginConfig()

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.cy.ts
@@ -22,13 +22,6 @@ const createSchema = (): FormSchema => ({
   }],
 })
 
-const RENDER_RULES = {
-  bundles: [
-    ['config.access_token_signing', 'config.access_token_upstream_header', 'config.access_token_keyset'],
-    ['config.channel_token_signing', 'config.channel_token_upstream_header', 'config.channel_token_keyset'],
-  ],
-}
-
 interface MountOptions {
   isEditing?: boolean
   model?: Record<string, any>
@@ -50,7 +43,6 @@ const mountForm = (options: MountOptions = {}) => {
       model: model ?? {},
       isEditing,
       pluginName: 'jwt-signer',
-      renderRules: RENDER_RULES,
       onFormChange: cy.spy().as('onFormChange'),
     },
     global: {

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.cy.ts
@@ -1,0 +1,247 @@
+import JwtSignerForm from './JwtSignerForm.vue'
+import { FORMS_CONFIG } from '@kong-ui-public/forms'
+import type { FormSchema } from '../../../../types/plugins/form-schema'
+
+const ERROR_MESSAGE_FRAGMENT = 'HTTP/HTTPS URL'
+
+const createSchema = (): FormSchema => ({
+  type: 'record',
+  fields: [{
+    config: {
+      type: 'record',
+      required: true,
+      fields: [
+        { access_token_keyset: { type: 'string', default: 'kong' } },
+        { access_token_signing: { type: 'boolean', default: true } },
+        { access_token_upstream_header: { type: 'string', default: 'Authorization:Bearer' } },
+        { channel_token_keyset: { type: 'string', default: 'kong' } },
+        { channel_token_signing: { type: 'boolean', default: true } },
+        { channel_token_upstream_header: { type: 'string' } },
+      ],
+    },
+  }],
+})
+
+const RENDER_RULES = {
+  bundles: [
+    ['config.access_token_signing', 'config.access_token_upstream_header', 'config.access_token_keyset'],
+    ['config.channel_token_signing', 'config.channel_token_upstream_header', 'config.channel_token_keyset'],
+  ],
+}
+
+interface MountOptions {
+  isEditing?: boolean
+  model?: Record<string, any>
+  app?: 'konnect' | 'kongManager'
+}
+
+const mountForm = (options: MountOptions = {}) => {
+  const { isEditing = false, model, app = 'konnect' } = options
+
+  const formsConfig = app === 'konnect'
+    ? { app: 'konnect' as const, apiBaseUrl: '/us/kong-api', controlPlaneId: '123' }
+    : { app: 'kongManager' as const, apiBaseUrl: '/kong-manager' }
+
+  cy.mount(JwtSignerForm as any, {
+    props: {
+      schema: createSchema(),
+      formSchema: {},
+      formModel: {},
+      model: model ?? {},
+      isEditing,
+      pluginName: 'jwt-signer',
+      renderRules: RENDER_RULES,
+      onFormChange: cy.spy().as('onFormChange'),
+    },
+    global: {
+      provide: {
+        [FORMS_CONFIG]: formsConfig,
+      },
+    },
+  })
+}
+
+const keysetInput = (scope: 'access' | 'channel') =>
+  cy.getTestId(`ff-config.${scope}_token_keyset`)
+
+const expectKeysetError = (scope: 'access' | 'channel', textFragment = ERROR_MESSAGE_FRAGMENT) => {
+  keysetInput(scope).parents('.k-input.input-error').should('exist')
+  keysetInput(scope).parents('.k-input').find('.help-text').should('contain.text', textFragment)
+}
+
+const expectNoKeysetError = (scope: 'access' | 'channel') => {
+  keysetInput(scope).parents('.k-input.input-error').should('not.exist')
+}
+
+describe('<JwtSignerForm /> - keyset URL validation', () => {
+  describe('Konnect', () => {
+    it('flags the default "kong" keyset as invalid when preconditions are met', () => {
+      mountForm()
+      expectKeysetError('access')
+    })
+
+    it('includes both precondition field labels in the error message', () => {
+      mountForm()
+      keysetInput('access').parents('.k-input').find('.help-text')
+        .should('contain.text', 'Access token signing')
+        .and('contain.text', 'Access token upstream header')
+    })
+
+    it('clears the error when the user enters a valid http URL', () => {
+      mountForm()
+      expectKeysetError('access')
+      keysetInput('access').clear().type('http://idp.example.com/.well-known/jwks.json')
+      expectNoKeysetError('access')
+    })
+
+    it('clears the error when the user enters a valid https URL', () => {
+      mountForm()
+      keysetInput('access').clear().type('https://idp.example.com/jwks')
+      expectNoKeysetError('access')
+    })
+
+    it('flags non-http schemes such as ftp://', () => {
+      mountForm()
+      keysetInput('access').clear().type('ftp://idp.example.com/jwks')
+      expectKeysetError('access')
+    })
+
+    it('flags an empty keyset', () => {
+      mountForm({
+        isEditing: true,
+        model: {
+          config: {
+            access_token_signing: true,
+            access_token_upstream_header: 'Authorization:Bearer',
+            access_token_keyset: '',
+            channel_token_signing: false,
+          },
+        },
+      })
+      expectKeysetError('access')
+    })
+
+    it('flags a null keyset', () => {
+      mountForm({
+        isEditing: true,
+        model: {
+          config: {
+            access_token_signing: true,
+            access_token_upstream_header: 'Authorization:Bearer',
+            access_token_keyset: null,
+            channel_token_signing: false,
+          },
+        },
+      })
+      expectKeysetError('access')
+    })
+
+    it('does not flag the keyset when signing is disabled', () => {
+      mountForm({
+        isEditing: true,
+        model: {
+          config: {
+            access_token_signing: false,
+            access_token_upstream_header: 'Authorization:Bearer',
+            access_token_keyset: 'kong',
+            channel_token_signing: false,
+          },
+        },
+      })
+      expectNoKeysetError('access')
+    })
+
+    it('does not flag the keyset when the upstream header is empty', () => {
+      mountForm({
+        isEditing: true,
+        model: {
+          config: {
+            access_token_signing: true,
+            access_token_upstream_header: '',
+            access_token_keyset: 'kong',
+            channel_token_signing: false,
+          },
+        },
+      })
+      expectNoKeysetError('access')
+    })
+
+    it('flags the channel keyset when channel preconditions are met', () => {
+      mountForm({
+        isEditing: true,
+        model: {
+          config: {
+            access_token_signing: false,
+            channel_token_signing: true,
+            channel_token_upstream_header: 'X-Channel-Token:Bearer',
+            channel_token_keyset: 'kong',
+          },
+        },
+      })
+      expectKeysetError('channel')
+      keysetInput('channel').parents('.k-input').find('.help-text')
+        .should('contain.text', 'Channel token signing')
+        .and('contain.text', 'Channel token upstream header')
+    })
+  })
+
+  describe('Field ordering via bundles', () => {
+    it('hoists access signing + upstream_header above keyset', () => {
+      mountForm()
+
+      cy.get([
+        '[data-testid="ff-config.access_token_signing"]',
+        '[data-testid="ff-config.access_token_upstream_header"]',
+        '[data-testid="ff-config.access_token_keyset"]',
+      ].join(', ')).then(($els) => {
+        const ids = [...$els].map(el => el.getAttribute('data-testid'))
+        expect(ids).to.deep.equal([
+          'ff-config.access_token_signing',
+          'ff-config.access_token_upstream_header',
+          'ff-config.access_token_keyset',
+        ])
+      })
+    })
+
+    it('hoists channel signing + upstream_header above keyset', () => {
+      mountForm()
+
+      cy.get([
+        '[data-testid="ff-config.channel_token_signing"]',
+        '[data-testid="ff-config.channel_token_upstream_header"]',
+        '[data-testid="ff-config.channel_token_keyset"]',
+      ].join(', ')).then(($els) => {
+        const ids = [...$els].map(el => el.getAttribute('data-testid'))
+        expect(ids).to.deep.equal([
+          'ff-config.channel_token_signing',
+          'ff-config.channel_token_upstream_header',
+          'ff-config.channel_token_keyset',
+        ])
+      })
+    })
+  })
+
+  describe('Kong Manager', () => {
+    it('never flags the keyset even when Konnect preconditions would trigger', () => {
+      mountForm({ app: 'kongManager' })
+      expectNoKeysetError('access')
+      expectNoKeysetError('channel')
+    })
+
+    it('does not flag a non-URL keyset on Kong Manager edit', () => {
+      mountForm({
+        app: 'kongManager',
+        isEditing: true,
+        model: {
+          config: {
+            access_token_signing: true,
+            access_token_upstream_header: 'Authorization:Bearer',
+            access_token_keyset: 'kong',
+            channel_token_signing: false,
+          },
+        },
+      })
+      expectNoKeysetError('access')
+    })
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.vue
@@ -1,5 +1,8 @@
 <template>
-  <StandardLayout v-bind="props">
+  <StandardLayout
+    v-bind="props"
+    :render-rules="renderRules"
+  >
     <template #field-renderers>
       <FieldRenderer
         v-slot="slotProps"
@@ -35,8 +38,16 @@ import StandardLayout from '../../shared/layout/StandardLayout.vue'
 import KeysetField from './KeysetField.vue'
 
 import type { Props } from '../../shared/layout/StandardLayout.vue'
+import type { RenderRules } from '../../shared/types'
 
 const props = defineProps<Props>()
+
+const renderRules: RenderRules = {
+  bundles: [
+    ['config.access_token_signing', 'config.access_token_upstream_header', 'config.access_token_keyset'],
+    ['config.channel_token_signing', 'config.channel_token_upstream_header', 'config.channel_token_keyset'],
+  ],
+}
 
 const slots = defineSlots<{
   [K in typeof AUTOFILL_SLOT_NAME]: () => any

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.vue
@@ -1,0 +1,46 @@
+<template>
+  <StandardLayout v-bind="props">
+    <template #field-renderers>
+      <FieldRenderer
+        v-slot="slotProps"
+        :match="({ path }) => path === 'config.access_token_keyset'"
+      >
+        <KeysetField
+          v-bind="slotProps"
+          scope="access"
+        />
+      </FieldRenderer>
+      <FieldRenderer
+        v-slot="slotProps"
+        :match="({ path }) => path === 'config.channel_token_keyset'"
+      >
+        <KeysetField
+          v-bind="slotProps"
+          scope="channel"
+        />
+      </FieldRenderer>
+    </template>
+
+    <ConfigForm />
+  </StandardLayout>
+</template>
+
+<script setup lang="ts">
+import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
+import { provide } from 'vue'
+
+import ConfigForm from '../../Common/ConfigForm.vue'
+import FieldRenderer from '../../shared/FieldRenderer.vue'
+import StandardLayout from '../../shared/layout/StandardLayout.vue'
+import KeysetField from './KeysetField.vue'
+
+import type { Props } from '../../shared/layout/StandardLayout.vue'
+
+const props = defineProps<Props>()
+
+const slots = defineSlots<{
+  [K in typeof AUTOFILL_SLOT_NAME]: () => any
+}>()
+
+provide(AUTOFILL_SLOT, slots?.[AUTOFILL_SLOT_NAME])
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/KeysetField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/KeysetField.vue
@@ -1,0 +1,85 @@
+<template>
+  <StringField
+    v-bind="$attrs"
+    :error="error"
+    :error-message="errorMessage"
+    :name="name"
+  />
+</template>
+
+<script setup lang="ts">
+import { FORMS_CONFIG } from '@kong-ui-public/forms'
+import { computed, inject } from 'vue'
+
+import useI18n from '../../../../composables/useI18n'
+import StringField from '../../shared/StringField.vue'
+import { defaultLabelFormatter, useFormShared } from '../../shared/composables'
+
+import type { KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
+import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
+
+defineOptions({ inheritAttrs: false })
+
+interface JwtSignerConfig {
+  access_token_signing?: boolean
+  access_token_upstream_header?: string | null
+  access_token_keyset?: string | null
+  channel_token_signing?: boolean
+  channel_token_upstream_header?: string | null
+  channel_token_keyset?: string | null
+}
+
+const props = defineProps<{
+  name: string
+  scope: 'access' | 'channel'
+}>()
+
+const { i18n: { t } } = useI18n()
+
+const appConfig = inject<KongManagerBaseFormConfig | KonnectBaseFormConfig | undefined>(FORMS_CONFIG)
+const isKonnect = computed(() => appConfig?.app === 'konnect')
+
+const { formData, config: sharedConfig } = useFormShared<FreeFormPluginData<JwtSignerConfig>>()
+
+function fieldLabel(fieldName: string): string {
+  const path = `config.${fieldName}`
+  const formatted = defaultLabelFormatter(fieldName)
+  return sharedConfig.value.transformLabel ? sharedConfig.value.transformLabel(formatted, path) : formatted
+}
+
+function isHttpOrHttpsUrl(value: unknown): value is string {
+  if (typeof value !== 'string' || !value) return false
+  try {
+    const url = new URL(value)
+    return (url.protocol === 'http:' || url.protocol === 'https:') && !!url.host
+  } catch {
+    return false
+  }
+}
+
+const validation = computed(() => {
+  // No validation for Kong Manager
+  if (!isKonnect.value) return { hasError: false, message: '' }
+
+  const config = formData.config
+  const signing = config?.[`${props.scope}_token_signing`]
+  const upstreamHeader = config?.[`${props.scope}_token_upstream_header`]
+
+  if (!signing) return { hasError: false, message: '' }
+  if (typeof upstreamHeader !== 'string' || upstreamHeader === '') return { hasError: false, message: '' }
+
+  const keyset = config?.[`${props.scope}_token_keyset`]
+  if (isHttpOrHttpsUrl(keyset)) return { hasError: false, message: '' }
+
+  return {
+    hasError: true,
+    message: t('plugins.free-form.jwt-signer.keyset_url_required', {
+      signingField: fieldLabel(`${props.scope}_token_signing`),
+      headerField: fieldLabel(`${props.scope}_token_upstream_header`),
+    }),
+  }
+})
+
+const error = computed(() => validation.value.hasError)
+const errorMessage = computed(() => validation.value.message)
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/index.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/index.ts
@@ -3,12 +3,4 @@ import JwtSignerForm from './JwtSignerForm.vue'
 
 export default definePluginConfig({
   component: JwtSignerForm,
-  renderRules: {
-    bundles: [
-      // Hoist signing + upstream_header before keyset so the dynamic
-      // URL-validation error on keyset is visible alongside its preconditions.
-      ['config.access_token_signing', 'config.access_token_upstream_header', 'config.access_token_keyset'],
-      ['config.channel_token_signing', 'config.channel_token_upstream_header', 'config.channel_token_keyset'],
-    ],
-  },
 })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/index.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/index.ts
@@ -1,0 +1,14 @@
+import { definePluginConfig } from '../../shared/define-plugin-config'
+import JwtSignerForm from './JwtSignerForm.vue'
+
+export default definePluginConfig({
+  component: JwtSignerForm,
+  renderRules: {
+    bundles: [
+      // Hoist signing + upstream_header before keyset so the dynamic
+      // URL-validation error on keyset is visible alongside its preconditions.
+      ['config.access_token_signing', 'config.access_token_upstream_header', 'config.access_token_keyset'],
+      ['config.channel_token_signing', 'config.channel_token_upstream_header', 'config.channel_token_keyset'],
+    ],
+  },
+})

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -807,6 +807,9 @@
         "entity_name": "Request callout",
         "by_lua_placeholder": "Enter Lua script here..."
       },
+      "jwt-signer": {
+        "keyset_url_required": "Provide a valid HTTP/HTTPS URL to ensure signing works correctly when \"{signingField}\" is enabled and \"{headerField}\" is set."
+      },
       "metering-and-billing": {
         "sections": {
           "plugin_config": {


### PR DESCRIPTION
- For Konnect, `*_keyset` will validate if the input value is a valid URL when `*_signing` is checked and `*_upstream_header` is not empty. For Kong Manager, it will behave as is.
- `*_signing` and `*_upstream_header` are moved before `*_keyset`.

## access_token_*

<img width="750" height="666" alt="Screenshot 2026-05-27 at 18 55 25" src="https://github.com/user-attachments/assets/88ee381d-b89b-4ae6-8786-4ad6401853f2" />  

## channel_token_*

<img width="750" height="529" alt="Screenshot 2026-05-27 at 18 58 39" src="https://github.com/user-attachments/assets/a3fa49ee-bd40-4159-b428-327fa99dd643" />


KM-2578