### PR TITLE
feat(entities-plugins): add ki in oidc

### DIFF
--- a/packages/core/forms/src/components/forms/OIDCForm.vue
+++ b/packages/core/forms/src/components/forms/OIDCForm.vue
@@ -42,41 +42,67 @@
             @model-updated="onModelUpdated"
           />
 
-          <KLabel>Authentication methods</KLabel>
-          <KMultiselect
-            :key="principalsMode"
-            class="auth-methods-multiselect"
-            data-testid="auth-methods-multiselect"
-            :items="authMethodItems"
-            :model-value="selectedAuthMethods"
-            placeholder="Select authentication methods"
-            @update:model-value="handleAuthMethodsSelect"
-          />
-          <p class="auth-methods-hint">
-            Configure which OAuth and OpenID Connect features are supported.
-          </p>
+          <template v-if="useNewAuthMethodsField">
+            <KLabel>Authentication methods</KLabel>
+            <KMultiselect
+              :key="principalsMode"
+              class="auth-methods-multiselect"
+              data-testid="auth-methods-multiselect"
+              :items="authMethodItems"
+              :model-value="selectedAuthMethods"
+              placeholder="Select authentication methods"
+              @update:model-value="handleAuthMethodsSelect"
+            />
+            <p class="auth-methods-hint">
+              Configure which OAuth and OpenID Connect features are supported.
+            </p>
 
-          <div class="session-management-section">
-            <KLabel>Session management</KLabel>
-            <div class="session-radio-group">
-              <KRadio
-                v-model="sessionManagement"
-                data-testid="session-radio-use"
-                description="Issue a session cookie after successful authentication. Subsequent requests use the session instead of re-authenticating with the identity provider."
-                label="Use sessions"
-                :selected-value="true"
-                @change="handleSessionChange(true)"
-              />
-              <KRadio
-                v-model="sessionManagement"
-                data-testid="session-radio-no-use"
-                description="Authenticate each request using the configured authentication flow."
-                label="Do not use sessions"
-                :selected-value="false"
-                @change="handleSessionChange(false)"
-              />
+            <div class="session-management-section">
+              <KLabel>Session management</KLabel>
+              <div class="session-radio-group">
+                <KRadio
+                  v-model="sessionManagement"
+                  data-testid="session-radio-use"
+                  description="Issue a session cookie after successful authentication. Subsequent requests use the session instead of re-authenticating with the identity provider."
+                  label="Use sessions"
+                  :selected-value="true"
+                  @change="handleSessionChange(true)"
+                />
+                <KRadio
+                  v-model="sessionManagement"
+                  data-testid="session-radio-no-use"
+                  description="Authenticate each request using the configured authentication flow."
+                  label="Do not use sessions"
+                  :selected-value="false"
+                  @change="handleSessionChange(false)"
+                />
+              </div>
             </div>
-          </div>
+          </template>
+          <template v-else>
+            <KLabel>Auth methods</KLabel>
+            <div class="auth-method-container">
+              <div
+                v-for="method in authMethods"
+                :key="method.value"
+                class="auth-method"
+              >
+                <KCheckbox
+                  v-model="method.prop"
+                  :data-testid="`auth-method-checkbox-${method.value}`"
+                  @change="evt => handleUpdate(evt, method.value)"
+                >
+                  {{ method.label }}
+                </KCheckbox>
+              </div>
+            </div>
+            <KInputSwitch
+              v-model="sessionManagement"
+              data-testid="session-management-switch"
+              label="Enable Session Management"
+              @change="handleUpdate"
+            />
+          </template>
         </div>
       </template>
       <template #authorization>
@@ -167,6 +193,8 @@ const AUTH_FIELD_MODELS = new Set([
   'config-groups_required',
   'config-authenticated_groups_claim',
 ])
+
+const KONG_IDENTITY_METHODS = ['bearer', 'client_credentials', 'introspection', 'userinfo']
 
 export default {
   name: 'OIDCForm',
@@ -267,8 +295,10 @@ export default {
     isKonnect() {
       return this.formsConfig?.app === 'konnect'
     },
+    useNewAuthMethodsField() {
+      return this.isKonnect
+    },
     authMethodItems() {
-      const KONG_IDENTITY_METHODS = ['bearer', 'client_credentials', 'introspection', 'userinfo']
       const methods = this.principalsMode === 'kong-identity'
         ? this.authMethods.filter(m => KONG_IDENTITY_METHODS.includes(m.value))
         : this.authMethods
@@ -507,8 +537,11 @@ export default {
     },
     handlePrincipalsModeChange(mode) {
       this.principalsMode = mode
-      const KONG_IDENTITY_METHODS = ['bearer', 'client_credentials', 'introspection', 'userinfo']
+
       if (mode === 'kong-identity') {
+        if (!this.isEditing) {
+          this.sessionManagement = true
+        }
         // Auto-select only the 4 Kong Identity methods
         for (const method of this.authMethods) {
           method.prop = KONG_IDENTITY_METHODS.includes(method.value)

--- a/packages/core/forms/src/components/forms/OIDCForm.vue
+++ b/packages/core/forms/src/components/forms/OIDCForm.vue
@@ -299,7 +299,13 @@ export default {
       return this.isKonnect
     },
     authMethodItems() {
-      const methods = this.principalsMode === 'kong-identity'
+      // principalsMode is set on create and on user toggles; on edit it stays
+      // null (the principals child doesn't emit), so fall back to the saved
+      // config to decide whether to restrict the list to Kong Identity methods.
+      const isKongIdentity = this.principalsMode !== null
+        ? this.principalsMode === 'kong-identity'
+        : this.formModel['config-principals-enabled'] === true
+      const methods = isKongIdentity
         ? this.authMethods.filter(m => KONG_IDENTITY_METHODS.includes(m.value))
         : this.authMethods
       return methods.map(m => ({

--- a/packages/core/forms/src/components/forms/OIDCForm.vue
+++ b/packages/core/forms/src/components/forms/OIDCForm.vue
@@ -30,6 +30,7 @@
             :form-model="formModel"
             :form-options="formOptions"
             :form-schema="formSchema"
+            :is-editing="isEditing"
             :on-model-updated="onModelUpdated"
             @mode-change="handlePrincipalsModeChange"
           />

--- a/packages/core/forms/src/components/forms/OIDCForm.vue
+++ b/packages/core/forms/src/components/forms/OIDCForm.vue
@@ -26,13 +26,14 @@
 
           <OIDCPrincipals
             v-if="isKonnect && hasPrincipalsFields"
+            :common-fields-schema="commonFieldsSchema"
             :form-model="formModel"
             :form-options="formOptions"
             :form-schema="formSchema"
             :on-model-updated="onModelUpdated"
           />
           <VueFormGenerator
-            v-if="displayForm"
+            v-else-if="displayForm"
             :model="formModel"
             :options="formOptions"
             :schema="commonFieldsSchema"

--- a/packages/core/forms/src/components/forms/OIDCForm.vue
+++ b/packages/core/forms/src/components/forms/OIDCForm.vue
@@ -31,6 +31,7 @@
             :form-options="formOptions"
             :form-schema="formSchema"
             :on-model-updated="onModelUpdated"
+            @mode-change="handlePrincipalsModeChange"
           />
           <VueFormGenerator
             v-else-if="displayForm"
@@ -40,26 +41,41 @@
             @model-updated="onModelUpdated"
           />
 
-          <KLabel>Auth methods</KLabel>
-          <div class="auth-method-container">
-            <div
-              v-for="(method) in authMethods"
-              :key="method.value"
-              class="auth-method"
-            >
-              <KCheckbox
-                v-model="method.prop"
-                @change="evt => handleUpdate(evt, method.value)"
-              >
-                {{ method.label }}
-              </KCheckbox>
+          <KLabel>Authentication methods</KLabel>
+          <KMultiselect
+            :key="principalsMode"
+            class="auth-methods-multiselect"
+            data-testid="auth-methods-multiselect"
+            :items="authMethodItems"
+            :model-value="selectedAuthMethods"
+            placeholder="Select authentication methods"
+            @update:model-value="handleAuthMethodsSelect"
+          />
+          <p class="auth-methods-hint">
+            Configure which OAuth and OpenID Connect features are supported.
+          </p>
+
+          <div class="session-management-section">
+            <KLabel>Session management</KLabel>
+            <div class="session-radio-group">
+              <KRadio
+                v-model="sessionManagement"
+                data-testid="session-radio-use"
+                description="Issue a session cookie after successful authentication. Subsequent requests use the session instead of re-authenticating with the identity provider."
+                label="Use sessions"
+                :selected-value="true"
+                @change="handleSessionChange(true)"
+              />
+              <KRadio
+                v-model="sessionManagement"
+                data-testid="session-radio-no-use"
+                description="Authenticate each request using the configured authentication flow."
+                label="Do not use sessions"
+                :selected-value="false"
+                @change="handleSessionChange(false)"
+              />
             </div>
           </div>
-          <KInputSwitch
-            v-model="sessionManagement"
-            label="Enable Session Management"
-            @change="handleUpdate"
-          />
         </div>
       </template>
       <template #authorization>
@@ -209,6 +225,7 @@ export default {
       init: false,
       authMethods: [],
       sessionManagement: false,
+      principalsMode: null,
       globalFields: null,
       commonFieldsSchema: null,
       authFieldsSchema: null,
@@ -248,6 +265,19 @@ export default {
     },
     isKonnect() {
       return this.formsConfig?.app === 'konnect'
+    },
+    authMethodItems() {
+      const KONG_IDENTITY_METHODS = ['bearer', 'client_credentials', 'introspection', 'userinfo']
+      const methods = this.principalsMode === 'kong-identity'
+        ? this.authMethods.filter(m => KONG_IDENTITY_METHODS.includes(m.value))
+        : this.authMethods
+      return methods.map(m => ({
+        label: m.label,
+        value: m.value,
+      }))
+    },
+    selectedAuthMethods() {
+      return this.authMethods.filter(m => m.prop).map(m => m.value)
     },
   },
   watch: {
@@ -449,6 +479,59 @@ export default {
       this.formModel['config-auth_methods'] = this.getAuthMethodsValue(prop, evt)
       this.onModelUpdated()
     },
+    handleAuthMethodsSelect(selectedValues) {
+      // Update authMethods prop state
+      for (const method of this.authMethods) {
+        method.prop = selectedValues.includes(method.value)
+      }
+      // Build the final array including session if enabled
+      const arr = [...selectedValues]
+      if (this.sessionManagement) {
+        arr.push('session')
+      }
+      // eslint-disable-next-line vue/no-mutating-props
+      this.formModel['config-auth_methods'] = arr
+      this.onModelUpdated()
+    },
+    handleSessionChange(value) {
+      this.sessionManagement = value
+      // Rebuild auth_methods with or without 'session'
+      const arr = this.authMethods.filter(m => m.prop).map(m => m.value)
+      if (value) {
+        arr.push('session')
+      }
+      // eslint-disable-next-line vue/no-mutating-props
+      this.formModel['config-auth_methods'] = arr
+      this.onModelUpdated()
+    },
+    handlePrincipalsModeChange(mode) {
+      this.principalsMode = mode
+      const KONG_IDENTITY_METHODS = ['bearer', 'client_credentials', 'introspection', 'userinfo']
+      if (mode === 'kong-identity') {
+        // Auto-select only the 4 Kong Identity methods
+        for (const method of this.authMethods) {
+          method.prop = KONG_IDENTITY_METHODS.includes(method.value)
+        }
+        const arr = [...KONG_IDENTITY_METHODS]
+        if (this.sessionManagement) {
+          arr.push('session')
+        }
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-auth_methods'] = arr
+        this.onModelUpdated()
+      } else {
+        // External mode: select all auth methods by default, including session
+        this.sessionManagement = true
+        for (const method of this.authMethods) {
+          method.prop = true
+        }
+        const arr = this.authMethods.map(m => m.value)
+        arr.push('session')
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-auth_methods'] = arr
+        this.onModelUpdated()
+      }
+    },
   },
 }
 </script>
@@ -480,6 +563,26 @@ export default {
       margin-bottom: 8px;
       width: 50%;
     }
+  }
+
+  .auth-methods-multiselect {
+    margin-bottom: var(--kui-space-40, $kui-space-40);
+  }
+
+  .auth-methods-hint {
+    color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+    font-size: var(--kui-font-size-20, $kui-font-size-20);
+    margin: var(--kui-space-20, $kui-space-20) 0 0;
+  }
+
+  .session-radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--kui-space-40, $kui-space-40);
+  }
+
+  .session-radio-label {
+    font-weight: 600;
   }
 
   .k-switch {

--- a/packages/core/forms/src/components/forms/OIDCPrincipals.vue
+++ b/packages/core/forms/src/components/forms/OIDCPrincipals.vue
@@ -338,8 +338,10 @@ const inferInitialLookupMethod = (formModel) => {
 }
 
 // Decide the initial radio mode from the existing record.
-const inferInitialMode = (formModel) => {
+const inferInitialMode = (formModel, isEditing) => {
   if (formModel['config-principals-enabled'] === true) return MODE_KONG_IDENTITY
+  // On edit, respect principals-enabled=false as External mode
+  if (isEditing && formModel['config-principals-enabled'] === false) return MODE_EXTERNAL
   for (const key of COMMON_FIELD_MODELS) {
     const v = formModel[key]
     if (v !== undefined && v !== null && v !== '') return MODE_EXTERNAL
@@ -381,6 +383,10 @@ export default {
       type: Function,
       required: true,
     },
+    isEditing: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ['mode-change'],
   data() {
@@ -391,13 +397,14 @@ export default {
       KUI_ICON_SIZE_20,
       KUI_ICON_SIZE_30,
       KUI_ICON_SIZE_40,
-      selectedMode: inferInitialMode(this.formModel),
+      selectedMode: inferInitialMode(this.formModel, this.isEditing),
       selectedLookupMethod: inferInitialLookupMethod(this.formModel),
       kongIdentityServers: [],
       kongIdentityServersLoading: false,
       clients: [],
       clientsLoading: false,
       selectedServer: null,
+      restoringServer: false,
       leavePromptType: null,
     }
   },
@@ -420,6 +427,12 @@ export default {
     },
   },
   mounted() {
+    // On create, Kong Identity is the default mode — ensure principals-enabled
+    // is set to true so the payload is correct.
+    if (!this.isEditing && this.selectedMode === MODE_KONG_IDENTITY) {
+      // eslint-disable-next-line vue/no-mutating-props
+      this.formModel['config-principals-enabled'] = true
+    }
     this.$emit('mode-change', this.selectedMode)
     this.fetchKongIdentityServers()
   },
@@ -434,9 +447,11 @@ export default {
         // If editing with an existing issuer, try to match a server
         const issuer = this.formModel['config-issuer']
         if (issuer && !this.selectedServer) {
-          this.selectedServer = this.kongIdentityServers.find(s => s.issuer === issuer) || null
-          if (this.selectedServer) {
-            this.fetchClients(this.selectedServer.id)
+          const matched = this.kongIdentityServers.find(s => s.issuer === issuer) || null
+          if (matched) {
+            this.restoringServer = true
+            this.selectedServer = matched
+            this.fetchClients(matched.id)
           }
         }
       } catch {
@@ -459,6 +474,11 @@ export default {
       }
     },
     handleServerChange(serverId) {
+      // Skip if this is the KSelect reacting to programmatic selectedServer restore
+      if (this.restoringServer) {
+        this.restoringServer = false
+        return
+      }
       // Find the selected server and prefill issuer
       this.selectedServer = this.kongIdentityServers.find(s => s.id === serverId) || null
       if (this.selectedServer?.issuer) {

--- a/packages/core/forms/src/components/forms/OIDCPrincipals.vue
+++ b/packages/core/forms/src/components/forms/OIDCPrincipals.vue
@@ -126,11 +126,10 @@
 
       <KInput
         data-testid="principals-issuer"
-        :disabled="!selectedServer"
+        disabled
         label="Issuer"
         :model-value="formModel['config-issuer']"
-        placeholder="e.g., https://issuer.example.com/auth"
-        @update:model-value="updateField('config-issuer', $event)"
+        placeholder="Automatically deciphered based on the selected auth server"
       />
 
       <KCollapse
@@ -159,47 +158,35 @@
         </div>
 
         <div class="principals-field-group">
-          <KLabel info="Choose whether Kong uses Consumers linked to the resolved principal or existing Consumer matching settings.">
-            Consumer matching behavior
-          </KLabel>
-          <KRadio
-            data-testid="principals-match-consumer-true"
-            description="Use consumers associated with the resolved principal and ignore existing consumer matching settings."
-            label="Use consumers linked to the principal"
+          <KCheckbox
+            data-testid="principals-match-consumer"
             :model-value="formModel['config-principals-match_consumer']"
-            :selected-value="true"
-            @change="updateField('config-principals-match_consumer', true)"
-          />
-          <KRadio
-            data-testid="principals-match-consumer-false"
-            description="Ignore consumers linked to the principal and continue using configured consumer matching behavior."
-            label="Use existing consumer matching settings"
-            :model-value="formModel['config-principals-match_consumer']"
-            :selected-value="false"
-            @change="updateField('config-principals-match_consumer', false)"
-          />
+            @update:model-value="handleMatchConsumerChange($event)"
+          >
+            Use linked consumers
+            <template #description>
+              Use the consumer linked to the authenticated principal so existing consumer-based plugins and policies continue to work.
+              <a
+                href="https://developer.konghq.com/how-to/create-centrally-managed-consumer/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >Learn how to link a consumer.</a>
+            </template>
+          </KCheckbox>
         </div>
 
         <div class="principals-field-group">
-          <KLabel info="Choose whether Kong uses Consumer Groups linked to the resolved principal or existing Consumer Group matching settings.">
-            Consumer group matching behavior
-          </KLabel>
-          <KRadio
-            data-testid="principals-match-consumer-groups-true"
-            description="Use consumer groups associated with the resolved principal and ignore existing consumer group matching settings."
-            label="Use consumer groups linked to the principal"
+          <KCheckbox
+            data-testid="principals-match-consumer-groups"
+            :disabled="!formModel['config-principals-match_consumer']"
             :model-value="formModel['config-principals-match_consumer_groups']"
-            :selected-value="true"
-            @change="updateField('config-principals-match_consumer_groups', true)"
-          />
-          <KRadio
-            data-testid="principals-match-consumer-groups-false"
-            description="Ignore consumer groups linked to the principal and continue using configured consumer group matching behavior."
-            label="Use existing consumer group matching settings"
-            :model-value="formModel['config-principals-match_consumer_groups']"
-            :selected-value="false"
-            @change="updateField('config-principals-match_consumer_groups', false)"
-          />
+            @update:model-value="updateField('config-principals-match_consumer_groups', $event)"
+          >
+            Use linked consumer groups
+            <template #description>
+              Use consumer groups associated with the linked consumer so existing consumer group policies and plugins continue to work. This setting applies only when  <b>Use linked consumer</b> is enabled.
+            </template>
+          </KCheckbox>
         </div>
       </KCollapse>
     </template>
@@ -383,6 +370,12 @@ export default {
       this.selectedClientId = clientId
       this.updateField('config-client_id', [clientId])
     },
+    handleMatchConsumerChange(checked) {
+      this.updateField('config-principals-match_consumer', checked)
+      if (!checked) {
+        this.updateField('config-principals-match_consumer_groups', false)
+      }
+    },
     updateField(field, value) {
       // eslint-disable-next-line vue/no-mutating-props
       this.formModel[field] = value
@@ -396,10 +389,10 @@ export default {
         ? new URL(geoApiServerUrl).hostname.split('.')[0]
         : (this.formsConfig?.apiBaseUrl?.match(/^\/([^/]+)/)?.[1] || 'us')
       if (type === 'authServer') {
-        const url = this.formsConfig?.createAuthServerUrl || `${window.location.origin}/${geo}/kong-identity/auth-servers/create`
+        const url = this.formsConfig?.createAuthServerUrl || `${window.location.origin}/${geo}/identity/create-auth-server`
         document.location.href = url
       } else if (type === 'client') {
-        const url = this.formsConfig?.createClientUrl || `${window.location.origin}/${geo}/kong-identity/auth-servers/${this.selectedServer?.id}/clients/create`
+        const url = this.formsConfig?.createClientUrl || `${window.location.origin}/${geo}/kong-identity/auth-servers/${this.selectedServer?.id}/create-auth-server-client`
         document.location.href = url
       }
     },
@@ -469,7 +462,7 @@ export default {
 }
 
 .principals-advanced-settings {
-  margin-top: var(--kui-space-50, $kui-space-50);
+  margin-top: var(--kui-space-70, $kui-space-70);
 
   :deep(.collapse-hidden-content) {
     display: flex;
@@ -496,7 +489,7 @@ export default {
 }
 
 .create-action {
-  align-items: center;
+  align-items: flex-start;
   color: var(--kui-color-text-primary, $kui-color-text-primary);
   cursor: pointer;
   display: flex;

--- a/packages/core/forms/src/components/forms/OIDCPrincipals.vue
+++ b/packages/core/forms/src/components/forms/OIDCPrincipals.vue
@@ -61,6 +61,7 @@
       <KSelect
         class="principals-directory-select"
         data-testid="principals-directory-select"
+        enable-filtering
         :items="kongIdentityServerItems"
         label="Authorization Server"
         :loading="kongIdentityServersLoading"
@@ -86,57 +87,125 @@
         </template>
       </KSelect>
 
-      <KSelect
-        class="principals-client-select"
-        data-testid="principals-client-select"
-        :disabled="!selectedServer"
-        :items="clientItems"
-        label="Client"
-        :loading="clientsLoading"
-        :model-value="selectedClientId"
-        placeholder="Select a client"
-        @update:model-value="handleClientChange"
+      <div
+        v-for="(clientId, index) in clientIdArray"
+        :key="index"
+        class="client-row"
+        :class="{ 'client-row-with-label': index === 0 }"
       >
-        <template #dropdown-footer-text>
-          <div
-            class="create-action"
-            data-testid="create-client-action"
-            @click.stop="leavePromptType = 'client'"
-          >
-            <AddIcon :size="KUI_ICON_SIZE_20" />
-            <div class="create-action-content">
-              <span>Create client</span>
-              <div class="create-action-hint">
-                You'll need to return here after creating a client. Your progress won't be saved.
+        <KSelect
+          class="principals-client-select"
+          data-testid="principals-client-select"
+          :disabled="!selectedServer"
+          enable-filtering
+          :items="getClientItemsForRow(index)"
+          :label="index === 0 ? 'Client' : undefined"
+          :loading="clientsLoading"
+          :model-value="clientId"
+          placeholder="Select a client"
+          @update:model-value="handleClientChange(index, $event)"
+        >
+          <template #dropdown-footer-text>
+            <div
+              class="create-action"
+              data-testid="create-client-action"
+              @click.stop="leavePromptType = 'client'"
+            >
+              <AddIcon :size="KUI_ICON_SIZE_20" />
+              <div class="create-action-content">
+                <span>Create client</span>
+                <div class="create-action-hint">
+                  You'll need to return here after creating a client. Your progress won't be saved.
+                </div>
               </div>
             </div>
-          </div>
-        </template>
-      </KSelect>
+          </template>
+        </KSelect>
+        <div class="principals-client-secret-wrapper">
+          <KInput
+            class="principals-client-secret"
+            data-testid="principals-client-secret"
+            :disabled="!selectedServer"
+            :label="index === 0 ? 'Client secret' : undefined"
+            :model-value="clientSecretArray[index]"
+            placeholder="e.g., your-client-secret"
+            show-password-mask-toggle
+            type="password"
+            @update:model-value="handleClientSecretChange(index, $event)"
+          />
+          <component
+            :is="autofillSlot"
+            v-if="autofillSlot"
+            :schema="{ model: 'config-client_secret', referenceable: true }"
+            :update="(val) => handleClientSecretChange(index, val)"
+            :value="clientSecretArray[index]"
+          />
+        </div>
+        <button
+          class="remove-client-btn"
+          data-testid="remove-client-action"
+          type="button"
+          @click="removeClientRow(index)"
+        >
+          <TrashIcon :size="KUI_ICON_SIZE_30" />
+        </button>
+      </div>
 
-      <KInput
-        data-testid="principals-client-secret"
-        :disabled="!selectedServer"
-        label="Client secret"
-        :model-value="formModel['config-client_secret']"
-        placeholder="e.g., your-client-secret"
-        type="password"
-        @update:model-value="updateField('config-client_secret', $event)"
-      />
-
-      <KInput
-        data-testid="principals-issuer"
-        disabled
-        label="Issuer"
-        :model-value="formModel['config-issuer']"
-        placeholder="Automatically deciphered based on the selected auth server"
-      />
+      <div
+        class="add-client-inline"
+        :class="{ 'add-client-inline-disabled': !selectedServer }"
+        data-testid="add-client-action"
+        @click="!selectedServer ? null : addClientRow()"
+      >
+        + Add client
+      </div>
 
       <KCollapse
         class="principals-advanced-settings"
         data-testid="principals-advanced-settings"
         trigger-label="Show additional settings"
       >
+        <div class="principals-field-group">
+          <KSelect
+            class="principals-lookup-method-select"
+            data-testid="principals-lookup-method"
+            :items="lookupMethodItems"
+            label="Principal lookup method"
+            :model-value="selectedLookupMethod"
+            placeholder="Select a principal directory"
+            @update:model-value="updateField('config-principals-directory', $event)"
+          >
+            <template #item-template="{ item }">
+              <div class="lookup-method-item">
+                <div class="lookup-method-item-label">
+                  {{ item.label }}
+                </div>
+                <div class="lookup-method-item-description">
+                  {{ item.description }}
+                </div>
+              </div>
+            </template>
+          </KSelect>
+
+          <template v-if="selectedLookupMethod === 'custom-plugin'">
+            <KInput
+              data-testid="principals-custom-identity-name"
+              help="Enter the custom identity name used to look up the principal. Kong matches the value from the token claim to a principal with the same custom identity name and value."
+              label="Custom Identity name"
+              :model-value="formModel['config-principals-principal_by']"
+              placeholder="e.g., Customer_ID"
+              @update:model-value="updateField('config-principals-principal_by', $event)"
+            />
+            <KInput
+              data-testid="principals-identifier-claim"
+              help="Enter the token claim used to identify the principal. Use dot notation for nested claims (for example, workload.id). Escape periods in claim names with \ (for example, workload\.id)."
+              label="Identifier claim"
+              :model-value="getIdentifierClaimInputValue()"
+              placeholder="e.g., user.employee_id"
+              @update:model-value="handleIdentifierClaimChange($event)"
+            />
+          </template>
+        </div>
         <div class="principals-field-group">
           <KLabel>If principal lookup fails</KLabel>
           <KRadio
@@ -167,7 +236,7 @@
             <template #description>
               Use the consumer linked to the authenticated principal so existing consumer-based plugins and policies continue to work.
               <a
-                href="https://developer.konghq.com/how-to/create-centrally-managed-consumer/"
+                href="https://developer.konghq.com/identity/principals/"
                 rel="noopener noreferrer"
                 target="_blank"
               >Learn how to link a consumer.</a>
@@ -184,7 +253,12 @@
           >
             Use linked consumer groups
             <template #description>
-              Use consumer groups associated with the linked consumer so existing consumer group policies and plugins continue to work. This setting applies only when  <b>Use linked consumer</b> is enabled.
+              Use consumer groups linked to the authenticated principal so existing consumer group policies and plugins continue to work. Consumer groups can be linked through principal metadata.
+              <a
+                href="https://developer.konghq.com/identity/principals/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >Learn how to link a consumer group.</a>
             </template>
           </KCheckbox>
         </div>
@@ -212,10 +286,10 @@
 
 <script>
 import VueFormGenerator from '../FormGenerator.vue'
-import { FORMS_CONFIG } from '../../const'
+import { FORMS_CONFIG, AUTOFILL_SLOT } from '../../const'
 import { useAxios } from '@kong-ui-public/entities-shared'
-import { AddIcon, KeyIcon, WorldIcon } from '@kong/icons'
-import { KUI_ICON_SIZE_20, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+import { AddIcon, KeyIcon, TrashIcon, WorldIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_20, KUI_ICON_SIZE_30, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const MODE_KONG_IDENTITY = 'kong-identity'
 const MODE_EXTERNAL = 'external'
@@ -223,22 +297,45 @@ const MODE_EXTERNAL = 'external'
 // TODO: Replace with the actual endpoint once the API is ready
 const KONG_IDENTITY_SERVERS_ENDPOINT = '/v1/auth-servers/_computed'
 
-const PRINCIPALS_FIELD_MODELS = new Set([
-  'config-principals-enabled',
-  'config-principals-directory',
-  'config-principals-principal_by',
-  'config-principals-principal_claim',
-  'config-principals-match_consumer',
-  'config-principals-match_consumer_groups',
-  'config-principals-error_on_miss',
-])
-
 // External-auth-server (commonFields) field models — kept in sync with OIDCForm.
 const COMMON_FIELD_MODELS = new Set([
   'config-client_id',
   'config-client_secret',
   'config-issuer',
 ])
+
+const lookupMethodItems = [
+  {
+    label: 'Kong Identity client',
+    value: 'kong-identity',
+    description: 'Match principals using the client ID from the token subject (sub) claim.',
+  },
+  {
+    label: 'Custom claim',
+    value: 'custom-plugin',
+    description: 'Match principals using a custom JWT claim.',
+  },
+]
+
+const hasValue = value => {
+  if (value === undefined || value === null || value === '') {
+    return false
+  }
+
+  if (Array.isArray(value)) {
+    return value.length > 0
+  }
+
+  return true
+}
+
+const inferInitialLookupMethod = (formModel) => {
+  if (hasValue(formModel['config-principals-principal_claim']) || hasValue(formModel['config-principals-principal_by'])) {
+    return 'custom-plugin'
+  }
+
+  return 'kong-identity'
+}
 
 // Decide the initial radio mode from the existing record.
 const inferInitialMode = (formModel) => {
@@ -252,11 +349,15 @@ const inferInitialMode = (formModel) => {
 
 export default {
   name: 'OIDCPrincipals',
-  components: { VueFormGenerator, AddIcon, KeyIcon, WorldIcon },
+  components: { VueFormGenerator, AddIcon, KeyIcon, TrashIcon, WorldIcon },
   inject: {
     formsConfig: {
       from: FORMS_CONFIG,
       default: () => ({}),
+    },
+    autofillSlot: {
+      from: AUTOFILL_SLOT,
+      default: undefined,
     },
   },
   props: {
@@ -281,18 +382,21 @@ export default {
       required: true,
     },
   },
+  emits: ['mode-change'],
   data() {
     return {
       MODE_KONG_IDENTITY,
       MODE_EXTERNAL,
+      lookupMethodItems,
       KUI_ICON_SIZE_20,
+      KUI_ICON_SIZE_30,
       KUI_ICON_SIZE_40,
       selectedMode: inferInitialMode(this.formModel),
+      selectedLookupMethod: inferInitialLookupMethod(this.formModel),
       kongIdentityServers: [],
       kongIdentityServersLoading: false,
       clients: [],
       clientsLoading: false,
-      selectedClientId: null,
       selectedServer: null,
       leavePromptType: null,
     }
@@ -304,14 +408,20 @@ export default {
     clientItems() {
       return this.clients.map(c => ({ label: c.name, value: c.client_id || c.id }))
     },
+    clientIdArray() {
+      const ids = this.formModel['config-client_id']
+      if (Array.isArray(ids) && ids.length > 0) return ids
+      return [null]
+    },
+    clientSecretArray() {
+      const secrets = this.formModel['config-client_secret']
+      if (Array.isArray(secrets) && secrets.length > 0) return secrets
+      return [null]
+    },
   },
   mounted() {
+    this.$emit('mode-change', this.selectedMode)
     this.fetchKongIdentityServers()
-    // Pre-select the first client_id if it exists (for edit mode)
-    const clientIds = this.formModel['config-client_id']
-    if (Array.isArray(clientIds) && clientIds.length > 0) {
-      this.selectedClientId = clientIds[0]
-    }
   },
   methods: {
     async fetchKongIdentityServers() {
@@ -355,16 +465,82 @@ export default {
         this.updateField('config-issuer', this.selectedServer.issuer)
       }
       // Reset client selection when server changes
-      this.selectedClientId = null
+      this.updateField('config-client_id', [null])
+      this.updateField('config-client_secret', [null])
       this.clients = []
       this.clientsLoading = !!serverId
       if (serverId) {
         this.fetchClients(serverId)
       }
     },
-    handleClientChange(clientId) {
-      this.selectedClientId = clientId
-      this.updateField('config-client_id', [clientId])
+    handleClientChange(index, clientId) {
+      const clientIds = Array.isArray(this.formModel['config-client_id'])
+        ? [...this.formModel['config-client_id']]
+        : []
+      clientIds[index] = clientId
+      this.updateField('config-client_id', clientIds)
+    },
+    addClientRow() {
+      const clientIds = Array.isArray(this.formModel['config-client_id'])
+        ? [...this.formModel['config-client_id']]
+        : []
+      clientIds.push(null)
+      this.updateField('config-client_id', clientIds)
+
+      const secrets = Array.isArray(this.formModel['config-client_secret'])
+        ? [...this.formModel['config-client_secret']]
+        : []
+      secrets.push(null)
+      this.updateField('config-client_secret', secrets)
+    },
+    removeClientRow(index) {
+      const clientIds = Array.isArray(this.formModel['config-client_id'])
+        ? [...this.formModel['config-client_id']]
+        : []
+      clientIds.splice(index, 1)
+      this.updateField('config-client_id', clientIds)
+
+      const secrets = Array.isArray(this.formModel['config-client_secret'])
+        ? [...this.formModel['config-client_secret']]
+        : []
+      secrets.splice(index, 1)
+      this.updateField('config-client_secret', secrets)
+    },
+    handleClientSecretChange(index, value) {
+      const secrets = Array.isArray(this.formModel['config-client_secret'])
+        ? [...this.formModel['config-client_secret']]
+        : []
+      secrets[index] = value
+      this.updateField('config-client_secret', secrets)
+    },
+    getClientItemsForRow(index) {
+      const selectedIds = this.clientIdArray
+      return this.clientItems.map(item => ({
+        ...item,
+        disabled: selectedIds.some((id, i) => i !== index && id === item.value),
+      }))
+    },
+    getIdentifierClaimInputValue() {
+      const claim = this.formModel['config-principals-principal_claim']
+      if (Array.isArray(claim)) {
+        // Escape literal dots within each part before joining
+        return claim.map(part => part.replace(/\./g, '\\.')).join('.')
+      }
+      return claim || ''
+    },
+    handleIdentifierClaimChange(rawValue) {
+      const value = typeof rawValue === 'string' ? rawValue.trim() : ''
+      if (!value) {
+        this.updateField('config-principals-principal_claim', [])
+        return
+      }
+
+      // Split on unescaped dots (dots not preceded by \), then unescape \. → .
+      const parts = value.split(/(?<!\\)\./).map(part => part.replace(/\\\./g, '.').trim()).filter(Boolean)
+      this.updateField('config-principals-principal_claim', parts)
+    },
+    syncLookupMethod() {
+      this.selectedLookupMethod = inferInitialLookupMethod(this.formModel)
     },
     handleMatchConsumerChange(checked) {
       this.updateField('config-principals-match_consumer', checked)
@@ -375,6 +551,18 @@ export default {
     updateField(field, value) {
       // eslint-disable-next-line vue/no-mutating-props
       this.formModel[field] = value
+      if (field === 'config-principals-directory') {
+        this.selectedLookupMethod = value
+        // Clear custom claim fields when switching back to kong-identity
+        if (value !== 'custom-plugin') {
+          // eslint-disable-next-line vue/no-mutating-props
+          this.formModel['config-principals-principal_by'] = null
+          // eslint-disable-next-line vue/no-mutating-props
+          this.formModel['config-principals-principal_claim'] = null
+        }
+      } else if (field === 'config-principals-principal_claim' || field === 'config-principals-principal_by') {
+        this.syncLookupMethod()
+      }
       this.onModelUpdated()
     },
     handleLeaveConfirmed() {
@@ -426,12 +614,19 @@ export default {
         this.formModel['config-principals-match_consumer'] = true
         // eslint-disable-next-line vue/no-mutating-props
         this.formModel['config-principals-match_consumer_groups'] = true
+        // Clear client fields
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-client_id'] = null
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-client_secret'] = null
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-issuer'] = null
         // Reset local state
         this.selectedServer = null
-        this.selectedClientId = null
         this.clients = []
       }
       this.onModelUpdated()
+      this.$emit('mode-change', newMode)
     },
   },
 }
@@ -468,6 +663,10 @@ export default {
     gap: var(--kui-space-70, $kui-space-70);
   }
 
+  .principals-lookup-method-select :deep(.k-label) {
+    margin-top: 0;
+  }
+
   .k-label {
     margin-top: var(--kui-space-0, $kui-space-0);
   }
@@ -486,6 +685,21 @@ export default {
   gap: var(--kui-space-40, $kui-space-40);
 }
 
+.lookup-method-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-10, $kui-space-10);
+}
+
+.lookup-method-item-label {
+  color: var(--kui-color-text, $kui-color-text);
+  font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+}
+
+.lookup-method-item-description {
+  color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+}
+
 .create-action {
   align-items: flex-start;
   color: var(--kui-color-text-primary, $kui-color-text-primary);
@@ -502,12 +716,80 @@ export default {
   }
 }
 
+.create-action-disabled {
+  color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+  cursor: default;
+}
+
+.client-row {
+  align-items: flex-start;
+  display: flex;
+  gap: var(--kui-space-40, $kui-space-40);
+  margin-top: var(--kui-space-40, $kui-space-40);
+
+  .principals-client-select {
+    flex: 1;
+    margin-top: 0;
+  }
+
+  .principals-client-secret-wrapper {
+    flex: 1;
+  }
+
+  .principals-client-secret {
+    width: 100%;
+  }
+}
+
+.remove-client-btn {
+  align-items: center;
+  background: none;
+  border: none;
+  color: var(--kui-color-text-primary, $kui-color-text-primary);
+  cursor: pointer;
+  display: flex;
+  flex-shrink: 0;
+  margin-top: var(--kui-space-30, $kui-space-30);
+  padding: var(--kui-space-20, $kui-space-20);
+
+  &:hover {
+    color: var(--kui-color-text-danger, $kui-color-text-danger);
+  }
+}
+
+.client-row-with-label .remove-client-btn {
+  margin-top: 60px;
+}
+
+.add-client-inline {
+  align-items: center;
+  color: var(--kui-color-text-primary, $kui-color-text-primary);
+  cursor: pointer;
+  display: flex;
+  font-size: var(--kui-font-size-30, $kui-font-size-30);
+  font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
+  gap: var(--kui-space-20, $kui-space-20);
+}
+
+.add-client-inline-disabled {
+  color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+  cursor: default;
+  pointer-events: none;
+}
+
 :deep(.create-action) {
   cursor: pointer;
 }
 
-.principals-directory-select,
+.principals-directory-select {
+  :deep(.dropdown-footer.dropdown-footer-sticky) {
+    pointer-events: auto;
+  }
+}
+
 .principals-client-select {
+  margin-top: var(--kui-space-40, $kui-space-40);
+
   :deep(.dropdown-footer.dropdown-footer-sticky) {
     pointer-events: auto;
   }

--- a/packages/core/forms/src/components/forms/OIDCPrincipals.vue
+++ b/packages/core/forms/src/components/forms/OIDCPrincipals.vue
@@ -144,10 +144,11 @@
         <button
           class="remove-client-btn"
           data-testid="remove-client-action"
+          :disabled="isRemoveClientDisabled"
           type="button"
           @click="removeClientRow(index)"
         >
-          <TrashIcon :size="KUI_ICON_SIZE_30" />
+          <CloseIcon :size="KUI_ICON_SIZE_30" />
         </button>
       </div>
 
@@ -172,8 +173,8 @@
             :items="lookupMethodItems"
             label="Principal lookup method"
             :model-value="selectedLookupMethod"
-            placeholder="Select a principal directory"
-            @update:model-value="updateField('config-principals-directory', $event)"
+            placeholder="Select a lookup method"
+            @update:model-value="handleLookupMethodChange"
           >
             <template #item-template="{ item }">
               <div class="lookup-method-item">
@@ -187,7 +188,7 @@
             </template>
           </KSelect>
 
-          <template v-if="selectedLookupMethod === 'custom-plugin'">
+          <template v-if="selectedLookupMethod === 'custom-identity'">
             <KInput
               data-testid="principals-custom-identity-name"
               help="Enter the custom identity name used to look up the principal. Kong matches the value from the token claim to a principal with the same custom identity name and value."
@@ -288,7 +289,7 @@
 import VueFormGenerator from '../FormGenerator.vue'
 import { FORMS_CONFIG, AUTOFILL_SLOT } from '../../const'
 import { useAxios } from '@kong-ui-public/entities-shared'
-import { AddIcon, KeyIcon, TrashIcon, WorldIcon } from '@kong/icons'
+import { AddIcon, CloseIcon, KeyIcon, WorldIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_20, KUI_ICON_SIZE_30, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const MODE_KONG_IDENTITY = 'kong-identity'
@@ -312,7 +313,7 @@ const lookupMethodItems = [
   },
   {
     label: 'Custom claim',
-    value: 'custom-plugin',
+    value: 'custom-identity',
     description: 'Match principals using a custom JWT claim.',
   },
 ]
@@ -331,7 +332,7 @@ const hasValue = value => {
 
 const inferInitialLookupMethod = (formModel) => {
   if (hasValue(formModel['config-principals-principal_claim']) || hasValue(formModel['config-principals-principal_by'])) {
-    return 'custom-plugin'
+    return 'custom-identity'
   }
 
   return 'kong-identity'
@@ -351,7 +352,7 @@ const inferInitialMode = (formModel, isEditing) => {
 
 export default {
   name: 'OIDCPrincipals',
-  components: { VueFormGenerator, AddIcon, KeyIcon, TrashIcon, WorldIcon },
+  components: { VueFormGenerator, AddIcon, CloseIcon, KeyIcon, WorldIcon },
   inject: {
     formsConfig: {
       from: FORMS_CONFIG,
@@ -425,6 +426,9 @@ export default {
       if (Array.isArray(secrets) && secrets.length > 0) return secrets
       return [null]
     },
+    isRemoveClientDisabled() {
+      return !this.selectedServer || this.clientIdArray.length <= 1
+    },
   },
   mounted() {
     // On create, Kong Identity is the default mode — ensure principals-enabled
@@ -433,7 +437,9 @@ export default {
       // eslint-disable-next-line vue/no-mutating-props
       this.formModel['config-principals-enabled'] = true
     }
-    this.$emit('mode-change', this.selectedMode)
+    if (!this.isEditing) {
+      this.$nextTick(() => this.$emit('mode-change', this.selectedMode))
+    }
     this.fetchKongIdentityServers()
   },
   methods: {
@@ -514,6 +520,8 @@ export default {
       this.updateField('config-client_secret', secrets)
     },
     removeClientRow(index) {
+      if (this.clientIdArray.length <= 1) return
+
       const clientIds = Array.isArray(this.formModel['config-client_id'])
         ? [...this.formModel['config-client_id']]
         : []
@@ -568,19 +576,20 @@ export default {
         this.updateField('config-principals-match_consumer_groups', false)
       }
     },
+    handleLookupMethodChange(value) {
+      this.selectedLookupMethod = value
+      if (value !== 'custom-identity') {
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-principal_by'] = null
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-principal_claim'] = null
+        this.onModelUpdated()
+      }
+    },
     updateField(field, value) {
       // eslint-disable-next-line vue/no-mutating-props
       this.formModel[field] = value
-      if (field === 'config-principals-directory') {
-        this.selectedLookupMethod = value
-        // Clear custom claim fields when switching back to kong-identity
-        if (value !== 'custom-plugin') {
-          // eslint-disable-next-line vue/no-mutating-props
-          this.formModel['config-principals-principal_by'] = null
-          // eslint-disable-next-line vue/no-mutating-props
-          this.formModel['config-principals-principal_claim'] = null
-        }
-      } else if (field === 'config-principals-principal_claim' || field === 'config-principals-principal_by') {
+      if (field === 'config-principals-principal_claim' || field === 'config-principals-principal_by') {
         this.syncLookupMethod()
       }
       this.onModelUpdated()
@@ -774,6 +783,15 @@ export default {
 
   &:hover {
     color: var(--kui-color-text-danger, $kui-color-text-danger);
+  }
+
+  &:disabled {
+    color: var(--kui-color-text-disabled, $kui-color-text-disabled);
+    cursor: not-allowed;
+  }
+
+  &:disabled:hover {
+    color: var(--kui-color-text-disabled, $kui-color-text-disabled);
   }
 }
 

--- a/packages/core/forms/src/components/forms/OIDCPrincipals.vue
+++ b/packages/core/forms/src/components/forms/OIDCPrincipals.vue
@@ -9,23 +9,232 @@
     <div class="principals-description">
       Use Consumers for Consumer-based authentication. Use Kong Identity for principal-based authentication and advanced integrations.
       <a
-        href="https://developer.konghq.com/kong-identity/"
+        href="https://developer.konghq.com/plugins/openid-connect/"
+        rel="noopener noreferrer"
         target="_blank"
       >Learn more.</a>
     </div>
+
+    <div
+      class="oidc-auth-mode-radio-group"
+      data-testid="oidc-auth-mode-radio-group"
+    >
+      <KRadio
+        v-model="selectedMode"
+        card
+        card-orientation="horizontal"
+        data-testid="oidc-auth-mode-kong-identity"
+        :selected-value="MODE_KONG_IDENTITY"
+        @change="handleModeChange"
+      >
+        <div class="auth-mode-card-content">
+          <KeyIcon :size="KUI_ICON_SIZE_40" />
+          <div class="auth-mode-card-label">
+            Kong Identity
+          </div>
+          <div class="auth-mode-card-description">
+            Use Kong Identity for principal-based authentication and advanced integrations.
+          </div>
+        </div>
+      </KRadio>
+      <KRadio
+        v-model="selectedMode"
+        card
+        card-orientation="horizontal"
+        data-testid="oidc-auth-mode-external"
+        :selected-value="MODE_EXTERNAL"
+        @change="handleModeChange"
+      >
+        <div class="auth-mode-card-content">
+          <WorldIcon :size="KUI_ICON_SIZE_40" />
+          <div class="auth-mode-card-label">
+            External auth server
+          </div>
+          <div class="auth-mode-card-description">
+            Authenticate against an external OpenID Connect issuer.
+          </div>
+        </div>
+      </KRadio>
+    </div>
+
+    <template v-if="selectedMode === MODE_KONG_IDENTITY">
+      <KSelect
+        class="principals-directory-select"
+        data-testid="principals-directory-select"
+        :items="kongIdentityServerItems"
+        label="Authorization Server"
+        :loading="kongIdentityServersLoading"
+        :model-value="selectedServer?.id"
+        placeholder="Select an Authorization Server"
+        required
+        @update:model-value="handleServerChange"
+      >
+        <template #dropdown-footer-text>
+          <div
+            class="create-action"
+            data-testid="create-auth-server-action"
+            @click.stop="leavePromptType = 'authServer'"
+          >
+            <AddIcon :size="KUI_ICON_SIZE_20" />
+            <div class="create-action-content">
+              <span>Create authorization server</span>
+              <div class="create-action-hint">
+                You’ll need to return here after creating a auth server. Your progress won’t be saved.
+              </div>
+            </div>
+          </div>
+        </template>
+      </KSelect>
+
+      <KSelect
+        class="principals-client-select"
+        data-testid="principals-client-select"
+        :disabled="!selectedServer"
+        :items="clientItems"
+        label="Client"
+        :loading="clientsLoading"
+        :model-value="selectedClientId"
+        placeholder="Select a client"
+        @update:model-value="handleClientChange"
+      >
+        <template #dropdown-footer-text>
+          <div
+            class="create-action"
+            data-testid="create-client-action"
+            @click.stop="leavePromptType = 'client'"
+          >
+            <AddIcon :size="KUI_ICON_SIZE_20" />
+            <div class="create-action-content">
+              <span>Create client</span>
+              <div class="create-action-hint">
+                You'll need to return here after creating a client. Your progress won't be saved.
+              </div>
+            </div>
+          </div>
+        </template>
+      </KSelect>
+
+      <KInput
+        data-testid="principals-client-secret"
+        :disabled="!selectedServer"
+        label="Client secret"
+        :model-value="formModel['config-client_secret']"
+        placeholder="e.g., your-client-secret"
+        type="password"
+        @update:model-value="updateField('config-client_secret', $event)"
+      />
+
+      <KInput
+        data-testid="principals-issuer"
+        :disabled="!selectedServer"
+        label="Issuer"
+        :model-value="formModel['config-issuer']"
+        placeholder="e.g., https://issuer.example.com/auth"
+        @update:model-value="updateField('config-issuer', $event)"
+      />
+
+      <KCollapse
+        class="principals-advanced-settings"
+        data-testid="principals-advanced-settings"
+        trigger-label="Show additional settings"
+      >
+        <div class="principals-field-group">
+          <KLabel>If principal lookup fails</KLabel>
+          <KRadio
+            data-testid="principals-error-on-miss-true"
+            description="Treat the request as unauthenticated if Kong Identity cannot resolve the principal."
+            label="Reject the request"
+            :model-value="formModel['config-principals-error_on_miss']"
+            :selected-value="true"
+            @change="updateField('config-principals-error_on_miss', true)"
+          />
+          <KRadio
+            data-testid="principals-error-on-miss-false"
+            description="Allow the request to continue without resolving a principal."
+            label="Continue without a principal"
+            :model-value="formModel['config-principals-error_on_miss']"
+            :selected-value="false"
+            @change="updateField('config-principals-error_on_miss', false)"
+          />
+        </div>
+
+        <div class="principals-field-group">
+          <KLabel info="Choose whether Kong uses Consumers linked to the resolved principal or existing Consumer matching settings.">
+            Consumer matching behavior
+          </KLabel>
+          <KRadio
+            data-testid="principals-match-consumer-true"
+            description="Use consumers associated with the resolved principal and ignore existing consumer matching settings."
+            label="Use consumers linked to the principal"
+            :model-value="formModel['config-principals-match_consumer']"
+            :selected-value="true"
+            @change="updateField('config-principals-match_consumer', true)"
+          />
+          <KRadio
+            data-testid="principals-match-consumer-false"
+            description="Ignore consumers linked to the principal and continue using configured consumer matching behavior."
+            label="Use existing consumer matching settings"
+            :model-value="formModel['config-principals-match_consumer']"
+            :selected-value="false"
+            @change="updateField('config-principals-match_consumer', false)"
+          />
+        </div>
+
+        <div class="principals-field-group">
+          <KLabel info="Choose whether Kong uses Consumer Groups linked to the resolved principal or existing Consumer Group matching settings.">
+            Consumer group matching behavior
+          </KLabel>
+          <KRadio
+            data-testid="principals-match-consumer-groups-true"
+            description="Use consumer groups associated with the resolved principal and ignore existing consumer group matching settings."
+            label="Use consumer groups linked to the principal"
+            :model-value="formModel['config-principals-match_consumer_groups']"
+            :selected-value="true"
+            @change="updateField('config-principals-match_consumer_groups', true)"
+          />
+          <KRadio
+            data-testid="principals-match-consumer-groups-false"
+            description="Ignore consumer groups linked to the principal and continue using configured consumer group matching behavior."
+            label="Use existing consumer group matching settings"
+            :model-value="formModel['config-principals-match_consumer_groups']"
+            :selected-value="false"
+            @change="updateField('config-principals-match_consumer_groups', false)"
+          />
+        </div>
+      </KCollapse>
+    </template>
+
     <VueFormGenerator
+      v-else
       :model="formModel"
       :options="formOptions"
-      :schema="principalsSchema"
+      :schema="commonFieldsSchema"
       @model-updated="onModelUpdated"
+    />
+
+    <KPrompt
+      action-button-text="Leave page"
+      message="Your unsaved changes will be lost if you continue."
+      title="Leave this page?"
+      :visible="!!leavePromptType"
+      @cancel="leavePromptType = null"
+      @proceed="handleLeaveConfirmed"
     />
   </div>
 </template>
 
 <script>
 import VueFormGenerator from '../FormGenerator.vue'
+import { FORMS_CONFIG } from '../../const'
+import { useAxios } from '@kong-ui-public/entities-shared'
+import { AddIcon, KeyIcon, WorldIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_20, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
-// TODO: check when gateway PR finalized
+const MODE_KONG_IDENTITY = 'kong-identity'
+const MODE_EXTERNAL = 'external'
+
+// TODO: Replace with the actual endpoint once the API is ready
+const KONG_IDENTITY_SERVERS_ENDPOINT = '/v1/auth-servers/_computed'
 
 const PRINCIPALS_FIELD_MODELS = new Set([
   'config-principals-enabled',
@@ -37,9 +246,32 @@ const PRINCIPALS_FIELD_MODELS = new Set([
   'config-principals-error_on_miss',
 ])
 
+// External-auth-server (commonFields) field models — kept in sync with OIDCForm.
+const COMMON_FIELD_MODELS = new Set([
+  'config-client_id',
+  'config-client_secret',
+  'config-issuer',
+])
+
+// Decide the initial radio mode from the existing record.
+const inferInitialMode = (formModel) => {
+  if (formModel['config-principals-enabled'] === true) return MODE_KONG_IDENTITY
+  for (const key of COMMON_FIELD_MODELS) {
+    const v = formModel[key]
+    if (v !== undefined && v !== null && v !== '') return MODE_EXTERNAL
+  }
+  return MODE_KONG_IDENTITY
+}
+
 export default {
   name: 'OIDCPrincipals',
-  components: { VueFormGenerator },
+  components: { VueFormGenerator, AddIcon, KeyIcon, WorldIcon },
+  inject: {
+    formsConfig: {
+      from: FORMS_CONFIG,
+      default: () => ({}),
+    },
+  },
   props: {
     formModel: {
       type: Object,
@@ -53,18 +285,162 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    commonFieldsSchema: {
+      type: Object,
+      required: true,
+    },
     onModelUpdated: {
       type: Function,
       required: true,
     },
   },
+  data() {
+    return {
+      MODE_KONG_IDENTITY,
+      MODE_EXTERNAL,
+      KUI_ICON_SIZE_20,
+      KUI_ICON_SIZE_40,
+      selectedMode: inferInitialMode(this.formModel),
+      kongIdentityServers: [],
+      kongIdentityServersLoading: false,
+      clients: [],
+      clientsLoading: false,
+      selectedClientId: null,
+      selectedServer: null,
+      leavePromptType: null,
+    }
+  },
   computed: {
-    principalsSchema() {
-      return {
-        fields: (this.formSchema.fields || []).filter(
-          (field) => PRINCIPALS_FIELD_MODELS.has(field.model),
-        ),
+    kongIdentityServerItems() {
+      return this.kongIdentityServers.map(s => ({ label: s.name, value: s.id }))
+    },
+    clientItems() {
+      return this.clients.map(c => ({ label: c.name, value: c.client_id || c.id }))
+    },
+  },
+  mounted() {
+    this.fetchKongIdentityServers()
+    // Pre-select the first client_id if it exists (for edit mode)
+    const clientIds = this.formModel['config-client_id']
+    if (Array.isArray(clientIds) && clientIds.length > 0) {
+      this.selectedClientId = clientIds[0]
+    }
+  },
+  methods: {
+    async fetchKongIdentityServers() {
+      try {
+        this.kongIdentityServersLoading = true
+        const { axiosInstance } = useAxios(this.formsConfig?.axiosRequestConfig)
+        const url = `${this.formsConfig.apiBaseUrl}${KONG_IDENTITY_SERVERS_ENDPOINT}`
+        const resp = await axiosInstance.get(url, {
+          // params: { 'page[size]': 30, 'page[number]': 1 },
+        })
+        this.kongIdentityServers = resp.data?.data ?? []
+        // If editing with an existing issuer, try to match a server
+        const issuer = this.formModel['config-issuer']
+        if (issuer && !this.selectedServer) {
+          this.selectedServer = this.kongIdentityServers.find(s => s.issuer === issuer) || null
+          if (this.selectedServer) {
+            this.fetchClients(this.selectedServer.id)
+          }
+        }
+      } catch {
+        this.kongIdentityServers = []
+      } finally {
+        this.kongIdentityServersLoading = false
       }
+    },
+    async fetchClients(serverId) {
+      try {
+        this.clientsLoading = true
+        const { axiosInstance } = useAxios(this.formsConfig?.axiosRequestConfig)
+        const url = `${this.formsConfig.apiBaseUrl}/v1/auth-servers/${serverId}/clients`
+        const resp = await axiosInstance.get(url, {
+          params: { 'page[size]': 30, 'page[number]': 1 },
+        })
+        this.clients = resp.data?.data ?? []
+      } catch {
+        this.clients = []
+      } finally {
+        this.clientsLoading = false
+      }
+    },
+    handleServerChange(serverId) {
+      // Find the selected server and prefill issuer
+      this.selectedServer = this.kongIdentityServers.find(s => s.id === serverId) || null
+      if (this.selectedServer?.issuer) {
+        this.updateField('config-issuer', this.selectedServer.issuer)
+      }
+      // Reset client selection when server changes
+      this.selectedClientId = null
+      this.clients = []
+      this.clientsLoading = !!serverId
+      if (serverId) {
+        this.fetchClients(serverId)
+      }
+    },
+    handleClientChange(clientId) {
+      this.selectedClientId = clientId
+      this.updateField('config-client_id', [clientId])
+    },
+    updateField(field, value) {
+      // eslint-disable-next-line vue/no-mutating-props
+      this.formModel[field] = value
+      this.onModelUpdated()
+    },
+    handleLeaveConfirmed() {
+      const type = this.leavePromptType
+      this.leavePromptType = null
+      const geoApiServerUrl = this.formsConfig?.geoApiServerUrl
+      const geo = geoApiServerUrl
+        ? new URL(geoApiServerUrl).hostname.split('.')[0]
+        : (this.formsConfig?.apiBaseUrl?.match(/^\/([^/]+)/)?.[1] || 'us')
+      if (type === 'authServer') {
+        const url = this.formsConfig?.createAuthServerUrl || `${window.location.origin}/${geo}/kong-identity/auth-servers/create`
+        document.location.href = url
+      } else if (type === 'client') {
+        const url = this.formsConfig?.createClientUrl || `${window.location.origin}/${geo}/kong-identity/auth-servers/${this.selectedServer?.id}/clients/create`
+        document.location.href = url
+      }
+    },
+    handleModeChange(newMode) {
+      if (newMode === MODE_KONG_IDENTITY) {
+        // Clear external-mode fields
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-client_id'] = null
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-client_secret'] = null
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-issuer'] = null
+        // Restore principals defaults
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-enabled'] = true
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-directory'] = 'default'
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-error_on_miss'] = true
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-match_consumer'] = true
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-match_consumer_groups'] = true
+      } else {
+        // Disable principals but keep directory as 'default'
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-enabled'] = false
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-directory'] = 'default'
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-error_on_miss'] = true
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-match_consumer'] = true
+        // eslint-disable-next-line vue/no-mutating-props
+        this.formModel['config-principals-match_consumer_groups'] = true
+        // Reset local state
+        this.selectedServer = null
+        this.selectedClientId = null
+        this.clients = []
+      }
+      this.onModelUpdated()
     },
   },
 }
@@ -89,6 +465,87 @@ export default {
 
   a {
     display: inline;
+  }
+}
+
+.principals-advanced-settings {
+  margin-top: var(--kui-space-50, $kui-space-50);
+
+  :deep(.collapse-hidden-content) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--kui-space-70, $kui-space-70);
+  }
+
+  .k-label {
+    margin-top: var(--kui-space-0, $kui-space-0);
+  }
+}
+
+.oidc-auth-mode-radio-group {
+  display: flex;
+  flex-direction: row;
+  gap: var(--kui-space-40, $kui-space-40);
+  margin-bottom: var(--kui-space-60, $kui-space-60);
+}
+
+.principals-field-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-40, $kui-space-40);
+}
+
+.create-action {
+  align-items: center;
+  color: var(--kui-color-text-primary, $kui-color-text-primary);
+  cursor: pointer;
+  display: flex;
+  font-size: var(--kui-font-size-30, $kui-font-size-30);
+  font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
+  gap: var(--kui-space-20, $kui-space-20);
+
+  .create-action-hint {
+    color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+    font-size: var(--kui-font-size-20, $kui-font-size-20);
+    margin-top: var(--kui-space-20, $kui-space-20);
+  }
+}
+
+:deep(.create-action) {
+  cursor: pointer;
+}
+
+.principals-directory-select,
+.principals-client-select {
+  :deep(.dropdown-footer.dropdown-footer-sticky) {
+    pointer-events: auto;
+  }
+}
+
+
+.auth-mode-card-content {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-20, $kui-space-20);
+  text-align: left;
+
+  .auth-mode-card-label {
+    color: var(--kui-color-text, $kui-color-text);
+    font-size: var(--kui-font-size-30, $kui-font-size-30);
+    font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+  }
+
+  .auth-mode-card-description {
+    color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+    font-size: var(--kui-font-size-20, $kui-font-size-20);
+    font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
+  }
+}
+
+.oidc-auth-mode-radio-group :deep(.k-radio.radio-card.checked.card-horizontal) {
+  .auth-mode-card-label {
+    color: var(--kui-color-text-primary, $kui-color-text-primary);
   }
 }
 </style>

--- a/packages/core/forms/src/components/forms/OIDCPrincipals.vue
+++ b/packages/core/forms/src/components/forms/OIDCPrincipals.vue
@@ -80,7 +80,7 @@
             <div class="create-action-content">
               <span>Create authorization server</span>
               <div class="create-action-hint">
-                You’ll need to return here after creating a auth server. Your progress won’t be saved.
+                You’ll need to return here after creating an authorization server. Your progress won’t be saved.
               </div>
             </div>
           </div>
@@ -142,6 +142,7 @@
           />
         </div>
         <button
+          aria-label="Remove client"
           class="remove-client-btn"
           data-testid="remove-client-action"
           :disabled="isRemoveClientDisabled"
@@ -266,13 +267,78 @@
       </KCollapse>
     </template>
 
-    <VueFormGenerator
-      v-else
-      :model="formModel"
-      :options="formOptions"
-      :schema="commonFieldsSchema"
-      @model-updated="onModelUpdated"
-    />
+    <template v-else>
+      <div
+        v-for="(clientId, index) in clientIdArray"
+        :key="index"
+        class="client-row"
+        :class="{ 'client-row-with-label': index === 0 }"
+      >
+        <div class="external-client-field">
+          <KInput
+            class="external-client-input"
+            data-testid="external-client-id"
+            :label="index === 0 ? 'Client id' : undefined"
+            :label-attributes="{ info: externalClientIdField?.help }"
+            :model-value="clientIdArray[index]"
+            placeholder="e.g., kong-gateway-client"
+            @update:model-value="handleClientChange(index, $event)"
+          />
+          <component
+            :is="autofillSlot"
+            v-if="autofillSlot"
+            :schema="{ model: 'config-client_id', referenceable: true }"
+            :update="(val) => handleClientChange(index, val)"
+            :value="clientIdArray[index]"
+          />
+        </div>
+        <div class="external-client-field">
+          <KInput
+            class="external-client-input"
+            data-testid="external-client-secret"
+            :label="index === 0 ? 'Client secret' : undefined"
+            :label-attributes="{ info: externalClientSecretField?.help }"
+            :model-value="clientSecretArray[index]"
+            placeholder="e.g., your-client-secret"
+            show-password-mask-toggle
+            type="password"
+            @update:model-value="handleClientSecretChange(index, $event)"
+          />
+          <component
+            :is="autofillSlot"
+            v-if="autofillSlot"
+            :schema="{ model: 'config-client_secret', referenceable: true }"
+            :update="(val) => handleClientSecretChange(index, val)"
+            :value="clientSecretArray[index]"
+          />
+        </div>
+        <button
+          aria-label="Remove client"
+          class="remove-client-btn"
+          data-testid="remove-external-client-action"
+          :disabled="clientIdArray.length <= 1"
+          type="button"
+          @click="removeClientRow(index)"
+        >
+          <CloseIcon :size="KUI_ICON_SIZE_30" />
+        </button>
+      </div>
+
+      <div
+        class="add-client-inline"
+        data-testid="add-external-client-action"
+        @click="addClientRow()"
+      >
+        + Add client
+      </div>
+
+      <VueFormGenerator
+        :model="formModel"
+        :options="formOptions"
+        :schema="issuerFieldsSchema"
+        @model-updated="onModelUpdated"
+      />
+    </template>
 
     <KPrompt
       action-button-text="Leave page"
@@ -342,7 +408,7 @@ const inferInitialLookupMethod = (formModel) => {
 const inferInitialMode = (formModel, isEditing) => {
   if (formModel['config-principals-enabled'] === true) return MODE_KONG_IDENTITY
   // On edit, respect principals-enabled=false as External mode
-  if (isEditing && formModel['config-principals-enabled'] === false) return MODE_EXTERNAL
+  if (isEditing && formModel['config-principals-enabled'] !== true) return MODE_EXTERNAL
   for (const key of COMMON_FIELD_MODELS) {
     const v = formModel[key]
     if (v !== undefined && v !== null && v !== '') return MODE_EXTERNAL
@@ -410,6 +476,18 @@ export default {
     }
   },
   computed: {
+    // External-mode schema for the issuer field only — client_id/client_secret
+    // are rendered as paired rows below, so VFG only handles issuer here.
+    issuerFieldsSchema() {
+      const fields = (this.commonFieldsSchema?.fields ?? []).filter(f => f.model === 'config-issuer')
+      return { ...this.commonFieldsSchema, fields }
+    },
+    externalClientIdField() {
+      return (this.commonFieldsSchema?.fields ?? []).find(f => f.model === 'config-client_id')
+    },
+    externalClientSecretField() {
+      return (this.commonFieldsSchema?.fields ?? []).find(f => f.model === 'config-client_secret')
+    },
     kongIdentityServerItems() {
       return this.kongIdentityServers.map(s => ({ label: s.name, value: s.id }))
     },
@@ -507,30 +585,24 @@ export default {
       this.updateField('config-client_id', clientIds)
     },
     addClientRow() {
-      const clientIds = Array.isArray(this.formModel['config-client_id'])
-        ? [...this.formModel['config-client_id']]
-        : []
+      // Base off the normalized arrays so the virtualized first row (when the
+      // model is still null) is preserved instead of being dropped.
+      const clientIds = [...this.clientIdArray]
       clientIds.push(null)
       this.updateField('config-client_id', clientIds)
 
-      const secrets = Array.isArray(this.formModel['config-client_secret'])
-        ? [...this.formModel['config-client_secret']]
-        : []
+      const secrets = [...this.clientSecretArray]
       secrets.push(null)
       this.updateField('config-client_secret', secrets)
     },
     removeClientRow(index) {
       if (this.clientIdArray.length <= 1) return
 
-      const clientIds = Array.isArray(this.formModel['config-client_id'])
-        ? [...this.formModel['config-client_id']]
-        : []
+      const clientIds = [...this.clientIdArray]
       clientIds.splice(index, 1)
       this.updateField('config-client_id', clientIds)
 
-      const secrets = Array.isArray(this.formModel['config-client_secret'])
-        ? [...this.formModel['config-client_secret']]
-        : []
+      const secrets = [...this.clientSecretArray]
       secrets.splice(index, 1)
       this.updateField('config-client_secret', secrets)
     },
@@ -567,9 +639,6 @@ export default {
       const parts = value.split(/(?<!\\)\./).map(part => part.replace(/\\\./g, '.').trim()).filter(Boolean)
       this.updateField('config-principals-principal_claim', parts)
     },
-    syncLookupMethod() {
-      this.selectedLookupMethod = inferInitialLookupMethod(this.formModel)
-    },
     handleMatchConsumerChange(checked) {
       this.updateField('config-principals-match_consumer', checked)
       if (!checked) {
@@ -589,9 +658,6 @@ export default {
     updateField(field, value) {
       // eslint-disable-next-line vue/no-mutating-props
       this.formModel[field] = value
-      if (field === 'config-principals-principal_claim' || field === 'config-principals-principal_by') {
-        this.syncLookupMethod()
-      }
       this.onModelUpdated()
     },
     handleLeaveConfirmed() {
@@ -817,6 +883,16 @@ export default {
 
 :deep(.create-action) {
   cursor: pointer;
+}
+
+// External auth server mode: client_id + client_secret share a row.
+.external-client-field {
+  flex: 1;
+  min-width: 0;
+
+  .external-client-input {
+    width: 100%;
+  }
 }
 
 .principals-directory-select {

--- a/packages/core/forms/src/components/forms/OIDCPrincipals.vue
+++ b/packages/core/forms/src/components/forms/OIDCPrincipals.vue
@@ -319,9 +319,7 @@ export default {
         this.kongIdentityServersLoading = true
         const { axiosInstance } = useAxios(this.formsConfig?.axiosRequestConfig)
         const url = `${this.formsConfig.apiBaseUrl}${KONG_IDENTITY_SERVERS_ENDPOINT}`
-        const resp = await axiosInstance.get(url, {
-          // params: { 'page[size]': 30, 'page[number]': 1 },
-        })
+        const resp = await axiosInstance.get(url)
         this.kongIdentityServers = resp.data?.data ?? []
         // If editing with an existing issuer, try to match a server
         const issuer = this.formModel['config-issuer']
@@ -342,9 +340,7 @@ export default {
         this.clientsLoading = true
         const { axiosInstance } = useAxios(this.formsConfig?.axiosRequestConfig)
         const url = `${this.formsConfig.apiBaseUrl}/v1/auth-servers/${serverId}/clients`
-        const resp = await axiosInstance.get(url, {
-          params: { 'page[size]': 30, 'page[number]': 1 },
-        })
+        const resp = await axiosInstance.get(url)
         this.clients = resp.data?.data ?? []
       } catch {
         this.clients = []
@@ -392,7 +388,9 @@ export default {
         const url = this.formsConfig?.createAuthServerUrl || `${window.location.origin}/${geo}/identity/create-auth-server`
         document.location.href = url
       } else if (type === 'client') {
-        const url = this.formsConfig?.createClientUrl || `${window.location.origin}/${geo}/kong-identity/auth-servers/${this.selectedServer?.id}/create-auth-server-client`
+        const url = this.formsConfig?.createClientUrl
+          ? this.formsConfig.createClientUrl(this.selectedServer?.id)
+          : `${window.location.origin}/${geo}/identity/auth-servers/${this.selectedServer?.id}/create-auth-server-client`
         document.location.href = url
       }
     },

--- a/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
@@ -228,6 +228,119 @@ describe('<OIDCForm />', () => {
       cy.getTestId('oidc-principals-section').should('exist')
     })
 
+    it('should select Use sessions by default for Kong Identity when creating', () => {
+      const formModel = {
+        ...OIDCModelWithPrincipals,
+        'config-auth_methods': [
+          'password',
+          'client_credentials',
+          'authorization_code',
+          'bearer',
+          'introspection',
+          'userinfo',
+          'kong_oauth2',
+          'refresh_token',
+          'session',
+        ],
+      }
+
+      cy.mount(OIDCForm, {
+        props: {
+          ...requiredProps,
+          formSchema: OIDCFormSchemaWithPrincipals,
+          formModel,
+        },
+        global: {
+          provide: {
+            'kong-ui-forms-config': baseConfigKonnect,
+          },
+        },
+      })
+
+      cy.getTestId('session-radio-use').closest('.k-radio').should('have.class', 'checked')
+      cy.wrap(formModel).its('config-auth_methods').should('deep.equal', [
+        'bearer',
+        'client_credentials',
+        'introspection',
+        'userinfo',
+        'session',
+      ])
+    })
+
+    it('should preserve Use sessions from auth_methods when editing Kong Identity', () => {
+      const formModel = {
+        ...OIDCModelWithPrincipals,
+        id: 'plugin-id',
+        'config-principals-enabled': true,
+        'config-auth_methods': [
+          'bearer',
+          'client_credentials',
+          'introspection',
+          'userinfo',
+          'session',
+        ],
+      }
+
+      cy.mount(OIDCForm, {
+        props: {
+          ...requiredProps,
+          isEditing: true,
+          formSchema: OIDCFormSchemaWithPrincipals,
+          formModel,
+        },
+        global: {
+          provide: {
+            'kong-ui-forms-config': baseConfigKonnect,
+          },
+        },
+      })
+
+      cy.getTestId('session-radio-use').closest('.k-radio').should('have.class', 'checked')
+      cy.wrap(formModel).its('config-auth_methods').should('deep.equal', [
+        'bearer',
+        'client_credentials',
+        'introspection',
+        'userinfo',
+        'session',
+      ])
+    })
+
+    it('should preserve disabled session management from auth_methods when editing Kong Identity', () => {
+      const formModel = {
+        ...OIDCModelWithPrincipals,
+        id: 'plugin-id',
+        'config-principals-enabled': true,
+        'config-auth_methods': [
+          'bearer',
+          'client_credentials',
+          'introspection',
+          'userinfo',
+        ],
+      }
+
+      cy.mount(OIDCForm, {
+        props: {
+          ...requiredProps,
+          isEditing: true,
+          formSchema: OIDCFormSchemaWithPrincipals,
+          formModel,
+        },
+        global: {
+          provide: {
+            'kong-ui-forms-config': baseConfigKonnect,
+          },
+        },
+      })
+
+      cy.getTestId('session-radio-no-use').closest('.k-radio').should('have.class', 'checked')
+      cy.wrap(formModel).its('config-auth_methods').should('deep.equal', [
+        'bearer',
+        'client_credentials',
+        'introspection',
+        'userinfo',
+      ])
+    })
+
     it('should not render principals section in Kong Manager', () => {
       cy.mount(OIDCForm, {
         props: {
@@ -243,6 +356,61 @@ describe('<OIDCForm />', () => {
       })
 
       cy.getTestId('oidc-principals-section').should('not.exist')
+    })
+
+    it('should render old auth_methods checkbox UI in Kong Manager', () => {
+      cy.mount(OIDCForm, {
+        props: {
+          ...requiredProps,
+          formSchema: OIDCFormSchemaWithPrincipals,
+          formModel: OIDCModelWithPrincipals,
+        },
+        global: {
+          provide: {
+            'kong-ui-forms-config': baseConfigKM,
+          },
+        },
+      })
+
+      cy.getTestId('auth-methods-multiselect').should('not.exist')
+      cy.getTestId('session-radio-use').should('not.exist')
+      cy.contains('Auth methods').should('exist')
+      cy.getTestId('auth-method-checkbox-authorization_code').should('exist')
+      cy.getTestId('auth-method-checkbox-bearer').should('exist')
+      cy.getTestId('auth-method-checkbox-refresh_token').should('exist')
+      cy.getTestId('session-management-switch').should('exist')
+    })
+
+    it('should not update principals directory when changing principal lookup method', () => {
+      const formModel = {
+        ...OIDCModelWithPrincipals,
+        'config-principals-enabled': true,
+        'config-principals-directory': 'default',
+        'config-principals-principal_by': null,
+        'config-principals-principal_claim': null,
+      }
+
+      cy.mount(OIDCForm, {
+        props: {
+          ...requiredProps,
+          formSchema: OIDCFormSchemaWithPrincipals,
+          formModel,
+        },
+        global: {
+          provide: {
+            'kong-ui-forms-config': baseConfigKonnect,
+          },
+        },
+      })
+
+      cy.getTestId('oidc-principals-section').within(() => {
+        cy.getTestId('collapse-trigger-label').click()
+        cy.getTestId('principals-lookup-method').click()
+      })
+      cy.getTestId('select-item-custom-identity').click()
+
+      cy.getTestId('principals-custom-identity-name').should('exist')
+      cy.wrap(formModel).its('config-principals-directory').should('equal', 'default')
     })
 
     it('should not render principals section in Konnect when schema has no principals fields', () => {

--- a/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
@@ -114,10 +114,17 @@ const OIDCModelWithPrincipals = {
   'config-principals-error_on_miss': false,
 }
 
+const requiredProps = {
+  isEditing: false,
+  onModelUpdated: () => {},
+  onPartialToggled: () => {},
+}
+
 describe('<OIDCForm />', () => {
   it('should render redis fields as common fields when enableRedisPartial is not passed', () => {
     cy.mount(OIDCForm, {
       props: {
+        ...requiredProps,
         formSchema: OIDCFormSchema,
         formModel: OIDCModel,
       },
@@ -159,6 +166,7 @@ describe('<OIDCForm />', () => {
     ).as('getRedisEEPartial')
     cy.mount(OIDCForm, {
       props: {
+        ...requiredProps,
         formSchema: OIDCFormSchema,
         formModel: OIDCModel,
         enableRedisPartial: true,
@@ -190,9 +198,23 @@ describe('<OIDCForm />', () => {
   })
 
   describe('Kong Identity principals', () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v1/auth-servers/_computed`,
+        },
+        {
+          statusCode: 200,
+          body: { data: [] },
+        },
+      ).as('getAuthServers')
+    })
+
     it('should render principals section in Konnect when schema has principals fields', () => {
       cy.mount(OIDCForm, {
         props: {
+          ...requiredProps,
           formSchema: OIDCFormSchemaWithPrincipals,
           formModel: OIDCModelWithPrincipals,
         },
@@ -209,6 +231,7 @@ describe('<OIDCForm />', () => {
     it('should not render principals section in Kong Manager', () => {
       cy.mount(OIDCForm, {
         props: {
+          ...requiredProps,
           formSchema: OIDCFormSchemaWithPrincipals,
           formModel: OIDCModelWithPrincipals,
         },
@@ -225,6 +248,7 @@ describe('<OIDCForm />', () => {
     it('should not render principals section in Konnect when schema has no principals fields', () => {
       cy.mount(OIDCForm, {
         props: {
+          ...requiredProps,
           formSchema: OIDCFormSchema,
           formModel: OIDCModel,
         },

--- a/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
@@ -38,6 +38,64 @@ const principalsFields = [
     valueType: 'string',
     order: 0,
   },
+  {
+    id: 'config-principals-principal_by',
+    model: 'config-principals-principal_by',
+    type: 'radio',
+    label: 'Config.Principals.Principal By',
+    default: 'username',
+    values: [
+      { name: 'username', value: 'username' },
+      { name: 'custom_id', value: 'custom_id' },
+    ],
+    order: 0,
+  },
+  {
+    id: 'config-principals-principal_claim',
+    model: 'config-principals-principal_claim',
+    type: 'input',
+    inputType: 'text',
+    label: 'Config.Principals.Principal Claim',
+    default: 'sub',
+    valueType: 'string',
+    order: 0,
+  },
+  {
+    id: 'config-principals-match_consumer',
+    model: 'config-principals-match_consumer',
+    type: 'radio',
+    label: 'Config.Principals.Match Consumer',
+    default: true,
+    values: [
+      { name: 'True', value: true },
+      { name: 'False', value: false },
+    ],
+    order: 0,
+  },
+  {
+    id: 'config-principals-match_consumer_groups',
+    model: 'config-principals-match_consumer_groups',
+    type: 'radio',
+    label: 'Config.Principals.Match Consumer Groups',
+    default: true,
+    values: [
+      { name: 'True', value: true },
+      { name: 'False', value: false },
+    ],
+    order: 0,
+  },
+  {
+    id: 'config-principals-error_on_miss',
+    model: 'config-principals-error_on_miss',
+    type: 'radio',
+    label: 'Config.Principals.Error On Miss',
+    default: false,
+    values: [
+      { name: 'True', value: true },
+      { name: 'False', value: false },
+    ],
+    order: 0,
+  },
 ]
 
 const OIDCFormSchemaWithPrincipals = {
@@ -49,6 +107,11 @@ const OIDCModelWithPrincipals = {
   ...OIDCModel,
   'config-principals-enabled': false,
   'config-principals-directory': 'default',
+  'config-principals-principal_by': 'username',
+  'config-principals-principal_claim': 'sub',
+  'config-principals-match_consumer': true,
+  'config-principals-match_consumer_groups': true,
+  'config-principals-error_on_miss': false,
 }
 
 describe('<OIDCForm />', () => {

--- a/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
@@ -147,6 +147,63 @@ describe('OIDCPrincipals', () => {
     })
   })
 
+  describe('identifier claim transformation', () => {
+    it('splits identifier claim by dot into a list', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-principals-directory': 'custom-plugin',
+        'config-principals-principal_claim': null,
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      ;(wrapper.vm as any).handleIdentifierClaimChange('user.employee_id')
+
+      expect(formModel['config-principals-principal_claim']).toEqual(['user', 'employee_id'])
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+  })
+
+  describe('client selection array behavior', () => {
+    it('handleClientChange updates the correct index in config-client_id', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-client_id': ['client-a'],
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      ;(wrapper.vm as any).handleClientChange(0, 'client-b')
+
+      expect(formModel['config-client_id']).toEqual(['client-b'])
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+
+    it('addClientRow pushes a null entry to config-client_id', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-client_id': ['client-a'],
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      ;(wrapper.vm as any).addClientRow()
+
+      expect(formModel['config-client_id']).toEqual(['client-a', null])
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+
+    it('removeClientRow splices the entry at the given index', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-client_id': ['client-a', 'client-b', 'client-c'],
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      ;(wrapper.vm as any).removeClientRow(1)
+
+      expect(formModel['config-client_id']).toEqual(['client-a', 'client-c'])
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+  })
+
   describe('edit after creation (principals fields populated)', () => {
     it('infers Kong Identity mode when config-principals-enabled is true', () => {
       const wrapper = mountComponent({
@@ -154,30 +211,17 @@ describe('OIDCPrincipals', () => {
         'config-issuer': 'https://my-issuer.example.com',
       })
 
-      // Should show Kong Identity UI (selects, issuer input)
+      // Should show Kong Identity UI (selects)
       expect(wrapper.find('[data-testid="principals-directory-select"]').exists()).toBe(true)
-      expect(wrapper.find('[data-testid="principals-issuer"]').exists()).toBe(true)
     })
 
-    it('issuer field is rendered with disabled attribute', () => {
-      const wrapper = mountComponent({
-        'config-principals-enabled': true,
-        'config-issuer': 'https://my-issuer.example.com',
-      })
-
-      const issuerWrapper = wrapper.find('[data-testid="principals-issuer"]')
-      expect(issuerWrapper.exists()).toBe(true)
-      // KInput receives the disabled prop — verify via component attributes
-      expect(issuerWrapper.attributes('disabled')).toBeDefined()
-    })
-
-    it('pre-selects the first client_id in edit mode', () => {
+    it('clientIdArray computed returns existing client_id array for edit mode', () => {
       const wrapper = mountComponent({
         'config-principals-enabled': true,
         'config-client_id': ['client-abc'],
       })
 
-      expect((wrapper.vm as any).selectedClientId).toBe('client-abc')
+      expect((wrapper.vm as any).clientIdArray).toEqual(['client-abc'])
     })
   })
 
@@ -208,6 +252,103 @@ describe('OIDCPrincipals', () => {
       // and common fields have values
       expect(wrapper.find('.stub-vfg').exists()).toBe(true)
       expect(wrapper.find('[data-testid="principals-directory-select"]').exists()).toBe(false)
+    })
+
+    it('defaults lookup method to the first option when principal fields are empty', () => {
+      const wrapper = mountComponent({
+        'config-principals-directory': 'default',
+        'config-principals-principal_claim': null,
+        'config-principals-principal_by': undefined,
+      })
+
+      expect((wrapper.vm as any).selectedLookupMethod).toBe('kong-identity')
+    })
+  })
+
+  describe('lookup method switching', () => {
+    it('selecting kong-identity clears principal_by and principal_claim', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-principals-directory': 'custom-plugin',
+        'config-principals-principal_by': 'Customer_ID',
+        'config-principals-principal_claim': ['user', 'employee_id'],
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      ;(wrapper.vm as any).updateField('config-principals-directory', 'kong-identity')
+
+      expect(formModel['config-principals-principal_by']).toBeNull()
+      expect(formModel['config-principals-principal_claim']).toBeNull()
+      expect((wrapper.vm as any).selectedLookupMethod).toBe('kong-identity')
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+
+    it('selecting custom-plugin does not clear principal fields', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-principals-directory': 'kong-identity',
+        'config-principals-principal_by': null,
+        'config-principals-principal_claim': null,
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      ;(wrapper.vm as any).updateField('config-principals-directory', 'custom-plugin')
+
+      expect((wrapper.vm as any).selectedLookupMethod).toBe('custom-plugin')
+      expect(formModel['config-principals-principal_by']).toBeNull()
+      expect(formModel['config-principals-principal_claim']).toBeNull()
+    })
+  })
+
+  describe('identifier claim escaping', () => {
+    it('parses simple dot notation into array parts', () => {
+      const wrapper = mountComponent()
+      const vm = wrapper.vm as any
+
+      vm.handleIdentifierClaimChange('user.name')
+
+      const formModel = wrapper.props('formModel')
+      expect(formModel['config-principals-principal_claim']).toEqual(['user', 'name'])
+    })
+
+    it('parses escaped dots as literal dots within a part', () => {
+      const wrapper = mountComponent()
+      const vm = wrapper.vm as any
+
+      vm.handleIdentifierClaimChange('user.name\\.first')
+
+      const formModel = wrapper.props('formModel')
+      expect(formModel['config-principals-principal_claim']).toEqual(['user', 'name.first'])
+    })
+
+    it('handles empty input', () => {
+      const wrapper = mountComponent()
+      const vm = wrapper.vm as any
+
+      vm.handleIdentifierClaimChange('')
+
+      const formModel = wrapper.props('formModel')
+      expect(formModel['config-principals-principal_claim']).toEqual([])
+    })
+
+    it('displays array with literal dots using escape notation', () => {
+      const wrapper = mountComponent({
+        'config-principals-principal_claim': ['user', 'name.first'],
+      })
+      const vm = wrapper.vm as any
+
+      expect(vm.getIdentifierClaimInputValue()).toBe('user.name\\.first')
+    })
+
+    it('round-trips complex claim correctly', () => {
+      const wrapper = mountComponent()
+      const vm = wrapper.vm as any
+
+      vm.handleIdentifierClaimChange('org\\.name.user.id\\.v2')
+
+      const formModel = wrapper.props('formModel')
+      expect(formModel['config-principals-principal_claim']).toEqual(['org.name', 'user', 'id.v2'])
+      expect(vm.getIdentifierClaimInputValue()).toBe('org\\.name.user.id\\.v2')
     })
   })
 })

--- a/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import OIDCPrincipals from '../OIDCPrincipals.vue'
+import { FORMS_CONFIG } from '../../../const'
+
+// Stub VueFormGenerator to avoid rendering real form fields in External mode
+vi.mock('../../FormGenerator.vue', () => ({
+  default: {
+    name: 'VueFormGenerator',
+    template: '<div class="stub-vfg" />',
+    props: ['model', 'options', 'schema'],
+  },
+}))
+
+// Stub useAxios so network calls don't fire
+vi.mock('@kong-ui-public/entities-shared', () => ({
+  useAxios: () => ({
+    axiosInstance: { get: vi.fn().mockResolvedValue({ data: { data: [] } }) },
+  }),
+}))
+
+const formsConfig = {
+  apiBaseUrl: '/us',
+}
+
+function buildFormModel(overrides = {}) {
+  return {
+    'config-client_id': null,
+    'config-client_secret': null,
+    'config-issuer': null,
+    'config-principals-enabled': true,
+    'config-principals-directory': 'default',
+    'config-principals-principal_by': null,
+    'config-principals-principal_claim': null,
+    'config-principals-match_consumer': true,
+    'config-principals-match_consumer_groups': true,
+    'config-principals-error_on_miss': true,
+    ...overrides,
+  }
+}
+
+const baseProps = {
+  formSchema: { fields: [] },
+  formOptions: {},
+  commonFieldsSchema: { fields: [] },
+  onModelUpdated: vi.fn(),
+}
+
+function mountComponent(formModelOverrides = {}, propsOverrides = {}) {
+  const formModel = buildFormModel(formModelOverrides)
+  return mount(OIDCPrincipals, {
+    props: {
+      ...baseProps,
+      formModel,
+      ...propsOverrides,
+    },
+    global: {
+      provide: {
+        [FORMS_CONFIG]: formsConfig,
+      },
+    },
+  })
+}
+
+describe('OIDCPrincipals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('mode toggle data changes', () => {
+    it('switching to External sets principals-enabled to false and resets local state', async () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({}, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      // Initially in Kong Identity mode
+      expect(wrapper.find('[data-testid="principals-directory-select"]').exists()).toBe(true)
+
+      // Switch to External
+      const externalRadio = wrapper.find('[data-testid="oidc-auth-mode-external"]')
+      await externalRadio.trigger('change')
+
+      // The component calls handleModeChange which sets these values
+      expect(formModel['config-principals-enabled']).toBe(false)
+      expect(formModel['config-principals-directory']).toBe('default')
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+
+    it('switching back to Kong Identity restores principals defaults and clears external fields', async () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-principals-enabled': false,
+        'config-client_id': ['my-client'],
+        'config-client_secret': 'secret',
+        'config-issuer': 'https://issuer.example.com',
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      // Starts in External mode
+      expect(wrapper.find('.stub-vfg').exists()).toBe(true)
+
+      // Call handleModeChange directly (KRadio event plumbing is a Kongponents concern)
+      ;(wrapper.vm as any).handleModeChange('kong-identity')
+      await wrapper.vm.$nextTick()
+
+      expect(formModel['config-principals-enabled']).toBe(true)
+      expect(formModel['config-principals-match_consumer']).toBe(true)
+      expect(formModel['config-principals-match_consumer_groups']).toBe(true)
+      expect(formModel['config-principals-error_on_miss']).toBe(true)
+      expect(formModel['config-client_id']).toBeNull()
+      expect(formModel['config-client_secret']).toBeNull()
+      expect(formModel['config-issuer']).toBeNull()
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+  })
+
+  describe('checkbox cascade', () => {
+    it('unchecking match_consumer unchecks match_consumer_groups', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-principals-match_consumer': true,
+        'config-principals-match_consumer_groups': true,
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      // Call the handler directly (avoids KCollapse visibility / KCheckbox DOM issues)
+      ;(wrapper.vm as any).handleMatchConsumerChange(false)
+
+      expect(formModel['config-principals-match_consumer']).toBe(false)
+      expect(formModel['config-principals-match_consumer_groups']).toBe(false)
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+
+    it('checking match_consumer does not automatically re-check match_consumer_groups', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-principals-match_consumer': false,
+        'config-principals-match_consumer_groups': false,
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      ;(wrapper.vm as any).handleMatchConsumerChange(true)
+
+      expect(formModel['config-principals-match_consumer']).toBe(true)
+      // consumer groups remains unchecked — user must re-enable explicitly
+      expect(formModel['config-principals-match_consumer_groups']).toBe(false)
+    })
+  })
+
+  describe('edit after creation (principals fields populated)', () => {
+    it('infers Kong Identity mode when config-principals-enabled is true', () => {
+      const wrapper = mountComponent({
+        'config-principals-enabled': true,
+        'config-issuer': 'https://my-issuer.example.com',
+      })
+
+      // Should show Kong Identity UI (selects, issuer input)
+      expect(wrapper.find('[data-testid="principals-directory-select"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="principals-issuer"]').exists()).toBe(true)
+    })
+
+    it('issuer field is rendered with disabled attribute', () => {
+      const wrapper = mountComponent({
+        'config-principals-enabled': true,
+        'config-issuer': 'https://my-issuer.example.com',
+      })
+
+      const issuerWrapper = wrapper.find('[data-testid="principals-issuer"]')
+      expect(issuerWrapper.exists()).toBe(true)
+      // KInput receives the disabled prop — verify via component attributes
+      expect(issuerWrapper.attributes('disabled')).toBeDefined()
+    })
+
+    it('pre-selects the first client_id in edit mode', () => {
+      const wrapper = mountComponent({
+        'config-principals-enabled': true,
+        'config-client_id': ['client-abc'],
+      })
+
+      expect((wrapper.vm as any).selectedClientId).toBe('client-abc')
+    })
+  })
+
+  describe('edit existing plugin before schema change (no principals fields)', () => {
+    it('infers External mode when principals fields are absent but common fields have values', () => {
+      // Simulate a plugin created before principals was added to the schema:
+      // No config-principals-* fields exist, but config-client_id and config-issuer are set
+      const formModel = {
+        'config-client_id': null,
+        'config-client_secret': null,
+        'config-issuer': 'https://legacy-issuer.example.com',
+        // principals fields are completely absent (undefined)
+      }
+
+      const wrapper = mount(OIDCPrincipals, {
+        props: {
+          ...baseProps,
+          formModel,
+        },
+        global: {
+          provide: {
+            [FORMS_CONFIG]: formsConfig,
+          },
+        },
+      })
+
+      // Should show VueFormGenerator (External mode) since principals-enabled is undefined
+      // and common fields have values
+      expect(wrapper.find('.stub-vfg').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="principals-directory-select"]').exists()).toBe(false)
+    })
+  })
+})

--- a/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import OIDCPrincipals from '../OIDCPrincipals.vue'
 import { FORMS_CONFIG } from '../../../const'
 
@@ -12,10 +12,11 @@ vi.mock('../../FormGenerator.vue', () => ({
   },
 }))
 
-// Stub useAxios so network calls don't fire
+// Configurable mock for useAxios
+const mockGet = vi.fn().mockResolvedValue({ data: { data: [] } })
 vi.mock('@kong-ui-public/entities-shared', () => ({
   useAxios: () => ({
-    axiosInstance: { get: vi.fn().mockResolvedValue({ data: { data: [] } }) },
+    axiosInstance: { get: (...args: any[]) => mockGet(...args) },
   }),
 }))
 
@@ -65,6 +66,8 @@ function mountComponent(formModelOverrides = {}, propsOverrides = {}) {
 describe('OIDCPrincipals', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default fallback so unmatched calls don't consume mockResolvedValueOnce
+    mockGet.mockResolvedValue({ data: { data: [] } })
   })
 
   describe('mode toggle data changes', () => {
@@ -350,5 +353,125 @@ describe('OIDCPrincipals', () => {
       expect(formModel['config-principals-principal_claim']).toEqual(['org.name', 'user', 'id.v2'])
       expect(vm.getIdentifierClaimInputValue()).toBe('org\\.name.user.id\\.v2')
     })
+  })
+
+  describe('auth server and client selection', () => {
+    const mockServers = [
+      { id: 'server-1', name: 'Auth Server 1', issuer: 'https://auth1.example.com' },
+      { id: 'server-2', name: 'Auth Server 2', issuer: 'https://auth2.example.com' },
+    ]
+    const mockClients = [
+      { id: 'client-1', name: 'Client A', client_id: 'client-id-a' },
+      { id: 'client-2', name: 'Client B', client_id: 'client-id-b' },
+    ]
+
+    it('fetches auth servers on mount and populates the list', async () => {
+      mockGet.mockResolvedValueOnce({ data: { data: mockServers } })
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      expect(vm.kongIdentityServers).toEqual(mockServers)
+      expect(vm.kongIdentityServerItems).toEqual([
+        { label: 'Auth Server 1', value: 'server-1' },
+        { label: 'Auth Server 2', value: 'server-2' },
+      ])
+    })
+
+    it('selecting a server sets issuer and fetches clients', async () => {
+      mockGet
+        .mockResolvedValueOnce({ data: { data: mockServers } }) // fetchKongIdentityServers
+        .mockResolvedValueOnce({ data: { data: mockClients } }) // fetchClients
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.handleServerChange('server-1')
+      await flushPromises()
+
+      const formModel = wrapper.props('formModel')
+      expect(formModel['config-issuer']).toBe('https://auth1.example.com')
+      expect(vm.selectedServer).toEqual(mockServers[0])
+      expect(vm.clients).toEqual(mockClients)
+      expect(vm.clientItems).toEqual([
+        { label: 'Client A', value: 'client-id-a' },
+        { label: 'Client B', value: 'client-id-b' },
+      ])
+    })
+
+    it('selecting a client updates config-client_id', async () => {
+      mockGet
+        .mockResolvedValueOnce({ data: { data: mockServers } })
+        .mockResolvedValueOnce({ data: { data: mockClients } })
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.handleServerChange('server-1')
+      await flushPromises()
+
+      vm.handleClientChange(0, 'client-id-a')
+
+      const formModel = wrapper.props('formModel')
+      expect(formModel['config-client_id']).toEqual(['client-id-a'])
+    })
+
+    it('changing server resets client selection', async () => {
+      mockGet
+        .mockResolvedValueOnce({ data: { data: mockServers } })
+        .mockResolvedValueOnce({ data: { data: mockClients } })
+        .mockResolvedValueOnce({ data: { data: [] } }) // new server has no clients
+
+      const wrapper = mountComponent({
+        'config-client_id': ['client-id-a'],
+        'config-client_secret': ['secret-a'],
+      })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.handleServerChange('server-2')
+      await flushPromises()
+
+      const formModel = wrapper.props('formModel')
+      expect(formModel['config-client_id']).toEqual([null])
+      expect(formModel['config-client_secret']).toEqual([null])
+      expect(formModel['config-issuer']).toBe('https://auth2.example.com')
+
+      wrapper.unmount()
+    })
+
+    // it('matches existing issuer to a server on mount when editing', async () => {
+    //   mockGet.mockImplementation((url: string) => {
+    //     if (url.includes('/auth-servers/_computed')) {
+    //       return Promise.resolve({ data: { data: mockServers } })
+    //     }
+    //     if (url.includes('/clients')) {
+    //       return Promise.resolve({ data: { data: mockClients } })
+    //     }
+    //     return Promise.resolve({ data: { data: [] } })
+    //   })
+
+    //   const wrapper = mountComponent({
+    //     'config-issuer': 'https://auth2.example.com',
+    //   })
+    //   await flushPromises()
+    //   await flushPromises()
+    //   await flushPromises()
+
+    //   // Debug
+    //   const calls = mockGet.mock.calls.map(c => c[0])
+    //   console.log('mockGet calls:', JSON.stringify(calls))
+    //   console.log('call count:', mockGet.mock.calls.length)
+
+    //   const vm = wrapper.vm as any
+    //   console.log('kongIdentityServers:', JSON.stringify(vm.kongIdentityServers))
+    //   console.log('kongIdentityServersLoading:', vm.kongIdentityServersLoading)
+    //   expect(vm.kongIdentityServers).toEqual(mockServers)
+    //   expect(vm.selectedServer).toEqual(mockServers[1])
+    //   expect(vm.clients).toEqual(mockClients)
+    // })
   })
 })

--- a/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
@@ -154,7 +154,7 @@ describe('OIDCPrincipals', () => {
     it('splits identifier claim by dot into a list', () => {
       const onModelUpdated = vi.fn()
       const wrapper = mountComponent({
-        'config-principals-directory': 'custom-plugin',
+        'config-principals-directory': 'default',
         'config-principals-principal_claim': null,
       }, { onModelUpdated })
       const formModel = wrapper.props('formModel')
@@ -167,6 +167,38 @@ describe('OIDCPrincipals', () => {
   })
 
   describe('client selection array behavior', () => {
+    it('disables remove client action when client row is disabled or last remaining row', async () => {
+      const wrapper = mountComponent()
+
+      expect(wrapper.find('[data-testid="remove-client-action"]').attributes('disabled')).toBeDefined()
+
+      ;(wrapper.vm as any).selectedServer = { id: 'server-1', name: 'Server 1' }
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[data-testid="remove-client-action"]').attributes('disabled')).toBeDefined()
+
+      const wrapperWithMultipleRows = mountComponent({
+        'config-client_id': ['client-a', 'client-b'],
+      })
+      ;(wrapperWithMultipleRows.vm as any).selectedServer = { id: 'server-1', name: 'Server 1' }
+      await wrapperWithMultipleRows.vm.$nextTick()
+
+      expect(wrapperWithMultipleRows.find('[data-testid="remove-client-action"]').attributes('disabled')).toBeUndefined()
+    })
+
+    it('does not remove the last remaining client row', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent({
+        'config-client_id': ['client-a'],
+      }, { onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      ;(wrapper.vm as any).removeClientRow(0)
+
+      expect(formModel['config-client_id']).toEqual(['client-a'])
+      expect(onModelUpdated).not.toHaveBeenCalled()
+    })
+
     it('handleClientChange updates the correct index in config-client_id', () => {
       const onModelUpdated = vi.fn()
       const wrapper = mountComponent({
@@ -272,32 +304,34 @@ describe('OIDCPrincipals', () => {
     it('selecting kong-identity clears principal_by and principal_claim', () => {
       const onModelUpdated = vi.fn()
       const wrapper = mountComponent({
-        'config-principals-directory': 'custom-plugin',
+        'config-principals-directory': 'default',
         'config-principals-principal_by': 'Customer_ID',
         'config-principals-principal_claim': ['user', 'employee_id'],
       }, { onModelUpdated })
       const formModel = wrapper.props('formModel')
 
-      ;(wrapper.vm as any).updateField('config-principals-directory', 'kong-identity')
+      ;(wrapper.vm as any).handleLookupMethodChange('kong-identity')
 
       expect(formModel['config-principals-principal_by']).toBeNull()
       expect(formModel['config-principals-principal_claim']).toBeNull()
+      expect(formModel['config-principals-directory']).toBe('default')
       expect((wrapper.vm as any).selectedLookupMethod).toBe('kong-identity')
       expect(onModelUpdated).toHaveBeenCalled()
     })
 
-    it('selecting custom-plugin does not clear principal fields', () => {
+    it('selecting custom-identity does not clear principal fields', () => {
       const onModelUpdated = vi.fn()
       const wrapper = mountComponent({
-        'config-principals-directory': 'kong-identity',
+        'config-principals-directory': 'default',
         'config-principals-principal_by': null,
         'config-principals-principal_claim': null,
       }, { onModelUpdated })
       const formModel = wrapper.props('formModel')
 
-      ;(wrapper.vm as any).updateField('config-principals-directory', 'custom-plugin')
+      ;(wrapper.vm as any).handleLookupMethodChange('custom-identity')
 
-      expect((wrapper.vm as any).selectedLookupMethod).toBe('custom-plugin')
+      expect((wrapper.vm as any).selectedLookupMethod).toBe('custom-identity')
+      expect(formModel['config-principals-directory']).toBe('default')
       expect(formModel['config-principals-principal_by']).toBeNull()
       expect(formModel['config-principals-principal_claim']).toBeNull()
     })
@@ -442,36 +476,5 @@ describe('OIDCPrincipals', () => {
 
       wrapper.unmount()
     })
-
-    // it('matches existing issuer to a server on mount when editing', async () => {
-    //   mockGet.mockImplementation((url: string) => {
-    //     if (url.includes('/auth-servers/_computed')) {
-    //       return Promise.resolve({ data: { data: mockServers } })
-    //     }
-    //     if (url.includes('/clients')) {
-    //       return Promise.resolve({ data: { data: mockClients } })
-    //     }
-    //     return Promise.resolve({ data: { data: [] } })
-    //   })
-
-    //   const wrapper = mountComponent({
-    //     'config-issuer': 'https://auth2.example.com',
-    //   })
-    //   await flushPromises()
-    //   await flushPromises()
-    //   await flushPromises()
-
-    //   // Debug
-    //   const calls = mockGet.mock.calls.map(c => c[0])
-    //   console.log('mockGet calls:', JSON.stringify(calls))
-    //   console.log('call count:', mockGet.mock.calls.length)
-
-    //   const vm = wrapper.vm as any
-    //   console.log('kongIdentityServers:', JSON.stringify(vm.kongIdentityServers))
-    //   console.log('kongIdentityServersLoading:', vm.kongIdentityServersLoading)
-    //   expect(vm.kongIdentityServers).toEqual(mockServers)
-    //   expect(vm.selectedServer).toEqual(mockServers[1])
-    //   expect(vm.clients).toEqual(mockClients)
-    // })
   })
 })

--- a/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
@@ -117,6 +117,54 @@ describe('OIDCPrincipals', () => {
     })
   })
 
+  describe('external mode client rows', () => {
+    // isEditing + principals-enabled=false forces External mode (see inferInitialMode)
+    const externalProps = { isEditing: true }
+    const externalModel = { 'config-principals-enabled': false }
+
+    it('renders one client row with id + secret inputs and a single add control', () => {
+      const wrapper = mountComponent(externalModel, externalProps)
+
+      expect(wrapper.find('[data-testid="external-client-id"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="external-client-secret"]').exists()).toBe(true)
+      // A single "+ Add client" control governs the paired row, not one per field
+      expect(wrapper.findAll('[data-testid="add-external-client-action"]')).toHaveLength(1)
+    })
+
+    it('+ Add client appends an entry to both client_id and client_secret arrays', async () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent(externalModel, { ...externalProps, onModelUpdated })
+      const formModel = wrapper.props('formModel')
+
+      await wrapper.find('[data-testid="add-external-client-action"]').trigger('click')
+
+      expect(formModel['config-client_id']).toHaveLength(2)
+      expect(formModel['config-client_secret']).toHaveLength(2)
+      expect(onModelUpdated).toHaveBeenCalled()
+    })
+
+    it('remove control is disabled with a single row and removes a row when multiple exist', async () => {
+      const wrapper = mountComponent({
+        ...externalModel,
+        'config-client_id': ['a', 'b'],
+        'config-client_secret': ['sa', 'sb'],
+      }, externalProps)
+      const formModel = wrapper.props('formModel')
+
+      const removeButtons = wrapper.findAll('[data-testid="remove-external-client-action"]')
+      expect(removeButtons).toHaveLength(2)
+
+      await removeButtons[1].trigger('click')
+
+      expect(formModel['config-client_id']).toEqual(['a'])
+      expect(formModel['config-client_secret']).toEqual(['sa'])
+
+      // With one row left, the remaining remove control is disabled
+      const remaining = wrapper.find('[data-testid="remove-external-client-action"]')
+      expect(remaining.attributes('disabled')).toBeDefined()
+    })
+  })
+
   describe('checkbox cascade', () => {
     it('unchecking match_consumer unchecks match_consumer_groups', () => {
       const onModelUpdated = vi.fn()
@@ -286,6 +334,31 @@ describe('OIDCPrincipals', () => {
       // Should show VueFormGenerator (External mode) since principals-enabled is undefined
       // and common fields have values
       expect(wrapper.find('.stub-vfg').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="principals-directory-select"]').exists()).toBe(false)
+    })
+
+    it('infers External mode on edit when principals-enabled is absent and no common fields are set', () => {
+      // Legacy plugin predating the principals feature: no principals-* fields,
+      // and no client/issuer either. On edit this must NOT default to Kong
+      // Identity (a legacy plugin cannot be KI).
+      const wrapper = mount(OIDCPrincipals, {
+        props: {
+          ...baseProps,
+          isEditing: true,
+          formModel: {
+            'config-client_id': null,
+            'config-client_secret': null,
+            'config-issuer': null,
+          },
+        },
+        global: {
+          provide: {
+            [FORMS_CONFIG]: formsConfig,
+          },
+        },
+      })
+
+      expect((wrapper.vm as any).selectedMode).toBe('external')
       expect(wrapper.find('[data-testid="principals-directory-select"]').exists()).toBe(false)
     })
 

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -460,6 +460,24 @@ describe('ConfigFormContent', () => {
       cy.getTestId('ff-kong-identity-field').should('not.exist')
     })
 
+    it('hides principals and identity_realms fields while keeping defaults in data', () => {
+      mountContent(schemaWithRealms, { isKonnect: false }, {
+        config: {
+          principals: { enabled: false, directory: 'default' },
+          identity_realms: null,
+        },
+      })
+
+      cy.getTestId('ff-kong-identity-field').should('not.exist')
+      cy.getTestId('ff-object-config.principals').should('not.exist')
+      cy.getTestId('ff-array-config.identity_realms').should('not.exist')
+      cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+        return val.config?.principals?.enabled === false
+          && val.config?.principals?.directory === 'default'
+          && val.config?.identity_realms === null
+      }))
+    })
+
     it('does not show Kong Identity selector without principals in schema', () => {
       mountContent(schemaWithoutPrincipals, { isKonnect: false })
 

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -78,6 +78,10 @@ export interface KonnectPluginFormConfig extends BasePluginFormConfig, KonnectBa
   isKonnectManagedRedisEnabled?: boolean
   /** When true, CP is a Cloud Gateway */
   isCloudGateway?: boolean
+  /** URL to navigate to when creating a new Kong Identity auth server */
+  createAuthServerUrl?: string
+  /** URL to navigate to when creating a new Kong Identity client */
+  createClientUrl?: string
 }
 
 /** Kong Manager Plugin form config */

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -80,8 +80,8 @@ export interface KonnectPluginFormConfig extends BasePluginFormConfig, KonnectBa
   isCloudGateway?: boolean
   /** URL to navigate to when creating a new Kong Identity auth server */
   createAuthServerUrl?: string
-  /** URL to navigate to when creating a new Kong Identity client */
-  createClientUrl?: string
+  /** Function that returns the URL to navigate to when creating a new Kong Identity client */
+  createClientUrl?: (authServerId: string) => string
 }
 
 /** Kong Manager Plugin form config */

--- a/packages/entities/entities-plugins/vite.config.ts
+++ b/packages/entities/entities-plugins/vite.config.ts
@@ -34,6 +34,7 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
         '@kong-ui-public/monaco-editor',
         '@kong-ui-public/monaco-editor/dist/runtime/style.css',
         '@kong-ui-public/forms',
+        '@kong-ui-public/forms/dist/style.css',
         '@vue-flow/background',
         '@vue-flow/controls',
         '@vue-flow/controls/dist/style.css',


### PR DESCRIPTION
# Summary

## feat: OIDC Principals — Kong Identity mode

Adds a principals section to the OIDC plugin form with two modes:
- **Kong Identity**: Auth server + client selects (API-fetched), auto-fills issuer, advanced settings (error-on-miss, consumer/group matching)
- **External**: Standard manual issuer/client config via VueFormGenerator

Key points:
- `createAuthServerUrl` / `createClientUrl` added to `KonnectPluginFormConfig` (flows via existing `FORMS_CONFIG` inject)
- Leave-page confirmation before navigating to create pages
- `config-principals-directory` always remains `'default'`; toggling modes restores defaults
- Geo-aware fallback URLs derived from `geoApiServerUrl` or `apiBaseUrl`