### PR TITLE
feat(entities-plugins): add milestone grouping to ff-migration-report

### DIFF
--- a/packages/entities/entities-plugins/docs/ff-migration-report.md
+++ b/packages/entities/entities-plugins/docs/ff-migration-report.md
@@ -3,11 +3,12 @@
 > ⚠️ **Auto-generated — do not edit manually.**
 > To regenerate: `pnpm --filter @kong-ui-public/entities-plugins report:ff-migration`
 >
-> Generated: 2026-05-21T09:01:29.186Z
+> Generated: 2026-05-28T09:39:24.015Z
 
 ## Summary
 
-`██████████░░░░░░░░░░░░░░░░░░░░` **33%**
+`█████▓▓▒▒▒░░░░░░░░░░░░░` **33%**
+> █ complete · ▓ ready for release · ▒ in progress · ░ not started
 
 | Metric | Count |
 |--------|-------|
@@ -15,125 +16,256 @@
 | ✅ Migrated | **37** |
 | ⏳ Pending | **76** |
 
----
+### Milestone Status
 
-## ✅ Migrated (37)
-
-- acl
-- ai-custom-guardrail
-- ai-mcp-proxy
-- aws-lambda
-- basic-auth
-- correlation-id
-- cors
-- datakit
-- exit-transformer
-- file-log
-- header-cert-auth
-- http-log
-- jwe-decrypt
-- jwt
-- jwt-signer
-- key-auth
-- metering-and-billing
-- mtls-auth
-- oauth2
-- opentelemetry
-- prometheus
-- proxy-cache
-- proxy-cache-advanced
-- rate-limiting
-- rate-limiting-advanced
-- request-callout
-- request-transformer
-- request-transformer-advanced
-- response-transformer
-- response-transformer-advanced
-- route-transformer-advanced
-- service-protection
-- session
-- solace-consume
-- solace-log
-- solace-upstream
-- upstream-oauth
+| Status | Count |
+|--------|-------|
+| ✅ Complete | **5** |
+| 🚀 Ready for Release | **2** |
+| 🔄 In Progress | **3** |
+| ⏸️ Not Started | **13** |
 
 ---
 
-## ⏳ Pending (76)
+## Milestones
 
-- ace
-- acme
-- ai-a2a-proxy
-- ai-aws-guardrails
-- ai-azure-content-safety
-- ai-gcp-model-armor
-- ai-lakera-guard
-- ai-llm-as-judge
-- ai-mcp-oauth2
-- ai-prompt-compressor
-- ai-prompt-decorator
-- ai-prompt-guard
-- ai-prompt-template
-- ai-proxy
-- ai-proxy-advanced
-- ai-rag-injector
-- ai-rate-limiting-advanced
-- ai-request-transformer
-- ai-response-transformer
-- ai-sanitizer
-- ai-semantic-cache
-- ai-semantic-prompt-guard
-- ai-semantic-response-guard
-- app-dynamics
-- azure-functions
-- bot-detection
-- canary
-- confluent
-- confluent-consume
-- datadog
-- degraphql
-- forward-proxy
-- graphql-proxy-cache-advanced
-- graphql-rate-limiting-advanced
-- grpc-gateway
-- grpc-web
-- hmac-auth
-- injection-protection
-- ip-restriction
-- jq
-- json-threat-protection
-- kafka-consume
-- kafka-log
-- kafka-upstream
-- key-auth-enc
-- ldap-auth
-- ldap-auth-advanced
-- loggly
-- mocking
-- oas-validation
-- oauth2-introspection
-- opa
-- openid-connect
-- openwhisk
-- post-function
-- pre-function
-- redirect
-- request-size-limiting
-- request-termination
-- request-validator
-- response-ratelimiting
-- route-by-header
-- saml
-- standard-webhooks
-- statsd
-- syslog
-- tcp-log
-- tls-handshake-modifier
-- tls-metadata-headers
-- udp-log
-- upstream-timeout
-- vault-auth
-- websocket-size-limit
-- websocket-validator
-- xml-threat-protection
-- zipkin
+<details>
+<summary><strong>✅ M1 — Key Auth, Rate Limiting & Core Transformations — Complete (7/7)</strong></summary>
+
+- ✅ `key-auth`
+- ✅ `rate-limiting`
+- ✅ `jwt`
+- ✅ `route-transformer-advanced`
+- ✅ `request-transformer`
+- ✅ `basic-auth`
+- ✅ `upstream-oauth`
+
+</details>
+
+---
+
+<details>
+<summary><strong>✅ M2 — CORS, ACL & Proxy Cache — Complete (5/5)</strong></summary>
+
+- ✅ `cors`
+- ✅ `acl`
+- ✅ `proxy-cache`
+- ✅ `proxy-cache-advanced`
+- ✅ `response-transformer`
+
+</details>
+
+---
+
+### ⏸️ M3 — AI Proxy Core — Not Started (0/5)
+
+- ⏳ `ai-proxy-advanced`
+- ⏳ `ai-proxy`
+- ⏳ `ai-prompt-decorator`
+- ⏳ `ai-prompt-guard`
+- ⏳ `ai-rate-limiting-advanced`
+
+---
+
+<details>
+<summary><strong>✅ M4 — Analytics & Monitoring Core — Complete (5/5)</strong></summary>
+
+- ✅ `prometheus`
+- ✅ `file-log`
+- ✅ `http-log`
+- ✅ `correlation-id`
+- ✅ `opentelemetry`
+
+</details>
+
+---
+
+<details>
+<summary><strong>✅ M5 — Advanced Transformations & Serverless — Complete (4/4)</strong></summary>
+
+- ✅ `request-transformer-advanced`
+- ✅ `response-transformer-advanced`
+- ✅ `aws-lambda`
+- ✅ `exit-transformer`
+
+</details>
+
+---
+
+### ⏸️ M6 — Security & Serverless Functions — Not Started (0/5)
+
+- ⏳ `pre-function`
+- ⏳ `ip-restriction`
+- ⏳ `post-function`
+- ⏳ `bot-detection`
+- ⏳ `request-size-limiting`
+
+---
+
+### ⏸️ M7 — AI Semantic & Transformers — Not Started (0/5)
+
+- ⏳ `ai-semantic-cache`
+- ⏳ `ai-prompt-template`
+- ⏳ `ai-semantic-prompt-guard`
+- ⏳ `ai-request-transformer`
+- ⏳ `ai-response-transformer`
+
+---
+
+### 🚀 M8 — JWT Signer, Datakit & Advanced Plugins — Ready for Release (5/5)
+
+- ✅ `jwt-signer`
+- ✅ `datakit`
+- ✅ `request-callout`
+- ✅ `ai-mcp-proxy`
+- ✅ `service-protection`
+
+---
+
+<details>
+<summary><strong>✅ M9 — Solace Integration — Complete (3/3)</strong></summary>
+
+- ✅ `solace-consume`
+- ✅ `solace-log`
+- ✅ `solace-upstream`
+
+</details>
+
+---
+
+### 🚀 M10 — Auth & Session — Ready for Release (5/5)
+
+- ✅ `header-cert-auth`
+- ✅ `jwe-decrypt`
+- ✅ `mtls-auth`
+- ✅ `oauth2`
+- ✅ `session`
+
+---
+
+### 🔄 M11 — Traffic Control: Rate Limiting — In Progress (1/5)
+
+- ✅ `rate-limiting-advanced`
+- ⏳ `response-ratelimiting`
+- ⏳ `graphql-rate-limiting-advanced`
+- ⏳ `redirect`
+- ⏳ `request-termination`
+
+---
+
+### ⏸️ M12 — Traffic Control: Validation & Routing — Not Started (0/5)
+
+- ⏳ `request-validator`
+- ⏳ `canary`
+- ⏳ `mocking`
+- ⏳ `oas-validation`
+- ⏳ `route-by-header`
+
+---
+
+### ⏸️ M13 — Traffic Control: WebSocket & Timeouts — Not Started (0/5)
+
+- ⏳ `websocket-size-limit`
+- ⏳ `websocket-validator`
+- ⏳ `xml-threat-protection`
+- ⏳ `upstream-timeout`
+- ⏳ `forward-proxy`
+
+---
+
+### ⏸️ M14 — Traffic Control: Messaging & Access — Not Started (0/5)
+
+- ⏳ `ace`
+- ⏳ `confluent-consume`
+- ⏳ `kafka-consume`
+- ⏳ `standard-webhooks`
+- ⏳ `graphql-proxy-cache-advanced`
+
+---
+
+### 🔄 M15 — Analytics, Monitoring & Monetization — In Progress (1/5)
+
+- ⏳ `app-dynamics`
+- ⏳ `datadog`
+- ⏳ `statsd`
+- ⏳ `zipkin`
+- ✅ `metering-and-billing`
+
+---
+
+### ⏸️ M16 — Authentication: Extended Methods — Not Started (0/5)
+
+- ⏳ `hmac-auth`
+- ⏳ `key-auth-enc`
+- ⏳ `ldap-auth`
+- ⏳ `ldap-auth-advanced`
+- ⏳ `oauth2-introspection`
+
+---
+
+### ⏸️ M17 — Authentication: OpenID & Enterprise — Not Started (0/3)
+
+- ⏳ `openid-connect`
+- ⏳ `saml`
+- ⏳ `vault-auth`
+
+---
+
+### ⏸️ M18 — Logging — Not Started (0/5)
+
+- ⏳ `kafka-log`
+- ⏳ `loggly`
+- ⏳ `syslog`
+- ⏳ `tcp-log`
+- ⏳ `udp-log`
+
+---
+
+### ⏸️ M19 — Security — Not Started (0/6)
+
+- ⏳ `acme`
+- ⏳ `injection-protection`
+- ⏳ `json-threat-protection`
+- ⏳ `opa`
+- ⏳ `tls-handshake-modifier`
+- ⏳ `tls-metadata-headers`
+
+---
+
+### ⏸️ M20 — Transformations & Serverless — Not Started (0/4)
+
+- ⏳ `confluent`
+- ⏳ `degraphql`
+- ⏳ `grpc-gateway`
+- ⏳ `grpc-web`
+
+---
+
+### ⏸️ M21 — Transformations & Serverless (cont.) — Not Started (0/4)
+
+- ⏳ `jq`
+- ⏳ `kafka-upstream`
+- ⏳ `azure-functions`
+- ⏳ `openwhisk`
+
+---
+
+### 🔄 M22 — AI: Guardrails — In Progress (1/5)
+
+- ⏳ `ai-a2a-proxy`
+- ⏳ `ai-aws-guardrails`
+- ⏳ `ai-azure-content-safety`
+- ✅ `ai-custom-guardrail`
+- ⏳ `ai-gcp-model-armor`
+
+---
+
+### ⏸️ M23 — AI: Advanced Safety & RAG — Not Started (0/7)
+
+- ⏳ `ai-llm-as-judge`
+- ⏳ `ai-lakera-guard`
+- ⏳ `ai-mcp-oauth2`
+- ⏳ `ai-sanitizer`
+- ⏳ `ai-prompt-compressor`
+- ⏳ `ai-rag-injector`
+- ⏳ `ai-semantic-response-guard`

--- a/packages/entities/entities-plugins/docs/ff-migration-report.md
+++ b/packages/entities/entities-plugins/docs/ff-migration-report.md
@@ -3,11 +3,11 @@
 > ⚠️ **Auto-generated — do not edit manually.**
 > To regenerate: `pnpm --filter @kong-ui-public/entities-plugins report:ff-migration`
 >
-> Generated: 2026-05-28T09:39:24.015Z
+> Generated: 2026-05-28T09:48:22.547Z
 
 ## Summary
 
-`█████▓▓▒▒▒░░░░░░░░░░░░░` **33%**
+`██████▓▒▒▒░░░░░░░░░░░░░` **33%**
 > █ complete · ▓ ready for release · ▒ in progress · ░ not started
 
 | Metric | Count |
@@ -20,8 +20,8 @@
 
 | Status | Count |
 |--------|-------|
-| ✅ Complete | **5** |
-| 🚀 Ready for Release | **2** |
+| ✅ Complete | **6** |
+| 🚀 Ready for Release | **1** |
 | 🔄 In Progress | **3** |
 | ⏸️ Not Started | **13** |
 
@@ -112,13 +112,16 @@
 
 ---
 
-### 🚀 M8 — JWT Signer, Datakit & Advanced Plugins — Ready for Release (5/5)
+<details>
+<summary><strong>✅ M8 — JWT Signer, Datakit & Advanced Plugins — Complete (5/5)</strong></summary>
 
 - ✅ `jwt-signer`
 - ✅ `datakit`
 - ✅ `request-callout`
 - ✅ `ai-mcp-proxy`
 - ✅ `service-protection`
+
+</details>
 
 ---
 

--- a/packages/entities/entities-plugins/scripts/ff-migration-report.mjs
+++ b/packages/entities/entities-plugins/scripts/ff-migration-report.mjs
@@ -8,6 +8,191 @@ const PLUGINS_DIR = resolve(__dirname, '../src/components/free-form/plugins')
 const OUTPUT_PATH = resolve(__dirname, '../docs/ff-migration-report.md')
 const API_URL = 'https://developer.konghq.com/plugins/'
 
+// ============================================================
+// MANUAL CONFIGURATION
+// ============================================================
+
+/**
+ * Milestone definitions. Each milestone groups a set of plugin slugs.
+ *
+ * M1–M10 are predefined by the team.
+ * M11+ are grouped by category from developer.konghq.com/plugins/.
+ * Plugins not listed in any milestone are shown in "Uncategorized".
+ *
+ * Rule: max 5 plugins per milestone (enforced for M11+).
+ *
+ * @type {Array<{ id: string, name: string, plugins: string[] }>}
+ */
+const MILESTONES = [
+  // ── M1–M10: team-defined ──────────────────────────────────
+  {
+    id: 'M1',
+    name: 'M1 — Key Auth, Rate Limiting & Core Transformations',
+    plugins: ['key-auth', 'rate-limiting', 'jwt', 'route-transformer-advanced', 'request-transformer', 'basic-auth', 'upstream-oauth'],
+  },
+  {
+    id: 'M2',
+    name: 'M2 — CORS, ACL & Proxy Cache',
+    plugins: ['cors', 'acl', 'proxy-cache', 'proxy-cache-advanced', 'response-transformer'],
+  },
+  {
+    id: 'M3',
+    name: 'M3 — AI Proxy Core',
+    plugins: ['ai-proxy-advanced', 'ai-proxy', 'ai-prompt-decorator', 'ai-prompt-guard', 'ai-rate-limiting-advanced'],
+  },
+  {
+    id: 'M4',
+    name: 'M4 — Analytics & Monitoring Core',
+    plugins: ['prometheus', 'file-log', 'http-log', 'correlation-id', 'opentelemetry'],
+  },
+  {
+    id: 'M5',
+    name: 'M5 — Advanced Transformations & Serverless',
+    plugins: ['request-transformer-advanced', 'response-transformer-advanced', 'aws-lambda', 'exit-transformer'],
+  },
+  {
+    id: 'M6',
+    name: 'M6 — Security & Serverless Functions',
+    plugins: ['pre-function', 'ip-restriction', 'post-function', 'bot-detection', 'request-size-limiting'],
+  },
+  {
+    id: 'M7',
+    name: 'M7 — AI Semantic & Transformers',
+    plugins: ['ai-semantic-cache', 'ai-prompt-template', 'ai-semantic-prompt-guard', 'ai-request-transformer', 'ai-response-transformer'],
+  },
+  {
+    id: 'M8',
+    name: 'M8 — JWT Signer, Datakit & Advanced Plugins',
+    plugins: ['jwt-signer', 'datakit', 'request-callout', 'ai-mcp-proxy', 'service-protection'],
+  },
+  {
+    id: 'M9',
+    name: 'M9 — Solace Integration',
+    plugins: ['solace-consume', 'solace-log', 'solace-upstream'],
+  },
+  {
+    id: 'M10',
+    name: 'M10 — Auth & Session',
+    plugins: ['header-cert-auth', 'jwe-decrypt', 'mtls-auth', 'oauth2', 'session'],
+  },
+
+  // ── Traffic Control ───────────────────────────────────────
+  {
+    id: 'M11',
+    name: 'M11 — Traffic Control: Rate Limiting',
+    plugins: ['rate-limiting-advanced', 'response-ratelimiting', 'graphql-rate-limiting-advanced', 'redirect', 'request-termination'],
+  },
+  {
+    id: 'M12',
+    name: 'M12 — Traffic Control: Validation & Routing',
+    plugins: ['request-validator', 'canary', 'mocking', 'oas-validation', 'route-by-header'],
+  },
+  {
+    id: 'M13',
+    name: 'M13 — Traffic Control: WebSocket & Timeouts',
+    plugins: ['websocket-size-limit', 'websocket-validator', 'xml-threat-protection', 'upstream-timeout', 'forward-proxy'],
+  },
+  {
+    id: 'M14',
+    name: 'M14 — Traffic Control: Messaging & Access',
+    plugins: ['ace', 'confluent-consume', 'kafka-consume', 'standard-webhooks', 'graphql-proxy-cache-advanced'],
+  },
+
+  // ── Analytics & Monitoring + Monetization ────────────────
+  {
+    id: 'M15',
+    name: 'M15 — Analytics, Monitoring & Monetization',
+    plugins: ['app-dynamics', 'datadog', 'statsd', 'zipkin', 'metering-and-billing'],
+  },
+
+  // ── Authentication ────────────────────────────────────────
+  {
+    id: 'M16',
+    name: 'M16 — Authentication: Extended Methods',
+    plugins: ['hmac-auth', 'key-auth-enc', 'ldap-auth', 'ldap-auth-advanced', 'oauth2-introspection'],
+  },
+  {
+    id: 'M17',
+    name: 'M17 — Authentication: OpenID & Enterprise',
+    plugins: ['openid-connect', 'saml', 'vault-auth'],
+  },
+
+  // ── Logging ───────────────────────────────────────────────
+  {
+    id: 'M18',
+    name: 'M18 — Logging',
+    plugins: ['kafka-log', 'loggly', 'syslog', 'tcp-log', 'udp-log'],
+  },
+
+  // ── Security ──────────────────────────────────────────────
+  {
+    id: 'M19',
+    name: 'M19 — Security',
+    plugins: ['acme', 'injection-protection', 'json-threat-protection', 'opa', 'tls-handshake-modifier', 'tls-metadata-headers'],
+  },
+
+  // ── Transformations & Serverless ─────────────────────────
+  {
+    id: 'M20',
+    name: 'M20 — Transformations & Serverless',
+    plugins: ['confluent', 'degraphql', 'grpc-gateway', 'grpc-web'],
+  },
+  {
+    id: 'M21',
+    name: 'M21 — Transformations & Serverless (cont.)',
+    plugins: ['jq', 'kafka-upstream', 'azure-functions', 'openwhisk'],
+  },
+
+  // ── AI ────────────────────────────────────────────────────
+  {
+    id: 'M22',
+    name: 'M22 — AI: Guardrails',
+    plugins: ['ai-a2a-proxy', 'ai-aws-guardrails', 'ai-azure-content-safety', 'ai-custom-guardrail', 'ai-gcp-model-armor'],
+  },
+  {
+    id: 'M23',
+    name: 'M23 — AI: Advanced Safety & RAG',
+    plugins: ['ai-llm-as-judge', 'ai-lakera-guard', 'ai-mcp-oauth2', 'ai-sanitizer', 'ai-prompt-compressor', 'ai-rag-injector', 'ai-semantic-response-guard'],
+  },
+]
+
+/**
+ * Milestone IDs that have been deployed to production (Complete status).
+ * Add a milestone ID here once it has been released.
+ *
+ * @type {Set<string>}
+ */
+const RELEASED_MILESTONES = new Set([
+  'M1', // key-auth, rate-limiting, jwt, route-transformer-advanced, request-transformer, basic-auth, upstream-oauth
+  'M2', // cors, acl, proxy-cache, proxy-cache-advanced, response-transformer
+  'M4', // prometheus, file-log, http-log, correlation-id, opentelemetry
+  'M5', // request-transformer-advanced, response-transformer-advanced, aws-lambda, exit-transformer
+  'M9', // solace-consume, solace-log, solace-upstream
+])
+
+// ============================================================
+
+const STATUS = /** @type {const} */ ({
+  COMPLETE: 'Complete',
+  READY: 'Ready for Release',
+  IN_PROGRESS: 'In Progress',
+  NOT_STARTED: 'Not Started',
+})
+
+const STATUS_EMOJI = {
+  [STATUS.COMPLETE]: '✅',
+  [STATUS.READY]: '🚀',
+  [STATUS.IN_PROGRESS]: '🔄',
+  [STATUS.NOT_STARTED]: '⏸️',
+}
+
+function getMilestoneStatus(milestone, localSlugs) {
+  const migratedCount = milestone.plugins.filter(p => localSlugs.has(p)).length
+  if (migratedCount === 0) return STATUS.NOT_STARTED
+  if (migratedCount < milestone.plugins.length) return STATUS.IN_PROGRESS
+  return RELEASED_MILESTONES.has(milestone.id) ? STATUS.COMPLETE : STATUS.READY
+}
+
 // --- Fetch Kong Inc plugin slugs from developer.konghq.com ---
 async function fetchKongIncPlugins() {
   const res = await fetch(API_URL)
@@ -44,16 +229,68 @@ function readLocalPlugins() {
 
 // --- Generate Markdown report ---
 function buildReport(kongPlugins, localSlugs) {
-  const migrated = kongPlugins.filter(s => localSlugs.has(s))
-  const pending = kongPlugins.filter(s => !localSlugs.has(s))
-  const pct = Math.round((migrated.length / kongPlugins.length) * 100)
+  const kongPluginSet = new Set(kongPlugins)
 
-  const BAR_WIDTH = 30
-  const filled = Math.round(pct / 100 * BAR_WIDTH)
-  const bar = '█'.repeat(filled) + '░'.repeat(BAR_WIDTH - filled)
+  // Plugins on Kong website not assigned to any configured milestone → Uncategorized
+  const configuredPlugins = new Set(MILESTONES.flatMap(m => m.plugins))
+  const uncategorized = kongPlugins.filter(p => !configuredPlugins.has(p))
 
-  const migratedList = migrated.map(s => `- ${s}`).join('\n')
-  const pendingList = pending.map(s => `- ${s}`).join('\n')
+  const allMilestones = [...MILESTONES]
+  if (uncategorized.length > 0) {
+    allMilestones.push({
+      id: 'Uncategorized',
+      name: 'Uncategorized',
+      plugins: uncategorized,
+    })
+  }
+
+  const milestonesWithStatus = allMilestones.map(m => ({
+    ...m,
+    status: getMilestoneStatus(m, localSlugs),
+    migratedCount: m.plugins.filter(p => localSlugs.has(p)).length,
+  }))
+
+  // Overall progress
+  const totalPlugins = kongPlugins.length
+  const totalMigrated = kongPlugins.filter(p => localSlugs.has(p)).length
+  const pct = Math.round((totalMigrated / totalPlugins) * 100)
+
+  // Count milestones by status
+  const statusCounts = Object.fromEntries(Object.values(STATUS).map(s => [s, 0]))
+  for (const m of milestonesWithStatus) statusCounts[m.status]++
+
+  const STATUS_ORDER = { [STATUS.COMPLETE]: 0, [STATUS.READY]: 1, [STATUS.IN_PROGRESS]: 2, [STATUS.NOT_STARTED]: 3 }
+  const STATUS_CHAR = {
+    [STATUS.COMPLETE]: '█',
+    [STATUS.READY]: '▓',
+    [STATUS.IN_PROGRESS]: '▒',
+    [STATUS.NOT_STARTED]: '░',
+  }
+  const bar = [...milestonesWithStatus]
+    .sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status])
+    .map(m => STATUS_CHAR[m.status])
+    .join('')
+
+  // Build per-milestone markdown sections
+  const milestoneSections = milestonesWithStatus.map((m) => {
+    const emoji = STATUS_EMOJI[m.status]
+    const heading = `${emoji} ${m.name} — ${m.status} (${m.migratedCount}/${m.plugins.length})`
+
+    const pluginList = m.plugins
+      .map((p) => {
+        const migrated = localSlugs.has(p)
+        const inKong = kongPluginSet.has(p)
+        const suffix = inKong ? '' : ' ⚠️ *(not found on Kong Inc website)*'
+        return `- ${migrated ? '✅' : '⏳'} \`${p}\`${suffix}`
+      })
+      .join('\n')
+
+    // Complete milestones are collapsed by default
+    if (m.status === STATUS.COMPLETE) {
+      return `<details>\n<summary><strong>${heading}</strong></summary>\n\n${pluginList}\n\n</details>`
+    }
+    return `### ${heading}\n\n${pluginList}`
+  }).join('\n\n---\n\n')
 
   return `# Free-form Plugin Migration Report
 
@@ -65,24 +302,28 @@ function buildReport(kongPlugins, localSlugs) {
 ## Summary
 
 \`${bar}\` **${pct}%**
+> █ complete · ▓ ready for release · ▒ in progress · ░ not started
 
 | Metric | Count |
 |--------|-------|
-| 📦 Total Kong Inc plugins | **${kongPlugins.length}** |
-| ✅ Migrated | **${migrated.length}** |
-| ⏳ Pending | **${pending.length}** |
+| 📦 Total Kong Inc plugins | **${totalPlugins}** |
+| ✅ Migrated | **${totalMigrated}** |
+| ⏳ Pending | **${totalPlugins - totalMigrated}** |
+
+### Milestone Status
+
+| Status | Count |
+|--------|-------|
+| ✅ Complete | **${statusCounts[STATUS.COMPLETE]}** |
+| 🚀 Ready for Release | **${statusCounts[STATUS.READY]}** |
+| 🔄 In Progress | **${statusCounts[STATUS.IN_PROGRESS]}** |
+| ⏸️ Not Started | **${statusCounts[STATUS.NOT_STARTED]}** |
 
 ---
 
-## ✅ Migrated (${migrated.length})
+## Milestones
 
-${migratedList}
-
----
-
-## ⏳ Pending (${pending.length})
-
-${pendingList}
+${milestoneSections}
 `
 }
 
@@ -94,6 +335,6 @@ const report = buildReport(kongPlugins, localSlugs)
 mkdirSync(dirname(OUTPUT_PATH), { recursive: true })
 writeFileSync(OUTPUT_PATH, report, 'utf-8')
 
-const migrated = kongPlugins.filter(s => localSlugs.has(s))
+const totalMigrated = kongPlugins.filter(s => localSlugs.has(s)).length
 console.log(`Report written to ${OUTPUT_PATH}`)
-console.log(`Progress: ${migrated.length}/${kongPlugins.length} (${Math.round(migrated.length / kongPlugins.length * 100)}%)`)
+console.log(`Progress: ${totalMigrated}/${kongPlugins.length} (${Math.round(totalMigrated / kongPlugins.length * 100)}%)`)

--- a/packages/entities/entities-plugins/scripts/ff-migration-report.mjs
+++ b/packages/entities/entities-plugins/scripts/ff-migration-report.mjs
@@ -168,6 +168,7 @@ const RELEASED_MILESTONES = new Set([
   'M4', // prometheus, file-log, http-log, correlation-id, opentelemetry
   'M5', // request-transformer-advanced, response-transformer-advanced, aws-lambda, exit-transformer
   'M9', // solace-consume, solace-log, solace-upstream
+  'M8', // jwt-signer, datakit, request-callout, ai-mcp-proxy, service-protection
 ])
 
 // ============================================================


### PR DESCRIPTION
## In this PR:
- Group plugins by milestone (M23) in the migration reportM1
- M10: team-defined; M23: grouped by category from developer.konghq.comM11M1
- Each milestone shows status: Complete / Ready for Release / In Progress / Not Started
- Complete milestones are collapsed by default in the report
  not started)in        progress
- Bar is sorted by status for visual clarity
- Uncategorized section auto-captures any new plugins not yet assigned to a milestone
- Mark M1, M2, M4, M5, M9 as released (Complete)
<img width="2424" height="2502" alt="image" src="https://github.com/user-attachments/assets/87fde53c-0f9e-4670-a688-4f66e04bb07a" />
