### PR TITLE
fix(entities-shared): make SensitiveInput modelValue optional

### DIFF
--- a/packages/entities/entities-shared/docs/sensitive-input.md
+++ b/packages/entities/entities-shared/docs/sensitive-input.md
@@ -34,7 +34,8 @@ An input component (built on top of `KInput`) for entering sensitive fields such
 #### `modelValue`
 
 - type: `String`
-- required: `true`
+- required: `false`
+- default: `''`
 
 The sensitive value. Bound via `v-model`.
 

--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
@@ -22,6 +22,18 @@ describe('<SensitiveInput />', () => {
         .should('not.be.undefined')
     })
 
+    it('defaults to an empty value when modelValue is omitted', () => {
+      cy.mount(SensitiveInput, {
+        props: {},
+      })
+
+      input().should('have.value', '')
+      input().should('not.have.attr', 'readonly')
+      input().type('my-secret')
+      cy.then(() => Cypress.vueWrapper.emitted('update:modelValue'))
+        .should('not.be.undefined')
+    })
+
     it('masks the value by default and toggles visibility with the eye icon', () => {
       cy.mount(SensitiveInput, {
         props: { modelValue: 'super-secret' },

--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
@@ -108,7 +108,7 @@ import type { SensitiveInputLabels } from '../../types'
 const MASKED_VALUE = '••••••••••••••'
 
 const {
-  modelValue,
+  modelValue = '',
   mode = 'create',
   generator,
   showOneTimeHint = false,
@@ -124,7 +124,7 @@ const {
   errorMessage,
 } = defineProps<{
   /** The sensitive value, bound via v-model. */
-  modelValue: string
+  modelValue?: string
   /**
    * `create` starts editable; `edit` starts masked (read-only) and reveals a
    * "Rotate key" action that switches the field to the editable state.


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Relaxes `SensitiveInput`'s `modelValue` prop from a required, non-nullable `string` to an optional `string` that defaults to `''`.

### Motivation

`modelValue` was declared as `modelValue: string` (required, non-nullable). Because most form drafts model not-yet-set / not-applicable fields as `string | undefined`, every consumer was forced to make its bound field a non-optional `string` purely to satisfy the prop type — leaking the component's constraint into the caller's data model. `KInput`, which this component wraps, already accepts `string | undefined`.