### PR TITLE
feat: Support TopN entity link mappings

### DIFF
--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -173,6 +173,29 @@ describe('dashboardSchema.v2', () => {
     expect(validateDashboardConfigSchema(topNEntityLinksConfig)).toBe(true)
   })
 
+  it('accepts dashboard queries with three dimensions', () => {
+    const topNThreeDimensionConfig = {
+      ...dashboardConfig,
+      tiles: [
+        {
+          ...dashboardConfig.tiles[0],
+          definition: {
+            query: {
+              ...strictQuery,
+              dimensions: ['route', 'gateway_service', 'consumer'],
+            },
+            chart: {
+              type: 'top_n',
+            },
+          },
+        },
+      ],
+    }
+
+    expect(validateValidDashboardQuery(topNThreeDimensionConfig.tiles[0].definition.query)).toBe(true)
+    expect(validateDashboardConfigSchema(topNThreeDimensionConfig)).toBe(true)
+  })
+
   it('rejects top_n entity link mappings with non-string values', () => {
     const topNEntityLinksConfig = {
       ...dashboardConfig,

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -149,6 +149,52 @@ describe('dashboardSchema.v2', () => {
     expect(validateDashboardConfigSchema(mixedDashboardConfig)).toBe(true)
   })
 
+  it('accepts top_n entity link mappings', () => {
+    const topNEntityLinksConfig = {
+      ...dashboardConfig,
+      tiles: [
+        {
+          ...dashboardConfig.tiles[0],
+          definition: {
+            query: strictQuery,
+            chart: {
+              type: 'top_n',
+              entity_link: 'https://example.com/routes/{entity-id}',
+              entity_links: {
+                route: 'https://example.com/routes/{entity-id}',
+                gateway_service: 'https://example.com/services/{entity-id}',
+              },
+            },
+          },
+        },
+      ],
+    }
+
+    expect(validateDashboardConfigSchema(topNEntityLinksConfig)).toBe(true)
+  })
+
+  it('rejects top_n entity link mappings with non-string values', () => {
+    const topNEntityLinksConfig = {
+      ...dashboardConfig,
+      tiles: [
+        {
+          ...dashboardConfig.tiles[0],
+          definition: {
+            query: strictQuery,
+            chart: {
+              type: 'top_n',
+              entity_links: {
+                route: 1,
+              },
+            },
+          },
+        },
+      ],
+    }
+
+    expect(validateDashboardConfigSchema(topNEntityLinksConfig)).toBe(false)
+  })
+
   it.each([
     [apiUsageQuerySchema, exploreAggregations, queryableExploreDimensions, filterableExploreDimensions],
     [basicQuerySchema, basicExploreAggregations, queryableBasicExploreDimensions, filterableBasicExploreDimensions],

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -50,6 +50,13 @@ const allowCsvExport = {
   type: 'boolean',
 } as const
 
+const entityLinks = {
+  type: 'object',
+  additionalProperties: {
+    type: 'string',
+  },
+} as const satisfies JSONSchema
+
 const chartDatasetColorsSchema = {
   type: ['object', 'array'],
   items: {
@@ -205,6 +212,7 @@ export const topNTableSchema = {
     entity_link: {
       type: 'string',
     },
+    entity_links: entityLinks,
   },
   required: ['type'],
   additionalProperties: false,

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -390,7 +390,7 @@ const dimensionsFn = <T extends readonly string[] | undefined>(dimensions?: T) =
   type: 'array',
   description: 'List of attributes or entity types to group by.',
   minItems: 0,
-  maxItems: 2,
+  maxItems: 3,
   items: {
     type: 'string',
     ...(dimensions ? { enum: dimensions } : {}),

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -7,6 +7,7 @@ import type {
   DatasourceAwareQuery,
   DatasourceConfig,
   ExploreFilterAll,
+  ExploreQuery,
   ExploreResultV4,
   TileConfig,
   Timeframe,
@@ -110,44 +111,77 @@ describe('<DashboardRenderer />', () => {
     setActivePinia(createPinia())
   })
 
+  const routeAndGatewayServiceExploreResponse: ExploreResultV4 = {
+    ...routeExploreResponse,
+    meta: {
+      ...routeExploreResponse.meta,
+      display: {
+        ...routeExploreResponse.meta.display,
+        gateway_service: {
+          'service-1': { name: 'Gateway Service 1', deleted: false },
+          'service-2': { name: 'Gateway Service 2', deleted: false },
+        },
+      },
+    },
+    data: routeExploreResponse.data.map((record, index) => {
+      return {
+        ...record,
+        event: {
+          ...record.event,
+          gateway_service: index === 0 ? 'service-1' : 'service-2',
+        },
+      }
+    }),
+  }
+
+  const getRouteResponse = (dimensions: ExploreQuery['dimensions']): ExploreResultV4 => {
+    return dimensions?.includes('gateway_service') ? routeAndGatewayServiceExploreResponse : routeExploreResponse
+  }
+
+  const getTimeSeriesResponse = (query: ExploreQuery): ExploreResultV4 => {
+    if (query.metrics?.[0] === 'request_count') {
+      // Traffic + Error rate cards
+      return nonTsExploreResponse
+    }
+
+    if (query.metrics?.[0] === 'response_latency_p99' && query.metrics.length === 1) {
+      // Latency metrics card
+      return timeSeriesExploreResponse
+    }
+
+    // Timeseries Line chart
+    return generateSingleMetricTimeSeriesData(
+      { name: 'TotalRequests', unit: 'count' },
+      { status_code: query.metrics as string[] },
+    ) as ExploreResultV4
+  }
+
+  const getCrossSectionalResponse = (): ExploreResultV4 => {
+    // Dimensions to use if query is not provided
+    const dimensionMap = { status_code: ['1XX', '2XX', '3XX', '4XX', '5XX'] }
+
+    return generateCrossSectionalData(
+      [
+        { name: 'TotalRequests', unit: 'count' },
+      ],
+      dimensionMap,
+    ) as ExploreResultV4
+  }
+
   const mockQueryProvider = (opts?: MockOptions): AnalyticsBridge => {
     const queryFn = (dsAwareQuery: DatasourceAwareQuery): Promise<ExploreResultV4> => {
       const { query } = dsAwareQuery as AdvancedDatasourceQuery
+      const dimensions = query.dimensions || []
 
-      // Dimensions to use if query is not provided
-      const dimensionMap = { status_code: ['1XX', '2XX', '3XX', '4XX', '5XX'] }
-
-      if (query.dimensions && query.dimensions.findIndex(d => d === 'route') > -1) {
-        return Promise.resolve(routeExploreResponse)
+      if (dimensions.includes('route')) {
+        return Promise.resolve(getRouteResponse(dimensions))
       }
 
-      if (query.dimensions && query.dimensions.findIndex(d => d === 'time') > -1) {
-        if (query.metrics && query.metrics[0] === 'request_count') {
-        // Traffic + Error rate cards
-          return Promise.resolve(nonTsExploreResponse)
-        } else if (query.metrics && query.metrics[0] === 'response_latency_p99' && query.metrics.length === 1) {
-        // Latency metrics card
-          return Promise.resolve(timeSeriesExploreResponse)
-        } else {
-        // Timeseries Line chart
-          const timeSeriesResponse = generateSingleMetricTimeSeriesData(
-            { name: 'TotalRequests', unit: 'count' },
-            { status_code: query.metrics as string[] },
-          ) as ExploreResultV4
-
-          return Promise.resolve(timeSeriesResponse)
-        }
-      } else {
-      // Bar charts (non-time series)
-        const nonTimeSeriesResponse = generateCrossSectionalData(
-          [
-            { name: 'TotalRequests', unit: 'count' },
-          ],
-          dimensionMap,
-        ) as ExploreResultV4
-
-        return Promise.resolve(nonTimeSeriesResponse)
+      if (dimensions.includes('time')) {
+        return Promise.resolve(getTimeSeriesResponse(query))
       }
+
+      return Promise.resolve(getCrossSectionalResponse())
     }
 
     const configFn = (): Promise<AnalyticsConfigV2> => {
@@ -483,6 +517,185 @@ describe('<DashboardRenderer />', () => {
 
     // Check value of href attribute
     cy.get('[data-testid="row-b486fb30-e058-4b5f-85c2-495ec26ba522:09ba7bc7-58d6-42d5-b9c0-3ffb28b307e6"] > [data-testid="entity-link-parent"] > a').should('have.attr', 'href').and('eq', 'https://test.com/cp/b486fb30-e058-4b5f-85c2-495ec26ba522/entity/09ba7bc7-58d6-42d5-b9c0-3ffb28b307e6')
+  })
+
+  it('Renders a dashboard with a TopNTable with EntityLinks mapped by dimension', () => {
+    const customTimeframe = datePickerSelectionToTimeframe({
+      timePeriodsKey: 'custom',
+      start: new Date('2024-03-03T21:10:28.969Z'),
+      end: new Date('2024-03-06T21:10:28.969Z'),
+    }) as Timeframe
+
+    const props = {
+      context: {
+        filters: [],
+        timeSpec: customTimeframe.v4Query(),
+      },
+      modelValue: {
+        tiles: [
+          {
+            definition: {
+              chart: {
+                type: 'top_n',
+                entity_links: {
+                  route: `https://test.com/routes/${ENTITY_ID_TOKEN}`,
+                  gateway_service: `https://test.com/services/${ENTITY_ID_TOKEN}`,
+                },
+              },
+              query: {
+                datasource: 'basic',
+                dimensions: ['route', 'gateway_service'],
+              },
+            },
+            layout: {
+              position: {
+                col: 0,
+                row: 0,
+              },
+              size: {
+                cols: 3,
+                rows: 2,
+              },
+            },
+          },
+        ],
+      },
+    }
+
+    cy.mount(DashboardRenderer, {
+      props,
+      global: {
+        provide: {
+          [INJECT_QUERY_PROVIDER]: mockQueryProvider({ renderEntityLink: true }),
+        },
+      },
+    })
+
+    cy.get('tbody tr').first().within(() => {
+      cy.get('td').eq(0).find('[data-testid="entity-link-parent"] > a')
+        .should('have.attr', 'href')
+        .and('eq', 'https://test.com/routes/09ba7bc7-58d6-42d5-b9c0-3ffb28b307e6')
+
+      cy.get('td').eq(1).find('[data-testid="entity-link-parent"] > a')
+        .should('have.attr', 'href')
+        .and('eq', 'https://test.com/services/service-1')
+    })
+  })
+
+  it('Prefers TopNTable EntityLinks mapped by dimension over the legacy EntityLink', () => {
+    const customTimeframe = datePickerSelectionToTimeframe({
+      timePeriodsKey: 'custom',
+      start: new Date('2024-03-03T21:10:28.969Z'),
+      end: new Date('2024-03-06T21:10:28.969Z'),
+    }) as Timeframe
+
+    const props = {
+      context: {
+        filters: [],
+        timeSpec: customTimeframe.v4Query(),
+      },
+      modelValue: {
+        tiles: [
+          {
+            definition: {
+              chart: {
+                type: 'top_n',
+                entity_link: `https://test.com/legacy/${ENTITY_ID_TOKEN}`,
+                entity_links: {
+                  route: `https://test.com/routes/${ENTITY_ID_TOKEN}`,
+                },
+              },
+              query: {
+                datasource: 'basic',
+                dimensions: ['route'],
+              },
+            },
+            layout: {
+              position: {
+                col: 0,
+                row: 0,
+              },
+              size: {
+                cols: 3,
+                rows: 2,
+              },
+            },
+          },
+        ],
+      },
+    }
+
+    cy.mount(DashboardRenderer, {
+      props,
+      global: {
+        provide: {
+          [INJECT_QUERY_PROVIDER]: mockQueryProvider({ renderEntityLink: true }),
+        },
+      },
+    })
+
+    cy.get('[data-testid="row-b486fb30-e058-4b5f-85c2-495ec26ba522:09ba7bc7-58d6-42d5-b9c0-3ffb28b307e6"] > [data-testid="entity-link-parent"] > a')
+      .should('have.attr', 'href')
+      .and('eq', 'https://test.com/routes/09ba7bc7-58d6-42d5-b9c0-3ffb28b307e6')
+  })
+
+  it('Uses the legacy TopNTable EntityLink only for the primary dimension', () => {
+    const customTimeframe = datePickerSelectionToTimeframe({
+      timePeriodsKey: 'custom',
+      start: new Date('2024-03-03T21:10:28.969Z'),
+      end: new Date('2024-03-06T21:10:28.969Z'),
+    }) as Timeframe
+
+    const props = {
+      context: {
+        filters: [],
+        timeSpec: customTimeframe.v4Query(),
+      },
+      modelValue: {
+        tiles: [
+          {
+            definition: {
+              chart: {
+                type: 'top_n',
+                entity_link: `https://test.com/routes/${ENTITY_ID_TOKEN}`,
+              },
+              query: {
+                datasource: 'basic',
+                dimensions: ['route', 'gateway_service'],
+              },
+            },
+            layout: {
+              position: {
+                col: 0,
+                row: 0,
+              },
+              size: {
+                cols: 3,
+                rows: 2,
+              },
+            },
+          },
+        ],
+      },
+    }
+
+    cy.mount(DashboardRenderer, {
+      props,
+      global: {
+        provide: {
+          [INJECT_QUERY_PROVIDER]: mockQueryProvider({ renderEntityLink: true }),
+        },
+      },
+    })
+
+    cy.get('tbody tr').first().within(() => {
+      cy.get('td').eq(0).find('[data-testid="entity-link-parent"] > a')
+        .should('have.attr', 'href')
+        .and('eq', 'https://test.com/routes/09ba7bc7-58d6-42d5-b9c0-3ffb28b307e6')
+
+      cy.get('td').eq(1).should('contain.text', 'Gateway Service 1')
+      cy.get('td').eq(1).find('a').should('not.exist')
+    })
   })
 
   it('Renders a dashboard with a TopNTable with fallback EntityLinks', () => {

--- a/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
@@ -11,10 +11,11 @@
       :synthetics-data-key="chartOptions.synthetics_data_key"
     >
       <template
-        v-if="props.chartOptions.entity_link"
+        v-if="hasEntityLinkOptions"
         #name="{ record }"
       >
         <AsyncEntityLink
+          v-if="getEntityLink(record)"
           :entity-link-data="{
             id: record.id,
             label: record.name,
@@ -22,6 +23,9 @@
           }"
           :external-link="parseLink(record)"
         />
+        <template v-else>
+          {{ record.name }}
+        </template>
       </template>
     </TopNTable>
   </QueryDataProvider>
@@ -34,7 +38,7 @@ import { CP_ID_TOKEN, ENTITY_ID_TOKEN, INJECT_QUERY_PROVIDER } from '../constant
 import { TopNTable } from '@kong-ui-public/analytics-chart'
 import type { TopNTableRecord } from '@kong-ui-public/analytics-chart'
 import QueryDataProvider from './QueryDataProvider.vue'
-import { inject, defineAsyncComponent } from 'vue'
+import { computed, defineAsyncComponent, inject } from 'vue'
 import FallbackEntityLink from './FallbackEntityLink.vue'
 
 const props = defineProps<RendererProps<TopNTableOptions>>()
@@ -57,16 +61,43 @@ const AsyncEntityLink = defineAsyncComponent(async () => {
   return FallbackEntityLink
 })
 
+const hasEntityLinkOptions = computed((): boolean => {
+  return !!props.chartOptions.entity_link || !!Object.keys(props.chartOptions.entity_links || {}).length
+})
+
+const getMappedEntityLink = (dimension: string): string => {
+  const entityLinks = props.chartOptions.entity_links
+
+  if (!entityLinks) {
+    return ''
+  }
+
+  return entityLinks[dimension] || Object.entries(entityLinks).find(([key]) => key.toLowerCase() === dimension.toLowerCase())?.[1] || ''
+}
+
+const isPrimaryDimensionRecord = (record: TopNTableRecord): boolean => {
+  const primaryDimension = record.dimensions?.[0]?.dimension
+
+  return !primaryDimension || primaryDimension === record.dimension
+}
+
+const getEntityLink = (record: TopNTableRecord): string => {
+  return getMappedEntityLink(record.dimension) || (isPrimaryDimensionRecord(record) ? props.chartOptions.entity_link || '' : '')
+}
+
 const parseLink = (record: TopNTableRecord) => {
-  if (props.chartOptions?.entity_link) {
+  const entityLink = getEntityLink(record)
+
+  if (entityLink) {
     if (record.id.includes(':')) {
       const [cpId, entityId] = record.id.split(':')
 
-      return props.chartOptions.entity_link.replace(CP_ID_TOKEN, cpId).replace(ENTITY_ID_TOKEN, entityId)
+      return entityLink.replace(CP_ID_TOKEN, cpId).replace(ENTITY_ID_TOKEN, entityId)
     } else {
-      return props.chartOptions.entity_link.replace(ENTITY_ID_TOKEN, record.id)
+      return entityLink.replace(ENTITY_ID_TOKEN, record.id)
     }
   }
+
   return ''
 }
 


### PR DESCRIPTION
## Summary

In service of: https://konghq.atlassian.net/browse/MA-5040 

Adds `entity_links` support for TopN dashboard tiles so each rendered dimension can resolve its own entity link template.

- Adds `entity_links` to the TopN dashboard chart schema while keeping the existing `entity_link` option.
- Updates `TopNTableRenderer` to resolve links by `record.dimension`, with case-insensitive matching.
- Preserves backwards compatibility by using legacy `entity_link` only as the primary-dimension fallback.
- Ensures mapped `entity_links` entries win over legacy `entity_link` when both are configured.
- Update dashboard schema to allow queries with 3 dimensions
