### PR TITLE
feat(entities-*): custom/cloned plugin permissions + View Configuration slideout

### DIFF
--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
@@ -569,7 +569,9 @@ const viewConfigFetchUrl = computed<string>(() => {
 
 const viewConfigRequestMethod = computed<'post' | 'put' | 'patch'>(() => {
   if (!editMode.value) return 'post'
-  return state.fields.pluginType === 'cloned' ? 'patch' : 'put'
+  if (state.fields.pluginType === 'cloned') return 'patch'
+  if (props.config.app === 'kongManager' && state.fields.pluginType === 'streamed') return 'patch'
+  return 'put'
 })
 
 const viewConfigDeckEntityType = computed<SupportedEntityType>(() => {

--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
@@ -1,12 +1,16 @@
 <template>
   <div class="kong-ui-entities-custom-plugin-form">
     <EntityBaseForm
+      ref="entityBaseFormRef"
       :can-submit="canSubmit"
       :config="config"
       :entity-type="SupportedEntityType.Plugin"
       :error-message="state.errorMessage"
-      :form-fields="state.fields"
+      :form-fields="viewConfigFormFields"
       :is-readonly="state.readonly"
+      :slideout-deck-entity-type="viewConfigDeckEntityType"
+      :slideout-fetch-url="viewConfigFetchUrl"
+      :slideout-request-method="viewConfigRequestMethod"
       @cancel="cancelHandler"
       @submit="submitData"
     >
@@ -410,6 +414,13 @@
           >
             {{ t('actions.cancel') }}
           </KButton>
+          <KButton
+            appearance="tertiary"
+            data-testid="custom-plugin-form-view-configuration"
+            @click="entityBaseFormRef?.viewConfig()"
+          >
+            {{ t('actions.view_configuration') }}
+          </KButton>
         </template>
         <span v-else />
       </template>
@@ -433,8 +444,9 @@ import { PluginIcon } from '@kong-ui-public/entities-plugins-icon'
 import composables from '../composables'
 import externalLinks from '../external-links'
 import { PLUGIN_METADATA } from '../definitions/metadata'
+import endpoints from '../plugins-endpoints'
 import '@kong-ui-public/entities-shared/dist/style.css'
-import type { PropType } from 'vue'
+import type { PropType, ComponentPublicInstance } from 'vue'
 import { computed, onMounted, provide, reactive, ref, watch } from 'vue'
 import type {
   ClonedPluginPayload,
@@ -524,6 +536,71 @@ const {
 
 // Force-enable the new plugin form layout
 provide(PLUGIN_FORM_LAYOUT_STATE, ref(true))
+
+const entityBaseFormRef = ref<ComponentPublicInstance & { viewConfig: () => void } | null>(null)
+
+const buildCustomPluginUrl = (template: string, pluginId?: string): string => {
+  const workspace = (props.config as KongManagerCustomPluginFormConfig).workspace ?? ''
+  const controlPlaneId = props.config.app === 'konnect'
+    ? (props.config as KonnectCustomPluginFormConfig).controlPlaneId
+    : ''
+  return `${props.config.apiBaseUrl}${template}`
+    .replace(/{controlPlaneId}/gi, controlPlaneId)
+    .replace(/{pluginId}/gi, pluginId ?? '')
+    .replace(/\/\{workspace\}/gi, workspace ? `/${workspace}` : '')
+}
+
+const viewConfigFetchUrl = computed<string>(() => {
+  const type = state.fields.pluginType
+  if (!type) return ''
+  const id = editMode.value ? props.pluginName : undefined
+  const key = id ? 'edit' : 'create'
+  const app = props.config.app
+  if (app === 'konnect') {
+    if (type === 'installed') return buildCustomPluginUrl(endpoints.customPlugin.konnect.installed[key], id)
+    if (type === 'streamed') return buildCustomPluginUrl(endpoints.customPlugin.konnect.streamed[key], id)
+    if (type === 'cloned') return buildCustomPluginUrl(endpoints.customPlugin.konnect.cloned[key], id)
+  } else {
+    if (type === 'streamed') return buildCustomPluginUrl(endpoints.customPlugin.kongManager.streamed[key], id)
+    if (type === 'cloned') return buildCustomPluginUrl(endpoints.customPlugin.kongManager.cloned[key], id)
+  }
+  return ''
+})
+
+const viewConfigRequestMethod = computed<'post' | 'put' | 'patch'>(() => {
+  if (!editMode.value) return 'post'
+  return state.fields.pluginType === 'cloned' ? 'patch' : 'put'
+})
+
+const viewConfigDeckEntityType = computed<SupportedEntityType>(() => {
+  switch (state.fields.pluginType) {
+    case 'installed': return SupportedEntityType.PluginSchema
+    case 'streamed': return SupportedEntityType.CustomPlugin
+    case 'cloned': return SupportedEntityType.ClonedPlugin
+    default: return SupportedEntityType.Plugin
+  }
+})
+
+const viewConfigFormFields = computed<Record<string, any>>(() => {
+  switch (state.fields.pluginType) {
+    case 'installed':
+      return { lua_schema: state.fields.schemaContent }
+    case 'streamed':
+      return {
+        name: state.fields.name,
+        schema: state.fields.schemaContent,
+        handler: state.fields.handlerContent,
+      }
+    case 'cloned':
+      return {
+        ref: state.fields.sourcePlugin,
+        name: state.fields.aliasName,
+        ...(state.fields.priority ? { priority: parseInt(state.fields.priority, 10) } : {}),
+      }
+    default:
+      return {}
+  }
+})
 
 const editMode = computed(() => !!props.pluginName)
 const isLoading = ref(false)

--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -76,7 +76,9 @@
             </p>
 
             <PluginSelectGrid
+              :can-delete-cloned-plugin="usercanDeleteClonedPlugin"
               :can-delete-custom-plugin="usercanDeleteCustomPlugin"
+              :can-edit-cloned-plugin="usercanEditClonedPlugin"
               :can-edit-custom-plugin="usercanEditCustomPlugin"
               :config="config"
               :hide-highlighted-plugins="filter.length > 0"
@@ -107,7 +109,9 @@
 
             <PluginCustomGrid
               :can-create-custom-plugin="usercanCreateCustomPlugin"
+              :can-delete-cloned-plugin="usercanDeleteClonedPlugin"
               :can-delete-custom-plugin="usercanDeleteCustomPlugin"
+              :can-edit-cloned-plugin="usercanEditClonedPlugin"
               :can-edit-custom-plugin="usercanEditCustomPlugin"
               :config="config"
               :navigate-on-click="navigateOnClick"
@@ -128,7 +132,9 @@
         />
 
         <PluginSelectGrid
+          :can-delete-cloned-plugin="usercanDeleteClonedPlugin"
           :can-delete-custom-plugin="usercanDeleteCustomPlugin"
+          :can-edit-cloned-plugin="usercanEditClonedPlugin"
           :can-edit-custom-plugin="usercanEditCustomPlugin"
           :config="config"
           :hide-highlighted-plugins="filter.length > 0"
@@ -202,11 +208,33 @@ const props = defineProps({
     required: false,
     default: async () => true,
   },
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can read custom plugin */
+  canReadCustomPlugin: {
+    type: Function as PropType<() => boolean | Promise<boolean>>,
+    required: false,
+    default: async () => true,
+  },
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can delete cloned plugin */
+  canDeleteClonedPlugin: {
+    type: Function as PropType<() => boolean | Promise<boolean>>,
+    required: false,
+  },
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can read cloned plugin */
+  canReadClonedPlugin: {
+    type: Function as PropType<() => boolean | Promise<boolean>>,
+    required: false,
+    default: async () => true,
+  },
   /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit custom plugin */
   canEditCustomPlugin: {
     type: Function as PropType<() => boolean | Promise<boolean>>,
     required: false,
     default: async () => true,
+  },
+  /** A synchronous or asynchronous function, that returns a boolean, that evaluates if the user can edit cloned plugin */
+  canEditClonedPlugin: {
+    type: Function as PropType<() => boolean | Promise<boolean>>,
+    required: false,
   },
   /**
    * @param {boolean} navigateOnClick if false, let consuming component handle event when clicking on a plugin
@@ -300,14 +328,6 @@ const customPluginsDisabled = computed(() => props.customPluginSupport === 'disa
 const hasCustomPluginSupport = computed(() => customPluginsDisabled.value || normalizedCustomPluginSupport.value.size > 0)
 const isStreamingCustomPluginSupported = computed(() => normalizedCustomPluginSupport.value.has('streaming'))
 const isClonedCustomPluginSupported = computed(() => normalizedCustomPluginSupport.value.has('cloned'))
-const shouldShowCreateCustomPluginCard = computed((): boolean => {
-  return props.config.app === 'kongManager'
-    && hasCustomPluginSupport.value
-    && !customPluginsDisabled.value
-    && usercanCreateCustomPlugin.value
-    && props.navigateOnClick
-    && !!props.config.createCustomRoute
-})
 
 const isRequestCancelled = (error: unknown): boolean => {
   return isAxiosError(error) && error.code === 'ERR_CANCELED'
@@ -332,17 +352,6 @@ const flattenPluginMap = computed(() => {
     }, {} as Record<string, PluginType>)
 })
 
-const createCustomPluginCard = computed((): PluginType => ({
-  id: 'custom-plugin-create',
-  name: t('plugins.select.tabs.custom.create.name'),
-  nameKey: 'plugins.select.tabs.custom.create.name',
-  description: t('plugins.select.tabs.custom.create.description'),
-  descriptionKey: 'plugins.select.tabs.custom.create.description',
-  available: true,
-  group: PluginGroup.CUSTOM_PLUGINS,
-  scope: [],
-}))
-
 const filteredPlugins = computed((): PluginCardList => {
   if (!pluginsList.value) {
     return {}
@@ -365,11 +374,6 @@ const filteredPlugins = computed((): PluginCardList => {
     } else {
       results[type] = matches
     }
-  }
-
-  if (shouldShowCreateCustomPluginCard.value && !query) {
-    const customPlugins = (results[PluginGroup.CUSTOM_PLUGINS] || []).filter((plugin: PluginType) => plugin.id !== createCustomPluginCard.value.id)
-    results[PluginGroup.CUSTOM_PLUGINS] = [createCustomPluginCard.value, ...customPlugins]
   }
 
   return results
@@ -524,23 +528,6 @@ const buildPluginList = (): PluginCardList => {
     }, {} as PluginCardList)
 }
 
-const injectKongManagerCreateCard = (list: PluginCardList): PluginCardList => {
-  if (!shouldShowCreateCustomPluginCard.value) {
-    return list
-  }
-
-  const customPlugins = list[PluginGroup.CUSTOM_PLUGINS] || []
-  const filteredCustomPlugins = customPlugins.filter((plugin) => plugin.id !== 'custom-plugin-create')
-
-  list[PluginGroup.CUSTOM_PLUGINS] = [createCustomPluginCard.value, ...filteredCustomPlugins]
-
-  return list
-}
-
-const buildPluginListWithCustomCreateCard = (): PluginCardList => {
-  return injectKongManagerCreateCard(buildPluginList())
-}
-
 const availablePluginsUrl = computed((): string => {
   let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].availablePlugins}`
 
@@ -610,13 +597,13 @@ const onTabsChange = (hash: string) => {
 // rebuild the list
 watch(() => props.disabledPlugins, (val, oldVal) => {
   if (!objectsAreEqual(val, oldVal) && !isLoading.value) {
-    pluginsList.value = buildPluginListWithCustomCreateCard()
+    pluginsList.value = buildPluginList()
   }
 })
 
 watch(() => props.ignoredPlugins, (val, oldVal) => {
   if (!objectsAreEqual(val, oldVal) && !isLoading.value) {
-    pluginsList.value = buildPluginListWithCustomCreateCard()
+    pluginsList.value = buildPluginList()
   }
 })
 
@@ -652,7 +639,7 @@ const loadEntityPlugins = async (signal?: AbortSignal): Promise<void> => {
 const loadCustomPlugins = async (signal?: AbortSignal): Promise<void> => {
   const requests: Array<Promise<void>> = []
 
-  if (streamingPluginsUrl.value) {
+  if (streamingPluginsUrl.value && usercanReadCustomPlugin.value) {
     requests.push(
       fetchAllPages<StreamingCustomPluginSchema>(axiosInstance, streamingPluginsUrl.value, signal)
         .then((plugins): void => {
@@ -671,7 +658,7 @@ const loadCustomPlugins = async (signal?: AbortSignal): Promise<void> => {
     )
   }
 
-  if (clonedPluginsUrl.value) {
+  if (clonedPluginsUrl.value && usercanReadClonedPlugin.value) {
     requests.push(
       fetchAllPages<ClonedPluginSchema>(axiosInstance, clonedPluginsUrl.value, signal)
         .then((plugins): void => {
@@ -724,7 +711,7 @@ const loadPlugins = async (): Promise<void> => {
     }
 
     await loadCustomPlugins(abortController.value.signal)
-    pluginsList.value = buildPluginListWithCustomCreateCard()
+    pluginsList.value = buildPluginList()
   } catch (error: any) {
     if (!isRequestCancelled(error)) {
       hasError.value = true
@@ -740,19 +727,45 @@ const loadPlugins = async (): Promise<void> => {
 const usercanCreateCustomPlugin = ref(false)
 const usercanEditCustomPlugin = ref(false)
 const usercanDeleteCustomPlugin = ref(false)
+const usercanReadCustomPlugin = ref(false)
+const usercanEditClonedPlugin = ref(false)
+const usercanDeleteClonedPlugin = ref(false)
+const usercanReadClonedPlugin = ref(false)
 
 const handleCustomPluginDeleteSuccess = (pluginName: string): void => {
   streamingCustomPlugins.value = streamingCustomPlugins.value.filter((plugin) => plugin.name !== pluginName)
   clonedCustomPlugins.value = clonedCustomPlugins.value.filter((plugin) => plugin.name !== pluginName)
-  pluginsList.value = buildPluginListWithCustomCreateCard()
+  pluginsList.value = buildPluginList()
   emit('delete-custom:success', pluginName)
 }
 
 onBeforeMount(async () => {
   // Evaluate the user permissions
-  usercanCreateCustomPlugin.value = await props.canCreateCustomPlugin()
-  usercanEditCustomPlugin.value = await props.canEditCustomPlugin()
-  usercanDeleteCustomPlugin.value = await props.canDeleteCustomPlugin()
+  const [
+    canCreateCustom,
+    canEditCustom,
+    canDeleteCustom,
+    canReadCustom,
+    canEditCloned,
+    canDeleteCloned,
+    canReadCloned,
+  ] = await Promise.all([
+    props.canCreateCustomPlugin(),
+    props.canEditCustomPlugin(),
+    props.canDeleteCustomPlugin(),
+    props.canReadCustomPlugin(),
+    props.canEditClonedPlugin ? props.canEditClonedPlugin() : Promise.resolve(null),
+    props.canDeleteClonedPlugin ? props.canDeleteClonedPlugin() : Promise.resolve(null),
+    props.canReadClonedPlugin(),
+  ])
+
+  usercanCreateCustomPlugin.value = canCreateCustom
+  usercanEditCustomPlugin.value = canEditCustom
+  usercanDeleteCustomPlugin.value = canDeleteCustom
+  usercanReadCustomPlugin.value = canReadCustom
+  usercanEditClonedPlugin.value = canEditCloned ?? canEditCustom
+  usercanDeleteClonedPlugin.value = canDeleteCloned ?? canDeleteCustom
+  usercanReadClonedPlugin.value = canReadCloned
 })
 
 const filterInput = useTemplateRef('filter-input')
@@ -779,12 +792,6 @@ watch(
     }
   },
 )
-
-watch(shouldShowCreateCustomPluginCard, () => {
-  if (!isLoading.value) {
-    pluginsList.value = buildPluginListWithCustomCreateCard()
-  }
-})
 
 onBeforeUnmount(() => {
   abortController.value?.abort()

--- a/packages/entities/entities-plugins/src/components/custom-plugins/PluginCustomGrid.vue
+++ b/packages/entities/entities-plugins/src/components/custom-plugins/PluginCustomGrid.vue
@@ -45,7 +45,9 @@
             v-for="(plugin, index) in modifiedCustomPlugins"
             :key="`plugin-card-${index}`"
             ref="pluginCardRef"
+            :can-delete-cloned-plugin="canDeleteClonedPlugin"
             :can-delete-custom-plugin="canDeleteCustomPlugin"
+            :can-edit-cloned-plugin="canEditClonedPlugin"
             :can-edit-custom-plugin="canEditCustomPlugin"
             :config="config"
             :navigate-on-click="navigateOnClick"
@@ -108,9 +110,23 @@ const props = defineProps({
     default: false,
   },
   /**
+   * Whether or not user has rights to delete cloned custom plugins
+   */
+  canDeleteClonedPlugin: {
+    type: Boolean,
+    default: false,
+  },
+  /**
    * Whether or not user has rights to edit custom plugins
    */
   canEditCustomPlugin: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Whether or not user has rights to edit cloned custom plugins
+   */
+  canEditClonedPlugin: {
     type: Boolean,
     default: false,
   },

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectCard.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectCard.vue
@@ -38,14 +38,14 @@
 
               <template #items>
                 <KDropdownItem
-                  v-if="canEditCustomPlugin && hasEditRoute"
+                  v-if="canEditCurrentPlugin && hasEditRoute"
                   data-testid="edit-plugin-schema"
                   @click.stop="handleCustomEdit(plugin.name, plugin.customPluginType!)"
                 >
                   {{ t('actions.edit') }}
                 </KDropdownItem>
                 <KDropdownItem
-                  v-if="canDeleteCustomPlugin"
+                  v-if="canDeleteCurrentPlugin"
                   danger
                   data-testid="delete-plugin-schema"
                   has-divider
@@ -147,9 +147,23 @@ const props = defineProps({
     default: false,
   },
   /**
+   * Whether or not user has rights to delete cloned custom plugins
+   */
+  canDeleteClonedPlugin: {
+    type: Boolean,
+    default: false,
+  },
+  /**
    * Whether or not user has rights to edit custom plugins
    */
   canEditCustomPlugin: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Whether or not user has rights to edit cloned custom plugins
+   */
+  canEditClonedPlugin: {
     type: Boolean,
     default: false,
   },
@@ -187,6 +201,13 @@ const customPluginBadges = computed((): string[] => {
 })
 const isDisabled = computed((): boolean => !!(!props.plugin.available || props.plugin.disabledMessage))
 const hasEditRoute = computed((): boolean => typeof props.config.getCustomEditRoute === 'function')
+const isClonedCustomPlugin = computed((): boolean => props.plugin.customPluginType === 'cloned')
+const canDeleteCurrentPlugin = computed((): boolean => {
+  return isClonedCustomPlugin.value ? props.canDeleteClonedPlugin : props.canDeleteCustomPlugin
+})
+const canEditCurrentPlugin = computed((): boolean => {
+  return isClonedCustomPlugin.value ? props.canEditClonedPlugin : props.canEditCustomPlugin
+})
 const canManageCustomPlugin = computed((): boolean => {
   return !(
     props.config.app === 'kongManager'
@@ -198,7 +219,7 @@ const hasActions = computed((): boolean => !!(
   && !isCreateCustomPlugin.value
   && canManageCustomPlugin.value
   && props.navigateOnClick
-  && (props.canDeleteCustomPlugin || (props.canEditCustomPlugin && hasEditRoute.value))
+  && (canDeleteCurrentPlugin.value || (canEditCurrentPlugin.value && hasEditRoute.value))
 ))
 
 const handleCreateClick = (): void => {

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectGrid.vue
@@ -24,7 +24,9 @@
     <PluginSelectGroup
       v-if="!props.hideHighlightedPlugins && props.highlightedPlugins.length > 0"
       v-model="isHighlightedPluginsCollapsed"
+      :can-delete-cloned-plugin="canDeleteClonedPlugin"
       :can-delete-custom-plugin="canDeleteCustomPlugin"
+      :can-edit-cloned-plugin="canEditClonedPlugin"
       :can-edit-custom-plugin="canEditCustomPlugin"
       :config="config"
       :name="props.highlightedPluginsTitle || t('plugins.select.highlighted_plugins.title')"
@@ -41,7 +43,9 @@
       >
         <PluginSelectGroup
           v-model="shouldCollapsed[group]"
+          :can-delete-cloned-plugin="canDeleteClonedPlugin"
           :can-delete-custom-plugin="canDeleteCustomPlugin"
+          :can-edit-cloned-plugin="canEditClonedPlugin"
           :can-edit-custom-plugin="canEditCustomPlugin"
           :config="config"
           :name="group"
@@ -98,7 +102,15 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  canDeleteClonedPlugin: {
+    type: Boolean,
+    default: false,
+  },
   canEditCustomPlugin: {
+    type: Boolean,
+    default: false,
+  },
+  canEditClonedPlugin: {
     type: Boolean,
     default: false,
   },

--- a/packages/entities/entities-plugins/src/components/select/PluginSelectGroup.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginSelectGroup.vue
@@ -23,7 +23,9 @@
           v-for="plugin in props.plugins"
           :key="`plugin-card-${plugin.id}`"
           ref="pluginCardRef"
+          :can-delete-cloned-plugin="canDeleteClonedPlugin"
           :can-delete-custom-plugin="canDeleteCustomPlugin"
+          :can-edit-cloned-plugin="canEditClonedPlugin"
           :can-edit-custom-plugin="canEditCustomPlugin"
           :config="config"
           :navigate-on-click="navigateOnClick"
@@ -91,7 +93,15 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  canDeleteClonedPlugin: {
+    type: Boolean,
+    default: false,
+  },
   canEditCustomPlugin: {
+    type: Boolean,
+    default: false,
+  },
+  canEditClonedPlugin: {
     type: Boolean,
     default: false,
   },

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -108,8 +108,8 @@
           <JsonCodeBlock
             :config="config"
             :entity-record="props.formFields"
-            :fetcher-url="fetcherUrl"
-            :request-method="props.editId ? 'put' : 'post'"
+            :fetcher-url="props.slideoutFetchUrl ?? fetcherUrl"
+            :request-method="(props.slideoutRequestMethod ?? (props.editId ? 'put' : 'post')) as BadgeAppearance"
           />
         </template>
         <template #yaml>
@@ -145,7 +145,7 @@
             :control-plane-name="config.app === 'konnect' ? config.controlPlaneName : undefined"
             :customization-options="deckCustomizationOptions"
             :entity-record="props.formFields"
-            :entity-type="(entityType as SupportedEntityDeck)"
+            :entity-type="((props.slideoutDeckEntityType ?? entityType) as SupportedEntityDeck)"
             :geo-api-server-url="config.app === 'konnect' ? config.geoApiServerUrl : undefined"
             :is-customization-modal-visible="isDeckCustomizationVisible"
             :kong-admin-api-url="config.app === 'kongManager' ? config.apiBaseUrl : undefined"
@@ -166,7 +166,7 @@ import type { AxiosError } from 'axios'
 import type { KonnectBaseFormConfig, KongManagerBaseFormConfig, SupportedEntityDeck } from '../../types'
 import { SupportedEntityTypesArray, SupportedEntityType } from '../../types'
 import composables from '../../composables'
-import type { Tab } from '@kong/kongponents'
+import type { BadgeAppearance, Tab } from '@kong/kongponents'
 import JsonCodeBlock from '../common/JsonCodeBlock.vue'
 import YamlCodeBlock from '../common/YamlCodeBlock.vue'
 import TerraformCodeBlock from '../common/TerraformCodeBlock.vue'
@@ -306,6 +306,32 @@ const props = defineProps({
   },
   cancelButtonText: {
     type: String,
+    default: undefined,
+  },
+  /**
+   * Override the fetcher URL shown in the slideout code blocks.
+   * Useful when the form manages its own fetching (e.g. CustomPluginForm).
+   * Should be the fully-resolved URL including the API base.
+   */
+  slideoutFetchUrl: {
+    type: String,
+    default: undefined,
+  },
+  /**
+   * Override the HTTP request method shown in the slideout JSON code block.
+   * Defaults to 'put' when editId is set, 'post' otherwise.
+   */
+  slideoutRequestMethod: {
+    type: String as PropType<BadgeAppearance>,
+    default: undefined,
+  },
+  /**
+   * Override the entity type used for the deck code block in the slideout.
+   * Use when the form represents a sub-type (e.g. PluginSchema, CustomPlugin, ClonedPlugin)
+   * that has a different decK YAML collection key than the base entityType.
+   */
+  slideoutDeckEntityType: {
+    type: String as PropType<SupportedEntityType>,
     default: undefined,
   },
 })

--- a/packages/entities/entities-shared/src/types/entity-base-config-card.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-config-card.ts
@@ -42,6 +42,11 @@ export enum SupportedEntityType {
   // If entityType is 'other' terraform scripts will not be available
   // Note: This is currently only supported by EntityBaseForm not EntityBaseConfigCard!!
   Other = 'other',
+  // Custom plugin variants — used only for slideout deck YAML key generation.
+  // Values map directly to decK YAML collection keys via `entityType + 's'`.
+  PluginSchema = 'plugin_schema',
+  CustomPlugin = 'custom_plugin',
+  ClonedPlugin = 'cloned_plugin',
 }
 
 export const SupportedEntityTypesArray = Object.values(SupportedEntityType)
@@ -55,6 +60,9 @@ export const SupportedEntityDeckArray = [
   SupportedEntityType.Key,
   SupportedEntityType.KeySet,
   SupportedEntityType.Plugin,
+  SupportedEntityType.PluginSchema,
+  SupportedEntityType.CustomPlugin,
+  SupportedEntityType.ClonedPlugin,
   SupportedEntityType.Route,
   SupportedEntityType.Upstream,
   SupportedEntityType.Target,


### PR DESCRIPTION
## Summary
[KM-2572](https://konghq.atlassian.net/browse/KM-2572)
[KM-2573](https://konghq.atlassian.net/browse/KM-2573)
[KM-2631](https://konghq.atlassian.net/browse/KM-2631)

Two related improvements to custom plugin support:

### 1. Split custom vs cloned plugin permissions (entities-plugins)

Previously `PluginSelect` used a single pair of `canEditCustomPlugin` / `canDeleteCustomPlugin` props for both streamed and cloned plugins, and included a KM-specific in-list create-card.

**Changes:**
- Add `canEditClonedPlugin`, `canDeleteClonedPlugin`, `canReadCustomPlugin`, `canReadClonedPlugin` props to `PluginSelect` (defaults preserve existing behavior)
- `PluginSelectCard` routes action-menu permissions by `customPluginType` ('cloned' vs 'streamed'/'schema')
- `PluginCustomGrid`, `PluginSelectGrid`, `PluginSelectGroup` thread new props through
- Parallelise `onBeforeMount` permission checks with `Promise.all`
- Remove KM-specific in-list create-card injection (replaced by PageHeader button in KM)

### 2. View Configuration slideout for CustomPluginForm (entities-plugins + entities-shared)

`CustomPluginForm` had no View Configuration button because it manages its own fetching and doesn't use `EntityBaseForm`'s built-in slideout plumbing.

**Changes in entities-shared (non-breaking):**
- Add `PluginSchema`, `CustomPlugin`, `ClonedPlugin` to `SupportedEntityType` and `SupportedEntityDeckArray` — the existing `entityType + 's'` rule in `DeckCodeBlockInternal` automatically generates the correct decK YAML keys (`plugin_schemas` / `custom_plugins` / `cloned_plugins`)
- Add three optional override props to `EntityBaseForm`: `slideoutFetchUrl`, `slideoutRequestMethod`, `slideoutDeckEntityType` — all default to `undefined`, existing callers unaffected

**Changes in entities-plugins:**
- Add View Configuration button to `CustomPluginForm`'s `form-actions` slot
- Compute API-shaped `viewConfigFormFields`, resolved `viewConfigFetchUrl`, correct HTTP `viewConfigRequestMethod` (post/put/patch), and `viewConfigDeckEntityType` per plugin type

[KM-2572]: https://konghq.atlassian.net/browse/KM-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KM-2573]: https://konghq.atlassian.net/browse/KM-2573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KM-2631]: https://konghq.atlassian.net/browse/KM-2631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ