### PR TITLE
Render platform timestamp axis title

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
@@ -1,6 +1,7 @@
 // Cypress component test spec file
 import AnalyticsChart from './AnalyticsChart.vue'
 import ChartTooltip from './chart-plugins/ChartTooltip.vue'
+import TimeSeriesChart from './chart-types/TimeSeriesChart.vue'
 import composables from '../composables'
 import { exploreResult, emptyExploreResult, multiDimensionExploreResult } from '../../fixtures/mockData'
 import { INJECT_QUERY_PROVIDER } from '../constants'
@@ -168,6 +169,20 @@ describe('<AnalyticsChart />', () => {
     cy.get('.sub-label').eq(2).should('include.text', '910K')
     cy.get('.label').eq(3).should('include.text', '300')
     cy.get('.sub-label').eq(3).should('include.text', '378K')
+  })
+
+  it('renders the platform datasource timestamp axis title', () => {
+    mount({
+      chartData: {
+        ...exploreResult,
+        meta: {
+          ...exploreResult.meta,
+          datasource: 'platform',
+        },
+      },
+    }).then(({ wrapper }) => {
+      expect(wrapper.findComponent(TimeSeriesChart).props('dimensionAxesTitle')).to.eq('@timestamp created at')
+    })
   })
 
   it('shows the empty state with no data', () => {

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -309,6 +309,10 @@ const dimensionAxesTitle = computed<string | undefined>(() => {
 })
 
 const timestampAxisTitle = computed(() => {
+  if (props.chartData.meta.datasource === 'platform') {
+    return i18n.t('timestampAxisTitles.platform')
+  }
+
   const granularity = msToGranularity(Number(props.chartData.meta.granularity_ms))
 
   if (!granularity) {

--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -315,6 +315,9 @@
     "daily": "@timestamp per day",
     "weekly": "@timestamp per week"
   },
+  "timestampAxisTitles": {
+    "platform": "@timestamp created at"
+  },
   "topNTable": {
     "nameLabel": "Name",
     "defaultEmptyStateTitle": "No data to display",


### PR DESCRIPTION
## Summary

https://konghq.atlassian.net/browse/MA-4896

- Render the time-series timestamp axis title as `@timestamp created at` when explore metadata has `datasource: 'platform'`.
- Add a localized `timestampAxisTitles.platform` string.
- Add a Cypress component regression test that checks the title passed to `TimeSeriesChart` for platform datasource results.
