### PR TITLE
feat(*): use SensitiveInput in vault form

### DIFF
--- a/packages/entities/entities-shared/docs/entity-base-form.md
+++ b/packages/entities/entities-shared/docs/entity-base-form.md
@@ -137,6 +137,14 @@ Wrapper component to use at component's root level.
 
 Text to display in the Save and Cancel buttons. If not provided, defaults to the localized strings for "Save" and "Cancel".
 
+#### `tabsToHide`
+
+- type: `Array as PropType<BaseFormConfigTab[]>`
+- required: `false`
+- default: `() => []`
+
+Hide tabs from the configuration slideout. Accepts any of `'json'`, `'yaml'`, `'terraform'`, or `'deck'` (e.g. `['yaml']`). Tabs that are otherwise conditionally shown (e.g. `terraform` only for Konnect, `deck` only when enabled) are unaffected unless they would already be visible. If the currently active tab is hidden, the slideout falls back to the first remaining tab.
+
 ### Events
 
 #### loading
@@ -180,6 +188,7 @@ TypeScript interfaces [are available here](https://github.com/Kong/public-ui-com
 ```ts
 import type {
   BaseFormConfig,
+  BaseFormConfigTab,
   KonnectBaseFormConfig,
   KongManagerBaseFormConfig,
   EntityBaseFormType,

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.cy.ts
@@ -405,4 +405,64 @@ describe('<EntityBaseForm />', () => {
       cy.getTestId('form-fetch-error').should('not.exist')
     })
   })
+
+  describe('tabsToHide', () => {
+    it('drops listed tabs from the configuration slideout', () => {
+      cy.mount(EntityBaseForm, {
+        props: {
+          config,
+          formFields: route,
+          entityType,
+          canSubmit: true,
+          tabsToHide: ['yaml'],
+        },
+      })
+
+      cy.getTestId(`${entityType}-create-form-view-configuration`).click()
+
+      cy.getTestId('form-view-configuration-slideout-tabs').should('exist')
+      cy.getTestId('yaml-tab').should('not.exist')
+      cy.getTestId('json-tab').should('exist')
+      cy.getTestId('terraform-tab').should('exist')
+      cy.getTestId('deck-tab').should('exist')
+    })
+
+    it('can hide several tabs at once', () => {
+      cy.mount(EntityBaseForm, {
+        props: {
+          config,
+          formFields: route,
+          entityType,
+          canSubmit: true,
+          tabsToHide: ['yaml', 'deck'],
+        },
+      })
+
+      cy.getTestId(`${entityType}-create-form-view-configuration`).click()
+
+      cy.getTestId('yaml-tab').should('not.exist')
+      cy.getTestId('deck-tab').should('not.exist')
+      cy.getTestId('json-tab').should('exist')
+      cy.getTestId('terraform-tab').should('exist')
+    })
+
+    it('falls back to the first available tab when the default tab is hidden', () => {
+      cy.mount(EntityBaseForm, {
+        props: {
+          config,
+          formFields: route,
+          entityType,
+          canSubmit: true,
+          tabsToHide: ['json'],
+        },
+      })
+
+      cy.getTestId(`${entityType}-create-form-view-configuration`).click()
+
+      cy.getTestId('json-tab').should('not.exist')
+      // The first remaining tab (terraform) becomes active and renders its panel
+      cy.getTestId('terraform-tab').should('exist')
+      cy.get('.terraform-config').should('exist')
+    })
+  })
 })

--- a/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-form/EntityBaseForm.vue
@@ -163,7 +163,7 @@ import type { PropType } from 'vue'
 import { computed, ref, onBeforeMount, watch, inject } from 'vue'
 import { useRouter } from 'vue-router'
 import type { AxiosError } from 'axios'
-import type { KonnectBaseFormConfig, KongManagerBaseFormConfig, SupportedEntityDeck } from '../../types'
+import type { BaseFormConfigTab, KonnectBaseFormConfig, KongManagerBaseFormConfig, SupportedEntityDeck } from '../../types'
 import { SupportedEntityTypesArray, SupportedEntityType } from '../../types'
 import composables from '../../composables'
 import type { BadgeAppearance, Tab } from '@kong/kongponents'
@@ -334,6 +334,14 @@ const props = defineProps({
     type: String as PropType<SupportedEntityType>,
     default: undefined,
   },
+  /**
+   * Hide tabs from the configuration slideout (eg. ['yaml']).
+   */
+  tabsToHide: {
+    type: Array as PropType<BaseFormConfigTab[]>,
+    required: false,
+    default: () => [],
+  },
 })
 
 const router = useRouter()
@@ -410,34 +418,47 @@ const handleClickSave = (): void => {
   emit('submit')
 }
 
-const tabs = ref<Tab[]>([
-  {
-    title: t('baseForm.configuration.json'),
-    hash: '#json',
-  },
-  {
-    title: t('baseForm.configuration.yaml'),
-    hash: '#yaml',
-  },
-])
+// Tabs built in display order, then filtered by `tabsToHide`
+const tabs = computed<Tab[]>(() => {
+  const items: Tab[] = [
+    {
+      title: t('baseForm.configuration.json'),
+      hash: '#json',
+    },
+    {
+      title: t('baseForm.configuration.yaml'),
+      hash: '#yaml',
+    },
+  ]
 
-// terraform is only available for konnect entities and non-Other entity types
-if (props.config.app === 'konnect' && props.entityType !== SupportedEntityType.Other) {
-  // insert terraform as the third option
-  tabs.value.splice(1, 0, {
-    title: t('baseForm.configuration.terraform'),
-    hash: '#terraform',
-  })
-}
+  // terraform is only available for konnect entities and non-Other entity types
+  if (props.config.app === 'konnect' && props.entityType !== SupportedEntityType.Other) {
+    // insert terraform as the third option
+    items.splice(1, 0, {
+      title: t('baseForm.configuration.terraform'),
+      hash: '#terraform',
+    })
+  }
 
-if (isDeckEnabled.value) {
-  tabs.value.push({
-    title: t('baseForm.configuration.deck'),
-    hash: '#deck',
-  })
-}
+  if (isDeckEnabled.value) {
+    items.push({
+      title: t('baseForm.configuration.deck'),
+      hash: '#deck',
+    })
+  }
 
-const configTab = ref(tabs.value[0].hash)
+  const hidden = new Set(props.tabsToHide.map(tab => `#${tab}`))
+  return items.filter(item => !hidden.has(item.hash as string))
+})
+
+const configTab = ref(tabs.value[0]?.hash)
+
+// Keep the active tab valid when the available tabs change (eg. via `tabsToHide`)
+watch(tabs, (newTabs) => {
+  if (!newTabs.some(tab => tab.hash === configTab.value)) {
+    configTab.value = newTabs[0]?.hash
+  }
+})
 
 watch(() => isLoading.value, (val: boolean) => {
   // Emit the loading state for the host app

--- a/packages/entities/entities-shared/src/types/entity-base-form.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-form.ts
@@ -28,3 +28,9 @@ export enum EntityBaseFormType {
   Edit = 'edit',
   Create = 'create',
 }
+
+// Runtime list of every tab in the configuration slideout
+export const BASE_FORM_CONFIG_TABS = ['json', 'yaml', 'terraform', 'deck'] as const
+
+// Union of all configuration slideout tab values
+export type BaseFormConfigTab = (typeof BASE_FORM_CONFIG_TABS)[number]

--- a/packages/entities/entities-vaults/src/components/VaultConfigCard.vue
+++ b/packages/entities/entities-vaults/src/components/VaultConfigCard.vue
@@ -7,6 +7,7 @@
       :config-schema="configSchema"
       :entity-type="SupportedEntityType.Vault"
       :fetch-url="fetchUrl"
+      :formats-to-hide="config.apiType === 'aiGateway' ? ['terraform', 'deck'] : []"
       :hide-title="hideTitle"
       :record-resolver="recordResolver"
       @fetch:error="(err: any) => $emit('fetch:error', err)"

--- a/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
+++ b/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
@@ -1438,5 +1438,49 @@ describe('<VaultForm />', () => {
         expect(request.body.config).to.have.property('prefix', 'dev2')
       })
     })
+
+    it('omits blank write-only fields from PUT body when editing an AI Gateway vault', () => {
+      // The server does not return write-only fields (e.g. Conjur api_key) on GET.
+      // Submitting without filling them must not send an empty value that would clear the secret.
+      cy.intercept(
+        { method: 'GET', url: `${aiVaultsUrl}/*` },
+        {
+          statusCode: 200,
+          body: {
+            id: '1',
+            type: 'conjur',
+            name: 'conjur-vault',
+            config: {
+              endpoint_url: 'https://conjur.example.com',
+              login: 'my-login',
+              account: 'my-account',
+              // api_key intentionally absent — write-only, not returned by server
+            },
+          },
+        },
+      ).as('getAiVault')
+      cy.intercept(
+        { method: 'PUT', url: `${aiVaultsUrl}/*` },
+        {
+          statusCode: 200,
+          body: { id: '1', type: 'conjur', name: 'conjur-vault-edited', config: {} },
+        },
+      ).as('updateAiVault')
+
+      cy.mount(VaultForm, {
+        props: { config: baseConfigAiGateway, vaultId: '1' },
+      })
+
+      cy.wait('@getAiVault')
+      // Make a non-write-only change to enable the submit button
+      cy.getTestId('vault-form-prefix').clear()
+      cy.getTestId('vault-form-prefix').type('conjur-vault-edited')
+      cy.getTestId('vault-edit-form-submit').click()
+
+      cy.wait('@updateAiVault').then(({ request }) => {
+        expect(request.body).to.have.property('type', 'conjur')
+        expect(request.body.config).to.not.have.property('api_key')
+      })
+    })
   })
 })

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -1847,7 +1847,7 @@ const getPayload = computed((): Record<string, any> => {
     const config: Record<string, any> = { ...aiPayload.config }
     const AI_WRITE_ONLY = ['token', 'client_secret', 'secret_access_key', 'api_key', 'key']
     AI_WRITE_ONLY.forEach(field => {
-      if (field in config && !config[field]) delete config[field]
+      if (field in config && isEmpty(config[field])) delete config[field]
     })
     return { ...aiPayload, config }
   }

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -9,6 +9,7 @@
       :fetch-url="fetchUrl"
       :form-fields="getPayload"
       :is-readonly="form.isReadonly"
+      :tabs-to-hide="config.apiType === 'aiGateway' ? ['terraform', 'deck'] : []"
       @cancel="cancelHandler"
       @fetch:error="fetchErrorHandler"
       @fetch:success="updateFormValues"
@@ -306,6 +307,7 @@
               class="vault-form-config-auth-method-container"
             >
               <KInput
+                v-if="!isAiGateway"
                 v-model.trim="configFields[VaultProviders.HCV].token"
                 autocomplete="off"
                 data-testid="vault-form-config-hcv-token"
@@ -314,6 +316,15 @@
                 required
                 show-password-mask-toggle
                 type="password"
+              />
+              <SensitiveInput
+                v-else
+                v-model="configFields[VaultProviders.HCV].token"
+                data-testid="vault-form-config-hcv-token"
+                :label="t('form.config.hcv.fields.token.label')"
+                :mode="sensitiveInputMode"
+                :readonly="form.isReadonly"
+                :required="sensitiveInputMode === 'create'"
               />
             </div>
             <div
@@ -387,6 +398,7 @@
                 type="password"
               />
               <KInput
+                v-if="!isAiGateway"
                 v-model.trim="configFields[VaultProviders.HCV].aws_secret_access_key"
                 autocomplete="off"
                 data-testid="vault-form-config-hcv-aws_secret_access_key"
@@ -394,6 +406,14 @@
                 :readonly="form.isReadonly"
                 show-password-mask-toggle
                 type="password"
+              />
+              <SensitiveInput
+                v-else
+                v-model="configFields[VaultProviders.HCV].aws_secret_access_key"
+                data-testid="vault-form-config-hcv-aws_secret_access_key"
+                :label="t('form.config.hcv.fields.aws_secret_access_key.label')"
+                :mode="sensitiveInputMode"
+                :readonly="form.isReadonly"
               />
               <KInput
                 v-model.trim="configFields[VaultProviders.HCV].aws_sts_endpoint_url"
@@ -622,6 +642,7 @@
                 required
               />
               <KInput
+                v-if="!isAiGateway"
                 v-model.trim="configFields[VaultProviders.HCV].oauth2_client_secret"
                 autocomplete="off"
                 data-testid="vault-form-config-hcv-oauth2_client_secret"
@@ -630,6 +651,15 @@
                 required
                 show-password-mask-toggle
                 type="password"
+              />
+              <SensitiveInput
+                v-else
+                v-model="configFields[VaultProviders.HCV].oauth2_client_secret"
+                data-testid="vault-form-config-hcv-oauth2_client_secret"
+                :label="t('form.config.hcv.fields.oauth2_client_secret.label')"
+                :mode="sensitiveInputMode"
+                :readonly="form.isReadonly"
+                :required="sensitiveInputMode === 'create'"
               />
               <KInput
                 v-model.trim="configFields[VaultProviders.HCV].jwt_role"
@@ -836,6 +866,7 @@
               type="text"
             />
             <KInput
+              v-if="!isAiGateway"
               v-model.trim="configFields[VaultProviders.CONJUR].api_key"
               autocomplete="off"
               data-testid="vault-form-config-conjur-api_key"
@@ -848,6 +879,19 @@
               required
               show-password-mask-toggle
               type="password"
+            />
+            <SensitiveInput
+              v-else
+              v-model="configFields[VaultProviders.CONJUR].api_key"
+              data-testid="vault-form-config-conjur-api_key"
+              :label="t('form.config.conjur.fields.api_key.label')"
+              :label-attributes="{
+                info: t('form.config.conjur.fields.api_key.tooltip'),
+                tooltipAttributes: { maxWidth: '400' },
+              }"
+              :mode="sensitiveInputMode"
+              :readonly="form.isReadonly"
+              :required="sensitiveInputMode === 'create'"
             />
             <KCheckbox
               v-if="config.base64FieldAvailable"
@@ -1002,6 +1046,7 @@ import {
   EntityBaseForm,
   EntityBaseFormType,
   SupportedEntityType,
+  SensitiveInput,
 } from '@kong-ui-public/entities-shared'
 import composables from '../composables'
 import '@kong-ui-public/entities-shared/dist/style.css'
@@ -1419,6 +1464,8 @@ const formType = computed((): EntityBaseFormType => props.vaultId
   ? EntityBaseFormType.Edit
   : EntityBaseFormType.Create)
 
+const sensitiveInputMode = computed((): 'edit' | 'create' => formType.value === EntityBaseFormType.Edit ? 'edit' : 'create')
+
 const fetchUrl = computed<string>(() => withAiGatewayId(endpoints.form[endpointKey.value]?.edit))
 
 // On edit, the provider/type cannot be changed for Kong Manager or AI Gateway vaults.
@@ -1578,6 +1625,10 @@ const isVaultConfigValid = computed((): boolean => {
       }
       // token is not needed if auth method is not token
       if (configFields[VaultProviders.HCV].auth_method !== VaultAuthMethods.TOKEN && key === 'token') {
+        return false
+      }
+      // In AI Gateway edit mode, write-only fields are optional: a blank value keeps the existing secret.
+      if (isAiGateway.value && formType.value === EntityBaseFormType.Edit && ['token', 'oauth2_client_secret', 'cert_auth_cert_key'].includes(key)) {
         return false
       }
       // approle_role_id and approle_response_wrapping don't need to be verified if auth method is not approle
@@ -1788,7 +1839,19 @@ const getPayload = computed((): Record<string, any> => {
   }
 
   // Remap the gateway-shaped payload to the AI Gateway request body at the boundary only.
-  return isAiGateway.value ? toAiGatewayVaultPayload(payload) : payload
+  if (!isAiGateway.value) return payload
+  const aiPayload = toAiGatewayVaultPayload(payload)
+  // In edit mode, write-only fields are not returned by GET; omit them when blank so the
+  // existing secret is preserved (sending an empty string would clear it on the server).
+  if (formType.value === EntityBaseFormType.Edit) {
+    const config: Record<string, any> = { ...aiPayload.config }
+    const AI_WRITE_ONLY = ['token', 'client_secret', 'secret_access_key', 'api_key', 'key']
+    AI_WRITE_ONLY.forEach(field => {
+      if (field in config && !config[field]) delete config[field]
+    })
+    return { ...aiPayload, config }
+  }
+  return aiPayload
 })
 
 const payloadWithConfigStoreId = computed<Record<string, any>>(() => (


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

- Improved handling of sensitive, write-only fields (e.g., tokens, secrets) for AI Gateway vaults:
  - Used the `SensitiveInput` component for these fields when appropriate.
  - In edit mode, blank values for write-only fields are omitted from the payload to preserve existing secrets.
  - Adjusted validation to make these fields optional in edit mode.
- Added a `tabsToHide` prop to `EntityBaseForm`, enabling consumers to hide specific configuration tabs (`json`, `yaml`, `terraform`, `deck`).
- Updated `VaultForm.vue` and `VaultConfigCard.vue` to pass the appropriate tabs to hide (`terraform`, `deck`) when the vault is of type AI Gateway.