### PR TITLE
feat(entities-plugins): expose freeform registry

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/provider.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/provider.ts
@@ -1,44 +1,12 @@
-import type { Component, InjectionKey } from 'vue'
+import type { InjectionKey } from 'vue'
 import { provide } from 'vue'
-import type { FormSchema } from '../../../../types/plugins/form-schema'
-import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
-import type { PluginValidityChangeEvent } from '../../../../types'
-import type { FieldRenderer as PluginFieldRenderer, FormConfig, RenderRules } from '../types'
+import type { PluginFormLayoutComponent } from '../types'
 
-export type PluginConfigurationBaseProps<T extends Record<string, any> = Record<string, any>> = {
-  /** FreeForm Schema */
-  schema: FormSchema
-  /** The **initial** entire plugin model, never update */
-  model: T
-  /** Emits the final submission payload to the parent, the payload will be merged with the `formModel` but it has high override priority */
-  onFormChange: (value: Partial<T>, fields?: string[]) => void
-  /** FreeForm configuration */
-  formConfig?: FormConfig<T>
-  renderRules?: RenderRules
-  fieldRenderers?: PluginFieldRenderer[]
-  pluginName: string
-  /** Konnect-managed Redis UI, from plugin form config */
-  isKonnectManagedRedisEnabled?: boolean
-}
-
-export type PluginFormLayoutProps<T extends FreeFormPluginData = FreeFormPluginData> = PluginConfigurationBaseProps<T> & {
-  onValidityChange?: (event: PluginValidityChangeEvent) => void
-  isEditing: boolean
-  /**
-   * Hide the built-in form/code switcher. Plugins that own a custom switcher
-   * (e.g. Datakit's flow/code control) should set this to true to avoid
-   * rendering duplicate controls into #plugin-form-page-actions.
-   */
-  hideEditorModeSwitcher?: boolean
-  /** Whether the plugin is being created for a portal developer */
-  developer?: boolean
-  generalInfoTitle?: string
-  generalInfoDescription?: string
-  pluginConfigTitle?: string
-  pluginConfigDescription?: string
-}
-
-export type PluginFormLayoutComponent<T extends FreeFormPluginData = FreeFormPluginData> = Component<PluginFormLayoutProps<T>>
+export type {
+  PluginConfigurationBaseProps,
+  PluginFormLayoutComponent,
+  PluginFormLayoutProps,
+} from '../types'
 
 export const FREE_FORM_PLUGIN_LAYOUT: InjectionKey<PluginFormLayoutComponent> = Symbol.for('kong-ui-public.entities-plugins.free-form-plugin-layout')
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/plugin-registry.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/plugin-registry.ts
@@ -1,9 +1,7 @@
-import type { PluginFormConfig } from './types'
-
-import type { Component } from 'vue'
+import type { PluginFormConfig, PluginFormLayoutComponent } from './types'
 
 export interface ResolvedPluginFormConfig extends PluginFormConfig {
-  component: Component
+  component: PluginFormLayoutComponent<any>
   experimental: boolean
   fieldRenderers: NonNullable<PluginFormConfig['fieldRenderers']>
 }
@@ -65,7 +63,7 @@ export function getPluginConfig(pluginName: string): ResolvedPluginFormConfig | 
 export function getFreeFormComponent(
   pluginName: string,
   experimentalWhitelist: string[],
-): Component | undefined {
+): PluginFormLayoutComponent<any> | undefined {
   const pluginConfig = getPluginConfig(pluginName)
 
   if (!pluginConfig) {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
@@ -1,4 +1,6 @@
-import type { UnionFieldSchema } from '../../../types/plugins/form-schema'
+import type { FormSchema, UnionFieldSchema } from '../../../types/plugins/form-schema'
+import type { FreeFormPluginData } from '../../../types/plugins/free-form'
+import type { PluginValidityChangeEvent } from '../../../types'
 import type { Component, ComponentPublicInstance, Ref, Slot } from 'vue'
 import { type LabelAttributes } from '@kong/kongponents'
 
@@ -201,6 +203,41 @@ export interface FieldRenderer {
   propsOverrides?: Record<string, unknown> | PropsOverridesFn
 }
 
+export type PluginConfigurationBaseProps<T extends Record<string, any> = Record<string, any>> = {
+  /** FreeForm Schema */
+  schema: FormSchema
+  /** The **initial** entire plugin model, never update */
+  model: T
+  /** Emits the final submission payload to the parent, the payload will be merged with the `formModel` but it has high override priority */
+  onFormChange: (value: Partial<T>, fields?: string[]) => void
+  /** FreeForm configuration */
+  formConfig?: FormConfig<T>
+  renderRules?: RenderRules
+  fieldRenderers?: FieldRenderer[]
+  pluginName: string
+  /** Konnect-managed Redis UI, from plugin form config */
+  isKonnectManagedRedisEnabled?: boolean
+}
+
+export type PluginFormLayoutProps<T extends FreeFormPluginData = FreeFormPluginData> = PluginConfigurationBaseProps<T> & {
+  onValidityChange?: (event: PluginValidityChangeEvent) => void
+  isEditing: boolean
+  /**
+   * Hide the built-in form/code switcher. Plugins that own a custom switcher
+   * (e.g. Datakit's flow/code control) should set this to true to avoid
+   * rendering duplicate controls into #plugin-form-page-actions.
+   */
+  hideEditorModeSwitcher?: boolean
+  /** Whether the plugin is being created for a portal developer */
+  developer?: boolean
+  generalInfoTitle?: string
+  generalInfoDescription?: string
+  pluginConfigTitle?: string
+  pluginConfigDescription?: string
+}
+
+export type PluginFormLayoutComponent<T extends FreeFormPluginData = FreeFormPluginData> = Component<PluginFormLayoutProps<T>>
+
 export interface PluginFormConfig {
   /**
    * Whether the plugin is experimental.
@@ -209,9 +246,10 @@ export interface PluginFormConfig {
   experimental?: boolean
   /**
    * Form-level custom component.
+    * Receives `PluginFormLayoutProps`.
    * @default CommonForm
    */
-  component: Component
+  component: PluginFormLayoutComponent<any>
   /**
    * Form-level rendering rules.
    */

--- a/packages/entities/entities-plugins/src/index.ts
+++ b/packages/entities/entities-plugins/src/index.ts
@@ -6,6 +6,7 @@ import PluginCatalog from './components/PluginCatalog.vue'
 import PluginSelectGrid from './components/select/PluginSelectGrid.vue'
 import PluginSelectCard from './components/select/PluginSelectCard.vue'
 import PluginConfigCard from './components/PluginConfigCard.vue'
+import CommonForm from './components/free-form/Common/CommonForm.vue'
 import DynamicLayout from './components/free-form/shared/layout/DynamicLayout.vue'
 import PluginConfigurationForm from './components/free-form/shared/layout/PluginConfigurationForm.vue'
 import composables from './composables'
@@ -22,6 +23,7 @@ export {
   PluginSelectGrid,
   PluginSelectCard,
   PluginConfigCard,
+  CommonForm,
   DynamicLayout,
   PluginConfigurationForm,
   usePluginMetaData,
@@ -37,6 +39,14 @@ export type {
   PluginFormLayoutComponent,
   PluginFormLayoutProps,
 } from './components/free-form/shared/layout/provider'
+
+export {
+  pluginConfigRegistry,
+} from './components/free-form/shared/plugin-registry'
+
+export type {
+  ResolvedPluginFormConfig,
+} from './components/free-form/shared/plugin-registry'
 
 export * from './types'
 


### PR DESCRIPTION
## Summary

Free-form consumers can now import the default `CommonForm` and inspect the built plugin config registry from the package entry point. Plugin registry components are typed as `PluginFormLayoutComponent`, so registry entries now preserve the `PluginFormLayoutProps` contract instead of accepting any Vue component.

This keeps the change stacked on the layout extraction work while exposing the registry pieces needed by host-specific free-form integrations.


