### PR TITLE
fix(entities-plugins): show inline realm error

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -217,7 +217,7 @@ import {
 import PluginEntityForm from './PluginEntityForm.vue'
 import PluginFormActionsWrapper from './PluginFormActionsWrapper.vue'
 import unset from 'lodash-es/unset'
-import { REDIS_PARTIAL_INFO } from '../components/free-form/shared/const'
+import { REDIS_PARTIAL_INFO, BEFORE_SAVE_KEY } from '../components/free-form/shared/const'
 import type { GlobalAction } from './free-form/shared/types'
 import { PLUGIN_FORM_LAYOUT_STATE } from '@kong-ui-public/entities-shared'
 import { FEATURE_FLAGS as PLUGIN_FEATURE_FLAGS } from '../constants'
@@ -429,6 +429,9 @@ provide(REDIS_PARTIAL_INFO, {
   redisPath: pluginRedisPath,
   isEditing: isEditing.value,
 })
+
+const beforeSaveCallbacks: Array<() => boolean> = []
+provide(BEFORE_SAVE_KEY, (cb: () => boolean) => beforeSaveCallbacks.push(cb))
 
 const isDeckCustomizationVisible = ref(false)
 
@@ -1464,6 +1467,11 @@ const viewConfigurationRecord = computed(() => {
 
 // make the actual API request to save on create/edit
 const saveFormData = async (): Promise<void> => {
+  // Run before-save guards; any callback returning false blocks submission
+  if (!beforeSaveCallbacks.every(cb => cb())) {
+    return
+  }
+
   if (form.clientErrorMessage) {
     // if there are still client errors, don't submit the form
     return

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -217,7 +217,8 @@ import {
 import PluginEntityForm from './PluginEntityForm.vue'
 import PluginFormActionsWrapper from './PluginFormActionsWrapper.vue'
 import unset from 'lodash-es/unset'
-import { REDIS_PARTIAL_INFO, BEFORE_SAVE_KEY } from '../components/free-form/shared/const'
+import { REDIS_PARTIAL_INFO } from '../components/free-form/shared/const'
+import { BEFORE_SAVE_KEY } from './const'
 import type { GlobalAction } from './free-form/shared/types'
 import { PLUGIN_FORM_LAYOUT_STATE } from '@kong-ui-public/entities-shared'
 import { FEATURE_FLAGS as PLUGIN_FEATURE_FLAGS } from '../constants'
@@ -431,7 +432,13 @@ provide(REDIS_PARTIAL_INFO, {
 })
 
 const beforeSaveCallbacks: Array<() => boolean> = []
-provide(BEFORE_SAVE_KEY, (cb: () => boolean) => beforeSaveCallbacks.push(cb))
+provide(BEFORE_SAVE_KEY, (cb: () => boolean) => {
+  beforeSaveCallbacks.push(cb)
+  return () => {
+    const i = beforeSaveCallbacks.indexOf(cb)
+    if (i !== -1) beforeSaveCallbacks.splice(i, 1)
+  }
+})
 
 const isDeckCustomizationVisible = ref(false)
 

--- a/packages/entities/entities-plugins/src/components/const.ts
+++ b/packages/entities/entities-plugins/src/components/const.ts
@@ -1,0 +1,5 @@
+import type { InjectionKey } from 'vue'
+
+/** Register a before-save guard. The callback returns true to allow saving, false to block it.
+ * Returns an unregister function to remove the guard when the component unmounts. */
+export const BEFORE_SAVE_KEY: InjectionKey<(cb: () => boolean) => () => void> = Symbol('before-save')

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -571,7 +571,7 @@ describe('ConfigFormContent', () => {
           config: { principals: { enabled: true, directory: 'default', error_on_miss: false }, identity_realms: null },
         })
 
-        cy.getTestId('principals-error-on-miss-true').click()
+        cy.getTestId('principals-error-on-miss-true').click({ force: true })
 
         cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
           return val.config?.principals?.error_on_miss === true
@@ -583,7 +583,7 @@ describe('ConfigFormContent', () => {
           config: { principals: { enabled: true, directory: 'default', error_on_miss: true }, identity_realms: null },
         })
 
-        cy.getTestId('principals-error-on-miss-false').click()
+        cy.getTestId('principals-error-on-miss-false').click({ force: true })
 
         cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
           return val.config?.principals?.error_on_miss === false

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -2,7 +2,7 @@ import { h } from 'vue'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import Form from '../../free-form/shared/Form.vue'
 import ConfigFormContent from './ConfigFormContent.vue'
-import { BEFORE_SAVE_KEY } from '../../free-form/shared/const'
+import { BEFORE_SAVE_KEY } from '../../const'
 import type { FormSchema } from '../../../types/plugins/form-schema'
 
 // Schema with both principals and identity_realms (like key-auth)
@@ -264,7 +264,9 @@ function mountContent(schema: FormSchema, options: { isKonnect: boolean, hasExis
     global: {
       provide: {
         [FORMS_CONFIG]: formsConfig,
-        [BEFORE_SAVE_KEY as symbol]: (cb: () => boolean) => beforeSaveCallbacks.push(cb),
+        [BEFORE_SAVE_KEY as symbol]: (cb: () => boolean) => {
+          beforeSaveCallbacks.push(cb); return () => {}
+        },
       },
     },
   })

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -2,6 +2,7 @@ import { h } from 'vue'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import Form from '../../free-form/shared/Form.vue'
 import ConfigFormContent from './ConfigFormContent.vue'
+import { BEFORE_SAVE_KEY } from '../../free-form/shared/const'
 import type { FormSchema } from '../../../types/plugins/form-schema'
 
 // Schema with both principals and identity_realms (like key-auth)
@@ -41,6 +42,12 @@ const schemaWithRealms: FormSchema = {
                     type: 'string',
                     required: true,
                     default: 'default',
+                  },
+                },
+                {
+                  error_on_miss: {
+                    type: 'boolean',
+                    default: true,
                   },
                 },
               ],
@@ -156,6 +163,52 @@ const schemaWithoutRealms: FormSchema = {
   ],
 }
 
+// Schema with principals required (like key-auth with required principals)
+const schemaWithRequiredPrincipals: FormSchema = {
+  type: 'record',
+  fields: [
+    {
+      config: {
+        type: 'record',
+        fields: [
+          {
+            principals: {
+              required: true,
+              type: 'record',
+              fields: [
+                {
+                  enabled: {
+                    type: 'boolean',
+                    default: false,
+                  },
+                },
+                {
+                  directory: {
+                    type: 'string',
+                    required: true,
+                    default: 'default',
+                  },
+                },
+                {
+                  error_on_miss: {
+                    type: 'boolean',
+                    default: true,
+                  },
+                },
+              ],
+            },
+          },
+          {
+            anonymous: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+    },
+  ],
+}
+
 // Schema without principals (older plugin version)
 const schemaWithoutPrincipals: FormSchema = {
   type: 'record',
@@ -196,6 +249,8 @@ function mountContent(schema: FormSchema, options: { isKonnect: boolean, hasExis
     : { data: [], meta: { next: null } }
   cy.intercept('GET', '**/v1/realms*', { body: realmsResponse }).as('fetchRealms')
 
+  const beforeSaveCallbacks: Array<() => boolean> = []
+
   cy.mount(() =>
     h('div', { style: 'padding: 20px' },
       h(Form, {
@@ -209,11 +264,12 @@ function mountContent(schema: FormSchema, options: { isKonnect: boolean, hasExis
     global: {
       provide: {
         [FORMS_CONFIG]: formsConfig,
+        [BEFORE_SAVE_KEY as symbol]: (cb: () => boolean) => beforeSaveCallbacks.push(cb),
       },
     },
   })
 
-  return onChangeSpy
+  return { triggerSave: () => beforeSaveCallbacks.every(cb => cb()) }
 }
 
 describe('ConfigFormContent', () => {
@@ -278,7 +334,7 @@ describe('ConfigFormContent', () => {
         mountContent(schemaWithRealms, { isKonnect: true }, {
           config: {
             principals: null,
-            identity_realms: [{ scope: 'cp', id: 'some-id', region: 'us' }],
+            identity_realms: [{ scope: 'realm', id: 'some-id', region: 'us' }],
           },
         })
 
@@ -410,16 +466,35 @@ describe('ConfigFormContent', () => {
         cy.getTestId('ff-array-config.identity_realms').should('not.exist')
       })
 
-      it('shows identity_realms field in centrally-managed mode (advanced section)', () => {
+      it('shows identity_realms field inline (not in advanced) in centrally-managed mode', () => {
         mountContent(schemaWithRealms, { isKonnect: true }, {
           config: { principals: null, identity_realms: null },
         })
 
         cy.getTestId('kong-identity-mode-centrally-managed').closest('.k-radio').click()
 
+        cy.getTestId('ff-identity-realms-field').should('exist')
         cy.getTestId('ff-advanced-fields-container').within(() => {
-          cy.getTestId('ff-array-config.identity_realms').should('exist')
+          cy.getTestId('ff-array-config.identity_realms').should('not.exist')
         })
+      })
+
+      it('hides inline identity_realms field in consumers mode', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: null, identity_realms: null },
+        })
+
+        cy.getTestId('ff-identity-realms-field').should('not.exist')
+      })
+
+      it('hides inline identity_realms field in kong-identity mode', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: null, identity_realms: null },
+        })
+
+        cy.getTestId('kong-identity-mode-kong-identity').closest('.k-radio').click()
+
+        cy.getTestId('ff-identity-realms-field').should('not.exist')
       })
 
       it('shows identity_realms normally when schema has no principals (old schema)', () => {
@@ -451,6 +526,84 @@ describe('ConfigFormContent', () => {
         })
       })
     })
+
+    describe('error_on_miss', () => {
+      it('shows error_on_miss group when kong-identity is selected and schema has error_on_miss', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: { enabled: true, directory: 'default', error_on_miss: true }, identity_realms: null },
+        })
+
+        cy.getTestId('ff-principals-error-on-miss-label').should('exist')
+        cy.getTestId('principals-error-on-miss-true').should('exist')
+        cy.getTestId('principals-error-on-miss-false').should('exist')
+      })
+
+      it('hides error_on_miss group when consumers mode is active', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: null, identity_realms: null },
+        })
+
+        cy.getTestId('ff-principals-error-on-miss-label').should('not.exist')
+      })
+
+      it('hides error_on_miss group when centrally-managed mode is active', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: null, identity_realms: null },
+        })
+
+        cy.getTestId('kong-identity-mode-centrally-managed').closest('.k-radio').click()
+
+        cy.getTestId('ff-principals-error-on-miss-label').should('not.exist')
+      })
+
+      it('does not show error_on_miss group when schema lacks principals.error_on_miss', () => {
+        mountContent(schemaWithoutRealms, { isKonnect: true }, {
+          config: { principals: { enabled: true, directory: 'default' } },
+        })
+
+        cy.getTestId('kong-identity-mode-kong-identity').closest('.k-radio').click()
+
+        cy.getTestId('ff-principals-error-on-miss-label').should('not.exist')
+      })
+
+      it('clicking reject radio sets error_on_miss to true', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: { enabled: true, directory: 'default', error_on_miss: false }, identity_realms: null },
+        })
+
+        cy.getTestId('principals-error-on-miss-true').click()
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return val.config?.principals?.error_on_miss === true
+        }))
+      })
+
+      it('clicking continue radio sets error_on_miss to false', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: { enabled: true, directory: 'default', error_on_miss: true }, identity_realms: null },
+        })
+
+        cy.getTestId('principals-error-on-miss-false').click()
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return val.config?.principals?.error_on_miss === false
+        }))
+      })
+    })
+
+    describe('Required principals behavior', () => {
+      it('uses schema default (not null) for principals when required and switching to consumers', () => {
+        mountContent(schemaWithRequiredPrincipals, { isKonnect: true }, {
+          config: { principals: { enabled: true, directory: 'default', error_on_miss: true } },
+        })
+
+        cy.getTestId('kong-identity-mode-consumers').closest('.k-radio').click()
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return val.config?.principals !== null
+        }))
+      })
+    })
   })
 
   describe('Kong Manager', () => {
@@ -464,6 +617,56 @@ describe('ConfigFormContent', () => {
       mountContent(schemaWithoutPrincipals, { isKonnect: false })
 
       cy.getTestId('ff-kong-identity-field').should('not.exist')
+    })
+  })
+
+  describe('Konnect', () => {
+    describe('Realm validation', () => {
+      it('does not show validation error immediately when switching to centrally-managed', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: null, identity_realms: null },
+        })
+
+        cy.getTestId('kong-identity-mode-centrally-managed').closest('.k-radio').click()
+
+        cy.getTestId('identity-realms-validation-error').should('not.exist')
+      })
+
+      it('shows validation error after clicking the realm section with no realm selected', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: null, identity_realms: null },
+        })
+
+        cy.getTestId('kong-identity-mode-centrally-managed').closest('.k-radio').click()
+        cy.getTestId('identity-realms-section').click()
+
+        cy.getTestId('identity-realms-validation-error').should('exist')
+      })
+
+      it('does not show validation error when a valid realm is already selected', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: null, identity_realms: [{ scope: 'konnect', id: 'realm-1' }] },
+        })
+
+        cy.getTestId('identity-realms-section').click()
+
+        cy.getTestId('identity-realms-validation-error').should('not.exist')
+      })
+
+      it('shows validation error after a blocked submit attempt with no realm selected', () => {
+        const { triggerSave } = mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: null, identity_realms: null },
+        })
+
+        cy.getTestId('kong-identity-mode-centrally-managed').closest('.k-radio').click()
+        cy.getTestId('identity-realms-validation-error').should('not.exist')
+
+        cy.then(() => {
+          triggerSave()
+        })
+
+        cy.getTestId('identity-realms-validation-error').should('exist')
+      })
     })
   })
 })

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, nextTick, onMounted, provide, ref, watch } from 'vue'
+import { computed, inject, nextTick, onMounted, onUnmounted, provide, ref, watch } from 'vue'
 import ObjectField from '../../free-form/shared/ObjectField.vue'
 import AdvancedFields from '../../free-form/shared/AdvancedFields.vue'
 import KongIdentityField from './KongIdentityField.vue'
@@ -84,7 +84,7 @@ import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import { useAxios } from '@kong-ui-public/entities-shared'
 import { KLabel, KRadio } from '@kong/kongponents'
 import { FETCHED_REALMS_KEY } from '../key-auth-identity-realms/const'
-import { BEFORE_SAVE_KEY } from '../../free-form/shared/const'
+import { BEFORE_SAVE_KEY } from '../../const'
 import composables from '../../../composables'
 
 import type { KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
@@ -226,13 +226,14 @@ const realmValidationVisible = computed(() =>
 )
 
 // Before-save guard: block submission and reveal the error if no realm is selected
-registerBeforeSave?.(() => {
+const unregisterBeforeSave = registerBeforeSave?.(() => {
   if (realmValidationError.value) {
     realmSubmitAttempted.value = true
     return false
   }
   return true
 })
+onUnmounted(() => unregisterBeforeSave?.())
 
 const realmRequired = computed(() => !!getSchema('$.config.realm')?.required)
 

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -40,6 +40,30 @@
     data-testid="ff-advanced-fields-container"
     hide-general-fields
   >
+    <div
+      v-if="isKonnect && hasPrincipals && selectedMode === 'kong-identity' && hasPrincipalsErrorOnMiss"
+      class="kong-identity-error-on-miss"
+    >
+      <KLabel data-testid="ff-principals-error-on-miss-label">
+        {{ i18n.t('custom_field.kong_identity.error_on_miss_label') }}
+      </KLabel>
+      <KRadio
+        data-testid="principals-error-on-miss-true"
+        :description="i18n.t('custom_field.kong_identity.error_on_miss_reject_description')"
+        :label="i18n.t('custom_field.kong_identity.error_on_miss_reject_label')"
+        :model-value="principalsErrorOnMiss"
+        :selected-value="true"
+        @update:model-value="handleErrorOnMissChange"
+      />
+      <KRadio
+        data-testid="principals-error-on-miss-false"
+        :description="i18n.t('custom_field.kong_identity.error_on_miss_continue_description')"
+        :label="i18n.t('custom_field.kong_identity.error_on_miss_continue_label')"
+        :model-value="principalsErrorOnMiss"
+        :selected-value="false"
+        @update:model-value="handleErrorOnMissChange"
+      />
+    </div>
     <ObjectField
       as-child
       name="config"
@@ -58,6 +82,7 @@ import IdentityRealmsField from '../../free-form/plugins/key-auth/IdentityRealms
 import { useFormShared } from '../../free-form/shared/composables'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import { useAxios } from '@kong-ui-public/entities-shared'
+import { KLabel, KRadio } from '@kong/kongponents'
 import { FETCHED_REALMS_KEY } from '../key-auth-identity-realms/const'
 import { BEFORE_SAVE_KEY } from '../../free-form/shared/const'
 import composables from '../../../composables'
@@ -75,6 +100,16 @@ const isKonnect = computed(() => appConfig?.app === 'konnect')
 const { axiosInstance } = useAxios(appConfig?.axiosRequestConfig)
 
 const { formData, getSchema } = useFormShared()
+
+const hasPrincipalsErrorOnMiss = computed(() => !!getSchema('$.config.principals.error_on_miss'))
+
+const principalsErrorOnMiss = computed(() => formData.config?.principals?.error_on_miss ?? true)
+
+function handleErrorOnMissChange(value: boolean) {
+  if (formData.config?.principals) {
+    formData.config.principals.error_on_miss = value
+  }
+}
 
 // Fetch realms from API only when the Konnect identity realms field is relevant
 type KonnectRealmResponse = { data: Array<{ id: string, name: string }>, meta: { next: string | null } }
@@ -251,6 +286,12 @@ const advancedOmit = computed(() => {
   font-size: var(--kui-font-size-20, $kui-font-size-20);
   margin-bottom: 0;
   margin-top: var(--kui-space-30, $kui-space-30);
+}
+
+.kong-identity-error-on-miss {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-40, $kui-space-40);
 }
 
 .ff-advanced-fields-container {

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -13,7 +13,27 @@
     class="kong-identity-section"
     :has-existing-realms="hasExistingRealms"
     :identity-realms-in-schema="identityRealmsInSchema"
+    :loading-realms="isLoadingRealms"
   />
+
+  <div
+    v-if="isKonnect && identityRealmsInSchema && selectedMode === 'centrally-managed'"
+    class="identity-realms-section"
+    data-testid="identity-realms-section"
+    @click="handleRealmFieldTouch"
+  >
+    <IdentityRealmsField
+      name="$.config.identity_realms"
+      :required="true"
+    />
+    <p
+      v-if="realmValidationVisible"
+      class="identity-realms-error"
+      data-testid="identity-realms-validation-error"
+    >
+      {{ i18n.t('custom_field.kong_identity.identity_realms_required') }}
+    </p>
+  </div>
 
   <AdvancedFields
     class="ff-advanced-fields-container"
@@ -30,18 +50,25 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, onMounted, provide, ref } from 'vue'
+import { computed, inject, nextTick, onMounted, provide, ref, watch } from 'vue'
 import ObjectField from '../../free-form/shared/ObjectField.vue'
 import AdvancedFields from '../../free-form/shared/AdvancedFields.vue'
 import KongIdentityField from './KongIdentityField.vue'
+import IdentityRealmsField from '../../free-form/plugins/key-auth/IdentityRealmsField.vue'
 import { useFormShared } from '../../free-form/shared/composables'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import { useAxios } from '@kong-ui-public/entities-shared'
 import { FETCHED_REALMS_KEY } from '../key-auth-identity-realms/const'
+import { BEFORE_SAVE_KEY } from '../../free-form/shared/const'
+import composables from '../../../composables'
 
 import type { KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
 import type { MultiselectItem } from '@kong/kongponents'
 import type { AxiosResponse } from 'axios'
+
+const registerBeforeSave = inject(BEFORE_SAVE_KEY)
+
+const { i18n } = composables.useI18n()
 
 const appConfig = inject<KongManagerBaseFormConfig | KonnectBaseFormConfig | undefined>(FORMS_CONFIG)
 const isKonnect = computed(() => appConfig?.app === 'konnect')
@@ -54,11 +81,13 @@ type KonnectRealmResponse = { data: Array<{ id: string, name: string }>, meta: {
 
 const fetchedRealms = ref<MultiselectItem[]>([])
 const hasExistingRealms = ref(false)
+const isLoadingRealms = ref(false)
 
 const fetchRealms = async () => {
   if (appConfig?.app !== 'konnect' || !identityRealmsInSchema.value) return
 
   try {
+    isLoadingRealms.value = true
     let nextUrl: string | null = `${appConfig.apiBaseUrl}/v1/realms`
     const items: MultiselectItem[] = []
 
@@ -77,6 +106,8 @@ const fetchRealms = async () => {
     hasExistingRealms.value = items.length > 0
   } catch {
     hasExistingRealms.value = false
+  } finally {
+    isLoadingRealms.value = false
   }
 }
 
@@ -92,11 +123,81 @@ const hasPrincipals = computed(() => !!getSchema('$.config.principals'))
 
 function detectInitialMode(): 'consumers' | 'kong-identity' | 'centrally-managed' {
   if (formData.config?.principals?.enabled) return 'kong-identity'
-  if (Array.isArray(formData.config?.identity_realms) && formData.config.identity_realms.length > 0) return 'centrally-managed'
+  // For Konnect: only treat as centrally-managed when there's at least one non-CP realm
+  if (isKonnect.value) {
+    if (hasActualRealm(formData.config?.identity_realms)) return 'centrally-managed'
+  } else {
+    if (Array.isArray(formData.config?.identity_realms) && formData.config.identity_realms.length > 0) return 'centrally-managed'
+  }
   return 'consumers'
 }
 
+// A 'real' realm is one with scope !== 'cp' and a non-null id
+function hasActualRealm(realms: any[] | null | undefined): boolean {
+  if (!Array.isArray(realms) || realms.length === 0) return false
+  return realms.some((r) => r.scope !== 'cp' && r.id != null)
+}
+
 const selectedMode = ref<'consumers' | 'kong-identity' | 'centrally-managed'>(detectInitialMode())
+
+// Show validation error when centrally-managed mode is active but no real realm is selected
+const realmValidationError = computed(() =>
+  isKonnect.value
+  && selectedMode.value === 'centrally-managed'
+  && !hasActualRealm(formData.config?.identity_realms),
+)
+
+// Touch tracking: show the inline error only after the user interacts with the
+// multiselect. We use nextTick to let the programmatic identity_realms change
+// (set by handleModeChange when entering centrally-managed) flush first, so
+// only genuine user changes flip the touched flag.
+const realmFieldTouched = ref(false)
+const realmSubmitAttempted = ref(false)
+let realmTouchReady = false
+
+watch(selectedMode, async (mode) => {
+  if (mode !== 'centrally-managed') return
+  realmFieldTouched.value = false
+  realmSubmitAttempted.value = false
+  realmTouchReady = false
+  await nextTick()
+  realmTouchReady = true
+})
+
+// When entering edit mode with existing realms, selectedMode starts as 'centrally-managed'
+// without ever triggering the watcher above, so realmTouchReady stays false.
+// Set it on mount so user edits (e.g. removing a realm) are tracked.
+onMounted(() => {
+  if (selectedMode.value === 'centrally-managed') {
+    realmTouchReady = true
+  }
+})
+
+watch(() => formData.config?.identity_realms, () => {
+  if (selectedMode.value === 'centrally-managed' && realmTouchReady) {
+    realmFieldTouched.value = true
+  }
+}, { deep: true })
+
+function handleRealmFieldTouch() {
+  if (realmTouchReady) {
+    realmFieldTouched.value = true
+  }
+}
+
+// Inline error: visible after touch or a blocked submit attempt, auto-clears when valid
+const realmValidationVisible = computed(() =>
+  (realmFieldTouched.value || realmSubmitAttempted.value) && realmValidationError.value,
+)
+
+// Before-save guard: block submission and reveal the error if no realm is selected
+registerBeforeSave?.(() => {
+  if (realmValidationError.value) {
+    realmSubmitAttempted.value = true
+    return false
+  }
+  return true
+})
 
 const realmRequired = computed(() => !!getSchema('$.config.realm')?.required)
 
@@ -118,7 +219,7 @@ const advancedOmit = computed(() => {
   if (!realmRequired.value && selectedMode.value !== 'kong-identity') {
     advancedSet.add('realm')
   }
-  if (isKonnect.value && identityRealmsInSchema.value && (!hasPrincipals.value || selectedMode.value === 'centrally-managed')) {
+  if (isKonnect.value && identityRealmsInSchema.value && !hasPrincipals.value) {
     advancedSet.add('identity_realms')
   }
 
@@ -136,6 +237,20 @@ const advancedOmit = computed(() => {
     border-top: none;
     padding-top: 0;
   }
+}
+
+.identity-realms-section {
+  + .ff-advanced-fields-container {
+    border-top: none;
+    padding-top: 0;
+  }
+}
+
+.identity-realms-error {
+  color: var(--kui-color-text-danger, $kui-color-text-danger);
+  font-size: var(--kui-font-size-20, $kui-font-size-20);
+  margin-bottom: 0;
+  margin-top: var(--kui-space-30, $kui-space-30);
 }
 
 .ff-advanced-fields-container {

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
@@ -67,31 +67,6 @@
         </KRadio>
       </template>
     </div>
-
-    <div
-      v-if="selectedMode === 'kong-identity' && hasPrincipalsErrorOnMiss"
-      class="kong-identity-error-on-miss"
-    >
-      <KLabel data-testid="ff-principals-error-on-miss-label">
-        {{ t('custom_field.kong_identity.error_on_miss_label') }}
-      </KLabel>
-      <KRadio
-        data-testid="principals-error-on-miss-true"
-        :description="t('custom_field.kong_identity.error_on_miss_reject_description')"
-        :label="t('custom_field.kong_identity.error_on_miss_reject_label')"
-        :model-value="principalsErrorOnMiss"
-        :selected-value="true"
-        @update:model-value="handleErrorOnMissChange"
-      />
-      <KRadio
-        data-testid="principals-error-on-miss-false"
-        :description="t('custom_field.kong_identity.error_on_miss_continue_description')"
-        :label="t('custom_field.kong_identity.error_on_miss_continue_label')"
-        :model-value="principalsErrorOnMiss"
-        :selected-value="false"
-        @update:model-value="handleErrorOnMissChange"
-      />
-    </div>
   </div>
 </template>
 
@@ -116,18 +91,6 @@ const { i18n } = composables.useI18n()
 const { t } = i18n
 
 const { formData, getSchema, getEmptyOrDefault } = useFormShared()
-
-const hasPrincipalsErrorOnMiss = computed(() => !!getSchema('$.config.principals.error_on_miss'))
-
-const principalsErrorOnMiss = computed(() => {
-  return formData.config?.principals?.error_on_miss ?? true
-})
-
-function handleErrorOnMissChange(value: boolean) {
-  if (formData.config?.principals) {
-    formData.config.principals.error_on_miss = value
-  }
-}
 
 // Determine if schema has identity_realms
 const identityRealmsInSchema = computed(() => {
@@ -208,13 +171,6 @@ function handleModeChange(mode: AuthMode) {
   &:hover {
     text-decoration: underline;
   }
-}
-
-.kong-identity-error-on-miss {
-  display: flex;
-  flex-direction: column;
-  gap: var(--kui-space-40, $kui-space-40);
-  margin-top: var(--kui-space-60, $kui-space-60);
 }
 
 .kong-identity-options {

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
@@ -20,52 +20,84 @@
     </p>
 
     <div class="kong-identity-options">
-      <KRadio
-        card
-        card-orientation="horizontal"
-        data-testid="kong-identity-mode-consumers"
-        :description="consumersDescription"
-        :label="t('custom_field.kong_identity.consumers_label')"
-        :model-value="selectedMode"
-        selected-value="consumers"
-        @update:model-value="handleModeChange"
-      >
-        <TeamIcon :size="KUI_ICON_SIZE_50" />
-      </KRadio>
+      <KSkeletonBox
+        v-if="loadingRealms"
+        class="kong-identity-options-skeleton"
+      />
 
-      <KRadio
-        v-if="showCentrallyManaged"
-        card
-        card-orientation="horizontal"
-        data-testid="kong-identity-mode-centrally-managed"
-        :description="t('custom_field.kong_identity.centrally_managed_description')"
-        :label="t('custom_field.kong_identity.centrally_managed_label')"
-        :model-value="selectedMode"
-        selected-value="centrally-managed"
-        @update:model-value="handleModeChange"
-      >
-        <AccountTreeIcon :size="KUI_ICON_SIZE_50" />
-      </KRadio>
+      <template v-else>
+        <KRadio
+          card
+          card-orientation="horizontal"
+          data-testid="kong-identity-mode-consumers"
+          :description="consumersDescription"
+          :label="t('custom_field.kong_identity.consumers_label')"
+          :model-value="selectedMode"
+          selected-value="consumers"
+          @update:model-value="handleModeChange"
+        >
+          <TeamIcon :size="KUI_ICON_SIZE_50" />
+        </KRadio>
 
+        <KRadio
+          v-if="showCentrallyManaged"
+          card
+          card-orientation="horizontal"
+          data-testid="kong-identity-mode-centrally-managed"
+          :description="t('custom_field.kong_identity.centrally_managed_description')"
+          :label="t('custom_field.kong_identity.centrally_managed_label')"
+          :model-value="selectedMode"
+          selected-value="centrally-managed"
+          @update:model-value="handleModeChange"
+        >
+          <AccountTreeIcon :size="KUI_ICON_SIZE_50" />
+        </KRadio>
+
+        <KRadio
+          card
+          card-orientation="horizontal"
+          data-testid="kong-identity-mode-kong-identity"
+          :description="kongIdentityDescription"
+          :label="t('custom_field.kong_identity.kong_identity_label')"
+          :model-value="selectedMode"
+          selected-value="kong-identity"
+          @update:model-value="handleModeChange"
+        >
+          <KeyIcon :size="KUI_ICON_SIZE_50" />
+        </KRadio>
+      </template>
+    </div>
+
+    <div
+      v-if="selectedMode === 'kong-identity' && hasPrincipalsErrorOnMiss"
+      class="kong-identity-error-on-miss"
+    >
+      <KLabel data-testid="ff-principals-error-on-miss-label">
+        {{ t('custom_field.kong_identity.error_on_miss_label') }}
+      </KLabel>
       <KRadio
-        card
-        card-orientation="horizontal"
-        data-testid="kong-identity-mode-kong-identity"
-        :description="kongIdentityDescription"
-        :label="t('custom_field.kong_identity.kong_identity_label')"
-        :model-value="selectedMode"
-        selected-value="kong-identity"
-        @update:model-value="handleModeChange"
-      >
-        <KeyIcon :size="KUI_ICON_SIZE_50" />
-      </KRadio>
+        data-testid="principals-error-on-miss-true"
+        :description="t('custom_field.kong_identity.error_on_miss_reject_description')"
+        :label="t('custom_field.kong_identity.error_on_miss_reject_label')"
+        :model-value="principalsErrorOnMiss"
+        :selected-value="true"
+        @update:model-value="handleErrorOnMissChange"
+      />
+      <KRadio
+        data-testid="principals-error-on-miss-false"
+        :description="t('custom_field.kong_identity.error_on_miss_continue_description')"
+        :label="t('custom_field.kong_identity.error_on_miss_continue_label')"
+        :model-value="principalsErrorOnMiss"
+        :selected-value="false"
+        @update:model-value="handleErrorOnMissChange"
+      />
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import { KLabel, KRadio } from '@kong/kongponents'
+import { KLabel, KRadio, KSkeletonBox } from '@kong/kongponents'
 import { TeamIcon, AccountTreeIcon, KeyIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
 import { useFormShared } from '../../free-form/shared/composables'
@@ -78,11 +110,24 @@ defineOptions({ name: 'KongIdentityField' })
 const props = defineProps<{
   identityRealmsInSchema?: boolean
   hasExistingRealms?: boolean
+  loadingRealms?: boolean
 }>()
 const { i18n } = composables.useI18n()
 const { t } = i18n
 
-const { formData, getSchema } = useFormShared()
+const { formData, getSchema, getEmptyOrDefault } = useFormShared()
+
+const hasPrincipalsErrorOnMiss = computed(() => !!getSchema('$.config.principals.error_on_miss'))
+
+const principalsErrorOnMiss = computed(() => {
+  return formData.config?.principals?.error_on_miss ?? true
+})
+
+function handleErrorOnMissChange(value: boolean) {
+  if (formData.config?.principals) {
+    formData.config.principals.error_on_miss = value
+  }
+}
 
 // Determine if schema has identity_realms
 const identityRealmsInSchema = computed(() => {
@@ -122,7 +167,7 @@ function handleModeChange(mode: AuthMode) {
 
   switch (mode) {
     case 'kong-identity':
-      formData.config.principals = { enabled: true, directory: 'default' }
+      formData.config.principals = { ...getEmptyOrDefault('$.config.principals'), enabled: true, directory: 'default' }
       if (identityRealmsInSchema.value) {
         formData.config.identity_realms = null
       }
@@ -130,16 +175,20 @@ function handleModeChange(mode: AuthMode) {
         formData.config.realm = null
       }
       break
-    case 'consumers':
-      formData.config.principals = null
+    case 'consumers': {
+      const principalsRequired = !!getSchema('$.config.principals')?.required
+      formData.config.principals = principalsRequired ? getEmptyOrDefault('$.config.principals') : null
       if (identityRealmsInSchema.value) {
         formData.config.identity_realms = null
       }
       break
-    case 'centrally-managed':
-      formData.config.principals = null
+    }
+    case 'centrally-managed': {
+      const principalsRequired = !!getSchema('$.config.principals')?.required
+      formData.config.principals = principalsRequired ? getEmptyOrDefault('$.config.principals') : null
       formData.config.identity_realms = [{ scope: 'cp', id: null, region: null }]
       break
+    }
   }
 }
 </script>
@@ -161,10 +210,22 @@ function handleModeChange(mode: AuthMode) {
   }
 }
 
+.kong-identity-error-on-miss {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-40, $kui-space-40);
+  margin-top: var(--kui-space-60, $kui-space-60);
+}
+
 .kong-identity-options {
   display: flex;
   gap: var(--kui-space-50, $kui-space-50);
   margin-top: var(--kui-space-40, $kui-space-40);
+
+  .kong-identity-options-skeleton {
+    border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
+    width: 100%;
+  }
 
   :deep(.k-radio.radio-card) {
     flex: 1;

--- a/packages/entities/entities-plugins/src/components/free-form/shared/const.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/const.ts
@@ -4,9 +4,6 @@ import type { PartialInfo } from './types'
 export const REDIS_PARTIAL_INFO: InjectionKey<PartialInfo> = Symbol('redis-partial-info')
 export const FORM_EDITING: InjectionKey<ComputedRef<boolean>> = Symbol('free-form-editing')
 
-/** Register a before-save guard. The callback returns true to allow saving, false to block it. */
-export const BEFORE_SAVE_KEY: InjectionKey<(cb: () => boolean) => void> = Symbol('before-save')
-
 export const partialEndpoints = {
   konnect: {
     getOne: '/v2/control-planes/{controlPlaneId}/core-entities/partials/{id}',

--- a/packages/entities/entities-plugins/src/components/free-form/shared/const.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/const.ts
@@ -4,6 +4,9 @@ import type { PartialInfo } from './types'
 export const REDIS_PARTIAL_INFO: InjectionKey<PartialInfo> = Symbol('redis-partial-info')
 export const FORM_EDITING: InjectionKey<ComputedRef<boolean>> = Symbol('free-form-editing')
 
+/** Register a before-save guard. The callback returns true to allow saving, false to block it. */
+export const BEFORE_SAVE_KEY: InjectionKey<(cb: () => boolean) => void> = Symbol('before-save')
+
 export const partialEndpoints = {
   konnect: {
     getOne: '/v2/control-planes/{controlPlaneId}/core-entities/partials/{id}',

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -1203,7 +1203,13 @@
       "consumers_description_key_auth": "Use consumer-managed API keys. Consumers provide their API key in a request header, query parameter, or request body to authenticate requests.",
       "consumers_description_basic_auth": "Use consumer-managed Basic Auth credentials. Consumers authenticate requests using a username and password.",
       "centrally_managed_label": "Centrally managed consumers",
-      "centrally_managed_description": "Authenticate centrally managed consumers in Konnect using identity realms. Identity realms are scoped to the control plane by default."
+      "centrally_managed_description": "Authenticate centrally managed consumers in Konnect using identity realms. Identity realms are scoped to the control plane by default.",
+      "identity_realms_required": "To use Centrally managed consumers, you must select at least one realm.",
+      "error_on_miss_label": "If principal lookup fails",
+      "error_on_miss_reject_label": "Reject the request",
+      "error_on_miss_reject_description": "Treat the request as unauthenticated if Kong Identity cannot resolve the principal.",
+      "error_on_miss_continue_label": "Continue without a principal",
+      "error_on_miss_continue_description": "Allow the request to continue without resolving a principal."
     }
   },
   "sp": {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -1204,7 +1204,7 @@
       "consumers_description_basic_auth": "Use consumer-managed Basic Auth credentials. Consumers authenticate requests using a username and password.",
       "centrally_managed_label": "Centrally managed consumers",
       "centrally_managed_description": "Authenticate centrally managed consumers in Konnect using identity realms. Identity realms are scoped to the control plane by default.",
-      "identity_realms_required": "To use Centrally managed consumers, you must select at least one realm.",
+      "identity_realms_required": "To use centrally managed consumers, you must select at least one Centrally managed consumer realm.",
       "error_on_miss_label": "If principal lookup fails",
       "error_on_miss_reject_label": "Reject the request",
       "error_on_miss_reject_description": "Treat the request as unauthenticated if Kong Identity cannot resolve the principal.",


### PR DESCRIPTION
# Summary

**Changes**

- Introduced a `BEFORE_SAVE_KEY` injection key so child components can register before-save guards. `PluginForm.vue` provides it and runs all guards before submitting; submission is silently blocked if any guard returns false.
- `ConfigFormContent.vue` registers a guard that blocks submission if no realm is selected, and only reveals the inline error after the user has touched the field (click or value change) or attempted to submit. The error auto-clears once a valid realm is selected.
- Moved the `identity_realms` field out of the advanced section and inline below the mode selector when in `centrally-managed` mode.
- Fixed `detectInitialMode` for Konnect: only treats existing data as `centrally-managed` when there is at least one non-placeholder realm (scope !== `'cp'` with a non-null id).
- Added `isLoadingRealms` state passed to `KongIdentityField` to show a loading skeleton while realms are being fetched.
- Fixed an edit-mode bug where removing all realms wouldn't trigger validation, because `realmTouchReady` was never initialized when the component mounted already in `centrally-managed` mode.
- Updated the `identity_realms_required` i18n string to clarify the requirement.
- Added Cypress tests for `error_on_miss`, `Required principals behavior`, and the new realm validation behavior.


https://github.com/user-attachments/assets/bcfe6612-053c-41e9-a80f-f7fdc4ae4c5d


