### PR TITLE
refactor(entities-plugins): centralize scope preparation

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
@@ -239,34 +239,20 @@ const ingestEndpointUrl = computed(() => {
     : 'https://{{region}}.api.konghq.com/v3/openmeter/events'
 })
 
-function getScopesFromFormModel(): Record<string, any> {
-  const data: Record<string, any> = {}
-  const scopeModelFields = ['service-id', 'route-id', 'consumer-id', 'consumer_group-id']
-  for (const field of scopeModelFields) {
-    if (props.formModel[field]) {
-      const name = field.split('-')[0]
-      if (name) data[name] = { id: props.formModel[field] }
-    }
-  }
-  return data
-}
-
 const formConfig = {
   hasValue: (data: any): boolean => !!data && Object.keys(data).length > 0,
   prepareFormData: (data: any): any => {
     if (props.isEditing) return data
 
-    const withScopes = { ...data, ...getScopesFromFormModel() }
-
     // Prefill ingest_endpoint for new Konnect plugins; Kong Manager has no regional endpoint
-    if ((appConfig as KonnectBaseFormConfig)?.app === 'konnect' && !withScopes?.config?.ingest_endpoint) {
+    if ((appConfig as KonnectBaseFormConfig)?.app === 'konnect' && !data?.config?.ingest_endpoint) {
       return {
-        ...withScopes,
-        config: { ...withScopes?.config, ingest_endpoint: ingestEndpointUrl.value },
+        ...data,
+        config: { ...data?.config, ingest_endpoint: ingestEndpointUrl.value },
       }
     }
 
-    return withScopes
+    return data
   },
 }
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/request-callout/RequestCalloutForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/request-callout/RequestCalloutForm.vue
@@ -73,20 +73,6 @@ function getNameMap(callouts: Callout[], reverse: boolean = false) {
   }, {} as Record<string, string>)
 }
 
-function getScopesFromFormModel(): Record<string, any> {
-  const data: Record<string, any> = {}
-  const scopeModelFields = ['service-id', 'route-id', 'consumer-id', 'consumer_group-id']
-  for (const field of scopeModelFields) {
-    if (props.formModel[field]) {
-      const name = field.split('-')[0]
-      if (name) {
-        data[name] = { id: props.formModel[field] }
-      }
-    }
-  }
-  return data
-}
-
 // Replace callout names in `depends_on` with freshly generated ids
 function prepareFormData(data: RequestCalloutPlugin) {
   const pluginConfig = cloneDeep(data)
@@ -105,10 +91,6 @@ function prepareFormData(data: RequestCalloutPlugin) {
     callouts.forEach((callout) => {
       callout.depends_on = callout.depends_on.map((name) => nameMap[name])
     })
-  }
-
-  if (!props.isEditing) {
-    return { ...pluginConfig, ...getScopesFromFormModel() } as RequestCalloutPlugin
   }
 
   return pluginConfig

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -359,13 +359,18 @@ const slots = defineSlots<{
 }>()
 
 const realFormConfig = computed(() => {
-  return props.formConfig ?? {
-    hasValue: (data?: T): boolean => !!data && Object.keys(data).length > 0,
+  const formConfig = props.formConfig as FormConfig<T> | undefined
+
+  return {
+    ...(formConfig ?? {}),
+    hasValue: formConfig?.hasValue ?? ((data?: T): boolean => !!data && Object.keys(data).length > 0),
     prepareFormData: (data: T): Partial<T> => {
-      if (props.isEditing) return data
+      const preparedData = formConfig?.prepareFormData?.(data) ?? data
+
+      if (props.isEditing) return preparedData
 
       // Init scope-related fields from formModel when creating a new plugin
-      return { ...data, ... getScopesFromFormModel() }
+      return { ...preparedData, ... getScopesFromFormModel() }
     },
   }
 })


### PR DESCRIPTION
## Summary

Legacy scope initialization now happens inside `StandardLayout` even when a plugin wrapper supplies its own `prepareFormData`. Request Callout and Metering and Billing wrappers now only handle their plugin-specific data preparation instead of reading the VFG `formModel` directly.
