### PR TITLE
fix(analytics-chart): add i18n messages for event-gateway dimensions [KM-2686]

### DIFF
--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -208,7 +208,16 @@
     "route_count": "Route count",
     "consumer_count": "Consumer count",
     "plugin_count": "Plugin count",
-    "node_count": "Data plane node count"
+    "node_count": "Data plane node count",
+    "virtual_cluster_id": "Virtual cluster",
+    "backend_cluster_id": "Backend cluster",
+    "listener_id": "Listener",
+    "principal_name": "Principal name",
+    "principal_type": "Principal type",
+    "request_type": "Request type",
+    "topic_name": "Topic name",
+    "partition_index": "Partition index",
+    "api_key": "API key"
   },
   "metricAxisTitles": {
     "error_rate": "Error rate in {unit}",


### PR DESCRIPTION
[KM-2686]

Add dimension label translations for event-gateway

Ref:
<img width="1081" height="890" alt="image" src="https://github.com/user-attachments/assets/391b1052-331f-45d4-bcd4-1df304fdb4f4" />


[KM-2686]: https://konghq.atlassian.net/browse/KM-2686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ