### PR TITLE
feat(datakit): add non-nil property option

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/node-forms/NodeFormProperty.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/node-forms/NodeFormProperty.vue
@@ -21,6 +21,11 @@
       @update:property-key="setConfig('property-key')"
     />
 
+    <BooleanField
+      name="non_nil"
+      @update:model-value="setConfig('non_nil')"
+    />
+
     <NodeFormDivider v-if="writable" />
 
     <InputsField
@@ -41,6 +46,7 @@ import PropertiesField from './PropertiesField.vue'
 import { useNodeForm, useSubSchema, type BaseFormData } from '../composables/useNodeForm'
 import { computed, useTemplateRef } from 'vue'
 import EnumField from '../../../../shared/EnumField.vue'
+import BooleanField from '../../../../shared/BooleanField.vue'
 import InputsField from './InputsField.vue'
 import NodeFormDivider from './NodeFormDivider.vue'
 import { extractKeyFromProperty, identifyPropertyHasKey, isReadableProperty, isWritableProperty } from '../node/property'
@@ -57,6 +63,7 @@ const { nodeId } = defineProps<{
 interface PropertyFormData extends BaseFormData {
   property: string | null
   content_type: string | null
+  non_nil?: boolean
 }
 
 const formRef = useTemplateRef('form')

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/schema/compat.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/schema/compat.ts
@@ -189,6 +189,7 @@ const JsonToXmlNodeSchema = ConfigNodeBaseSchema.safeExtend({
 const PropertyNodeSchema = ConfigNodeBaseSchema.safeExtend({
   type: z.literal('property'),
   content_type: z.string().nullish(),
+  non_nil: z.boolean().nullish(),
   property: z.string().nullish(),
   inputs: z.never().nullish(),
   outputs: z.never().nullish(),

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/schema/strict.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/schema/strict.ts
@@ -388,6 +388,11 @@ export const PropertyNodeSchema = ConfigNodeBaseSchema.safeExtend({
     .nullish(),
   /** The property name to get/set. */
   property: z.string().min(1).max(255),
+  /**
+   * When true, the property value must exist: in SET mode, input must not be
+   * nil/null; in GET mode, output must not be nil/null.
+   */
+  non_nil: z.boolean().default(false).nullish(),
   inputs: z.never().nullish(),
   outputs: z.never().nullish(),
 }).strict()


### PR DESCRIPTION
# Summary

[KM-2612]

Add a non_nil option to Datakit property nodes, including form control, schema support, and label text.

[KM-2612]: https://konghq.atlassian.net/browse/KM-2612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ