### PR TITLE
feat(entities-plugins): conditional fields for oidc

### DIFF
--- a/packages/core/forms/src/components/fields/FieldArray.vue
+++ b/packages/core/forms/src/components/fields/FieldArray.vue
@@ -203,6 +203,20 @@ export default {
       if (schema) {
         copy = JSON.parse(JSON.stringify(schema))
 
+        // Restore function properties (e.g., `visible`) that JSON.parse/stringify strips
+        if (schema.schema?.fields) {
+          copy.schema?.fields?.forEach?.((field, i) => {
+            const originalField = schema.schema.fields[i]
+            if (originalField) {
+              Object.keys(originalField).forEach(key => {
+                if (typeof originalField[key] === 'function') {
+                  field[key] = originalField[key]
+                }
+              })
+            }
+          })
+        }
+
         copy.schema?.fields?.map?.(field => {
           field.id = `${field.id || field.model}-${index}`
           return field

--- a/packages/core/forms/src/components/fields/FieldCheckbox.vue
+++ b/packages/core/forms/src/components/fields/FieldCheckbox.vue
@@ -28,6 +28,7 @@
 </template>
 
 <script lang="ts" setup>
+import DOMPurify from 'dompurify'
 import { computed, toRefs, type PropType } from 'vue'
 import composables from '../../composables'
 
@@ -83,8 +84,7 @@ const { getFieldID, value: inputValue, clearValidationErrors } = composables.use
 
 const tooltipHtml = computed(() => {
   if (!props.schema.help) return ''
-  // Strip all <p> and </p> tags to avoid extra margins/spacing in tooltip
-  return props.schema.help.replace(/<\/?p>/g, '').trim()
+  return DOMPurify.sanitize(props.schema.help.replace(/<\/?p>/g, '').trim())
 })
 
 const checkboxDescription = computed(() => {

--- a/packages/core/forms/src/components/fields/FieldCheckbox.vue
+++ b/packages/core/forms/src/components/fields/FieldCheckbox.vue
@@ -6,18 +6,29 @@
       v-model="inputValue"
       :autocomplete="schema.autocomplete"
       :class="schema.fieldClasses"
+      :description="checkboxDescription || undefined"
       :disabled="disabled || undefined"
       :help="hint ? hint : undefined"
+      :label="schema.checkboxLabel || undefined"
+      :label-attributes="schema.checkboxLabel && schema.help ? { tooltipAttributes: { maxWidth: '300' } } : undefined"
       :name="schema.inputName"
       :readonly="schema.readonly"
       :required="schema.required"
       :width="schema.width"
-    />
+    >
+      <template
+        v-if="schema.checkboxLabel && schema.help"
+        #tooltip
+      >
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <span v-html="tooltipHtml" />
+      </template>
+    </KCheckbox>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { toRefs, type PropType } from 'vue'
+import { computed, toRefs, type PropType } from 'vue'
 import composables from '../../composables'
 
 const props = defineProps({
@@ -68,6 +79,18 @@ const { getFieldID, value: inputValue, clearValidationErrors } = composables.use
   emitModelUpdated: (data: { value: any, model: Record<string, any> }): void => {
     emit('modelUpdated', data.value, data.model)
   },
+})
+
+const tooltipHtml = computed(() => {
+  if (!props.schema.help) return ''
+  // Strip all <p> and </p> tags to avoid extra margins/spacing in tooltip
+  return props.schema.help.replace(/<\/?p>/g, '').trim()
+})
+
+const checkboxDescription = computed(() => {
+  const desc = props.schema.checkboxDescription
+  if (typeof desc === 'function') return desc(props.model) || undefined
+  return desc || undefined
 })
 
 defineExpose({

--- a/packages/core/forms/src/components/fields/__tests__/FieldArray.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldArray.cy.ts
@@ -1,0 +1,117 @@
+import type { FormSchema } from '../../../types'
+import FieldTester from '../../../../sandbox/FieldTester.vue'
+
+describe('<FieldTester /> - FieldArray', () => {
+  const fieldKey = 'issuers'
+
+  // An array of objects whose item schema contains a field with a `visible`
+  // function. `generateSchema` deep-clones the item schema via
+  // JSON.parse(JSON.stringify(...)), which strips functions, so the clone must
+  // explicitly restore them for conditional fields to keep working.
+  const schema: FormSchema = {
+    fields: [{
+      type: 'array',
+      model: fieldKey,
+      id: fieldKey,
+      label: 'Issuers',
+      newElementButtonLabel: 'Add Issuer',
+      items: {
+        type: 'object',
+        schema: {
+          fields: [
+            {
+              id: 'verify_signature',
+              model: 'verify_signature',
+              type: 'checkbox',
+              label: 'Verify Signature',
+            },
+            {
+              id: 'jwks_uri',
+              model: 'jwks_uri',
+              type: 'input',
+              inputType: 'text',
+              label: 'JWKS URI',
+              // conditionally visible based on the sibling field
+              visible: (model: Record<string, any>) => model.verify_signature === true,
+            },
+          ],
+        },
+      },
+    }],
+  }
+
+  it('preserves the `visible` function on item schema fields after cloning', () => {
+    cy.mount(FieldTester, {
+      props: {
+        schema,
+        model: {
+          [fieldKey]: [{ verify_signature: false, jwks_uri: '' }],
+        },
+      },
+    })
+
+    cy.get('.field-tester-container').should('exist')
+
+    // the controlling field renders with its index-suffixed id
+    cy.get('#verify_signature-0').should('exist')
+
+    // jwks_uri is hidden while verify_signature is false
+    // (without the function-restoration fix it would always be visible)
+    cy.get('#jwks_uri-0').should('not.exist')
+
+    // toggling verify_signature should reveal jwks_uri, proving the `visible`
+    // function survived the JSON clone
+    cy.get('#verify_signature-0').click()
+    cy.get('#jwks_uri-0').should('be.visible')
+
+    // toggling back hides it again
+    cy.get('#verify_signature-0').click()
+    cy.get('#jwks_uri-0').should('not.exist')
+  })
+
+  it('applies the restored `visible` function to dynamically added items', () => {
+    cy.mount(FieldTester, {
+      props: {
+        schema,
+        model: {
+          [fieldKey]: [],
+        },
+      },
+    })
+
+    cy.get('.field-tester-container').should('exist')
+
+    // add a new item via the array's add button
+    cy.getTestId(`add-${fieldKey}`).should('be.visible')
+    cy.getTestId(`add-${fieldKey}`).click()
+
+    // newly added item starts with verify_signature unchecked -> jwks_uri hidden
+    cy.get('#verify_signature-0').should('exist')
+    cy.get('#jwks_uri-0').should('not.exist')
+
+    // the restored function works on the dynamically generated item too
+    cy.get('#verify_signature-0').click()
+    cy.get('#jwks_uri-0').should('be.visible')
+  })
+
+  it('evaluates the `visible` function independently per item', () => {
+    cy.mount(FieldTester, {
+      props: {
+        schema,
+        model: {
+          [fieldKey]: [
+            { verify_signature: true, jwks_uri: 'https://example.com/jwks' },
+            { verify_signature: false, jwks_uri: '' },
+          ],
+        },
+      },
+    })
+
+    cy.get('.field-tester-container').should('exist')
+
+    // first item has verify_signature on -> jwks_uri shown
+    cy.get('#jwks_uri-0').should('be.visible')
+    // second item has verify_signature off -> jwks_uri hidden
+    cy.get('#jwks_uri-1').should('not.exist')
+  })
+})

--- a/packages/core/forms/src/components/fields/__tests__/FieldCheckbox.cy.ts
+++ b/packages/core/forms/src/components/fields/__tests__/FieldCheckbox.cy.ts
@@ -129,4 +129,139 @@ describe('<FieldTester /> - FieldCheckbox', () => {
     // check field test form model also matches
     cy.getTestId(`field-tester-form-model-${fieldKey}-value`).should('contain.text', updatedFieldValue)
   })
+
+  describe('checkbox label, description and tooltip', () => {
+    const checkboxLabel = 'Verify signature'
+
+    it('renders `checkboxLabel` and a string `checkboxDescription` directly on the checkbox', () => {
+      const description = 'JSON Web Keys are fetched automatically.'
+
+      cy.mount(FieldTester, {
+        props: {
+          schema: {
+            fields: [{
+              type: 'checkbox',
+              model: fieldKey,
+              id: fieldKey,
+              checkboxLabel,
+              checkboxDescription: description,
+            }],
+          },
+          model: { [fieldKey]: true },
+        },
+      })
+
+      // label renders on the KCheckbox itself
+      cy.get('.checkbox-label').should('be.visible')
+      cy.get('.checkbox-label').should('contain.text', checkboxLabel)
+
+      // no FormGroup-level label is rendered (schema.label is unset)
+      cy.get(`.form-group-label[for="${fieldKey}"]`).should('not.exist')
+
+      // description renders on the checkbox
+      cy.get('.checkbox-description').should('be.visible')
+      cy.get('.checkbox-description').should('contain.text', description)
+    })
+
+    it('evaluates a function `checkboxDescription` against the model and reacts to changes', () => {
+      const description = 'Enter a JWKS URI below to override this.'
+
+      cy.mount(FieldTester, {
+        props: {
+          schema: {
+            fields: [{
+              type: 'checkbox',
+              model: fieldKey,
+              id: fieldKey,
+              checkboxLabel,
+              // only shown when this checkbox is checked
+              checkboxDescription: (model: Record<string, any>) => model[fieldKey] === true ? description : undefined,
+            }],
+          },
+          model: { [fieldKey]: false },
+        },
+      })
+
+      // unchecked -> description function returns undefined -> not rendered
+      cy.get(`#${fieldKey}`).should('not.be.checked')
+      cy.get('.checkbox-description').should('not.exist')
+
+      // checking the box -> description appears
+      cy.get(`#${fieldKey}`).click()
+      cy.get('.checkbox-description').should('be.visible')
+      cy.get('.checkbox-description').should('contain.text', description)
+
+      // unchecking -> description disappears again
+      cy.get(`#${fieldKey}`).click()
+      cy.get('.checkbox-description').should('not.exist')
+    })
+
+    it('renders the tooltip trigger only when both `checkboxLabel` and `help` are set', () => {
+      // help without checkboxLabel -> no checkbox tooltip trigger
+      cy.mount(FieldTester, {
+        props: {
+          schema: {
+            fields: [{
+              type: 'checkbox',
+              model: fieldKey,
+              id: fieldKey,
+              checkboxLabel,
+              help: '',
+            }],
+          },
+          model: { [fieldKey]: true },
+        },
+      })
+      cy.get('.checkbox-label .tooltip-trigger-icon').should('not.exist')
+
+      // checkboxLabel + help -> tooltip trigger rendered on the checkbox label
+      cy.mount(FieldTester, {
+        props: {
+          schema: {
+            fields: [{
+              type: 'checkbox',
+              model: fieldKey,
+              id: fieldKey,
+              checkboxLabel,
+              help: '<p>Some <strong>helpful</strong> info</p>',
+            }],
+          },
+          model: { [fieldKey]: true },
+        },
+      })
+      cy.get('.checkbox-label .tooltip-trigger-icon').should('exist')
+    })
+
+    it('sanitizes the tooltip `help` HTML and strips paragraph wrappers', () => {
+      cy.mount(FieldTester, {
+        props: {
+          schema: {
+            fields: [{
+              type: 'checkbox',
+              model: fieldKey,
+              id: fieldKey,
+              checkboxLabel,
+              // <p> wrappers should be stripped; malicious markup should be sanitized away
+              help: '<p>Safe <strong>bold</strong> text<img src="x" onerror="window.__xss = true"></p>',
+            }],
+          },
+          model: { [fieldKey]: true },
+        },
+      })
+
+      // open the tooltip (its content is teleported out of .checkbox-label and
+      // mounted lazily, so query it at the document level)
+      cy.get('.checkbox-label .tooltip-trigger-icon').trigger('mouseenter')
+
+      // the content mounted, allowed formatting is preserved, and the <p>
+      // wrapper was stripped (text reads as one line, no paragraph break)
+      cy.contains('Safe bold text').should('exist')
+      cy.contains('Safe bold text').find('strong').should('contain.text', 'bold')
+
+      // the onerror handler was sanitized away and never executed
+      cy.window().then((win) => {
+        expect((win as any).__xss).to.not.equal(true)
+      })
+    })
+  })
 })

--- a/packages/core/forms/src/components/forms/OIDCForm.vue
+++ b/packages/core/forms/src/components/forms/OIDCForm.vue
@@ -328,6 +328,41 @@ export default {
                   })
                   break
                 }
+                case 'config-token_exchange-subject_token_issuers': {
+                  if (Array.isArray(field.items?.schema?.fields)) {
+                    const itemFields = field.items.schema.fields
+                    // Add help text to verify_signature and conditional visibility to jwks_uri
+                    const verifySignatureField = itemFields.find(f => f.model === 'verify_signature')
+                    const jwksUriField = itemFields.find(f => f.model === 'jwks_uri')
+
+                    if (verifySignatureField) {
+                      verifySignatureField.checkboxLabel = verifySignatureField.label
+                      verifySignatureField.label = undefined
+                      verifySignatureField.checkboxDescription = (model) => model.verify_signature === true
+                        ? 'JSON Web Keys are automatically fetched from the issuer\'s well-known endpoint. Enter a JWKS URI below to override this.'
+                        : undefined
+                    }
+                    if (jwksUriField) {
+                      jwksUriField.visible = (model) => model.verify_signature === true
+                    }
+
+                    // Move jwks_uri to directly after verify_signature
+                    if (verifySignatureField && jwksUriField) {
+                      const vsIndex = itemFields.indexOf(verifySignatureField)
+                      const jwksIndex = itemFields.indexOf(jwksUriField)
+                      if (jwksIndex !== vsIndex + 1) {
+                        itemFields.splice(jwksIndex, 1)
+                        itemFields.splice(vsIndex + 1, 0, jwksUriField)
+                      }
+                    }
+                  }
+
+                  fields.push({
+                    ...field,
+                    newElementButtonLabel: '+ Add Subject Token Issuer',
+                  })
+                  break
+                }
                 case 'config-session_redis_cluster_nodes': {
                   fields.push({
                     ...field,

--- a/packages/core/forms/src/components/forms/OIDCForm.vue
+++ b/packages/core/forms/src/components/forms/OIDCForm.vue
@@ -357,10 +357,7 @@ export default {
                     }
                   }
 
-                  fields.push({
-                    ...field,
-                    newElementButtonLabel: '+ Add Subject Token Issuer',
-                  })
+                  fields.push(field)
                   break
                 }
                 case 'config-session_redis_cluster_nodes': {

--- a/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
@@ -175,4 +175,141 @@ describe('<OIDCForm />', () => {
       cy.getTestId('oidc-principals-section').should('not.exist')
     })
   })
+
+  describe('Token Exchange subject_token_issuers', () => {
+    const verifySignatureDescription = 'JSON Web Keys are automatically fetched from the issuer\'s well-known endpoint. Enter a JWKS URI below to override this.'
+
+    // Built fresh per test: OIDCForm mutates the item schema fields in place
+    // (sets checkboxLabel / checkboxDescription / visible and reorders them).
+    const makeSchema = () => {
+      const subjectTokenIssuersField = {
+        id: 'config-token_exchange-subject_token_issuers',
+        model: 'config-token_exchange-subject_token_issuers',
+        type: 'array',
+        label: 'Subject Token Issuers',
+        valueType: 'array',
+        order: 0,
+        items: {
+          type: 'object',
+          schema: {
+            fields: [
+              {
+                id: 'verify_signature',
+                model: 'verify_signature',
+                type: 'checkbox',
+                label: 'Verify Signature',
+                valueType: 'boolean',
+              },
+              // `issuer` sits between verify_signature and jwks_uri so we can
+              // assert the form moves jwks_uri to directly follow verify_signature
+              {
+                id: 'issuer',
+                model: 'issuer',
+                type: 'input',
+                inputType: 'text',
+                label: 'Issuer',
+                valueType: 'string',
+              },
+              {
+                id: 'jwks_uri',
+                model: 'jwks_uri',
+                type: 'input',
+                inputType: 'text',
+                label: 'JWKS URI',
+                valueType: 'string',
+              },
+            ],
+          },
+        },
+      }
+
+      return {
+        ...OIDCFormSchema,
+        fields: [...OIDCFormSchema.fields, subjectTokenIssuersField],
+      }
+    }
+
+    const makeModel = (issuers: Array<Record<string, any>>, extra: Record<string, any> = {}) => ({
+      ...OIDCModel,
+      ...extra,
+      'config-token_exchange-subject_token_issuers': issuers,
+    })
+
+    it('renders verify_signature as a checkbox label and toggles its description + jwks_uri', () => {
+      cy.mount(OIDCForm, {
+        props: {
+          formSchema: makeSchema(),
+          formModel: makeModel([{ verify_signature: false, issuer: '', jwks_uri: '' }]),
+        },
+        global: { provide: { 'kong-ui-forms-config': baseConfigKM } },
+      })
+
+      cy.get('#advanced-tab').click()
+
+      // verify_signature renders its label on the checkbox, not as a FormGroup label
+      cy.get('.checkbox-label').should('contain.text', 'Verify Signature')
+
+      // verify_signature is off -> no description and jwks_uri hidden
+      cy.get('.checkbox-description').should('not.exist')
+      cy.get('#jwks_uri-0').should('not.exist')
+
+      // turn verify_signature on
+      cy.get('#verify_signature-0').click()
+
+      // description appears and jwks_uri becomes visible
+      cy.get('.checkbox-description').should('contain.text', verifySignatureDescription)
+      cy.get('#jwks_uri-0').should('be.visible')
+    })
+
+    it('moves jwks_uri to directly follow verify_signature', () => {
+      cy.mount(OIDCForm, {
+        props: {
+          formSchema: makeSchema(),
+          formModel: makeModel([{ verify_signature: true, issuer: '', jwks_uri: '' }]),
+        },
+        global: { provide: { 'kong-ui-forms-config': baseConfigKM } },
+      })
+
+      cy.get('#advanced-tab').click()
+
+      // all three fields are present (verify_signature is on)
+      cy.get('#verify_signature-0').should('exist')
+      cy.get('#jwks_uri-0').should('exist')
+      cy.get('#issuer-0').should('exist')
+
+      // jwks_uri must appear before issuer in the DOM (reordered to follow verify_signature)
+      cy.get('#jwks_uri-0').then(($jwks) => {
+        cy.get('#issuer-0').then(($issuer) => {
+          const issuerFollowsJwks = $jwks[0].compareDocumentPosition($issuer[0]) & Node.DOCUMENT_POSITION_FOLLOWING
+          expect(issuerFollowsJwks, 'jwks_uri precedes issuer').to.be.greaterThan(0)
+        })
+      })
+    })
+
+    it('renders saved subject_token_issuers values when editing an existing plugin', () => {
+      const savedIssuer = {
+        verify_signature: true,
+        issuer: 'https://issuer.example.com',
+        jwks_uri: 'https://issuer.example.com/.well-known/jwks.json',
+      }
+
+      cy.mount(OIDCForm, {
+        props: {
+          formSchema: makeSchema(),
+          formModel: makeModel([savedIssuer], { id: 'oidc-plugin-id' }),
+          isEditing: true,
+        },
+        global: { provide: { 'kong-ui-forms-config': baseConfigKM } },
+      })
+
+      cy.get('#advanced-tab').click()
+
+      // saved boolean renders the checkbox as checked
+      cy.get('#verify_signature-0').should('be.checked')
+      // and because it is checked, the conditional fields render the saved values
+      cy.get('.checkbox-description').should('contain.text', verifySignatureDescription)
+      cy.get('#issuer-0').should('have.value', savedIssuer.issuer)
+      cy.get('#jwks_uri-0').should('have.value', savedIssuer.jwks_uri)
+    })
+  })
 })

--- a/packages/entities/entities-plugins/src/types/plugins/oidc.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/oidc.ts
@@ -23,6 +23,8 @@ export interface TokenExchange {
     } | null
 
     issuer?: string
+    jwks_uri?: string
+    verify_signature?: boolean
   }> | null
 }
 


### PR DESCRIPTION
# Summary

KAG-8643

Customize OIDC Token Exchange subject_token_issuers fields

When verify_signature is checked, show jwks_uri field below it and display a description: "JSON Web Keys are automatically fetched from the issuer's well-known endpoint. Enter a JWKS URI below to override this."
FieldCheckbox now supports checkboxLabel, checkboxDescription, and `#tooltip` slot for rendering label/description/help directly on KCheckbox (bypassing FormGroup's KLabel)
FieldArray preserves function properties on schema fields after JSON clone