### PR TITLE
fix(entities-consumer-groups): hydrate edit consumers

### DIFF
--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.cy.ts
@@ -882,13 +882,9 @@ describe('<ConsumerGroupForm />', () => {
         { statusCode: 200, body: { data: [], total: 0 } },
       )
       cy.intercept(
-        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumer_groups/${groupId}?list_consumers=false` },
-        { statusCode: 200, body: { item: { id: groupId, name: 'test', tags: [] } } },
+        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumer_groups/${groupId}` },
+        { statusCode: 200, body: { item: { id: groupId, name: 'test', tags: [] }, consumers: [] } },
       ).as('getGroupWithWorkspace')
-      cy.intercept(
-        { method: 'GET', url: `${konnectConfig.apiBaseUrl}/v2/control-planes/${konnectConfig.controlPlaneId}/core-entities/default/consumer_groups/${groupId}/consumers*` },
-        { statusCode: 200, body: { data: [], total: 0 } },
-      ).as('getConsumersWithWorkspace')
       cy.intercept(
         {
           method: 'PUT',
@@ -902,7 +898,6 @@ describe('<ConsumerGroupForm />', () => {
       }).then(({ wrapper }) => wrapper).as('vueWrapper')
 
       cy.wait('@getGroupWithWorkspace')
-      cy.wait('@getConsumersWithWorkspace')
 
       cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
       cy.wait('@updateGroupWithWorkspace')

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupForm.vue
@@ -182,7 +182,7 @@ const displayedConsumers = computed((): MultiselectItem[] => {
   }))
 })
 
-const fetchUrl = computed<string>(() => endpoints.item[props.config?.app])
+const fetchUrl = computed<string>(() => endpoints.form[props.config?.app].edit)
 
 const formType = computed((): EntityBaseFormType => props.consumerGroupId
   ? EntityBaseFormType.Edit


### PR DESCRIPTION
[KM-2697]

## Summary
- Fetch consumer group edit data from the form edit endpoint so consumers are included in the initial form payload.
- Update the workspace URL test to expect the edit form request without `list_consumers=false`.

[KM-2697]: https://konghq.atlassian.net/browse/KM-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ