### PR TITLE
fix(deps): align vue-router versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "vite-plugin-vue-devtools": "^7.7.9",
     "vitest": "^3.2.4",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7",
+    "vue-router": "^5.1.0",
     "vue-tsc": "^3.3.2"
   },
   "pnpm": {

--- a/packages/core/app-layout/package.json
+++ b/packages/core/app-layout/package.json
@@ -55,7 +55,7 @@
     "@kong/kongponents": "9.56.2",
     "@types/lodash.clonedeep": "^4.5.9",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "repository": {
     "type": "git",

--- a/packages/core/forms/package.json
+++ b/packages/core/forms/package.json
@@ -70,7 +70,8 @@
     "@kong/kongponents": "9.56.2",
     "@types/lodash-es": "^4.17.12",
     "axios": "^1.16.1",
-    "pug": "^3.0.4"
+    "pug": "^3.0.4",
+    "vue-router": "^5.1.0"
   },
   "distSizeChecker": {
     "errorLimit": "1.2MB"

--- a/packages/core/page-layout/package.json
+++ b/packages/core/page-layout/package.json
@@ -44,7 +44,7 @@
     "@kong/icons": "^1.56.0",
     "@kong/kongponents": "9.56.2",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "repository": {
     "type": "git",

--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -42,7 +42,7 @@
     "@kong/design-tokens": "1.22.2",
     "@kong/kongponents": "9.56.2",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "repository": {
     "type": "git",

--- a/packages/entities/entities-certificates/package.json
+++ b/packages/entities/entities-certificates/package.json
@@ -39,7 +39,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-consumer-credentials/package.json
+++ b/packages/entities/entities-consumer-credentials/package.json
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-consumer-groups/package.json
+++ b/packages/entities/entities-consumer-groups/package.json
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-consumers/package.json
+++ b/packages/entities/entities-consumers/package.json
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-data-plane-nodes/package.json
+++ b/packages/entities/entities-data-plane-nodes/package.json
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-gateway-services/package.json
+++ b/packages/entities/entities-gateway-services/package.json
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-key-sets/package.json
+++ b/packages/entities/entities-key-sets/package.json
@@ -36,7 +36,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-keys/package.json
+++ b/packages/entities/entities-keys/package.json
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-plugins/package.json
+++ b/packages/entities/entities-plugins/package.json
@@ -88,7 +88,7 @@
     "nanoid": "^5.1.11",
     "reflect-metadata": "^0.2.2",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7",
+    "vue-router": "^5.1.0",
     "zod": "^4.4.3"
   },
   "scripts": {

--- a/packages/entities/entities-redis-configurations/package.json
+++ b/packages/entities/entities-redis-configurations/package.json
@@ -50,7 +50,7 @@
     "axios": "^1.16.1",
     "swrv": "^1.2.0",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "repository": {
     "type": "git",

--- a/packages/entities/entities-routes/package.json
+++ b/packages/entities/entities-routes/package.json
@@ -39,7 +39,7 @@
     "axios": "^1.16.1",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-shared/package.json
+++ b/packages/entities/entities-shared/package.json
@@ -54,7 +54,7 @@
     "monaco-editor": "^0.55.1",
     "shiki": "^3.23.0",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-snis/package.json
+++ b/packages/entities/entities-snis/package.json
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-upstreams-targets/package.json
+++ b/packages/entities/entities-upstreams-targets/package.json
@@ -37,7 +37,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/packages/entities/entities-vaults/package.json
+++ b/packages/entities/entities-vaults/package.json
@@ -36,7 +36,7 @@
     "@kong/kongponents": "9.56.2",
     "axios": "^1.16.1",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.1.0"
   },
   "scripts": {
     "dev": "cross-env USE_SANDBOX=true vite",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         version: 1.6.2(@typescript-eslint/parser@8.50.0(eslint@9.39.4(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.5.1))(typescript@5.9.3)
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@stylistic/stylelint-plugin':
         specifier: ^5.1.0
         version: 5.1.0(stylelint@17.12.0(typescript@5.9.3))
@@ -182,8 +182,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.3.2
         version: 3.3.2(typescript@5.9.3)
@@ -486,7 +486,7 @@ importers:
         version: 1.22.2
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -494,8 +494,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/core/cli:
     devDependencies:
@@ -612,7 +612,7 @@ importers:
         version: 1.22.2
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -624,10 +624,10 @@ importers:
         version: 1.1.0(monaco-editor@0.55.1)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 1.6.0(rollup@4.59.0)(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 3.6.0(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))
       vue:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
@@ -671,6 +671,9 @@ importers:
       pug:
         specifier: ^3.0.4
         version: 3.0.4
+      vue-router:
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/core/i18n:
     dependencies:
@@ -762,13 +765,13 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       vue:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/core/sandbox-layout:
     dependencies:
@@ -781,13 +784,13 @@ importers:
         version: 1.22.2
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       vue:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/core/split-pane:
     dependencies:
@@ -847,7 +850,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -855,8 +858,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-consumer-credentials:
     devDependencies:
@@ -874,7 +877,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -882,8 +885,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-consumer-groups:
     devDependencies:
@@ -901,7 +904,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -909,8 +912,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-consumers:
     devDependencies:
@@ -928,7 +931,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -936,8 +939,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-data-plane-nodes:
     devDependencies:
@@ -955,7 +958,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -963,8 +966,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-gateway-services:
     devDependencies:
@@ -982,7 +985,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -990,8 +993,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-key-sets:
     devDependencies:
@@ -1006,7 +1009,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -1014,8 +1017,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-keys:
     devDependencies:
@@ -1033,7 +1036,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -1041,8 +1044,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-plugins:
     dependencies:
@@ -1100,13 +1103,13 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@peculiar/x509':
         specifier: ^2.0.0
         version: 2.0.0
       '@playwright/experimental-ct-vue':
         specifier: ^1.60.0
-        version: 1.60.0(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)
+        version: 1.60.0(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -1153,8 +1156,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1202,7 +1205,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -1216,8 +1219,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-routes:
     dependencies:
@@ -1242,7 +1245,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@types/lodash.isequal':
         specifier: ^4.5.8
         version: 4.5.8
@@ -1256,8 +1259,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-shared:
     dependencies:
@@ -1282,7 +1285,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@shikijs/core':
         specifier: ^3.23.0
         version: 3.23.0
@@ -1308,8 +1311,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-snis:
     devDependencies:
@@ -1327,7 +1330,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -1335,8 +1338,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-upstreams-targets:
     devDependencies:
@@ -1354,7 +1357,7 @@ importers:
         version: 1.56.0(vue@3.5.34(typescript@5.9.3))
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -1362,8 +1365,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/entities/entities-vaults:
     dependencies:
@@ -1382,7 +1385,7 @@ importers:
         version: 1.22.2
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       axios:
         specifier: ^1.16.1
         version: 1.16.1
@@ -1390,8 +1393,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
       vue-router:
-        specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
   packages/portal/document-viewer:
     dependencies:
@@ -1407,13 +1410,13 @@ importers:
         version: 1.22.2
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@types/prismjs':
         specifier: ^1.26.6
         version: 1.26.6
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.2.0
-        version: 4.2.0(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
+        version: 4.2.0(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       vue:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
@@ -1441,10 +1444,10 @@ importers:
         version: 1.22.2
       '@kong/kongponents':
         specifier: 9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.1
-        version: 1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))
+        version: 1.1.1(rollup@4.59.0)(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))
       '@types/lodash.clonedeep':
         specifier: ^4.5.9
         version: 4.5.9
@@ -1552,10 +1555,6 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@8.0.0-rc.5':
-    resolution: {integrity: sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/generator@8.0.0-rc.6':
     resolution: {integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -1614,10 +1613,6 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@8.0.0-rc.5':
-    resolution: {integrity: sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/helper-string-parser@8.0.0-rc.6':
     resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -1629,10 +1624,6 @@ packages:
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.5':
-    resolution: {integrity: sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-identifier@8.0.0-rc.6':
     resolution: {integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==}
@@ -1651,11 +1642,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
@@ -1664,11 +1650,6 @@ packages:
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@8.0.0-rc.5':
-    resolution: {integrity: sha512-/Mfg83rK3+jsRbl4Vbd0jqxc6M1A1/WNFtgrowRM1unEsD3XcNnrBdMM0JWakd0/RN9lseQKwPduW1TiEwKOlQ==}
-    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/parser@8.0.0-rc.6':
@@ -1740,10 +1721,6 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/types@8.0.0-rc.5':
-    resolution: {integrity: sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/types@8.0.0-rc.6':
     resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
@@ -4218,9 +4195,6 @@ packages:
   '@vue/devtools-api@7.7.9':
     resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
 
-  '@vue/devtools-api@8.1.1':
-    resolution: {integrity: sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==}
-
   '@vue/devtools-api@8.1.2':
     resolution: {integrity: sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==}
 
@@ -4232,17 +4206,11 @@ packages:
   '@vue/devtools-kit@7.7.9':
     resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
 
-  '@vue/devtools-kit@8.1.1':
-    resolution: {integrity: sha512-gVBaBv++i+adg4JpH71k9ppl4soyR7Y2McEqO5YNgv0BI1kMZ7BDX5gnwkZ5COYgiCyhejZG+yGNrBAjj6Coqg==}
-
   '@vue/devtools-kit@8.1.2':
     resolution: {integrity: sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ==}
 
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
-
-  '@vue/devtools-shared@8.1.1':
-    resolution: {integrity: sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==}
 
   '@vue/devtools-shared@8.1.2':
     resolution: {integrity: sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==}
@@ -4654,10 +4622,6 @@ packages:
 
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
-    engines: {node: '>=20.19.0'}
-
-  ast-walker-scope@0.8.3:
-    resolution: {integrity: sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==}
     engines: {node: '>=20.19.0'}
 
   ast-walker-scope@0.9.0:
@@ -7609,10 +7573,6 @@ packages:
   loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
-
-  local-pkg@1.1.2:
-    resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
-    engines: {node: '>=14'}
 
   local-pkg@1.2.1:
     resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
@@ -10828,21 +10788,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
-  vue-router@5.0.7:
-    resolution: {integrity: sha512-dqfk8kvRbCutmCOCj/XLDqDEYxc1wBdAOGLuVy5M93ifYMsBd5fIjfaPN4tQAbxr5IprdBDIox1gr4wYyOx/SA==}
-    peerDependencies:
-      '@pinia/colada': '>=0.21.2'
-      '@vue/compiler-sfc': ^3.5.34
-      pinia: ^3.0.4
-      vue: 3.5.34
-    peerDependenciesMeta:
-      '@pinia/colada':
-        optional: true
-      '@vue/compiler-sfc':
-        optional: true
-      pinia:
-        optional: true
-
   vue-router@5.1.0:
     resolution: {integrity: sha512-HAbiLzLEHQwxPgvsbOJDAwtavszEgLwri6XfyrsPECIFez8+59xc9LofWVdc/HEaSRT822lJ8H9Ns38VVond5g==}
     peerDependencies:
@@ -11144,11 +11089,6 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -11250,7 +11190,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -11282,15 +11222,6 @@ snapshots:
       '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
-  '@babel/generator@8.0.0-rc.5':
-    dependencies:
-      '@babel/parser': 8.0.0-rc.5
-      '@babel/types': 8.0.0-rc.5
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
   '@babel/generator@8.0.0-rc.6':
@@ -11376,15 +11307,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-string-parser@8.0.0-rc.5': {}
-
   '@babel/helper-string-parser@8.0.0-rc.6': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.5': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.6': {}
 
@@ -11399,10 +11326,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.7
-
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.7
@@ -11410,10 +11333,6 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
-
-  '@babel/parser@8.0.0-rc.5':
-    dependencies:
-      '@babel/types': 8.0.0-rc.5
 
   '@babel/parser@8.0.0-rc.6':
     dependencies:
@@ -11494,11 +11413,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-
-  '@babel/types@8.0.0-rc.5':
-    dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.5
-      '@babel/helper-validator-identifier': 8.0.0-rc.5
 
   '@babel/types@8.0.0-rc.6':
     dependencies:
@@ -12509,31 +12423,6 @@ snapshots:
       vue-draggable-next: 2.3.0(sortablejs@1.15.7)(vue@3.5.34(typescript@5.9.3))
       vue-router: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
 
-  '@kong/kongponents@9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@floating-ui/vue': 1.1.11(vue@3.5.34(typescript@5.9.3))
-      '@kong/icons': 1.56.0(vue@3.5.34(typescript@5.9.3))
-      '@popperjs/core': 2.11.8
-      date-fns: 2.30.0
-      date-fns-tz: 2.0.1(date-fns@2.30.0)
-      focus-trap: 7.8.0
-      focus-trap-vue: 4.1.0(focus-trap@7.8.0)(vue@3.5.34(typescript@5.9.3))
-      lodash-es: 4.18.1
-      nanoid: 5.1.11
-      sortablejs: 1.15.7
-      swrv: 1.2.0(vue@3.5.34(typescript@5.9.3))
-      v-calendar: 3.1.2(@popperjs/core@2.11.8)(vue@3.5.34(typescript@5.9.3))
-      virtua: 0.49.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue@3.5.34(typescript@5.9.3))
-      vue: 3.5.34(typescript@5.9.3)
-      vue-draggable-next: 2.3.0(sortablejs@1.15.7)(vue@3.5.34(typescript@5.9.3))
-      vue-router: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - react
-      - react-dom
-      - solid-js
-      - svelte
-
   '@kong/kongponents@9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@floating-ui/vue': 1.1.11(vue@3.5.34(typescript@5.9.3))
@@ -12559,7 +12448,7 @@ snapshots:
       - solid-js
       - svelte
 
-  '@kong/kongponents@9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))':
+  '@kong/kongponents@9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@floating-ui/vue': 1.1.11(vue@3.5.34(typescript@5.9.3))
       '@kong/icons': 1.56.0(vue@3.5.34(typescript@5.9.3))
@@ -12576,7 +12465,7 @@ snapshots:
       virtua: 0.49.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue@3.5.34(typescript@5.9.3))
       vue: 3.5.34(typescript@5.9.3)
       vue-draggable-next: 2.3.0(sortablejs@1.15.7)(vue@3.5.34(typescript@5.9.3))
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - react
@@ -12721,12 +12610,12 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))':
+  '@modyfi/vite-plugin-yaml@1.1.1(rollup@4.59.0)(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.59.0)
       js-yaml: 4.1.0
       tosource: 2.0.0-alpha.3
-      vite: 5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
 
@@ -13195,10 +13084,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-vue@1.60.0(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)':
+  '@playwright/experimental-ct-vue@1.60.0(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
       '@playwright/experimental-ct-core': 1.60.0(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0)
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14334,13 +14223,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.2.0(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@rolldown/pluginutils': 1.0.0-beta.32
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.0)
-      vite: 5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0)
       vue: 3.5.34(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
@@ -14348,11 +14237,6 @@ snapshots:
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       vite: 5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
-      vue: 3.5.34(typescript@5.9.3)
-
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      vite: 5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
       vue: 3.5.34(typescript@5.9.3)
 
   '@vitest/expect@3.2.6':
@@ -14455,7 +14339,7 @@ snapshots:
     dependencies:
       '@vue/compiler-sfc': 3.5.34
       ast-kit: 2.2.0
-      local-pkg: 1.1.2
+      local-pkg: 1.2.1
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.1
     optionalDependencies:
@@ -14524,10 +14408,6 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.9
 
-  '@vue/devtools-api@8.1.1':
-    dependencies:
-      '@vue/devtools-kit': 8.1.1
-
   '@vue/devtools-api@8.1.2':
     dependencies:
       '@vue/devtools-kit': 8.1.2
@@ -14554,13 +14434,6 @@ snapshots:
       speakingurl: 14.0.1
       superjson: 2.2.6
 
-  '@vue/devtools-kit@8.1.1':
-    dependencies:
-      '@vue/devtools-shared': 8.1.1
-      birpc: 2.9.0
-      hookable: 5.5.3
-      perfect-debounce: 2.1.0
-
   '@vue/devtools-kit@8.1.2':
     dependencies:
       '@vue/devtools-shared': 8.1.2
@@ -14571,8 +14444,6 @@ snapshots:
   '@vue/devtools-shared@7.7.9':
     dependencies:
       rfdc: 1.4.1
-
-  '@vue/devtools-shared@8.1.1': {}
 
   '@vue/devtools-shared@8.1.2': {}
 
@@ -14967,13 +14838,8 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       pathe: 2.0.3
-
-  ast-walker-scope@0.8.3:
-    dependencies:
-      '@babel/parser': 7.29.2
-      ast-kit: 2.2.0
 
   ast-walker-scope@0.9.0:
     dependencies:
@@ -18346,12 +18212,6 @@ snapshots:
       emojis-list: 3.0.0
       json5: 2.2.3
 
-  local-pkg@1.1.2:
-    dependencies:
-      mlly: 1.8.2
-      pkg-types: 2.3.1
-      quansync: 0.2.11
-
   local-pkg@1.2.1:
     dependencies:
       mlly: 1.8.2
@@ -19100,7 +18960,7 @@ snapshots:
       proc-log: 6.1.0
       semver: 7.7.4
       tar: 7.5.11
-      tinyglobby: 0.2.12
+      tinyglobby: 0.2.17
       which: 6.0.1
     transitivePeerDependencies:
       - supports-color
@@ -21824,13 +21684,13 @@ snapshots:
     dependencies:
       monaco-editor: 0.55.1
 
-  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)):
+  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
       '@swc/core': 1.15.7
       '@swc/wasm': 1.15.7
       uuid: 10.0.0
-      vite: 5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
@@ -21866,9 +21726,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-wasm@3.6.0(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)):
+  vite-plugin-wasm@3.6.0(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0)):
     dependencies:
-      vite: 5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0)
 
   vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1):
     dependencies:
@@ -21877,18 +21737,6 @@ snapshots:
       rollup: 4.59.0
     optionalDependencies:
       '@types/node': 24.12.4
-      fsevents: 2.3.3
-      sass: 1.99.0
-      sass-embedded: 1.80.3
-      terser: 5.43.1
-
-  vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.15
-      rollup: 4.59.0
-    optionalDependencies:
-      '@types/node': 25.9.0
       fsevents: 2.3.3
       sass: 1.99.0
       sass-embedded: 1.80.3
@@ -21984,30 +21832,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      '@babel/generator': 8.0.0-rc.5
-      '@vue-macros/common': 3.1.2(vue@3.5.34(typescript@5.9.3))
-      '@vue/devtools-api': 8.1.1
-      ast-walker-scope: 0.8.3
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.15
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.34(typescript@5.9.3)
-      yaml: 2.8.3
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.34
-      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
-
   vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
@@ -22033,7 +21857,7 @@ snapshots:
       pinia: 3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
       vite: 5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.34(typescript@5.9.3)):
+  vue-router@5.1.0(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vite@6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
       '@vue-macros/common': 3.1.2(vue@3.5.34(typescript@5.9.3))
@@ -22056,7 +21880,7 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.34
       pinia: 3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
-      vite: 5.4.21(@types/node@25.9.0)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)
+      vite: 6.4.3(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0)
 
   vue-screen-utils@1.0.0-beta.13(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -22402,8 +22226,6 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
-
-  yaml@2.8.3: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
[KM-2698]

## Summary
- Align explicit `vue-router` devDependency ranges to `^5.1.0` across the workspace.
- Add `vue-router` as a forms devDependency so `@kong-ui-public/forms` resolves the same router version as Kongponents.




[KM-2698]: https://konghq.atlassian.net/browse/KM-2698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ