### PR TITLE
feat(entities-plugins): add dynamic freeform layout

### DIFF
--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormWithIdentity.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormWithIdentity.vue
@@ -1,16 +1,16 @@
 <template>
-  <StandardLayout v-bind="props">
+  <DynamicLayout v-bind="props">
     <ConfigFormContent />
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
 import { provide } from 'vue'
 import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
-import StandardLayout from '../../free-form/shared/layout/StandardLayout.vue'
+import DynamicLayout from '../../free-form/shared/layout/DynamicLayout.vue'
 import ConfigFormContent from './ConfigFormContent.vue'
 
-import type { Props } from '../../free-form/shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../../free-form/shared/layout/provider'
 
 const props = defineProps<Props>()
 

--- a/packages/entities/entities-plugins/src/components/free-form/Common/CommonForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/Common/CommonForm.vue
@@ -1,16 +1,16 @@
 <template>
-  <StandardLayout v-bind="props">
+  <DynamicLayout v-bind="props">
     <ConfigForm />
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
 import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
 import { provide } from 'vue'
 import ConfigForm from './ConfigForm.vue'
-import StandardLayout from '../shared/layout/StandardLayout.vue'
+import DynamicLayout from '../shared/layout/DynamicLayout.vue'
 
-import type { Props } from '../shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../shared/layout/provider'
 
 const props = defineProps<Props>()
 

--- a/packages/entities/entities-plugins/src/components/free-form/README.md
+++ b/packages/entities/entities-plugins/src/components/free-form/README.md
@@ -35,7 +35,9 @@ free-form/
 │   ├── EntityChecksAlert.vue # Validation constraint alerts
 │   ├── composables/         # Vue composables (core logic, including map entry tracking)
 │   ├── layout/              # Layout components
-│   │   ├── StandardLayout.vue  # Shared layout with form/code modes
+│   │   ├── DynamicLayout.vue   # Runtime-selected layout wrapper
+│   │   ├── StandardLayout.vue  # Default API Gateway layout with form/code modes
+│   │   ├── provider.ts         # Layout injection key and provider helper
 │   │   └── ConditionField.vue  # Optional condition editor in General Info
 │   ├── types.ts             # Core type definitions
 │   ├── const.ts             # Injection keys (REDIS_PARTIAL_INFO, FORM_EDITING)
@@ -183,11 +185,13 @@ Constraints:
 
 ## Layout
 
-All plugin forms use `StandardLayout` (`shared/layout/StandardLayout.vue`) as the unified layout component. In form mode it provides a 3-step structure:
+Plugin forms use `DynamicLayout` (`shared/layout/DynamicLayout.vue`) as the layout entry point. It renders a host-provided layout from `FREE_FORM_PLUGIN_LAYOUT` when one is available, and otherwise falls back to `StandardLayout` (`shared/layout/StandardLayout.vue`). The default StandardLayout form mode provides a 3-step structure:
 
 1. **Plugin Scope** — Global vs Scoped (service/route/consumer/consumer_group) via radio buttons + ScopeEntityField for entity selection
 2. **Plugin Configuration** — Free-form rendered config fields via default slot
 3. **General Info** — enabled, instance_name, tags, protocols, condition
+
+Consuming apps can call `useProvideFreeFormPluginLayout()` to replace the layout shell for free-form plugin forms.
 
 ## Plugin-Specific Forms
 
@@ -240,10 +244,10 @@ Simple plugins and custom plugins follow different patterns:
 
 1. **Simple config module**: `plugins/<name>.ts` exports `definePluginConfig({...})` and relies on `CommonForm`
 2. **Folder-based custom form**: `plugins/<name>/index.ts` exports a config that points to `[Plugin]Form.vue`
-3. **Main wrapper**: custom forms usually use `StandardLayout`
+3. **Main wrapper**: custom forms usually use `DynamicLayout`
 4. **Config form**: `ConfigForm.vue` is optional and only exists when plugin-specific composition is needed
 5. **Data hooks**: some custom forms use `prepareFormData()` and custom change handling, but simple configs do not
-6. **Autofill slot**: forms built on `StandardLayout` typically provide `AUTOFILL_SLOT` for vault secret picker integration
+6. **Autofill slot**: forms built on `DynamicLayout` typically provide `AUTOFILL_SLOT` for vault secret picker integration
 
 ## Integration with Parent System
 
@@ -376,6 +380,7 @@ filler.fillField('config.host', 'example.com')
 | `FORMS_CONFIG` | App config (konnect / kongManager) | `PluginEntityForm.vue` |
 | `REDIS_PARTIAL_INFO` | Redis partial state | Layout components |
 | `FORM_EDITING` | Edit mode flag | Layout components |
+| `FREE_FORM_PLUGIN_LAYOUT` | Optional host-provided free-form layout component | Consuming app |
 | `FIELD_RENDERERS` | Slot name for custom renderers | `Form.vue` |
 | `FIELD_RENDERER_SLOTS` | Inherited parent slots | `Form.vue` |
 | `FEATURE_FLAGS.*` | Feature toggles | Consuming app |

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <StandardLayout v-bind="props">
+  <DynamicLayout v-bind="props">
     <ACLModeCard />
 
     <ObjectField
@@ -8,17 +8,17 @@
       :omit="['allow', 'deny']"
       reset-label-path="reset"
     />
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
 import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
 import { provide } from 'vue'
-import StandardLayout from '../../shared/layout/StandardLayout.vue'
+import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 import ObjectField from '../../shared/ObjectField.vue'
 import ACLModeCard from './ACLModeCard.vue'
 
-import type { Props } from '../../shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 
 const props = defineProps<Props>()
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/ai-mcp-proxy/AIMcpProxyForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/ai-mcp-proxy/AIMcpProxyForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <StandardLayout v-bind="props">
+  <DynamicLayout v-bind="props">
     <template #field-renderers>
       <FieldRenderer
         v-slot="slotProps"
@@ -46,19 +46,19 @@
       name="config"
       reset-label-path="reset"
     />
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
 import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
 import { provide } from 'vue'
-import StandardLayout from '../../shared/layout/StandardLayout.vue'
+import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 import ArrayField from '../../shared/ArrayField.vue'
 import FieldRenderer from '../../shared/FieldRenderer.vue'
 import ObjectField from '../../shared/ObjectField.vue'
 import composables from '../../../../composables'
 
-import type { Props } from '../../shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 import StringArrayField from '../../shared/StringArrayField.vue'
 import MapField from '../../shared/MapField.vue'
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.vue
@@ -28,7 +28,7 @@
   </Teleport>
 
   <DynamicLayout
-    v-bind="props"
+    v-bind="{ ...attrs, ...props }"
     class="dk-form"
     :editor-mode="layoutEditorMode"
     hide-editor-mode-switcher
@@ -67,7 +67,7 @@ import type { ZodError } from 'zod'
 import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 import type { EditorMode, DatakitPluginData } from './types'
 
-import { computed, inject, onMounted, ref, watch } from 'vue'
+import { computed, inject, onMounted, ref, watch, useAttrs } from 'vue'
 import { escape } from 'lodash-es'
 import { createI18n } from '@kong-ui-public/i18n'
 import { CodeblockIcon, DesignIcon } from '@kong/icons'
@@ -85,9 +85,12 @@ import {
   DatakitConfigSchema as DatakitConfigCompatSchema,
 } from './schema/compat'
 
+defineOptions({ inheritAttrs: false })
+
 const { t } = createI18n<typeof english>('en-us', english)
 
 const props = defineProps<Props<DatakitPluginData>>()
+const attrs = useAttrs()
 
 // provided by consumer apps
 const formConfig = inject<KonnectPluginFormConfig | KongManagerPluginFormConfig>(FORMS_CONFIG)!

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.vue
@@ -27,7 +27,7 @@
     </KSegmentedControl>
   </Teleport>
 
-  <StandardLayout
+  <DynamicLayout
     v-bind="props"
     class="dk-form"
     :editor-mode="layoutEditorMode"
@@ -56,7 +56,7 @@
       <!-- eslint-disable-next-line vue/no-v-html -->
       <span v-html="description" />
     </template>
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
@@ -64,7 +64,7 @@ import type { SegmentedControlOption } from '@kong/kongponents'
 import type { Component } from 'vue'
 import type { ZodError } from 'zod'
 
-import type { Props } from '../../shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 import type { EditorMode, DatakitPluginData } from './types'
 
 import { computed, inject, onMounted, ref, watch } from 'vue'
@@ -76,7 +76,7 @@ import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import type { KonnectPluginFormConfig, KongManagerPluginFormConfig } from '../../../../types'
 
 import english from '../../../../locales/en.json'
-import StandardLayout from '../../shared/layout/StandardLayout.vue'
+import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 import CodeEditor from './CodeEditor.vue'
 import { usePreferences } from './composables'
 import FlowEditor from './flow-editor/FlowEditor.vue'

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/jwt-signer/JwtSignerForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <StandardLayout
+  <DynamicLayout
     v-bind="props"
     :render-rules="renderRules"
   >
@@ -25,7 +25,7 @@
     </template>
 
     <ConfigForm />
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
@@ -34,10 +34,10 @@ import { provide } from 'vue'
 
 import ConfigForm from '../../Common/ConfigForm.vue'
 import FieldRenderer from '../../shared/FieldRenderer.vue'
-import StandardLayout from '../../shared/layout/StandardLayout.vue'
+import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 import KeysetField from './KeysetField.vue'
 
-import type { Props } from '../../shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 import type { RenderRules } from '../../shared/types'
 
 const props = defineProps<Props>()

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/metering-and-billing/MeteringAndBillingForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <StandardLayout
+  <DynamicLayout
     v-bind="props"
     :form-config="formConfig"
     :plugin-config-description="t('plugins.free-form.metering-and-billing.sections.plugin_config.description')"
@@ -196,7 +196,7 @@
         />
       </div>
     </AdvancedFields>
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
@@ -204,7 +204,7 @@ import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME, FORMS_CONFIG } from '@kong-ui-public
 import { computed, inject, provide, ref } from 'vue'
 import type { KonnectBaseFormConfig, KongManagerBaseFormConfig } from '@kong-ui-public/entities-shared'
 import { KLabel } from '@kong/kongponents'
-import StandardLayout from '../../shared/layout/StandardLayout.vue'
+import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 import FieldRenderer from '../../shared/FieldRenderer.vue'
 import Field from '../../shared/Field.vue'
 import BooleanField from '../../shared/BooleanField.vue'
@@ -217,7 +217,7 @@ import CollapsibleSection from '../../shared/CollapsibleSection.vue'
 import StringField from '../../shared/StringField.vue'
 import useI18n from '../../../../composables/useI18n'
 
-import type { Props } from '../../shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 
 const props = defineProps<Props>()
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RateLimitingAdvancedForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RateLimitingAdvancedForm.vue
@@ -1,19 +1,19 @@
 <template>
-  <StandardLayout
+  <DynamicLayout
     v-bind="props"
     :on-form-change="handleFormChange"
   >
     <ConfigForm />
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
 import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
 import { provide } from 'vue'
 import ConfigForm from './ConfigForm.vue'
-import StandardLayout from '../../shared/layout/StandardLayout.vue'
+import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 
-import type { Props } from '../../shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
 
 const props = defineProps<Props>()

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/request-callout/RequestCalloutForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/request-callout/RequestCalloutForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <StandardLayout
+  <DynamicLayout
     v-bind="props"
     :form-config="formConfig"
     :on-form-change="handleFormChange"
@@ -33,7 +33,7 @@
     </template>
 
     <ConfigForm />
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
@@ -41,14 +41,14 @@ import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
 import { provide } from 'vue'
 import { cloneDeep } from 'lodash-es'
 import ConfigForm from './ConfigForm.vue'
-import StandardLayout from '../../shared/layout/StandardLayout.vue'
+import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 import ArrayField from '../../shared/ArrayField.vue'
 import FieldRenderer from '../../shared/FieldRenderer.vue'
 import StringField from '../../shared/StringField.vue'
 import useI18n from '../../../../composables/useI18n'
 import { getCalloutId } from './utils'
 
-import type { Props } from '../../shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 import type { FormConfig } from '../../shared/types'
 import { CalloutId, type Callout, type RequestCalloutPlugin } from './types'
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/service-protection/ServiceProtectionForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/service-protection/ServiceProtectionForm.vue
@@ -1,19 +1,19 @@
 <template>
-  <StandardLayout
+  <DynamicLayout
     v-bind="props"
     :on-form-change="handleFormChange"
   >
     <ConfigForm />
-  </StandardLayout>
+  </DynamicLayout>
 </template>
 
 <script setup lang="ts">
 import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME } from '@kong-ui-public/forms'
 import { provide } from 'vue'
 import ConfigForm from './ConfigForm.vue'
-import StandardLayout from '../../shared/layout/StandardLayout.vue'
+import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 
-import type { Props } from '../../shared/layout/StandardLayout.vue'
+import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
 
 const props = defineProps<Props>()

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/DynamicLayout.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/DynamicLayout.cy.ts
@@ -1,0 +1,145 @@
+import { h } from 'vue'
+import DynamicLayout from './DynamicLayout.vue'
+import { useProvideFreeFormPluginLayout } from './provider'
+
+import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
+import type { PluginFormLayoutComponent, PluginFormLayoutProps } from './provider'
+import type { Slots } from 'vue'
+
+type DynamicLayoutMountProps = PluginFormLayoutProps<FreeFormPluginData> & {
+  formSchema: any
+  formModel: Record<string, any>
+}
+
+const createBaseSchema = () => ({
+  type: 'record',
+  fields: [
+    {
+      config: {
+        type: 'record',
+        fields: [],
+      },
+    },
+  ],
+})
+
+const createFormSchema = () => ({
+  fields: [
+    {
+      model: 'enabled',
+      type: 'switch',
+      default: true,
+    },
+    {
+      type: 'selectionGroup',
+      fields: [
+        {
+          label: 'Global',
+          description: 'Plugin will apply to all requests',
+        },
+        {
+          label: 'Scoped',
+          description: 'Specific Services, Routes, Consumers, and/or Consumer Groups',
+          fields: [],
+        },
+      ],
+    },
+  ],
+})
+
+const createLayoutProps = (overrides: Partial<DynamicLayoutMountProps> = {}): DynamicLayoutMountProps => ({
+  schema: createBaseSchema() as any,
+  formSchema: createFormSchema(),
+  model: {
+    enabled: true,
+    config: {},
+  },
+  formModel: {
+    enabled: true,
+  },
+  onFormChange: cy.spy().as('onFormChange'),
+  pluginName: 'test-plugin',
+  isEditing: false,
+  ...overrides,
+})
+
+const InjectedLayout = {
+  name: 'InjectedLayout',
+  props: {
+    pluginName: {
+      type: String,
+      required: true,
+    },
+    isEditing: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  setup(props: { pluginName: string, isEditing: boolean }, { slots }: { slots: Slots }) {
+    return () => h('section', { 'data-testid': 'injected-layout' }, [
+      h('span', { 'data-testid': 'injected-plugin-name' }, props.pluginName),
+      h('span', { 'data-testid': 'injected-editing-state' }, String(props.isEditing)),
+      slots.default?.(),
+      slots['plugin-config-description']?.({ description: 'forwarded slot prop' }),
+    ])
+  },
+} as PluginFormLayoutComponent
+
+describe('<DynamicLayout />', () => {
+  it('falls back to StandardLayout when no layout is provided', () => {
+    cy.mount(DynamicLayout as any, {
+      props: createLayoutProps(),
+      slots: {
+        default: () => h('div', { 'data-testid': 'default-config-slot' }, 'Plugin config fields'),
+      },
+    })
+
+    cy.get('.ff-standard-layout').should('exist')
+    cy.get('[data-testid="form-section-plugin-config"]').should('contain.text', 'Plugin config fields')
+    cy.get('[data-testid="default-config-slot"]').should('exist')
+  })
+
+  it('renders the provided layout from useProvideFreeFormPluginLayout', () => {
+    const Host = {
+      name: 'DynamicLayoutHost',
+      setup() {
+        useProvideFreeFormPluginLayout(InjectedLayout)
+
+        return () => h(DynamicLayout as any, createLayoutProps({
+          pluginName: 'provided-plugin',
+          isEditing: true,
+        }))
+      },
+    }
+
+    cy.mount(Host as any)
+
+    cy.get('[data-testid="injected-layout"]').should('exist')
+    cy.get('.ff-standard-layout').should('not.exist')
+    cy.get('[data-testid="injected-plugin-name"]').should('contain.text', 'provided-plugin')
+    cy.get('[data-testid="injected-editing-state"]').should('contain.text', 'true')
+  })
+
+  it('forwards named slots and slot props through the provided layout', () => {
+    const Host = {
+      name: 'DynamicLayoutSlotHost',
+      setup() {
+        useProvideFreeFormPluginLayout(InjectedLayout)
+
+        return () => h(DynamicLayout as any, createLayoutProps(), {
+          default: () => h('div', { 'data-testid': 'forwarded-default-slot' }, 'Default slot content'),
+          'plugin-config-description': ({ description }: { description: string }) => h(
+            'span',
+            { 'data-testid': 'forwarded-named-slot' },
+            description,
+          ),
+        })
+      },
+    }
+
+    cy.mount(Host as any)
+
+    cy.get('[data-testid="forwarded-default-slot"]').should('contain.text', 'Default slot content')
+    cy.get('[data-testid="forwarded-named-slot"]').should('contain.text', 'forwarded slot prop')
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/DynamicLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/DynamicLayout.vue
@@ -1,0 +1,40 @@
+<template>
+  <component
+    :is="layoutComponent"
+    v-bind="forwardedProps"
+  >
+    <template
+      v-for="(_, slotName) in slots"
+      #[slotName]="slotProps"
+    >
+      <slot
+        :name="slotName"
+        v-bind="slotProps ?? {}"
+      />
+    </template>
+  </component>
+</template>
+
+<script setup lang="ts" generic="T extends FreeFormPluginData">
+import { computed, inject, useAttrs, useSlots } from 'vue'
+import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
+import StandardLayout from './StandardLayout.vue'
+import { FREE_FORM_PLUGIN_LAYOUT } from './provider'
+import type { PluginFormLayoutComponent, PluginFormLayoutProps } from './provider'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps<PluginFormLayoutProps<T>>()
+const attrs = useAttrs()
+const slots = useSlots()
+
+const layoutComponent = inject(
+  FREE_FORM_PLUGIN_LAYOUT,
+  StandardLayout as PluginFormLayoutComponent,
+) as PluginFormLayoutComponent<T>
+
+const forwardedProps = computed(() => ({
+  ...attrs,
+  ...props,
+}))
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -221,22 +221,10 @@
 
 <script lang="ts">
 export interface Props<T extends FreeFormPluginData = any> extends PluginFormLayoutProps<T> {
-  generalInfoTitle?: string
-  generalInfoDescription?: string
-  pluginConfigTitle?: string
-  pluginConfigDescription?: string
   /** VFG schema */
   formSchema: any
   /** VFG form model */
   formModel: Record<string, any>
-  /**
-   * Hide the built-in form/code switcher. Plugins that own a custom switcher
-   * (e.g. Datakit's flow/code control) should set this to true to avoid
-   * rendering duplicate controls into #plugin-form-page-actions.
-   */
-  hideEditorModeSwitcher?: boolean
-  /** Whether the plugin is being created for a portal developer */
-  developer?: boolean
 }
 </script>
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -14,6 +14,7 @@
 
   <Form
     ref="form"
+    v-bind="attrs"
     class="ff-standard-layout"
     :config="realFormConfig"
     :data="(prunedData as T)"
@@ -219,43 +220,28 @@
 </template>
 
 <script lang="ts">
-export type Props<T extends FreeFormPluginData = any> = {
+export interface Props<T extends FreeFormPluginData = any> extends PluginFormLayoutProps<T> {
   generalInfoTitle?: string
   generalInfoDescription?: string
   pluginConfigTitle?: string
   pluginConfigDescription?: string
-  /** FreeForm Schema */
-  schema: FormSchema
   /** VFG schema */
   formSchema: any
-  /** The **initial** entire plugin model, never update */
-  model: T
   /** VFG form model */
   formModel: Record<string, any>
-  isEditing: boolean
-  /** Emits the final submission payload to the parent, the payload will be merged with the `formModel` but it has high override priority */
-  onFormChange: (value: Partial<T>, fields?: string[]) => void
-  onValidityChange?: (event: PluginValidityChangeEvent) => void
   /**
    * Hide the built-in form/code switcher. Plugins that own a custom switcher
    * (e.g. Datakit's flow/code control) should set this to true to avoid
    * rendering duplicate controls into #plugin-form-page-actions.
    */
   hideEditorModeSwitcher?: boolean
-  /** FreeForm configuration */
-  formConfig?: FormConfig<T>
-  renderRules?: RenderRules
-  fieldRenderers?: PluginFieldRenderer[]
-  pluginName: string
-  /** Konnect-managed Redis UI, from plugin form config */
-  isKonnectManagedRedisEnabled?: boolean
   /** Whether the plugin is being created for a portal developer */
   developer?: boolean
 }
 </script>
 
 <script setup lang="ts" generic="T extends FreeFormPluginData">
-import { computed, inject, nextTick, ref, useTemplateRef, useId } from 'vue'
+import { computed, inject, nextTick, ref, useAttrs, useTemplateRef, useId } from 'vue'
 import { EntityFormBlock } from '@kong-ui-public/entities-shared'
 import { has, pick } from 'lodash-es'
 import { KRadio, KSegmentedControl, KTooltip } from '@kong/kongponents'
@@ -265,11 +251,10 @@ import { FEATURE_FLAGS } from '../../../../constants'
 import Form from '../Form.vue'
 import type { FormSchema } from '../../../../types/plugins/form-schema'
 import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
-import type { PluginValidityChangeEvent } from '../../../../types'
 import SwitchField from '../SwitchField.vue'
 import ScopeEntityField from '../ScopeEntityField.vue'
 import { normalizeMatch } from '../utils'
-import type { FieldRenderer as PluginFieldRenderer, FormConfig, RenderRules } from '../types'
+import type { FieldRenderer as PluginFieldRenderer, FormConfig } from '../types'
 import FieldRenderer from '../FieldRenderer.vue'
 import { REDIS_PARTIAL_INFO } from '../const'
 import RedisSelector from '../RedisSelector.vue'
@@ -280,6 +265,9 @@ import StringField from '../StringField.vue'
 import CodeEditor from '../CodeEditor.vue'
 import ConditionField from './ConditionField.vue'
 import useI18n from '../../../../composables/useI18n'
+import type { PluginFormLayoutProps } from './provider'
+
+defineOptions({ inheritAttrs: false })
 
 const FREE_FORM_CONTROLLED_FIELDS: Array<keyof FreeFormPluginData> = [
   // plugin specific config
@@ -306,6 +294,7 @@ const instanceId = useId()
 const { i18n: { t } } = useI18n()
 
 const { hideEditorModeSwitcher = false, ...props } = defineProps<Props<T>>()
+const attrs = useAttrs()
 const configFieldRenderers = computed<PluginFieldRenderer[]>(() => props.fieldRenderers ?? [])
 
 const enableCodeMode = inject<boolean>(FEATURE_FLAGS.KM_2262_CODE_MODE, false)

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/provider.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/provider.ts
@@ -21,6 +21,18 @@ export type PluginFormLayoutProps<T extends FreeFormPluginData = FreeFormPluginD
   /** Konnect-managed Redis UI, from plugin form config */
   isKonnectManagedRedisEnabled?: boolean
   isEditing: boolean
+  /**
+   * Hide the built-in form/code switcher. Plugins that own a custom switcher
+   * (e.g. Datakit's flow/code control) should set this to true to avoid
+   * rendering duplicate controls into #plugin-form-page-actions.
+   */
+  hideEditorModeSwitcher?: boolean
+  /** Whether the plugin is being created for a portal developer */
+  developer?: boolean
+  generalInfoTitle?: string
+  generalInfoDescription?: string
+  pluginConfigTitle?: string
+  pluginConfigDescription?: string
 }
 
 export type PluginFormLayoutComponent<T extends FreeFormPluginData = FreeFormPluginData> = Component<PluginFormLayoutProps<T>>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/provider.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/provider.ts
@@ -1,0 +1,32 @@
+import type { Component, InjectionKey } from 'vue'
+import { provide } from 'vue'
+import type { FormSchema } from '../../../../types/plugins/form-schema'
+import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
+import type { PluginValidityChangeEvent } from '../../../../types'
+import type { FieldRenderer as PluginFieldRenderer, FormConfig, RenderRules } from '../types'
+
+export type PluginFormLayoutProps<T extends FreeFormPluginData = FreeFormPluginData> = {
+  /** FreeForm Schema */
+  schema: FormSchema
+  /** The **initial** entire plugin model, never update */
+  model: T
+  /** Emits the final submission payload to the parent, the payload will be merged with the `formModel` but it has high override priority */
+  onFormChange: (value: Partial<T>, fields?: string[]) => void
+  onValidityChange?: (event: PluginValidityChangeEvent) => void
+  /** FreeForm configuration */
+  formConfig?: FormConfig<T>
+  renderRules?: RenderRules
+  fieldRenderers?: PluginFieldRenderer[]
+  pluginName: string
+  /** Konnect-managed Redis UI, from plugin form config */
+  isKonnectManagedRedisEnabled?: boolean
+  isEditing: boolean
+}
+
+export type PluginFormLayoutComponent<T extends FreeFormPluginData = FreeFormPluginData> = Component<PluginFormLayoutProps<T>>
+
+export const FREE_FORM_PLUGIN_LAYOUT: InjectionKey<PluginFormLayoutComponent> = Symbol.for('kong-ui-public.entities-plugins.free-form-plugin-layout')
+
+export function useProvideFreeFormPluginLayout(layoutComponent: PluginFormLayoutComponent): void {
+  provide(FREE_FORM_PLUGIN_LAYOUT, layoutComponent)
+}

--- a/packages/entities/entities-plugins/src/index.ts
+++ b/packages/entities/entities-plugins/src/index.ts
@@ -6,6 +6,7 @@ import PluginCatalog from './components/PluginCatalog.vue'
 import PluginSelectGrid from './components/select/PluginSelectGrid.vue'
 import PluginSelectCard from './components/select/PluginSelectCard.vue'
 import PluginConfigCard from './components/PluginConfigCard.vue'
+import DynamicLayout from './components/free-form/shared/layout/DynamicLayout.vue'
 import composables from './composables'
 import pluginEndpoints from './plugins-endpoints'
 
@@ -20,9 +21,19 @@ export {
   PluginSelectGrid,
   PluginSelectCard,
   PluginConfigCard,
+  DynamicLayout,
   usePluginMetaData,
   useProvideExperimentalFreeForms,
 }
+
+export {
+  useProvideFreeFormPluginLayout,
+} from './components/free-form/shared/layout/provider'
+
+export type {
+  PluginFormLayoutComponent,
+  PluginFormLayoutProps,
+} from './components/free-form/shared/layout/provider'
 
 export * from './types'
 


### PR DESCRIPTION
## Summary


[KM-2663](https://konghq.atlassian.net/browse/KM-2663)


Freeform plugin forms can now render through a dynamic layout entry point. The existing StandardLayout remains the default, while consuming apps can provide a replacement layout for host-specific shells such as AI Gateway policy forms.

This migrates the existing free-form wrappers to use `DynamicLayout`, keeps the shared layout prop contract broad enough for current wrappers, and documents the provider hook exposed from `entities-plugins`.


### Before
Standard Layout and custom forms are bound in source code.
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/32d535e3-939f-4fdc-ba8a-ccb8d3cca260" />


### After
Layout is runtime replaceable.
<img width="2528" height="1326" alt="image" src="https://github.com/user-attachments/assets/54ff76f5-69be-488f-812e-6dc8c5336297" />


[KM-2663]: https://konghq.atlassian.net/browse/KM-2663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ