### PR TITLE
fix(monaco-editor): adjust z-index values for toolbar and split pane [KHCP-20406]

### DIFF
--- a/packages/core/monaco-editor/src/components/MonacoEditorToolbar.vue
+++ b/packages/core/monaco-editor/src/components/MonacoEditorToolbar.vue
@@ -258,7 +258,7 @@ $defaultHeight: 44px;
   padding-right: var(--kui-space-40, $kui-space-40);
   position: sticky;
   top: 0;
-  z-index: 3; // Keep over the sidebars
+  z-index: 2; // Keep over the sidebars
 
 
   &-left,

--- a/packages/core/split-pane/src/components/SplitPane.vue
+++ b/packages/core/split-pane/src/components/SplitPane.vue
@@ -301,6 +301,7 @@ $inner-panes-min-width: 300px; // INNER_PANES_MIN_WIDTH
 
     &.has-toolbar {
       max-height: calc(100vh - $toolbar-height); // 44px for the toolbar height
+      z-index: 1; // Ensure elements are above the toolbar background
     }
 
     &.is-dragging-pane {


### PR DESCRIPTION
# Summary

ticket: https://konghq.atlassian.net/browse/KHCP-20406

while working on apis documentation we had to do some overrides for the toolbar zIndexes. this PR removes the usage of overrides