### PR TITLE
refactor(entities-plugins): extract plugin configuration form

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/README.md
+++ b/packages/entities/entities-plugins/src/components/free-form/README.md
@@ -185,7 +185,7 @@ Constraints:
 
 ## Layout
 
-Plugin forms use `DynamicLayout` (`shared/layout/DynamicLayout.vue`) as the layout entry point. It renders a host-provided layout from `FREE_FORM_PLUGIN_LAYOUT` when one is available, and otherwise falls back to `StandardLayout` (`shared/layout/StandardLayout.vue`). The default StandardLayout form mode provides a 3-step structure:
+Plugin forms use `DynamicLayout` (`shared/layout/DynamicLayout.vue`) as the layout entry point. It renders a host-provided layout from `FREE_FORM_PLUGIN_LAYOUT` when one is available, and otherwise falls back to `StandardLayout` (`shared/layout/StandardLayout.vue`). Layouts that need the common free-form `Form` wrapper can compose `PluginConfigurationForm` (`shared/layout/PluginConfigurationForm.vue`) and provide their own surrounding product-specific blocks. The default StandardLayout form mode provides a 3-step structure:
 
 1. **Plugin Scope** — Global vs Scoped (service/route/consumer/consumer_group) via radio buttons + ScopeEntityField for entity selection
 2. **Plugin Configuration** — Free-form rendered config fields via default slot

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/PluginConfigurationForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/PluginConfigurationForm.cy.ts
@@ -1,0 +1,84 @@
+import { h } from 'vue'
+import PluginConfigurationForm from './PluginConfigurationForm.vue'
+import { FREE_FORM_SCHEMA_MAP_KEY } from '../../../../constants'
+import type { FormSchema } from 'src/types/plugins/form-schema.ts'
+
+const createSchema = () => ({
+  type: 'record',
+  fields: [
+    {
+      config: {
+        type: 'record',
+        fields: [],
+      },
+    },
+    {
+      enabled: {
+        type: 'boolean',
+        default: true,
+      },
+    },
+  ],
+} as FormSchema)
+
+const createProps = (overrides: Record<string, any> = {}) => ({
+  schema: createSchema(),
+  model: {
+    enabled: true,
+    config: {},
+    ignored: 'not-controlled',
+  },
+  controlledFields: ['config', 'enabled'],
+  onFormChange: cy.spy().as('onFormChange'),
+  pluginName: 'test-plugin',
+  ...overrides,
+})
+
+describe('<PluginConfigurationForm />', () => {
+  it('renders schema fields when no default slot is provided', () => {
+    cy.mount(PluginConfigurationForm as any, {
+      props: createProps(),
+    })
+
+    cy.getTestId('ff-enabled').should('exist')
+  })
+
+  it('uses caller default slot when provided', () => {
+    cy.mount(PluginConfigurationForm as any, {
+      props: createProps(),
+      slots: {
+        default: () => h('div', { 'data-testid': 'plugin-config-fields' }, 'Plugin config fields'),
+      },
+    })
+
+    cy.getTestId('plugin-config-fields').should('contain.text', 'Plugin config fields')
+    cy.getTestId('ff-enabled').should('not.exist')
+  })
+
+  it('forwards attrs to the underlying form and exposes the schema', () => {
+    const Host = {
+      name: 'PluginConfigurationFormHost',
+      setup() {
+        return () => h(PluginConfigurationForm as any, {
+          ...createProps(),
+          class: 'custom-layout-class',
+          'data-testid': 'custom-plugin-configuration-form',
+        })
+      },
+    }
+
+    cy.mount(Host as any)
+
+    cy.getTestId('custom-plugin-configuration-form')
+      .should('have.class', 'ff-plugin-configuration-form')
+      .and('have.class', 'custom-layout-class')
+      .invoke('attr', 'data-instance-id')
+      .then((instanceId) => {
+        cy.window().then((win) => {
+          const map = (win as any)[FREE_FORM_SCHEMA_MAP_KEY]
+          expect(map[instanceId as string].fields).to.have.length(2)
+        })
+      })
+  })
+
+})

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/PluginConfigurationForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/PluginConfigurationForm.cy.ts
@@ -1,7 +1,7 @@
 import { h } from 'vue'
 import PluginConfigurationForm from './PluginConfigurationForm.vue'
 import { FREE_FORM_SCHEMA_MAP_KEY } from '../../../../constants'
-import type { FormSchema } from 'src/types/plugins/form-schema.ts'
+import type { FormSchema } from 'src/types/plugins/form-schema'
 
 const createSchema = () => ({
   type: 'record',

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/PluginConfigurationForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/PluginConfigurationForm.vue
@@ -1,0 +1,123 @@
+<template>
+  <Form
+    ref="form"
+    v-bind="formAttrs"
+    class="ff-plugin-configuration-form"
+    :config="realFormConfig"
+    :data="(formData as T)"
+    :data-instance-id="instanceId"
+    :data-plugin-name="pluginName"
+    :data-testid="formTestId"
+    :render-rules="renderRules"
+    :schema="schema"
+    tag="div"
+    @change="handleDataChange"
+  >
+    <template #[FIELD_RENDERERS]>
+      <FieldRenderer
+        v-for="(renderer, index) in configFieldRenderers"
+        :key="`${pluginName}-${index}`"
+        v-slot="slotProps"
+        :match="normalizeMatch(renderer.match)"
+      >
+        <component
+          :is="renderer.component"
+          v-bind="{
+            ...slotProps,
+            ...((typeof renderer.propsOverrides === 'function')
+              ? renderer.propsOverrides(slotProps)
+              : renderer.propsOverrides) ?? {},
+          }"
+        />
+      </FieldRenderer>
+
+      <FieldRenderer :match="({ path }) => path === redisPartialInfo?.redisPath?.value">
+        <RedisSelector :is-konnect-managed-redis-enabled="props.isKonnectManagedRedisEnabled ?? false" />
+      </FieldRenderer>
+
+      <slot name="field-renderers" />
+    </template>
+
+    <template
+      v-if="$slots.default"
+      #default
+    >
+      <slot />
+    </template>
+  </Form>
+</template>
+
+<script lang="ts">
+export interface Props<T extends Record<string, any> = Record<string, any>> extends PluginConfigurationBaseProps<T> {
+  controlledFields?: string[]
+  prepareFormData?: (data: Partial<T>) => Partial<T>
+}
+</script>
+
+<script setup lang="ts" generic="T extends Record<string, any>">
+import { computed, inject, useAttrs, useId, useTemplateRef } from 'vue'
+import { pick } from 'lodash-es'
+import Form from '../Form.vue'
+import { normalizeMatch } from '../utils'
+import type { FieldRenderer as PluginFieldRenderer, FormConfig } from '../types'
+import FieldRenderer from '../FieldRenderer.vue'
+import { REDIS_PARTIAL_INFO } from '../const'
+import RedisSelector from '../RedisSelector.vue'
+import { FIELD_RENDERERS, useSchemaExposer } from '../composables'
+import type { PluginConfigurationBaseProps } from './provider'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps<Props<T>>()
+
+const emit = defineEmits<{
+  change: [value: T]
+}>()
+
+const attrs = useAttrs()
+const instanceId = useId()
+const formRef = useTemplateRef('form')
+
+const redisPartialInfo = inject(REDIS_PARTIAL_INFO)
+
+const configFieldRenderers = computed<PluginFieldRenderer[]>(() => props.fieldRenderers ?? [])
+
+const formTestId = computed(() => attrs['data-testid'] ?? 'ff-plugin-configuration-form')
+
+const formAttrs = computed(() => {
+  const { 'data-testid': _, ...formAttrs } = attrs
+
+  return formAttrs
+})
+
+const realFormConfig = computed(() => {
+  const formConfig = props.formConfig as FormConfig<T> | undefined
+
+  return {
+    ...(formConfig ?? {}),
+    hasValue: formConfig?.hasValue ?? ((data?: T): boolean => !!data && Object.keys(data).length > 0),
+    prepareFormData: (data: T): Partial<T> => {
+      const preparedData = formConfig?.prepareFormData?.(data) ?? data
+
+      return props.prepareFormData?.(preparedData) ?? preparedData
+    },
+  }
+})
+
+const formData = computed(() => {
+  if (!Array.isArray(props.controlledFields)) return props.model
+  return pick(props.model, props.controlledFields)
+})
+
+function handleDataChange(value: T) {
+  emit('change', value)
+  props.onFormChange(value, props.controlledFields)
+}
+
+defineExpose({
+  getValue: () => formRef.value?.getValue(),
+  setValue: (value: T) => formRef.value?.setValue(value),
+})
+
+useSchemaExposer(() => props.schema, instanceId)
+</script>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.cy.ts
@@ -1,3 +1,4 @@
+import { h } from 'vue'
 import StandardLayout from './StandardLayout.vue'
 import { FREE_FORM_SCHEMA_MAP_KEY } from '../../../../constants'
 
@@ -235,6 +236,32 @@ describe('<StandardLayout />', () => {
 
     // Code editor section should not exist
     cy.get('.plugin-code-editor').should('not.exist')
+  })
+
+  it('should own plugin configuration block slots', () => {
+    cy.mount(StandardLayout as any, {
+      props: {
+        schema: createBaseSchema(),
+        formSchema: createFormSchema(),
+        model: createBaseModel(),
+        formModel: { enabled: true },
+        isEditing: false,
+        onFormChange: cy.spy(),
+        pluginName: 'test-plugin',
+      },
+      slots: {
+        default: () => h('div', { 'data-testid': 'plugin-config-fields' }, 'Plugin config fields'),
+        'plugin-config-title': () => h('span', { 'data-testid': 'custom-config-title' }, 'Custom config title'),
+        'plugin-config-description': () => h('span', { 'data-testid': 'custom-config-description' }, 'Custom config description'),
+        'plugin-config-extra': () => h('button', { 'data-testid': 'custom-config-extra' }, 'Extra action'),
+      },
+    })
+
+    cy.getTestId('form-section-plugin-config').should('exist')
+    cy.getTestId('plugin-config-fields').should('contain.text', 'Plugin config fields')
+    cy.getTestId('custom-config-title').should('contain.text', 'Custom config title')
+    cy.getTestId('custom-config-description').should('contain.text', 'Custom config description')
+    cy.getTestId('custom-config-extra').should('contain.text', 'Extra action')
   })
 
   it('should show code editor and hide form sections when editorMode is code', () => {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -12,200 +12,177 @@
     />
   </Teleport>
 
-  <Form
+  <PluginConfigurationForm
     ref="form"
     v-bind="attrs"
     class="ff-standard-layout"
-    :config="realFormConfig"
-    :data="(prunedData as T)"
-    :data-instance-id="instanceId"
-    :data-plugin-name="pluginName"
+    :controlled-fields="FREE_FORM_CONTROLLED_FIELDS"
     data-testid="ff-standard-layout-form"
+    :field-renderers="fieldRenderers"
+    :form-config="formConfig"
+    :is-konnect-managed-redis-enabled="isKonnectManagedRedisEnabled"
+    :model="model"
+    :on-form-change="onFormChange"
+    :plugin-name="pluginName"
+    :prepare-form-data="prepareFormData"
     :render-rules="renderRules"
     :schema="freeFormSchema"
-    tag="div"
     @change="handleDataChange"
   >
-    <!-- global field templates -->
-    <template #[FIELD_RENDERERS]>
-      <FieldRenderer
-        v-for="(renderer, index) in configFieldRenderers"
-        :key="`${pluginName}-${index}`"
-        v-slot="slotProps"
-        :match="normalizeMatch(renderer.match)"
-      >
-        <component
-          :is="renderer.component"
-          v-bind="{
-            ...slotProps,
-            ...((typeof renderer.propsOverrides === 'function')
-              ? renderer.propsOverrides(slotProps)
-              : renderer.propsOverrides) ?? {},
-          }"
-        />
-      </FieldRenderer>
-
-      <!-- Redis partial selector -->
-      <FieldRenderer :match="({ path }) => path === redisPartialInfo?.redisPath?.value">
-        <RedisSelector :is-konnect-managed-redis-enabled="props.isKonnectManagedRedisEnabled ?? false" />
-      </FieldRenderer>
-
-      <!-- Custom field renderers from consuming components -->
+    <template #field-renderers>
       <slot name="field-renderers" />
     </template>
 
-    <template v-if="editorMode === 'form'">
-      <!-- Plugin scope -->
-      <EntityFormBlock
-        data-testid="form-section-plugin-scope"
-        :description="generalInfoDescription ?? t('plugins.form.sections.plugin_scope.description')"
-        :step="1"
-        :title="generalInfoTitle ?? t('plugins.form.sections.plugin_scope.title')"
+    <EntityFormBlock
+      v-if="editorMode === 'form'"
+      data-testid="form-section-plugin-scope"
+      :description="generalInfoDescription ?? t('plugins.form.sections.plugin_scope.description')"
+      :step="1"
+      :title="generalInfoTitle ?? t('plugins.form.sections.plugin_scope.title')"
+    >
+      <component
+        :is="scopeSchema?.disabled ? KTooltip : 'div'"
+        v-bind="scopeWrapperAttrs"
       >
-        <component
-          :is="scopeSchema?.disabled ? KTooltip : 'div'"
-          v-bind="scopeWrapperAttrs"
-        >
-          <div class="radio-group">
-            <KRadio
-              v-model="scoped"
-              card
-              card-orientation="horizontal"
-              v-bind="radioGroup[0]"
-              :disabled="scopeSchema?.disabled"
-              :selected-value="false"
-              @update:model-value="handleScopeChange"
-            />
-            <KRadio
-              v-if="radioGroup[1]"
-              v-model="scoped"
-              card
-              card-orientation="horizontal"
-              v-bind="radioGroup[1]"
-              :disabled="scopeSchema?.disabled"
-              :selected-value="true"
-              @update:model-value="handleScopeChange"
-            />
-          </div>
-        </component>
-        <div
-          v-if="scopeEntitiesSchema"
-          v-show="scoped"
-          class="scope-detail"
-        >
-          <ScopeEntityField
-            v-for="scopeField in scopeEntityFields"
-            :key="scopeField.name"
-            :developer="developer"
-            :disabled="scopeField.disabled"
-            :disabled-tooltip="scopeField.disabledTooltip"
-            :entity="scopeField.entity"
-            :fields="scopeField.fields"
-            :help="scopeField.help"
-            :label="scopeField.label"
-            :label-field="scopeField.labelField"
-            :name="scopeField.name"
-            :placeholder="scopeField.placeholder"
+        <div class="radio-group">
+          <KRadio
+            v-model="scoped"
+            card
+            card-orientation="horizontal"
+            v-bind="radioGroup[0]"
+            :disabled="scopeSchema?.disabled"
+            :selected-value="false"
+            @update:model-value="handleScopeChange"
+          />
+          <KRadio
+            v-if="radioGroup[1]"
+            v-model="scoped"
+            card
+            card-orientation="horizontal"
+            v-bind="radioGroup[1]"
+            :disabled="scopeSchema?.disabled"
+            :selected-value="true"
+            @update:model-value="handleScopeChange"
           />
         </div>
-
-        <template
-          v-if="slots['general-info-title']"
-          #title
-        >
-          <slot name="general-info-title" />
-        </template>
-
-        <template
-          v-if="slots['general-info-description']"
-          #description
-        >
-          <slot name="general-info-description" />
-        </template>
-
-        <template
-          v-if="slots['general-info-extra']"
-          #extra
-        >
-          <slot name="general-info-extra" />
-        </template>
-      </EntityFormBlock>
-
-      <!-- Plugin configuration -->
-      <EntityFormBlock
-        data-testid="form-section-plugin-config"
-        :description="pluginConfigDescription ?? t('plugins.form.sections.plugin_config.description')"
-        :step="2"
-        :title="pluginConfigTitle ?? t('plugins.form.sections.plugin_config.title')"
+      </component>
+      <div
+        v-if="scopeEntitiesSchema"
+        v-show="scoped"
+        class="scope-detail"
       >
-        <slot />
+        <ScopeEntityField
+          v-for="scopeField in scopeEntityFields"
+          :key="scopeField.name"
+          :developer="developer"
+          :disabled="scopeField.disabled"
+          :disabled-tooltip="scopeField.disabledTooltip"
+          :entity="scopeField.entity"
+          :fields="scopeField.fields"
+          :help="scopeField.help"
+          :label="scopeField.label"
+          :label-field="scopeField.labelField"
+          :name="scopeField.name"
+          :placeholder="scopeField.placeholder"
+        />
+      </div>
 
-        <template
-          v-if="slots['plugin-config-title']"
-          #title
-        >
-          <slot name="plugin-config-title" />
-        </template>
-
-        <template
-          v-if="slots['plugin-config-description']"
-          #description
-        >
-          <slot name="plugin-config-description" />
-        </template>
-
-        <template
-          v-if="slots['plugin-config-extra']"
-          #extra
-        >
-          <slot name="plugin-config-extra" />
-        </template>
-      </EntityFormBlock>
-
-      <!-- General information -->
-      <EntityFormBlock
-        data-testid="form-section-general-info"
-        :description="t('plugins.form.sections.plugin_general_info.description')"
-        :step="3"
-        :title="t('plugins.form.sections.general_info.title')"
+      <template
+        v-if="slots['general-info-title']"
+        #title
       >
-        <SwitchField
-          v-if="freeFormFieldNames.has('enabled')"
-          :disabled-text="t('plugins.form.fields.plugin_status.text_off')"
-          :enabled-text="t('plugins.form.fields.plugin_status.text_on')"
-          :label="t('plugins.form.fields.plugin_status.label')"
-          name="enabled"
-        />
+        <slot name="general-info-title" />
+      </template>
 
-        <StringField
-          v-if="freeFormFieldNames.has('instance_name')"
-          :label="t('plugins.form.fields.instance_name.label')"
-          name="instance_name"
-          :placeholder="t('plugins.form.fields.instance_name.placeholder')"
-        />
+      <template
+        v-if="slots['general-info-description']"
+        #description
+      >
+        <slot name="general-info-description" />
+      </template>
 
-        <StringArrayField
-          v-if="freeFormFieldNames.has('tags')"
-          :help="t('plugins.form.fields.tags.help')"
-          name="tags"
-          :placeholder="t('plugins.form.fields.tags.placeholder')"
-        />
+      <template
+        v-if="slots['general-info-extra']"
+        #extra
+      >
+        <slot name="general-info-extra" />
+      </template>
+    </EntityFormBlock>
 
-        <Field
-          v-if="freeFormFieldNames.has('protocols')"
-          name="protocols"
-        />
+    <EntityFormBlock
+      v-if="editorMode === 'form'"
+      data-testid="form-section-plugin-config"
+      :description="pluginConfigDescription ?? t('plugins.form.sections.plugin_config.description')"
+      :step="2"
+      :title="pluginConfigTitle ?? t('plugins.form.sections.plugin_config.title')"
+    >
+      <slot />
 
-        <KCollapse
-          v-if="!!freeFormSchema.fields.find(f => Object.keys(f)[0] === 'condition')"
-          v-model="advancedCollapsed"
-          data-testid="view-general-info-additional-settings"
-          :trigger-label="advancedCollapsed ? t('plugins.form.grouping.advanced_parameters.view') : t('plugins.form.grouping.advanced_parameters.hide')"
-        >
-          <ConditionField />
-        </KCollapse>
-      </EntityFormBlock>
-    </template>
+      <template
+        v-if="slots['plugin-config-title']"
+        #title
+      >
+        <slot name="plugin-config-title" />
+      </template>
+
+      <template
+        v-if="slots['plugin-config-description']"
+        #description
+      >
+        <slot name="plugin-config-description" />
+      </template>
+
+      <template
+        v-if="slots['plugin-config-extra']"
+        #extra
+      >
+        <slot name="plugin-config-extra" />
+      </template>
+    </EntityFormBlock>
+
+    <EntityFormBlock
+      v-if="editorMode === 'form'"
+      data-testid="form-section-general-info"
+      :description="t('plugins.form.sections.plugin_general_info.description')"
+      :step="3"
+      :title="t('plugins.form.sections.general_info.title')"
+    >
+      <SwitchField
+        v-if="freeFormFieldNames.has('enabled')"
+        :disabled-text="t('plugins.form.fields.plugin_status.text_off')"
+        :enabled-text="t('plugins.form.fields.plugin_status.text_on')"
+        :label="t('plugins.form.fields.plugin_status.label')"
+        name="enabled"
+      />
+
+      <StringField
+        v-if="freeFormFieldNames.has('instance_name')"
+        :label="t('plugins.form.fields.instance_name.label')"
+        name="instance_name"
+        :placeholder="t('plugins.form.fields.instance_name.placeholder')"
+      />
+
+      <StringArrayField
+        v-if="freeFormFieldNames.has('tags')"
+        :help="t('plugins.form.fields.tags.help')"
+        name="tags"
+        :placeholder="t('plugins.form.fields.tags.placeholder')"
+      />
+
+      <Field
+        v-if="freeFormFieldNames.has('protocols')"
+        name="protocols"
+      />
+
+      <KCollapse
+        v-if="!!freeFormSchema.fields.find(f => Object.keys(f)[0] === 'condition')"
+        v-model="advancedCollapsed"
+        data-testid="view-general-info-additional-settings"
+        :trigger-label="advancedCollapsed ? t('plugins.form.grouping.advanced_parameters.view') : t('plugins.form.grouping.advanced_parameters.hide')"
+      >
+        <ConditionField />
+      </KCollapse>
+    </EntityFormBlock>
 
     <EntityFormBlock
       v-if="editorMode === 'code'"
@@ -216,7 +193,7 @@
         <CodeEditor />
       </slot>
     </EntityFormBlock>
-  </Form>
+  </PluginConfigurationForm>
 </template>
 
 <script lang="ts">
@@ -229,24 +206,17 @@ export interface Props<T extends FreeFormPluginData = any> extends PluginFormLay
 </script>
 
 <script setup lang="ts" generic="T extends FreeFormPluginData">
-import { computed, inject, nextTick, ref, useAttrs, useTemplateRef, useId } from 'vue'
+import { computed, inject, nextTick, ref, useAttrs, useTemplateRef } from 'vue'
 import { EntityFormBlock } from '@kong-ui-public/entities-shared'
 import { has, pick } from 'lodash-es'
-import { KRadio, KSegmentedControl, KTooltip } from '@kong/kongponents'
+import { KCollapse, KRadio, KSegmentedControl, KTooltip } from '@kong/kongponents'
 import type { SegmentedControlOption } from '@kong/kongponents'
 import { useLocalStorage } from '@vueuse/core'
 import { FEATURE_FLAGS } from '../../../../constants'
-import Form from '../Form.vue'
 import type { FormSchema } from '../../../../types/plugins/form-schema'
 import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
 import SwitchField from '../SwitchField.vue'
 import ScopeEntityField from '../ScopeEntityField.vue'
-import { normalizeMatch } from '../utils'
-import type { FieldRenderer as PluginFieldRenderer, FormConfig } from '../types'
-import FieldRenderer from '../FieldRenderer.vue'
-import { REDIS_PARTIAL_INFO } from '../const'
-import RedisSelector from '../RedisSelector.vue'
-import { FIELD_RENDERERS, useSchemaExposer } from '../composables'
 import Field from '../Field.vue'
 import StringArrayField from '../StringArrayField.vue'
 import StringField from '../StringField.vue'
@@ -254,6 +224,7 @@ import CodeEditor from '../CodeEditor.vue'
 import ConditionField from './ConditionField.vue'
 import useI18n from '../../../../composables/useI18n'
 import type { PluginFormLayoutProps } from './provider'
+import PluginConfigurationForm from './PluginConfigurationForm.vue'
 
 defineOptions({ inheritAttrs: false })
 
@@ -277,13 +248,10 @@ const FREE_FORM_CONTROLLED_FIELDS: Array<keyof FreeFormPluginData> = [
   'service',
 ]
 
-const instanceId = useId()
-
 const { i18n: { t } } = useI18n()
 
 const { hideEditorModeSwitcher = false, ...props } = defineProps<Props<T>>()
 const attrs = useAttrs()
-const configFieldRenderers = computed<PluginFieldRenderer[]>(() => props.fieldRenderers ?? [])
 
 const enableCodeMode = inject<boolean>(FEATURE_FLAGS.KM_2262_CODE_MODE, false)
 
@@ -322,7 +290,6 @@ function handleEditorModeChange(newMode: EditorMode) {
   editorModePreference.value = newMode
 }
 
-const redisPartialInfo = inject(REDIS_PARTIAL_INFO)
 const slots = defineSlots<{
   default: () => any
   'code-editor'?: () => any
@@ -334,23 +301,6 @@ const slots = defineSlots<{
   'plugin-config-extra'?: () => any
   'field-renderers'?: () => any
 }>()
-
-const realFormConfig = computed(() => {
-  const formConfig = props.formConfig as FormConfig<T> | undefined
-
-  return {
-    ...(formConfig ?? {}),
-    hasValue: formConfig?.hasValue ?? ((data?: T): boolean => !!data && Object.keys(data).length > 0),
-    prepareFormData: (data: T): Partial<T> => {
-      const preparedData = formConfig?.prepareFormData?.(data) ?? data
-
-      if (props.isEditing) return preparedData
-
-      // Init scope-related fields from formModel when creating a new plugin
-      return { ...preparedData, ... getScopesFromFormModel() }
-    },
-  }
-})
 
 const scopeWrapperAttrs = computed(() => {
   if (scopeSchema.value?.disabled) {
@@ -544,8 +494,14 @@ const scopesCache = ref(
 // `scopeIds` is not reactive. Initialize `scoped` in one shot.
 const scoped = ref(Object.values(scopesCache.value).some(hasScopeId))
 
-const formRef = useTemplateRef('form')
+const formRef = useTemplateRef<any>('form')
 let skipUpdateScopeCache = false
+
+function prepareFormData(data: Partial<T>): Partial<T> {
+  if (props.isEditing) return data
+
+  return { ...data, ... getScopesFromFormModel() }
+}
 
 function handleScopeChange() {
   if (!formRef.value) return
@@ -591,7 +547,6 @@ function handleDataChange(value: T) {
     }
   }
 
-  props.onFormChange(value, FREE_FORM_CONTROLLED_FIELDS)
 }
 
 function updateScopeCache(value: T) {
@@ -621,8 +576,6 @@ function getScopesFromFormModel(): Partial<T> {
   })
   return data
 }
-
-useSchemaExposer(freeFormSchema, instanceId)
 
 const advancedCollapsed = ref(true)
 </script>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/provider.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/provider.ts
@@ -1,41 +1,12 @@
-import type { Component, InjectionKey } from 'vue'
+import type { InjectionKey } from 'vue'
 import { provide } from 'vue'
-import type { FormSchema } from '../../../../types/plugins/form-schema'
-import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
-import type { PluginValidityChangeEvent } from '../../../../types'
-import type { FieldRenderer as PluginFieldRenderer, FormConfig, RenderRules } from '../types'
+import type { PluginFormLayoutComponent } from '../types'
 
-export type PluginFormLayoutProps<T extends FreeFormPluginData = FreeFormPluginData> = {
-  /** FreeForm Schema */
-  schema: FormSchema
-  /** The **initial** entire plugin model, never update */
-  model: T
-  /** Emits the final submission payload to the parent, the payload will be merged with the `formModel` but it has high override priority */
-  onFormChange: (value: Partial<T>, fields?: string[]) => void
-  onValidityChange?: (event: PluginValidityChangeEvent) => void
-  /** FreeForm configuration */
-  formConfig?: FormConfig<T>
-  renderRules?: RenderRules
-  fieldRenderers?: PluginFieldRenderer[]
-  pluginName: string
-  /** Konnect-managed Redis UI, from plugin form config */
-  isKonnectManagedRedisEnabled?: boolean
-  isEditing: boolean
-  /**
-   * Hide the built-in form/code switcher. Plugins that own a custom switcher
-   * (e.g. Datakit's flow/code control) should set this to true to avoid
-   * rendering duplicate controls into #plugin-form-page-actions.
-   */
-  hideEditorModeSwitcher?: boolean
-  /** Whether the plugin is being created for a portal developer */
-  developer?: boolean
-  generalInfoTitle?: string
-  generalInfoDescription?: string
-  pluginConfigTitle?: string
-  pluginConfigDescription?: string
-}
-
-export type PluginFormLayoutComponent<T extends FreeFormPluginData = FreeFormPluginData> = Component<PluginFormLayoutProps<T>>
+export type {
+  PluginConfigurationBaseProps,
+  PluginFormLayoutComponent,
+  PluginFormLayoutProps,
+} from '../types'
 
 export const FREE_FORM_PLUGIN_LAYOUT: InjectionKey<PluginFormLayoutComponent> = Symbol.for('kong-ui-public.entities-plugins.free-form-plugin-layout')
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/plugin-registry.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/plugin-registry.ts
@@ -1,9 +1,7 @@
-import type { PluginFormConfig } from './types'
-
-import type { Component } from 'vue'
+import type { PluginFormConfig, PluginFormLayoutComponent } from './types'
 
 export interface ResolvedPluginFormConfig extends PluginFormConfig {
-  component: Component
+  component: PluginFormLayoutComponent<any>
   experimental: boolean
   fieldRenderers: NonNullable<PluginFormConfig['fieldRenderers']>
 }
@@ -65,7 +63,7 @@ export function getPluginConfig(pluginName: string): ResolvedPluginFormConfig | 
 export function getFreeFormComponent(
   pluginName: string,
   experimentalWhitelist: string[],
-): Component | undefined {
+): PluginFormLayoutComponent<any> | undefined {
   const pluginConfig = getPluginConfig(pluginName)
 
   if (!pluginConfig) {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
@@ -1,4 +1,5 @@
-import type { UnionFieldSchema } from '../../../types/plugins/form-schema'
+import type { FormSchema, UnionFieldSchema } from '../../../types/plugins/form-schema'
+import type { FreeFormPluginData } from '../../../types/plugins/free-form'
 import type { Component, ComponentPublicInstance, Ref, Slot } from 'vue'
 import { type LabelAttributes } from '@kong/kongponents'
 
@@ -185,7 +186,7 @@ export type Match = (opt: {
   path: string
   /**
    * A generic path pattern that can be used for matching multiple fields,
-   * e.g. `config.callouts.0.redis` can match `config.callouts.1.redis` and `config.callouts.2.redis`.
+   * e.g. `config.callouts.*.redis` can match `config.callouts.1.redis` and `config.callouts.2.redis`.
    */
   genericPath: string
   schema: UnionFieldSchema
@@ -201,6 +202,41 @@ export interface FieldRenderer {
   propsOverrides?: Record<string, unknown> | PropsOverridesFn
 }
 
+export type PluginConfigurationBaseProps<T extends Record<string, any> = Record<string, any>> = {
+  /** FreeForm Schema */
+  schema: FormSchema
+  /** The **initial** entire plugin model, never update */
+  model: T
+  /** Emits the final submission payload to the parent, the payload will be merged with the `formModel` but it has high override priority */
+  onFormChange: (value: Partial<T>, fields?: string[]) => void
+  /** FreeForm configuration */
+  formConfig?: FormConfig<T>
+  renderRules?: RenderRules
+  fieldRenderers?: FieldRenderer[]
+  pluginName: string
+  /** Konnect-managed Redis UI, from plugin form config */
+  isKonnectManagedRedisEnabled?: boolean
+}
+
+export type PluginFormLayoutProps<T extends FreeFormPluginData = FreeFormPluginData> = PluginConfigurationBaseProps<T> & {
+  onValidityChange?: (event: { model: string, valid: boolean, error?: Error | string }) => void
+  isEditing: boolean
+  /**
+   * Hide the built-in form/code switcher. Plugins that own a custom switcher
+   * (e.g. Datakit's flow/code control) should set this to true to avoid
+   * rendering duplicate controls into #plugin-form-page-actions.
+   */
+  hideEditorModeSwitcher?: boolean
+  /** Whether the plugin is being created for a portal developer */
+  developer?: boolean
+  generalInfoTitle?: string
+  generalInfoDescription?: string
+  pluginConfigTitle?: string
+  pluginConfigDescription?: string
+}
+
+export type PluginFormLayoutComponent<T extends FreeFormPluginData = FreeFormPluginData> = Component<PluginFormLayoutProps<T>>
+
 export interface PluginFormConfig {
   /**
    * Whether the plugin is experimental.
@@ -209,9 +245,10 @@ export interface PluginFormConfig {
   experimental?: boolean
   /**
    * Form-level custom component.
+    * Receives `PluginFormLayoutProps`.
    * @default CommonForm
    */
-  component: Component
+  component: PluginFormLayoutComponent<any>
   /**
    * Form-level rendering rules.
    */

--- a/packages/entities/entities-plugins/src/index.ts
+++ b/packages/entities/entities-plugins/src/index.ts
@@ -6,7 +6,9 @@ import PluginCatalog from './components/PluginCatalog.vue'
 import PluginSelectGrid from './components/select/PluginSelectGrid.vue'
 import PluginSelectCard from './components/select/PluginSelectCard.vue'
 import PluginConfigCard from './components/PluginConfigCard.vue'
+import CommonForm from './components/free-form/Common/CommonForm.vue'
 import DynamicLayout from './components/free-form/shared/layout/DynamicLayout.vue'
+import PluginConfigurationForm from './components/free-form/shared/layout/PluginConfigurationForm.vue'
 import composables from './composables'
 import pluginEndpoints from './plugins-endpoints'
 
@@ -21,7 +23,9 @@ export {
   PluginSelectGrid,
   PluginSelectCard,
   PluginConfigCard,
+  CommonForm,
   DynamicLayout,
+  PluginConfigurationForm,
   usePluginMetaData,
   useProvideExperimentalFreeForms,
 }
@@ -31,9 +35,18 @@ export {
 } from './components/free-form/shared/layout/provider'
 
 export type {
+  PluginConfigurationBaseProps,
   PluginFormLayoutComponent,
   PluginFormLayoutProps,
 } from './components/free-form/shared/layout/provider'
+
+export {
+  pluginConfigRegistry,
+} from './components/free-form/shared/plugin-registry'
+
+export type {
+  ResolvedPluginFormConfig,
+} from './components/free-form/shared/plugin-registry'
 
 export * from './types'
 


### PR DESCRIPTION
## Summary

[KM-2663](https://konghq.atlassian.net/browse/KM-2663)

Plugin configuration can now be reused without taking on the API Gateway-specific StandardLayout shell. StandardLayout still owns editor mode, scope, general info, the plugin configuration block, and code editor behavior, while the shared PluginConfigurationForm is only a free-form `Form` wrapper with field renderers, Redis selector wiring, schema exposure, and controlled data forwarding.

This keeps the stacked change focused on the reusable form layer needed by custom layouts such as AI Gateway policy forms.


[KM-2663]: https://konghq.atlassian.net/browse/KM-2663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ