### PR TITLE
feat(entities-plugins): migrate plugin to freeform M6

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -115,6 +115,7 @@ useProvideExperimentalFreeForms([
   'basic-auth',
   'key-auth',
   'pre-function',
+  'ip-restriction',
 ])
 
 const enableDeckConfigCustomization = ref(false)

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -116,6 +116,7 @@ useProvideExperimentalFreeForms([
   'key-auth',
   'pre-function',
   'ip-restriction',
+  'post-function',
 ])
 
 const enableDeckConfigCustomization = ref(false)

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -118,6 +118,7 @@ useProvideExperimentalFreeForms([
   'ip-restriction',
   'post-function',
   'bot-detection',
+  'request-size-limiting',
 ])
 
 const enableDeckConfigCustomization = ref(false)

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -114,6 +114,7 @@ useProvideExperimentalFreeForms([
   'mtls-auth',
   'basic-auth',
   'key-auth',
+  'pre-function',
 ])
 
 const enableDeckConfigCustomization = ref(false)

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -117,6 +117,7 @@ useProvideExperimentalFreeForms([
   'pre-function',
   'ip-restriction',
   'post-function',
+  'bot-detection',
 ])
 
 const enableDeckConfigCustomization = ref(false)

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/bot-detection.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/bot-detection.ts
@@ -1,0 +1,5 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+
+export default definePluginConfig({
+  experimental: true,
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/ip-restriction.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/ip-restriction.ts
@@ -1,0 +1,5 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+
+export default definePluginConfig({
+  experimental: true,
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/post-function.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/post-function.ts
@@ -1,0 +1,24 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+import StringField from '../shared/StringField.vue'
+
+export default definePluginConfig({
+  experimental: true,
+  fieldRenderers: [
+    {
+      match: ({ genericPath }) => [
+        'config.access.*',
+        'config.body_filter.*',
+        'config.header_filter.*',
+        'config.certificate.*',
+        'config.functions.*',
+        'config.log.*',
+        'config.rewrite.*',
+      ].includes(genericPath),
+      component: StringField,
+      propsOverrides: {
+        multiline: true,
+        rows: 3,
+      },
+    },
+  ],
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/pre-function.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/pre-function.ts
@@ -1,0 +1,25 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+import StringField from '../shared/StringField.vue'
+
+const LUA_FUNCTION_FIELDS = [
+  'access',
+  'body_filter',
+  'certificate',
+  'functions',
+  'header_filter',
+  'log',
+  'rewrite',
+]
+
+export default definePluginConfig({
+  experimental: true,
+  fieldRenderers: LUA_FUNCTION_FIELDS.map((field) => ({
+    match: ({ genericPath }) => genericPath === `config.${field}.*`,
+    component: StringField,
+    propsOverrides: (props) => ({
+      ...props,
+      multiline: true,
+      rows: 3,
+    }),
+  })),
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/request-size-limiting.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/request-size-limiting.ts
@@ -1,0 +1,5 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+
+export default definePluginConfig({
+  experimental: true,
+})


### PR DESCRIPTION
## M6 — Security & Serverless Functions

This PR migrates the following plugins to the free-form plugin registry:

- `pre-function` (cherry-picked from #3301)
- `ip-restriction` (cherry-picked from #3337)
- `post-function` (cherry-picked from #3290)
- `bot-detection` (cherry-picked from #3306)
- `request-size-limiting` (cherry-picked from #3339)

Each plugin's free-form definition has been added under `src/components/free-form/plugins/`.