### PR TITLE
fix(analytics-chart): pass increaseIsBad to defineIcon in SingleValue

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
@@ -141,7 +141,7 @@ describe('<SingleValue />', () => {
   it('applies positive/negative classes based on increaseIsBad', () => {
     const exploreResult = buildExploreResult({ previous: 100, current: 250 })
 
-    // increase is good (default)
+    // increase is good (default): green color, arrow still points up
     cy.mount(SingleValue, {
       props: {
         data: exploreResult,
@@ -151,8 +151,9 @@ describe('<SingleValue />', () => {
     })
 
     cy.get('.trend-change').should('have.class', 'positive')
+    cy.get('.trend-change .trend-up-icon').should('exist')
 
-    // increase is bad
+    // increase is bad: red color, but arrow should still point up
     cy.mount(SingleValue, {
       props: {
         data: exploreResult,
@@ -162,6 +163,7 @@ describe('<SingleValue />', () => {
     })
 
     cy.get('.trend-change').should('have.class', 'negative')
+    cy.get('.trend-change .trend-up-icon').should('exist')
   })
 
   it('renders value and unit on the same horizontal line', () => {

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
@@ -214,7 +214,7 @@ const formattedValue = computed((): string => {
 
 const change = computed(() => calculateChange(singleValue.value ?? 0, previousValue.value ?? 0) || 0)
 const polarity = computed(() => changePolarity(change.value, true, props.increaseIsBad)) // Assume hasTrendAccess=true
-const trendIcon = computed(() => defineIcon(polarity.value))
+const trendIcon = computed(() => defineIcon(polarity.value, props.increaseIsBad))
 const formattedChange = computed(() => metricChange(change.value, true, i18n.t('singleValue.trend.not_available')))
 const trendRange = useTrendRange(computed(() => props.showTrend), undefined, computed(() => props.data.meta))
 


### PR DESCRIPTION
[KM-2674]

`SingleValue` computes `trendIcon` from `polarity` (already flipped by `increaseIsBad`) but doesn't forward `increaseIsBad` to `defineIcon()`. This causes the arrow direction to flip along with the color, when only the color should change.


**Before:** `increaseIsBad: true` + value increasing -> red **down** arrow (wrong direction)
<img width="579" height="279" alt="image" src="https://github.com/user-attachments/assets/609d361e-2893-4271-8291-50ec154d4318" />

**After:** `increaseIsBad: true` + value increasing -> red **up** arrow (correct direction)
<img width="782" height="285" alt="image" src="https://github.com/user-attachments/assets/f1562079-0501-49a0-a460-43889cd711ac" />


[KM-2674]: https://konghq.atlassian.net/browse/KM-2674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ