### PR TITLE
fix(entities-shared): z-index on copy button in decK editor

### DIFF
--- a/packages/entities/entities-shared/src/components/common/DeckCommandEditor.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCommandEditor.vue
@@ -107,6 +107,7 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
 
 <style lang="scss" scoped>
 .deck-command-editor-wrapper {
+  isolation: isolate;
   position: relative;
 
   .deck-command-editor {


### PR DESCRIPTION
<img width="696" height="582" alt="Screenshot 2026-05-28 at 14 10 23" src="https://github.com/user-attachments/assets/1b4de724-774c-4532-a799-ee432220cf4d" />
