### PR TITLE
feat(entities-plugins): add KM cloned/streaming plugin support to PluginCatalog

### DIFF
--- a/packages/entities/entities-plugins/fixtures/mockData.ts
+++ b/packages/entities/entities-plugins/fixtures/mockData.ts
@@ -548,6 +548,18 @@ export const konnectStreamingCustomPlugins = {
   ],
 }
 
+export const kmStreamingCustomPlugins = {
+  data: [
+    { id: 'km-stream-001', name: 'km-streaming-plugin', schema: 'schema text', handler: 'handler text', created_at: 1710000000 },
+  ],
+}
+
+export const kmClonedCustomPlugins = {
+  data: [
+    { id: 'km-cloned-001', name: 'km-cloned-plugin', ref: 'rate-limiting', created_at: 1710000001 },
+  ],
+}
+
 /**
  * Form page data
  */

--- a/packages/entities/entities-plugins/sandbox/pages/PluginCatalogPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginCatalogPage.vue
@@ -1,5 +1,71 @@
 <template>
   <div class="plugin-select-sandbox">
+    <div class="sandbox-controls">
+      <div class="controls-section">
+        <h4>Feature Flags</h4>
+        <label>
+          <input
+            v-model="enableClonedPlugin"
+            type="checkbox"
+          > Enable Cloned Plugin
+        </label>
+        <label>
+          <input
+            v-model="enableStreamedPlugin"
+            type="checkbox"
+          > Enable Streamed Plugin
+        </label>
+        <label>
+          <input
+            v-model="showKmFeatured"
+            type="checkbox"
+          > KM Featured Group
+        </label>
+      </div>
+      <div class="controls-section">
+        <h4>RBAC — Cloned Plugin</h4>
+        <label>
+          <input
+            v-model="canReadClonedPlugin"
+            type="checkbox"
+          > Read
+        </label>
+        <label>
+          <input
+            v-model="canUpdateClonedPlugin"
+            type="checkbox"
+          > Update
+        </label>
+        <label>
+          <input
+            v-model="canDeleteClonedPlugin"
+            type="checkbox"
+          > Delete
+        </label>
+      </div>
+      <div class="controls-section">
+        <h4>RBAC — Custom Plugin</h4>
+        <label>
+          <input
+            v-model="canReadCustomPlugin"
+            type="checkbox"
+          > Read
+        </label>
+        <label>
+          <input
+            v-model="canUpdateCustomPlugin"
+            type="checkbox"
+          > Update
+        </label>
+        <label>
+          <input
+            v-model="canDeleteCustomPlugin"
+            type="checkbox"
+          > Delete
+        </label>
+      </div>
+    </div>
+
     <h2>Konnect API</h2>
     <PluginCatalog
       :config="konnectConfig"
@@ -9,13 +75,54 @@
       :highlighted-plugin-ids="highlightedPluginIds"
       @delete-custom:success="handleDeleteSuccess"
     />
+
+    <h2>Kong Manager API — streaming + cloned + schema</h2>
+    <PluginCatalog
+      :can-delete-cloned-plugin="canDeleteClonedPlugin"
+      :can-delete-custom-plugin="canDeleteCustomPlugin"
+      :can-read-cloned-plugin="canReadClonedPlugin"
+      :can-read-custom-plugin="canReadCustomPlugin"
+      :can-update-cloned-plugin="canUpdateClonedPlugin"
+      :can-update-custom-plugin="canUpdateCustomPlugin"
+      :config="kongManagerConfig"
+      :custom-plugin-support="kmCustomPluginSupport"
+      :highlighted-plugin-ids="highlightedPluginIds"
+      :ignored-plugins="['acl']"
+      :show-featured-group="showKmFeatured"
+      @delete-custom:success="handleDeleteSuccess"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import type { KonnectPluginSelectConfig, CustomPluginType } from '../../src'
+import { computed, provide, ref } from 'vue'
+import type { KonnectPluginSelectConfig, KongManagerPluginSelectConfig, CustomPluginType } from '../../src'
 import { PluginCatalog } from '../../src'
+import { FEATURE_FLAGS } from '../../src/constants'
+
+provide(FEATURE_FLAGS.KM_2485_CLONED_PLUGINS, true)
+
+// Feature flag toggles
+const enableClonedPlugin = ref(true)
+const enableStreamedPlugin = ref(true)
+const showKmFeatured = ref(false)
+
+// RBAC toggles — Cloned/schema plugins (path: cloned-plugins)
+const canReadClonedPlugin = ref(true)
+const canUpdateClonedPlugin = ref(true)
+const canDeleteClonedPlugin = ref(true)
+
+// RBAC toggles — Streaming custom plugins (path: custom-plugins)
+const canReadCustomPlugin = ref(true)
+const canUpdateCustomPlugin = ref(true)
+const canDeleteCustomPlugin = ref(true)
+
+const kmCustomPluginSupport = computed(() => {
+  const support: Array<'schema' | 'cloned' | 'streaming'> = ['schema']
+  if (enableClonedPlugin.value) support.push('cloned')
+  if (enableStreamedPlugin.value) support.push('streaming')
+  return support
+})
 
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 
@@ -46,6 +153,24 @@ const konnectConfig = ref<KonnectPluginSelectConfig>({
   }),
 })
 
+const kongManagerConfig = ref<KongManagerPluginSelectConfig>({
+  app: 'kongManager',
+  workspace: 'default',
+  apiBaseUrl: '/kong-manager', // dev proxy: see vite.config.local.js
+  // force the scope
+  // entityType: 'consumers',
+  // entityId: '123-abc',
+  getCreateRoute: (plugin: string) => ({
+    name: 'create-plugin',
+    params: { plugin },
+  }),
+  createCustomRoute: { name: 'create-custom-plugin' },
+  getCustomEditRoute: (plugin: string, type: CustomPluginType) => ({
+    name: 'edit-custom-plugin',
+    params: { plugin, customPluginType: type },
+  }),
+})
+
 const highlightedPluginIds = ref([
   'basic-auth', 'ip-restriction', 'jwt', 'key-auth',
   'rate-limiting', 'request-termination', 'response-ratelimiting', 'tcp-log',
@@ -59,5 +184,42 @@ const handleDeleteSuccess = (plugin: string): void => {
 <style lang="scss" scoped>
 .plugin-select-sandbox {
   padding: 20px;
+  position: relative;
+
+  .sandbox-controls {
+    background: #f9f9f9;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    padding: 12px 16px;
+    position: sticky;
+    right: 0;
+    top: 0;
+    z-index: 10;
+
+    .controls-section {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-width: 160px;
+
+      h4 {
+        font-size: 12px;
+        font-weight: 600;
+        margin: 0 0 4px;
+        text-transform: uppercase;
+      }
+
+      label {
+        align-items: center;
+        cursor: pointer;
+        display: flex;
+        font-size: 13px;
+        gap: 6px;
+      }
+    }
+  }
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/PluginCatalog.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.cy.ts
@@ -1,10 +1,18 @@
 import PluginCatalog from './PluginCatalog.vue'
-import { PluginGroupArraySortedAlphabetically, type KonnectPluginSelectConfig } from '../types'
+import {
+  PluginGroupArraySortedAlphabetically,
+  type KonnectPluginSelectConfig,
+  type KongManagerPluginSelectConfig,
+} from '../types'
 import { PluginGroup } from '@kong-ui-public/entities-plugins-metadata'
 import {
   konnectAvailablePlugins,
   konnectStreamingCustomPlugins,
+  kmAvailablePlugins,
+  kmClonedCustomPlugins,
+  kmStreamingCustomPlugins,
 } from '../../fixtures/mockData'
+import { FEATURE_FLAGS } from '../constants'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 const baseConfigKonnect: KonnectPluginSelectConfig = {
@@ -289,5 +297,322 @@ describe('<PluginCatalog />', {
     cy.getTestId('clear-filter-selection').should('not.be.disabled').click()
     cy.getTestId(`plugin-filter-checkbox-${PluginGroup.TRAFFIC_CONTROL}`).should('not.be.checked')
     cy.getTestId('clear-filter-selection').should('be.disabled')
+  })
+
+  it('should hide the featured filter and group when showFeaturedGroup is false', () => {
+    interceptKonnect()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKonnect,
+        highlightedPluginIds: ['basic-auth'],
+        showFeaturedGroup: false,
+      },
+      router,
+    })
+
+    cy.wait('@getAvailablePlugins')
+
+    // featured filter sidebar item should not exist
+    cy.getTestId('plugin-filter-item-Featured').should('not.exist')
+    // featured group in results should not exist
+    cy.getTestId('plugin-group-Featured').should('not.exist')
+  })
+
+  it('should render streaming custom plugins in the Custom Plugins group', () => {
+    interceptKonnect()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKonnect,
+        customPluginSupport: 'streaming',
+      },
+      router,
+    })
+
+    cy.wait('@getAvailablePlugins')
+    cy.wait('@getStreamingCustomPlugins')
+
+    cy.getTestId('plugin-group-Custom Plugins').should('exist')
+    cy.getTestId('plugin-1-card').should('exist')
+    cy.getTestId('plugin-2-card').should('exist')
+  })
+})
+
+describe('<PluginCatalog /> Kong Manager', {
+  viewportWidth: 1024,
+  viewportHeight: 576,
+}, () => {
+  const baseConfigKongManager: KongManagerPluginSelectConfig = {
+    app: 'kongManager',
+    workspace: 'default',
+    apiBaseUrl: '/kong-manager',
+    getCreateRoute: (plugin: string) => ({
+      name: 'create-plugin',
+      params: { plugin },
+    }),
+    createCustomRoute: { name: 'create-custom-plugin' },
+    getCustomEditRoute: (plugin: string, type: 'schema' | 'streaming' | 'cloned') => ({
+      name: 'edit-custom-plugin',
+      params: { plugin, customPluginType: type },
+    }),
+  }
+
+  let router: ReturnType<typeof createRouter>
+
+  const interceptKMAvailablePlugins = (mockData = kmAvailablePlugins) => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: `${baseConfigKongManager.apiBaseUrl}/${baseConfigKongManager.workspace}/kong`,
+      },
+      { statusCode: 200, body: mockData },
+    ).as('getKMAvailablePlugins')
+  }
+
+  const interceptKMClonedPlugins = (options?: { statusCode?: number, mockData?: object }) => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: `${baseConfigKongManager.apiBaseUrl}/${baseConfigKongManager.workspace}/cloned-plugins`,
+      },
+      { statusCode: options?.statusCode ?? 200, body: options?.mockData ?? kmClonedCustomPlugins },
+    ).as('getKMClonedPlugins')
+  }
+
+  const interceptKMStreamingPlugins = (mockData = kmStreamingCustomPlugins) => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: `${baseConfigKongManager.apiBaseUrl}/${baseConfigKongManager.workspace}/custom-plugins`,
+      },
+      { statusCode: 200, body: mockData },
+    ).as('getKMStreamingPlugins')
+  }
+
+  beforeEach(() => {
+    router = createRouter({
+      routes: [
+        { path: '/', name: 'list-plugin', component: { template: '<div>ListPage</div>' } },
+        { path: '/create-plugin', name: 'create-plugin', component: { template: '<div>CreatePlugin</div>' } },
+        { path: '/create-custom-plugin', name: 'create-custom-plugin', component: { template: '<div>CreateCustomPlugin</div>' } },
+        { path: '/edit-custom-plugin', name: 'edit-custom-plugin', component: { template: '<div>EditCustomPlugin</div>' } },
+      ],
+      history: createMemoryHistory(),
+    })
+  })
+
+  it('should render plugin groups from Kong Manager API', () => {
+    interceptKMAvailablePlugins()
+
+    cy.mount(PluginCatalog, {
+      props: { config: baseConfigKongManager },
+      router,
+    })
+
+    cy.wait('@getKMAvailablePlugins')
+    cy.getTestId('plugin-catalog').should('exist')
+    cy.getTestId(`plugin-group-${PluginGroup.AUTHENTICATION}`).should('exist')
+  })
+
+  it('should render cloned custom plugins with cloned-from badge', () => {
+    interceptKMAvailablePlugins()
+    interceptKMClonedPlugins()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKongManager,
+        customPluginSupport: ['cloned', 'schema'],
+      },
+      global: {
+        provide: {
+          [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+        },
+      },
+      router,
+    })
+
+    cy.wait('@getKMAvailablePlugins')
+    cy.wait('@getKMClonedPlugins')
+
+    cy.getTestId('plugin-group-Custom Plugins').should('exist')
+    cy.getTestId('km-cloned-plugin-card').should('exist')
+    cy.getTestId('km-cloned-plugin-card').find('.cloned-from-badge').should('exist')
+  })
+
+  it('should render streaming custom plugins in the Custom Plugins group', () => {
+    interceptKMAvailablePlugins()
+    interceptKMStreamingPlugins()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKongManager,
+        customPluginSupport: 'streaming',
+      },
+      router,
+    })
+
+    cy.wait('@getKMAvailablePlugins')
+    cy.wait('@getKMStreamingPlugins')
+
+    cy.getTestId('plugin-group-Custom Plugins').should('exist')
+    cy.getTestId('km-streaming-plugin-card').should('exist')
+  })
+
+  it('should show overflow actions menu on cloned plugin card', () => {
+    interceptKMAvailablePlugins()
+    interceptKMClonedPlugins()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKongManager,
+        customPluginSupport: ['cloned', 'schema'],
+        canUpdateClonedPlugin: true,
+        canDeleteClonedPlugin: true,
+      },
+      global: {
+        provide: {
+          [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+        },
+      },
+      router,
+    })
+
+    cy.wait('@getKMAvailablePlugins')
+    cy.wait('@getKMClonedPlugins')
+
+    cy.getTestId('km-cloned-plugin-card')
+      .within(() => {
+        cy.getTestId('overflow-actions-button').should('be.visible').click()
+      })
+    cy.getTestId('edit-plugin-schema').should('be.visible')
+    cy.getTestId('delete-plugin-schema').should('be.visible')
+  })
+
+  it('should open delete modal when Delete is clicked on a cloned plugin card', () => {
+    interceptKMAvailablePlugins()
+    interceptKMClonedPlugins()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKongManager,
+        customPluginSupport: ['cloned', 'schema'],
+        canDeleteClonedPlugin: true,
+      },
+      global: {
+        provide: {
+          [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+        },
+      },
+      router,
+    })
+
+    cy.wait('@getKMAvailablePlugins')
+    cy.wait('@getKMClonedPlugins')
+
+    cy.getTestId('km-cloned-plugin-card')
+      .within(() => {
+        cy.getTestId('overflow-actions-button').click()
+      })
+    cy.getTestId('delete-plugin-schema').click()
+    cy.getTestId('delete-custom-plugin-schema-modal').should('exist')
+  })
+
+  it('should not render cloned plugin edit action for KM schema-type plugins', () => {
+    // schema-type custom plugins in KM are server-installed — not editable/deletable
+    interceptKMAvailablePlugins()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKongManager,
+        // schema support only, no cloned
+        customPluginSupport: 'schema',
+        availableOnServer: false,
+      },
+      global: {
+        provide: {
+          [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+        },
+      },
+      router,
+    })
+
+    cy.wait('@getKMAvailablePlugins')
+
+    // If a schema plugin exists in the custom group, it should NOT have an overflow menu
+    // (schema plugins in KM are server-installed, not manageable)
+    cy.getTestId('plugin-group-Custom Plugins').should('not.exist')
+  })
+
+  it('should filter out ignoredPlugins from Kong Manager plugin list', () => {
+    interceptKMAvailablePlugins()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKongManager,
+        ignoredPlugins: ['acl'],
+      },
+      router,
+    })
+
+    cy.wait('@getKMAvailablePlugins')
+
+    cy.getTestId('acl-card').should('not.exist')
+    // other plugins should still be present
+    cy.getTestId('basic-auth-card').should('exist')
+  })
+
+  it('should show warning alert when cloned plugins API fails', () => {
+    interceptKMAvailablePlugins()
+    interceptKMClonedPlugins({ statusCode: 500, mockData: { message: 'Internal Server Error' } })
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKongManager,
+        customPluginSupport: ['cloned', 'schema'],
+      },
+      global: {
+        provide: {
+          [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+        },
+      },
+      router,
+    })
+
+    cy.wait('@getKMAvailablePlugins')
+    cy.wait('@getKMClonedPlugins')
+
+    // warning alert should be shown; other Kong plugins still render
+    cy.get('.custom-plugins-warning').should('exist')
+    cy.getTestId(`plugin-group-${PluginGroup.AUTHENTICATION}`).should('exist')
+  })
+
+  it('should not show overflow actions when canUpdateClonedPlugin and canDeleteClonedPlugin are false', () => {
+    interceptKMAvailablePlugins()
+    interceptKMClonedPlugins()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKongManager,
+        customPluginSupport: ['cloned', 'schema'],
+        canUpdateClonedPlugin: false,
+        canDeleteClonedPlugin: false,
+      },
+      global: {
+        provide: {
+          [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+        },
+      },
+      router,
+    })
+
+    cy.wait('@getKMAvailablePlugins')
+    cy.wait('@getKMClonedPlugins')
+
+    cy.getTestId('km-cloned-plugin-card').should('exist')
+    cy.getTestId('km-cloned-plugin-card')
+      .within(() => {
+        cy.getTestId('overflow-actions-button').should('not.exist')
+      })
   })
 })

--- a/packages/entities/entities-plugins/src/components/PluginCatalog.vue
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.vue
@@ -19,7 +19,10 @@
           {{ t('plugins.select.filter.clear') }}
         </KButton>
       </div>
-      <KCollapse v-model="featuredFilterCollapse">
+      <KCollapse
+        v-if="showFeaturedGroup"
+        v-model="featuredFilterCollapse"
+      >
         <template #title>
           <div class="featured-title">
             {{ t('plugins.select.filter.featured') }}
@@ -129,17 +132,23 @@
         aria-live="polite"
         class="plugins-results-container"
       >
+        <KAlert
+          v-if="customPluginsListError"
+          appearance="warning"
+          class="custom-plugins-warning"
+          :message="customPluginsListError"
+        />
         <PluginCatalogListView
           v-if="isListView"
           :config="config"
           :plugin-list="filteredPlugins"
-          @delete:success="(name: string) => $emit('delete-custom:success', name)"
+          @delete:success="(name: string) => handleCustomPluginDeleteSuccess(name)"
         />
         <PluginCatalogGrid
           v-else
           :config="config"
           :plugin-list="filteredPlugins"
-          @delete:success="(name: string) => $emit('delete-custom:success', name)"
+          @delete:success="(name: string) => handleCustomPluginDeleteSuccess(name)"
           @plugin-clicked="(val: PluginType) => $emit('plugin-clicked', val)"
         />
       </section>
@@ -148,24 +157,30 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, provide, ref, useTemplateRef, watch } from 'vue'
+import { isAxiosError } from 'axios'
 import {
   PluginGroup,
   PluginScope,
   PluginFeaturedArray,
   PluginGroupArraySortedAlphabetically,
+  type ClonedPluginSchema,
   type CustomPluginSupportLevel,
+  type CustomPluginType,
   type KongManagerPluginSelectConfig,
   type KonnectPluginSelectConfig,
   type PluginType,
   type DisabledPlugin,
   type PluginCardList,
   type StreamingCustomPluginSchema,
+  type PluginCatalogPermissions,
 } from '../types'
 import composables from '../composables'
 import endpoints from '../plugins-endpoints'
+import { FEATURE_FLAGS as PLUGIN_FEATURE_FLAGS, PLUGIN_CATALOG_PERMISSIONS_KEY } from '../constants'
 import PluginCatalogGrid from './select/PluginCatalogGrid.vue'
 import { useAxios, useHelpers, useErrors } from '@kong-ui-public/entities-shared'
+import { fetchAllPages } from '../composables/useCustomPluginApi'
 import { KUI_ICON_COLOR_PRIMARY } from '@kong/design-tokens'
 import { GridIcon, ListIcon } from '@kong/icons'
 import { lcsRecursive } from '../utils/helper'
@@ -191,11 +206,38 @@ const props = withDefaults(defineProps<{
   config: KonnectPluginSelectConfig | KongManagerPluginSelectConfig
   disabledPlugins?: DisabledPlugin
   highlightedPluginIds?: string[]
+  showFeaturedGroup?: boolean
   customPluginSupport?: CustomPluginSupportLevel
   availableOnServer?: boolean
+  ignoredPlugins?: string[]
+  /** RBAC permission gates for streaming/schema custom plugins (path: custom-plugins) */
+  canReadCustomPlugin?: boolean
+  canUpdateCustomPlugin?: boolean
+  canDeleteCustomPlugin?: boolean
+  /** RBAC permission gates for cloned/schema custom plugins (path: cloned-plugins) */
+  canReadClonedPlugin?: boolean
+  canUpdateClonedPlugin?: boolean
+  canDeleteClonedPlugin?: boolean
 }>(), {
   availableOnServer: true,
+  showFeaturedGroup: true,
+  ignoredPlugins: () => [],
+  canReadCustomPlugin: true,
+  canUpdateCustomPlugin: true,
+  canDeleteCustomPlugin: true,
+  canReadClonedPlugin: true,
+  canUpdateClonedPlugin: true,
+  canDeleteClonedPlugin: true,
 })
+
+provide(PLUGIN_CATALOG_PERMISSIONS_KEY, computed((): PluginCatalogPermissions => ({
+  canReadCustomPlugin: props.canReadCustomPlugin,
+  canUpdateCustomPlugin: props.canUpdateCustomPlugin,
+  canDeleteCustomPlugin: props.canDeleteCustomPlugin,
+  canReadClonedPlugin: props.canReadClonedPlugin,
+  canUpdateClonedPlugin: props.canUpdateClonedPlugin,
+  canDeleteClonedPlugin: props.canDeleteClonedPlugin,
+})))
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 
@@ -215,6 +257,22 @@ const existingEntityPlugins = ref<string[]>([])
 const isListView = ref(false)
 const viewModeIcon = computed(() => (isListView.value ? GridIcon : ListIcon))
 
+const clonedCustomPlugins = ref<ClonedPluginSchema[]>([])
+const customPluginsListError = ref('')
+const abortController = ref<AbortController | null>(null)
+
+const enabledClonedPlugin = inject<boolean>(PLUGIN_FEATURE_FLAGS.KM_2485_CLONED_PLUGINS, false)
+
+const normalizeCustomPluginSupport = (support: CustomPluginSupportLevel | undefined): Set<CustomPluginType> => {
+  if (!support || support === 'none' || support === 'disabled') return new Set()
+  return new Set(Array.isArray(support) ? support : [support])
+}
+const normalizedCustomPluginSupport = computed<Set<CustomPluginType>>(() => normalizeCustomPluginSupport(props.customPluginSupport))
+const customPluginSupportKey = computed(() => [...normalizedCustomPluginSupport.value].sort().join('|'))
+const customPluginsDisabled = computed(() => props.customPluginSupport === 'disabled')
+const isStreamingCustomPluginSupported = computed(() => normalizedCustomPluginSupport.value.has('streaming'))
+const isClonedCustomPluginSupported = computed(() => enabledClonedPlugin && normalizedCustomPluginSupport.value.has('cloned'))
+
 const availablePluginsUrl = computed((): string => {
   let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].availablePlugins}`
 
@@ -228,12 +286,29 @@ const availablePluginsUrl = computed((): string => {
 })
 
 const streamingPluginsUrl = computed<string | null>(() => {
-  if (props.config.app === 'konnect' && props.customPluginSupport === 'streaming') {
-    return `${props.config.apiBaseUrl}${endpoints.select[props.config.app].streamingCustomPlugins}`
-      .replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
-      .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
+  if (isStreamingCustomPluginSupported.value && props.canReadCustomPlugin) {
+    let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].streamingCustomPlugins}`
+
+    if (props.config.app === 'konnect') {
+      url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+    }
+
+    return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
   }
-  // Kong Manager and other support level does not support streaming custom plugins now
+  return null
+})
+
+const clonedPluginsUrl = computed<string | null>(() => {
+  if (isClonedCustomPluginSupported.value && props.canReadClonedPlugin) {
+    let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].clonedPlugins}`
+
+    if (props.config.app === 'konnect') {
+      url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+    }
+
+    return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
+  }
+
   return null
 })
 
@@ -330,16 +405,22 @@ const clearTypeFilter = (): void => {
 }
 
 const buildPluginList = (): PluginCardList => {
-  // If availableOnServer is false, we included unavailable plugins from pluginMeta in addition to available plugins
-  // returning an array of unique plugin ids
-  // either grab all plugins from metadata file or use list of available plugins provided by API
+  const clonedPluginMap = new Map(clonedCustomPlugins.value.map(p => [p.name, p]))
+  const streamingPluginSet = new Set(streamingCustomPlugins.value.map(p => p.name))
+  const allCustomPluginNames = new Set<string>([
+    ...streamingPluginSet,
+    ...clonedPluginMap.keys(),
+  ])
+
   const list = [...new Set(
     [
       ...Object.keys({ ...(!props.availableOnServer ? pluginMetaData : {}) }),
       ...availablePlugins.value,
+      ...allCustomPluginNames,
     ],
   )]
-    // Used to filter out ignored plugins, seems we don't need it anymore
+    // Filter out ignored plugins
+    .filter((plugin: string) => !props.ignoredPlugins.includes(plugin))
     // Filter plugins by entity type if adding scoped plugin
     .filter((plugin: string) => {
       // For Global Plugins
@@ -347,29 +428,31 @@ const buildPluginList = (): PluginCardList => {
         return plugin
       }
 
+      const pluginName = clonedPluginMap.has(plugin) ? clonedPluginMap.get(plugin)!.ref : plugin
+
       if (props.config.entityType === 'services') {
-        const isNotServicePlugin = (pluginMetaData[plugin] && !pluginMetaData[plugin].scope.includes(PluginScope.SERVICE))
+        const isNotServicePlugin = (pluginMetaData[pluginName] && !pluginMetaData[pluginName].scope.includes(PluginScope.SERVICE))
         if (isNotServicePlugin) {
           return false
         }
       }
 
       if (props.config.entityType === 'routes') {
-        const isNotRoutePlugin = (pluginMetaData[plugin] && !pluginMetaData[plugin].scope.includes(PluginScope.ROUTE))
+        const isNotRoutePlugin = (pluginMetaData[pluginName] && !pluginMetaData[pluginName].scope.includes(PluginScope.ROUTE))
         if (isNotRoutePlugin) {
           return false
         }
       }
 
       if (props.config.entityType === 'consumer_groups') {
-        const isNotConsumerGroupPlugin = (pluginMetaData[plugin] && !pluginMetaData[plugin].scope.includes(PluginScope.CONSUMER_GROUP))
+        const isNotConsumerGroupPlugin = (pluginMetaData[pluginName] && !pluginMetaData[pluginName].scope.includes(PluginScope.CONSUMER_GROUP))
         if (isNotConsumerGroupPlugin) {
           return false
         }
       }
 
       if (props.config.entityType === 'consumers') {
-        const isNotConsumerPlugin = (pluginMetaData[plugin] && !pluginMetaData[plugin].scope.includes(PluginScope.CONSUMER))
+        const isNotConsumerPlugin = (pluginMetaData[pluginName] && !pluginMetaData[pluginName].scope.includes(PluginScope.CONSUMER))
         if (isNotConsumerPlugin) {
           return false
         }
@@ -380,19 +463,26 @@ const buildPluginList = (): PluginCardList => {
     // build the actual card list
     .reduce((list: PluginCardList, pluginId: string) => {
       const pluginName = (pluginMetaData[pluginId] && pluginMetaData[pluginId].name) || pluginId
+      const clonedPlugin = clonedPluginMap.get(pluginId)
+      const isStreamingPlugin = streamingPluginSet.has(pluginId)
       const plugin: PluginType = {
         ...pluginMetaData[pluginId],
         id: pluginId,
         name: pluginName,
-        available: availablePlugins.value.includes(pluginId),
+        available: availablePlugins.value.includes(pluginId) || !!clonedPlugin || isStreamingPlugin,
         disabledMessage: '',
         group: pluginMetaData[pluginId]?.group || PluginGroup.CUSTOM_PLUGINS,
       }
 
       if (plugin.group === PluginGroup.CUSTOM_PLUGINS) {
-        plugin.customPluginType = streamingCustomPlugins.value.find(sp => sp.name === pluginId)
-          ? 'streaming'
-          : 'schema'
+        if (clonedPlugin) {
+          plugin.customPluginType = 'cloned'
+          plugin.clonedFromRef = clonedPlugin.ref
+        } else if (isStreamingPlugin) {
+          plugin.customPluginType = 'streaming'
+        } else {
+          plugin.customPluginType = 'schema'
+        }
       }
 
       if (props.disabledPlugins) {
@@ -412,10 +502,11 @@ const buildPluginList = (): PluginCardList => {
       list[groupName] = plugins
 
       return list
-    }, {})
+    }, {} as PluginCardList)
+
   // Pick highlighted plugin objects from pluginMetaData and assign to 'Featured'
   // Only include plugins that passed scope filtering (i.e., already present in the list)
-  if (props.highlightedPluginIds && props.highlightedPluginIds.length > 0) {
+  if (props.showFeaturedGroup && props.highlightedPluginIds && props.highlightedPluginIds.length > 0) {
     const scopedIds = new Set(Object.values(list).flat().map(p => p?.id))
     const featuredPlugins = props.highlightedPluginIds
       .flatMap(pluginId => {
@@ -435,7 +526,135 @@ const buildPluginList = (): PluginCardList => {
       list[PluginGroup.FEATURED] = featuredPlugins
     }
   }
+
   return list
+}
+
+const isRequestCancelled = (error: unknown): boolean => {
+  return isAxiosError(error) && error.code === 'ERR_CANCELED'
+}
+
+const isClonedPluginLicenseError = (error: unknown): boolean => {
+  return getMessageFromError(error).toLowerCase().includes('requires a license')
+}
+
+const loadEntityPlugins = async (signal?: AbortSignal): Promise<void> => {
+  if (!fetchEntityPluginsUrl.value) {
+    existingEntityPlugins.value = []
+    return
+  }
+
+  try {
+    const { data: { data } } = await axiosInstance.get(fetchEntityPluginsUrl.value, { signal })
+
+    if (data?.length) {
+      existingEntityPlugins.value = data.reduce((plugins: string[], plugin: Record<string, any>) => {
+        if (plugin.name) {
+          plugins.push(plugin.name)
+        }
+
+        return plugins
+      }, [])
+    }
+  } catch (error) {
+    if (!isRequestCancelled(error)) {
+      existingEntityPlugins.value = []
+    }
+  }
+}
+
+const loadCustomPlugins = async (signal?: AbortSignal): Promise<void> => {
+  const requests: Array<Promise<void>> = []
+
+  if (streamingPluginsUrl.value) {
+    requests.push(
+      fetchAllPages<StreamingCustomPluginSchema>(axiosInstance, streamingPluginsUrl.value, signal)
+        .then((plugins): void => {
+          streamingCustomPlugins.value = plugins
+          return undefined
+        })
+        .catch((error) => {
+          if (isRequestCancelled(error)) {
+            return
+          }
+
+          if (!customPluginsListError.value) {
+            customPluginsListError.value = getMessageFromError(error) ?? t('plugins.select.tabs.custom.fetch_error')
+          }
+        }),
+    )
+  }
+
+  if (clonedPluginsUrl.value) {
+    requests.push(
+      fetchAllPages<ClonedPluginSchema>(axiosInstance, clonedPluginsUrl.value, signal)
+        .then((plugins): void => {
+          clonedCustomPlugins.value = plugins
+          return undefined
+        })
+        .catch((error) => {
+          if (isRequestCancelled(error)) {
+            return
+          }
+
+          const isLicenseError = isClonedPluginLicenseError(error)
+          if (isLicenseError || !customPluginsListError.value) {
+            customPluginsListError.value = isLicenseError
+              ? t('plugins.select.tabs.custom.license_required')
+              : getMessageFromError(error) ?? t('plugins.select.tabs.custom.fetch_error')
+          }
+        }),
+    )
+  }
+
+  requests.push(loadEntityPlugins(signal))
+
+  await Promise.allSettled(requests)
+}
+
+const loadPlugins = async (): Promise<void> => {
+  abortController.value?.abort()
+  abortController.value = new AbortController()
+
+  isLoading.value = true
+  hasError.value = false
+  fetchErrorMessage.value = ''
+  customPluginsListError.value = ''
+  availablePlugins.value = []
+  streamingCustomPlugins.value = []
+  clonedCustomPlugins.value = []
+  existingEntityPlugins.value = []
+
+  try {
+    const { data } = await axiosInstance.get(availablePluginsUrl.value, { signal: abortController.value.signal })
+
+    if (props.config.app === 'konnect') {
+      const { names: allAvailablePlugins } = data
+      availablePlugins.value = allAvailablePlugins || []
+    } else if (props.config.app === 'kongManager') {
+      const { plugins: { available_on_server: aPlugins } } = data
+      availablePlugins.value = aPlugins ? Object.keys(aPlugins) : []
+    }
+
+    await loadCustomPlugins(abortController.value.signal)
+    pluginsList.value = buildPluginList()
+  } catch (error: any) {
+    if (!isRequestCancelled(error)) {
+      hasError.value = true
+      fetchErrorMessage.value = getMessageFromError(error)
+    }
+  } finally {
+    if (!abortController.value?.signal.aborted) {
+      isLoading.value = false
+    }
+  }
+}
+
+const handleCustomPluginDeleteSuccess = (pluginName: string): void => {
+  streamingCustomPlugins.value = streamingCustomPlugins.value.filter((plugin) => plugin.name !== pluginName)
+  clonedCustomPlugins.value = clonedCustomPlugins.value.filter((plugin) => plugin.name !== pluginName)
+  pluginsList.value = buildPluginList()
+  emit('delete-custom:success', pluginName)
 }
 
 // race condition between fetch of available plugins and setting
@@ -450,60 +669,43 @@ watch(() => props.disabledPlugins, (val, oldVal) => {
   }
 })
 
+watch(() => props.ignoredPlugins, (val, oldVal) => {
+  if (!objectsAreEqual(val || [], oldVal || []) && !isLoading.value) {
+    pluginsList.value = buildPluginList()
+  }
+})
+
 watch((isLoading), (loading: boolean) => {
   emit('loading', loading)
 })
 
+const hasMounted = ref(false)
+
+watch(
+  () => [
+    props.config.app === 'konnect' ? props.config.controlPlaneId : undefined,
+    props.config.workspace,
+    props.config.entityType,
+    props.config.entityId,
+    props.config.app === 'kongManager' ? props.config.gatewayInfo?.edition : undefined,
+    customPluginSupportKey.value,
+    customPluginsDisabled.value,
+  ],
+  async () => {
+    if (hasMounted.value) {
+      await loadPlugins()
+    }
+  },
+)
+
 onMounted(async () => {
+  hasMounted.value = true
   searchFilterInput.value?.input?.focus()
+  await loadPlugins()
+})
 
-  try {
-    const { data } = await axiosInstance.get(availablePluginsUrl.value)
-
-    if (props.config.app === 'konnect') {
-      const { names: allAvailablePlugins } = data
-      availablePlugins.value = allAvailablePlugins || []
-      if (streamingPluginsUrl.value) {
-        // fetch streaming custom plugins for plugin type partition
-        const { data: streamingCustomPluginsData } = await axiosInstance.get<{ data: StreamingCustomPluginSchema[] }>(streamingPluginsUrl.value)
-        streamingCustomPlugins.value = streamingCustomPluginsData.data || []
-      }
-    } else if (props.config.app === 'kongManager') {
-      const { plugins: { available_on_server: aPlugins } } = data
-      availablePlugins.value = aPlugins ? Object.keys(aPlugins) : []
-    }
-  } catch (error: any) {
-    hasError.value = true
-    fetchErrorMessage.value = getMessageFromError(error)
-  }
-
-  // fetch scoped entity to check for pre-existing plugins
-  if (fetchEntityPluginsUrl.value) {
-    try {
-      const { data: { data } } = await axiosInstance.get(fetchEntityPluginsUrl.value)
-
-      if (data?.length) {
-        const eplugins = data.reduce((plugins: string[], plugin: Record<string, any>) => {
-          if (plugin.name) {
-            plugins.push(plugin.name)
-          }
-
-          return plugins
-        }, [])
-
-        existingEntityPlugins.value = existingEntityPlugins.value.concat(eplugins)
-      }
-    } catch {
-      // no op if it fails, backend will catch if they try to create
-      // duplicate plugins
-    }
-  }
-
-  if (!hasError.value) {
-    pluginsList.value = buildPluginList()
-  }
-
-  isLoading.value = false
+onBeforeUnmount(() => {
+  abortController.value?.abort()
 })
 
 

--- a/packages/entities/entities-plugins/src/components/select/PluginCatalogCard.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginCatalogCard.vue
@@ -47,15 +47,17 @@
 
               <template #items>
                 <KDropdownItem
+                  v-if="canEditPlugin"
                   data-testid="edit-plugin-schema"
                   @click.stop.prevent="handleCustomEdit(plugin.name, plugin.customPluginType!)"
                 >
                   {{ t('actions.edit') }}
                 </KDropdownItem>
                 <KDropdownItem
+                  v-if="canDeletePlugin"
                   danger
                   data-testid="delete-plugin-schema"
-                  has-divider
+                  :has-divider="canEditPlugin"
                   @click.stop.prevent="handleCustomDelete"
                 >
                   {{ t('actions.delete') }}
@@ -71,31 +73,31 @@
           :title="!plugin.available ? t('plugins.select.unavailable_tooltip') : plugin.name"
         >
           <div
-            v-if="plugin.description || customPluginBadges.length"
+            v-if="plugin.description"
+            :title="plugin.description"
           >
-            <div
-              v-if="customPluginBadges.length"
-              class="custom-plugin-badges"
-            >
-              <KBadge
-                v-for="badge in customPluginBadges"
-                :key="badge"
-                appearance="info"
-              >
-                {{ badge }}
-              </KBadge>
-            </div>
-
-            <div
-              v-if="plugin.description"
-              :title="plugin.description"
-            >
-              {{ plugin.description }}
-            </div>
+            {{ plugin.description }}
           </div>
         </div>
         <div class="plugin-card-footer">
           <div>{{ isCreateCustomPlugin ? t('actions.create_custom') : t('actions.configure') }}</div>
+          <KBadge
+            v-if="footerBadgeText"
+            appearance="info"
+          >
+            {{ footerBadgeText }}
+          </KBadge>
+          <KTooltip
+            v-if="clonedFromText"
+            :text="clonedFromText"
+          >
+            <KBadge
+              appearance="info"
+              class="cloned-from-badge"
+            >
+              <span class="cloned-badge-text">{{ clonedFromText }}</span>
+            </KBadge>
+          </KTooltip>
           <slot name="footer-extra" />
         </div>
       </RouterLink>
@@ -104,15 +106,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject } from 'vue'
+import type { ComputedRef } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   PluginGroup,
   type CustomPluginType,
   type KongManagerPluginSelectConfig,
   type KonnectPluginSelectConfig,
+  type PluginCatalogPermissions,
   type PluginType,
 } from '../../types'
+import { PLUGIN_CATALOG_PERMISSIONS_KEY } from '../../constants'
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { MoreIcon } from '@kong/icons'
 import composables from '../../composables'
@@ -135,24 +140,39 @@ const props = defineProps<{
 
 const router = useRouter()
 const { i18n: { t } } = composables.useI18n()
-const controlPlaneId = computed((): string => props.config.app === 'konnect' ? props.config.controlPlaneId : '')
-const customPluginBadges = computed((): string[] => {
+
+const DEFAULT_PERMISSIONS: PluginCatalogPermissions = {
+  canReadCustomPlugin: true,
+  canUpdateCustomPlugin: true,
+  canDeleteCustomPlugin: true,
+  canReadClonedPlugin: true,
+  canUpdateClonedPlugin: true,
+  canDeleteClonedPlugin: true,
+}
+const injectedPerms = inject<ComputedRef<PluginCatalogPermissions>>(PLUGIN_CATALOG_PERMISSIONS_KEY)
+const permissions = computed(() => injectedPerms?.value ?? DEFAULT_PERMISSIONS)
+
+const footerBadgeText = computed((): string | null => {
   if (!isCustomPlugin.value || isCreateCustomPlugin.value) {
-    return []
+    return null
   }
-
-  if (props.plugin.customPluginType === 'cloned' && props.plugin.clonedFromRef) {
-    return [t('plugins.select.cloned_from_badge', { link: props.plugin.clonedFromRef })]
-  }
-
   if (props.plugin.customPluginType === 'streaming') {
-    return [t('plugins.select.streamed_custom_badge')]
+    return t('plugins.select.streamed_custom_badge')
   }
+  if (props.plugin.customPluginType === 'schema') {
+    return t('plugins.select.installed_custom_badge')
+  }
+  return null
+})
 
-  return [t('plugins.select.installed_custom_badge')]
+const clonedFromText = computed((): string | null => {
+  if (props.plugin.customPluginType === 'cloned' && props.plugin.clonedFromRef) {
+    return t('plugins.select.cloned_from_badge', { link: props.plugin.clonedFromRef })
+  }
+  return null
 })
 const isDisabled = computed((): boolean => !!(!props.plugin.available || props.plugin.disabledMessage))
-const hasActions = computed((): boolean => !!(isCustomPlugin.value && !isCreateCustomPlugin.value && controlPlaneId.value))
+const hasActions = computed((): boolean => !!(isCustomPlugin.value && !isCreateCustomPlugin.value && (canEditPlugin.value || canDeletePlugin.value)))
 
 const pluginCardLink = computed(() => {
   if (isDisabled.value) {
@@ -160,9 +180,8 @@ const pluginCardLink = computed(() => {
   }
 
   if (isCustomPlugin.value) {
-    const konnectConfig = props.config as KonnectPluginSelectConfig
-    if (isCreateCustomPlugin.value && konnectConfig.createCustomRoute) {
-      return konnectConfig.createCustomRoute
+    if (isCreateCustomPlugin.value && props.config.createCustomRoute) {
+      return props.config.createCustomRoute
     }
   }
 
@@ -173,18 +192,32 @@ const pluginCardLink = computed(() => {
  * Custom Plugin logic
  */
 const isCreateCustomPlugin = computed((): boolean => props.plugin.id === 'custom-plugin-create')
-const isCustomPlugin = computed((): boolean => props.config.app === 'konnect' && props.plugin.group === PluginGroup.CUSTOM_PLUGINS)
+const isCustomPlugin = computed((): boolean => (props.config.app === 'konnect' || props.config.app === 'kongManager') && props.plugin.group === PluginGroup.CUSTOM_PLUGINS)
+
+// 'cloned' and 'schema' types are both managed via the cloned-plugins RBAC path
+const isClonedType = computed(() => props.plugin.customPluginType === 'cloned' || props.plugin.customPluginType === 'schema')
+
+const canEditPlugin = computed((): boolean => {
+  if (!isCustomPlugin.value || isCreateCustomPlugin.value) return false
+  // schema plugins in KM are installed plugins — not manageable, no RBAC control
+  if (props.config.app === 'kongManager' && props.plugin.customPluginType === 'schema') return false
+  return isClonedType.value ? permissions.value.canUpdateClonedPlugin : permissions.value.canUpdateCustomPlugin
+})
+
+const canDeletePlugin = computed((): boolean => {
+  if (!isCustomPlugin.value || isCreateCustomPlugin.value) return false
+  // schema plugins in KM are installed plugins — not manageable, no RBAC control
+  if (props.config.app === 'kongManager' && props.plugin.customPluginType === 'schema') return false
+  return isClonedType.value ? permissions.value.canDeleteClonedPlugin : permissions.value.canDeleteCustomPlugin
+})
 
 const handleCustomDelete = (): void => {
-  if (props.config.app === 'konnect') {
-    emit('custom-plugin-delete')
-  }
+  emit('custom-plugin-delete')
 }
 
 const handleCustomEdit = (pluginName: string, type: CustomPluginType): void => {
-  const konnectConfig = props.config as KonnectPluginSelectConfig
-  if (props.config.app === 'konnect' && typeof konnectConfig.getCustomEditRoute === 'function') {
-    router.push(konnectConfig.getCustomEditRoute(pluginName, type))
+  if (typeof props.config.getCustomEditRoute === 'function') {
+    router.push(props.config.getCustomEditRoute(pluginName, type))
   }
 }
 
@@ -262,12 +295,6 @@ const handleCustomEdit = (pluginName: string, type: CustomPluginType): void => {
       overflow: hidden;
       text-align: left;
 
-      .custom-plugin-badges {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--kui-space-40, $kui-space-40);
-        margin-bottom: var(--kui-space-40, $kui-space-40);
-      }
     }
 
     .plugin-card-footer {
@@ -277,6 +304,15 @@ const handleCustomEdit = (pluginName: string, type: CustomPluginType): void => {
       font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
       justify-content: space-between;
       text-align: center;
+
+      .cloned-badge-text {
+        display: inline-block;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        vertical-align: bottom;
+        white-space: nowrap;
+      }
     }
 
     &.disabled * {

--- a/packages/entities/entities-plugins/src/components/select/PluginCatalogListView.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginCatalogListView.vue
@@ -61,7 +61,7 @@
         #more-actions="{ row }"
       >
         <div
-          v-if="row.plugin?.customPluginType"
+          v-if="row.plugin?.customPluginType && (canEditRow(row.plugin) || canDeleteRow(row.plugin))"
           class="plugin-more-action-cell"
           data-testid="plugin-catalog-list-view-more-actions"
         >
@@ -74,15 +74,17 @@
           >
             <template #items>
               <KDropdownItem
+                v-if="canEditRow(row.plugin)"
                 data-testid="edit-plugin-schema"
-                :item="{ label: t('actions.edit'), to: (config as KonnectPluginSelectConfig).getCustomEditRoute?.(row.plugin!.name, row.plugin!.customPluginType!) }"
+                :item="{ label: t('actions.edit'), to: props.config.getCustomEditRoute?.(row.plugin!.name, row.plugin!.customPluginType!) }"
               >
                 {{ t('actions.edit') }}
               </KDropdownItem>
               <KDropdownItem
+                v-if="canDeleteRow(row.plugin)"
                 danger
                 data-testid="delete-plugin-schema"
-                has-divider
+                :has-divider="canEditRow(row.plugin)"
                 @click="() => handleCustomPluginDelete(row.plugin!)"
               >
                 {{ t('actions.delete') }}
@@ -107,7 +109,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, inject, ref, watch } from 'vue'
+import type { ComputedRef } from 'vue'
 import composables from '../../composables'
 import { MoreIcon } from '@kong/icons'
 import DeleteCustomPluginSchemaModal from '../custom-plugins/DeleteCustomPluginSchemaModal.vue'
@@ -119,7 +122,9 @@ import type {
   KongManagerPluginSelectConfig,
   KonnectPluginSelectConfig,
   PluginCardList,
+  PluginCatalogPermissions,
 } from '../../types'
+import { PLUGIN_CATALOG_PERMISSIONS_KEY } from '../../constants'
 
 interface TableSortPayload {
   prevKey: string
@@ -139,9 +144,37 @@ const props = defineProps<{
 
 const { i18n: { t } } = composables.useI18n()
 
+const DEFAULT_PERMISSIONS: PluginCatalogPermissions = {
+  canReadCustomPlugin: true,
+  canUpdateCustomPlugin: true,
+  canDeleteCustomPlugin: true,
+  canReadClonedPlugin: true,
+  canUpdateClonedPlugin: true,
+  canDeleteClonedPlugin: true,
+}
+const injectedPerms = inject<ComputedRef<PluginCatalogPermissions>>(PLUGIN_CATALOG_PERMISSIONS_KEY)
+const permissions = computed(() => injectedPerms?.value ?? DEFAULT_PERMISSIONS)
+
+const isClonedType = (type?: string) => type === 'cloned' || type === 'schema'
+const canEditRow = (plugin?: PluginType | null): boolean => {
+  if (!plugin?.customPluginType) return false
+  // schema plugins in KM are installed plugins — not manageable, no RBAC control
+  if (props.config.app === 'kongManager' && plugin.customPluginType === 'schema') return false
+  return isClonedType(plugin.customPluginType)
+    ? permissions.value.canUpdateClonedPlugin
+    : permissions.value.canUpdateCustomPlugin
+}
+const canDeleteRow = (plugin?: PluginType | null): boolean => {
+  if (!plugin?.customPluginType) return false
+  // schema plugins in KM are installed plugins — not manageable, no RBAC control
+  if (props.config.app === 'kongManager' && plugin.customPluginType === 'schema') return false
+  return isClonedType(plugin.customPluginType)
+    ? permissions.value.canDeleteClonedPlugin
+    : permissions.value.canDeleteCustomPlugin
+}
 
 const showMoreActions = computed(() => {
-  return paginatedData.value.some(row => Boolean(row.plugin?.customPluginType))
+  return paginatedData.value.some(row => Boolean(row.plugin?.customPluginType) && (canEditRow(row.plugin) || canDeleteRow(row.plugin)))
 })
 
 const headers = computed(() => {

--- a/packages/entities/entities-plugins/src/constants/index.ts
+++ b/packages/entities/entities-plugins/src/constants/index.ts
@@ -10,4 +10,6 @@ export const FEATURE_FLAGS = {
 
 export const TOASTER_PROVIDER = Symbol('TOASTER_PROVIDER')
 
+export const PLUGIN_CATALOG_PERMISSIONS_KEY = Symbol('plugin-catalog-permissions')
+
 export const FREE_FORM_SCHEMA_MAP_KEY = '__FREEFORM_SCHEMA_MAP__'

--- a/packages/entities/entities-plugins/src/types/plugin.ts
+++ b/packages/entities/entities-plugins/src/types/plugin.ts
@@ -187,4 +187,13 @@ export interface ClonedPluginSchema {
   tags?: string[] | null
 }
 
+export interface PluginCatalogPermissions {
+  canReadCustomPlugin: boolean
+  canUpdateCustomPlugin: boolean
+  canDeleteCustomPlugin: boolean
+  canReadClonedPlugin: boolean
+  canUpdateClonedPlugin: boolean
+  canDeleteClonedPlugin: boolean
+}
+
 export { PluginGroup, PluginScope }


### PR DESCRIPTION
## Summary

Kong Manager's PluginCatalog previously rendered all available plugins without awareness of KM-specific custom plugin types (streaming schemas and cloned pre-functions). This PR wires KM's cloned and streaming custom plugin support into PluginCatalog, adds RBAC permission gating throughout, and introduces the `showFeaturedGroup` prop so KM can opt out of the Konnect-only Featured filter panel.

## What changed

**`PluginCatalog.vue`**

- `showFeaturedGroup` prop (default `true`) — KM passes `false` to suppress the Featured filter collapse
- `ignoredPlugins` prop — array of plugin IDs to exclude from the catalog entirely
- RBAC props: `canRead/Update/DeleteCustomPlugin` and `canRead/Update/DeleteClonedPlugin`; published via `PLUGIN_CATALOG_PERMISSIONS_KEY` so descendant cards can consume them without prop-drilling
- Injects `FEATURE_FLAGS.KM_2485_CLONED_PLUGINS` (boolean, default `false`) to gate cloned-plugin fetching — KM provides `true` from `Select.vue`
- Fetches cloned plugins from `/cloned-plugins` using `fetchAllPages` when the flag is on and the user has read permission; coexists with the existing streaming custom plugin fetch
- Shows a `KAlert` warning (`.custom-plugins-warning`) when either custom-plugin list returns a non-404 error, without blocking the rest of the catalog

**`PluginCatalogCard.vue`**

- Overflow actions menu (edit schema / delete schema) is now shown for custom plugin types and gated by `canUpdate`/`canDelete` from the injected permissions key
- Displays a "Cloned from: `{ref}`" badge (`.cloned-from-badge`) for cloned plugin entries

**`PluginCatalogListView.vue`** — list-view row renders the same RBAC-gated overflow actions as the card grid

**`constants/index.ts`** — exports `FEATURE_FLAGS.KM_2485_CLONED_PLUGINS` and `PLUGIN_CATALOG_PERMISSIONS_KEY`

**`types/plugin.ts`** — adds `PluginCatalogPermissions` type and `ClonedPluginSchema` interface

## Tests

Added a `<PluginCatalog /> Kong Manager` Cypress component test suite covering:

- Basic KM render with `showFeaturedGroup=false` (filter panel and Featured group hidden)
- Cloned plugins appear in Custom Plugins group with the cloned-from badge
- Streaming plugins appear in Custom Plugins group
- Overflow actions menu is accessible and routes to edit/delete
- Delete confirmation modal flow
- Schema-type plugins with `canUpdate=false` hide overflow actions
- `ignoredPlugins` prop filters plugins from the grid
- Warning alert renders when the custom-plugins API returns 500
- RBAC: `canUpdate=false` / `canDelete=false` hide overflow actions
