### PR TITLE
fix(entities-plugins): fix loading state when realms is empty array

### DIFF
--- a/packages/entities/entities-plugins/src/components/fields/key-auth-identity-realms/Base.vue
+++ b/packages/entities/entities-plugins/src/components/fields/key-auth-identity-realms/Base.vue
@@ -123,7 +123,7 @@ onMounted(() => {
 })
 
 watch(() => props.realms, (realms) => {
-  if (realms && realms.length > 0) {
+  if (realms) {
     realmItems.value = [kCurrentCPSelectItem, ...realms.map(item => ({
       ...item,
       group: t('custom_field.key_auth_identity_realms.realm_group_label'),


### PR DESCRIPTION
# Summary

Fix loading state when `props.realms` is an empty array