### PR TITLE
Feat: Add table-data-grid infinite scroll support

### DIFF
--- a/packages/core/table-data-grid/README.md
+++ b/packages/core/table-data-grid/README.md
@@ -59,7 +59,6 @@ const fetchRows: TableDataGridFetcher<Row> = async ({ offset = 0, pageSize }) =>
 | `headers` | `Array<TableDataGridHeader<Row>>` | Yes | - | Basic column definitions mapped to AG Grid columns. |
 | `fetcher` | `TableDataGridFetcher<Row>` | Yes | - | Async row loader called with the initial infinite-placeholder fetch params. |
 | `pageSize` | `number` | No | `25` | Page size sent to the basic fetcher. No pagination controls are rendered in this PR. |
-| `agGridOptions` | `TableDataGridGridOptions<Row>` | No | `{}` | Pass-through for lower-level AG Grid options. Keep this narrow until the package owns more grid behavior. |
 
 ## Fetcher Contract
 
@@ -113,5 +112,4 @@ No slots are part of the initial public contract.
 - `TableDataGridFetcherParams`
 - `TableDataGridFetcherResult`
 - `TableDataGridFetcher`
-- `TableDataGridGridOptions`
 - `TableDataGridReadyPayload`

--- a/packages/core/table-data-grid/README.md
+++ b/packages/core/table-data-grid/README.md
@@ -4,6 +4,17 @@ Reusable Vue wrapper around AG Grid for Kong table data grids.
 
 This initial package version supports a basic infinite-placeholder fetcher and AG Grid rendering.
 
+## Peer Dependencies
+
+Consumers must provide `vue` and `@kong/kongponents`. The host app should register Kongponents and load its styles because TableDataGrid presentation states render Kongponents components.
+
+```ts
+import Kongponents from '@kong/kongponents'
+import '@kong/kongponents/dist/style.css'
+
+app.use(Kongponents)
+```
+
 ## Usage
 
 ```vue

--- a/packages/core/table-data-grid/README.md
+++ b/packages/core/table-data-grid/README.md
@@ -2,11 +2,15 @@
 
 Reusable Vue wrapper around AG Grid for Kong table data grids.
 
-This initial package version supports a basic infinite-placeholder fetcher and AG Grid rendering.
+This package currently supports AG Grid infinite row loading with a cursor-first
+fetcher contract, basic column definitions, empty/error presentation states, and
+state lifecycle emits.
 
 ## Peer Dependencies
 
-Consumers must provide `vue` and `@kong/kongponents`. The host app should register Kongponents and load its styles because TableDataGrid presentation states render Kongponents components.
+Consumers must provide `vue` and `@kong/kongponents`. The host app should
+register Kongponents and load its styles because TableDataGrid presentation
+states render Kongponents components.
 
 ```ts
 import Kongponents from '@kong/kongponents'
@@ -19,15 +23,34 @@ app.use(Kongponents)
 
 ```vue
 <template>
+  <KButton @click="refreshRows">
+    Refresh rows
+  </KButton>
+
   <TableDataGrid
     :fetcher="fetchRows"
     :headers="headers"
-    @grid:ready="onGridReady"
-  />
+    :page-size="25"
+    :refresh-key="refreshKey"
+    @state="handleState"
+  >
+    <template #empty-state>
+      <KEmptyState
+        message="Try changing filters or refreshing the dataset."
+        title="No rows found"
+      />
+    </template>
+  </TableDataGrid>
 </template>
 
 <script setup lang="ts">
-import type { TableDataGridFetcher, TableDataGridHeader } from '@kong-ui-public/table-data-grid'
+import type {
+  TableDataGridFetcher,
+  TableDataGridHeader,
+  TableDataGridInfiniteFetcherParams,
+  TableDataGridStatePayload,
+} from '@kong-ui-public/table-data-grid'
+import { ref } from 'vue'
 import { TableDataGrid } from '@kong-ui-public/table-data-grid'
 
 type Row = {
@@ -41,14 +64,32 @@ const headers: Array<TableDataGridHeader<Row>> = [
   { key: 'status', label: 'Status' },
 ]
 
-const rows: Row[] = [
-  { id: 'row-1', name: 'Gateway service', status: 'Active' },
-]
+const refreshKey = ref(0)
+const lastState = ref<TableDataGridStatePayload>()
 
-const fetchRows: TableDataGridFetcher<Row> = async ({ offset = 0, pageSize }) => ({
-  data: rows.slice(offset, offset + pageSize),
-  total: rows.length,
-})
+const fetchRows: TableDataGridFetcher<Row> = async ({
+  pageSize,
+  cursor,
+}: TableDataGridInfiniteFetcherParams) => {
+  const response = await getRows({
+    size: pageSize,
+    cursor,
+  })
+
+  return {
+    data: response.data,
+    cursor: response.cursor,
+    hasMore: response.hasMore,
+  }
+}
+
+const refreshRows = () => {
+  refreshKey.value += 1
+}
+
+const handleState = (payload: TableDataGridStatePayload) => {
+  lastState.value = payload
+}
 </script>
 ```
 
@@ -57,32 +98,90 @@ const fetchRows: TableDataGridFetcher<Row> = async ({ offset = 0, pageSize }) =>
 | Prop | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
 | `headers` | `Array<TableDataGridHeader<Row>>` | Yes | - | Basic column definitions mapped to AG Grid columns. |
-| `fetcher` | `TableDataGridFetcher<Row>` | Yes | - | Async row loader called with the initial infinite-placeholder fetch params. |
-| `pageSize` | `number` | No | `25` | Page size sent to the basic fetcher. No pagination controls are rendered in this PR. |
+| `fetcher` | `TableDataGridFetcher<Row>` | Yes | - | Async row loader called by the AG Grid infinite datasource. |
+| `error` | `boolean` | No | `false` | Host-controlled visible error state. Internal fetch failures emit state but do not render error UI unless this prop is true. |
+| `pageSize` | `number` | No | `25` | AG Grid cache block size and fetcher request size. |
+| `refreshKey` | `string \| number \| boolean` | No | - | Parent invalidation signal that rebuilds the datasource from the beginning. |
 
 ## Fetcher Contract
 
-The initial fetcher uses the package's future infinite-scroll-oriented shape but only performs the first fetch.
+`TableDataGrid` uses AG Grid's infinite row model internally. The public fetcher
+receives only the stable cursor-first request shape:
 
 ```ts
-type TableDataGridFetcherParams = {
+type TableDataGridInfiniteFetcherParams = {
   mode: 'infinite'
-  cursor?: unknown
-  offset?: number
   pageSize: number
+  cursor?: unknown
 }
 
 type TableDataGridFetcherResult<Row> = {
   data: Row[]
+  cursor?: unknown
   total?: number
+  hasMore?: boolean
 }
 
 type TableDataGridFetcher<Row> = (
-  params: TableDataGridFetcherParams,
+  params: TableDataGridInfiniteFetcherParams,
 ) => Promise<TableDataGridFetcherResult<Row>>
 ```
 
-`offset` is the numeric starting row for offset/limit APIs. `cursor` is an opaque positioning token for cursor-based APIs. These fields are optional because consumers generally use one positioning model or the other. This initial version passes `offset: 0` for a single fetch; real infinite-scroll sequencing will be added later.
+`cursor` is an opaque token returned by the previous response. The first request
+uses `cursor: undefined`; later requests receive the previous response cursor.
+
+AG Grid range details are datasource internals. Consumers should not depend on,
+or return, datasource request positions or AG Grid row-count callback values in
+the public fetcher contract.
+
+`total` gives AG Grid an explicit row count when the backend knows it. If `total`
+is omitted, `hasMore: false` or a response shorter than `pageSize` marks the last
+loaded row as the end of the dataset.
+
+## Refresh Behavior
+
+`refreshKey` is a parent-owned invalidation signal. Changing it rebuilds the
+infinite datasource, clears stored cursors, and starts again from the first
+block with `cursor: undefined`.
+
+This reset is required for cursor APIs because cursor values are only valid
+relative to the response and query chain that produced them. Reusing a later
+cursor after the parent changes request context could fetch the wrong rows.
+
+## Presentation States
+
+`TableDataGrid` keeps the grid mounted while internal fetches are running so AG
+Grid can request rows and show its own loading treatment.
+
+Visible error UI is host-controlled through the `error` prop. A rejected fetch
+emits an error state, but it does not render error chrome by itself.
+
+An empty state renders after the first successful block resolves with no rows.
+Use the `empty-state` slot to replace the default empty content. Use the
+`error-state` slot to replace the default host-controlled error content.
+
+```vue
+<TableDataGrid
+  :error="showError"
+  :fetcher="fetchRows"
+  :headers="headers"
+>
+  <template #empty-state>
+    <KEmptyState
+      message="Adjust the source data and refresh."
+      title="No matching rows"
+    />
+  </template>
+
+  <template #error-state>
+    <KEmptyState
+      icon-variant="error"
+      message="Refresh or try again later."
+      title="Rows could not be loaded"
+    />
+  </template>
+</TableDataGrid>
+```
 
 ## Header Options
 
@@ -99,17 +198,23 @@ type TableDataGridFetcher<Row> = (
 | Event | Payload | When it fires |
 | --- | --- | --- |
 | `grid:ready` | `GridApi<Row>` | AG Grid is ready. |
+| `state` | `{ state: 'loading' \| 'success' \| 'error', hasData: boolean }` | Internal fetch lifecycle changes after the datasource starts requesting rows. |
 
 ## Slots
 
-No slots are part of the initial public contract.
+| Slot | Purpose |
+| --- | --- |
+| `empty-state` | Replaces the default empty state after a successful empty first block. |
+| `error-state` | Replaces the default visible error state when `error` is true. |
 
 ## Exports
 
 - `TableDataGrid`
 - `TableDataGridMode`
+- `TableDataGridState`
+- `TableDataGridStatePayload`
 - `TableDataGridHeader`
-- `TableDataGridFetcherParams`
+- `TableDataGridInfiniteFetcherParams`
 - `TableDataGridFetcherResult`
 - `TableDataGridFetcher`
 - `TableDataGridReadyPayload`

--- a/packages/core/table-data-grid/README.md
+++ b/packages/core/table-data-grid/README.md
@@ -185,13 +185,18 @@ Use the `empty-state` slot to replace the default empty content. Use the
 
 ## Header Options
 
+Columns without a `width` or `maxWidth` fill the available table width by
+default. Use `width` for an explicit initial pixel width, `minWidth` for a
+lower bound on either flexible or fixed columns, and `maxWidth` when a column
+should opt out of the default flexible fill behavior.
+
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `key` | `Extract<keyof Row, string>` | Yes | Row property read for the cell value and used as the AG Grid column id. |
 | `label` | `string` | Yes | Header label rendered by AG Grid. |
-| `width` | `number` | No | Initial AG Grid column width in pixels. |
-| `minWidth` | `number` | No | Minimum AG Grid column width in pixels. |
-| `maxWidth` | `number` | No | Maximum AG Grid column width in pixels. |
+| `width` | `number` | No | Explicit initial AG Grid column width in pixels. Columns with `width` do not receive default flex sizing. |
+| `minWidth` | `number` | No | Minimum AG Grid column width in pixels. Columns with only `minWidth` still fill available width by default. |
+| `maxWidth` | `number` | No | Maximum AG Grid column width in pixels. Columns with `maxWidth` do not receive default flex sizing. |
 
 ## Events
 

--- a/packages/core/table-data-grid/package.json
+++ b/packages/core/table-data-grid/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@kong/kongponents": "^9.56.2",
-    "vue": "^3.5.34"
+    "vue": "^3.5.35"
   },
   "repository": {
     "type": "git",
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "@kong/kongponents": "^9.56.2",
-    "vue": "^3.5.34"
+    "vue": "^3.5.35"
   },
   "dependencies": {
     "ag-grid-community": "^34.3.1",

--- a/packages/core/table-data-grid/package.json
+++ b/packages/core/table-data-grid/package.json
@@ -39,6 +39,7 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
   },
   "devDependencies": {
+    "@kong-ui-public/i18n": "workspace:^",
     "@kong/kongponents": "9.59.0",
     "vue": "^3.5.35"
   },
@@ -60,6 +61,7 @@
     "errorLimit": "500KB"
   },
   "peerDependencies": {
+    "@kong-ui-public/i18n": "workspace:^",
     "@kong/kongponents": "^9.59.0",
     "vue": "^3.5.35"
   },

--- a/packages/core/table-data-grid/package.json
+++ b/packages/core/table-data-grid/package.json
@@ -39,7 +39,8 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
   },
   "devDependencies": {
-    "vue": "^3.5.35"
+    "@kong/kongponents": "^9.56.2",
+    "vue": "^3.5.34"
   },
   "repository": {
     "type": "git",
@@ -59,7 +60,8 @@
     "errorLimit": "500KB"
   },
   "peerDependencies": {
-    "vue": "^3.5.35"
+    "@kong/kongponents": "^9.56.2",
+    "vue": "^3.5.34"
   },
   "dependencies": {
     "ag-grid-community": "^34.3.1",

--- a/packages/core/table-data-grid/package.json
+++ b/packages/core/table-data-grid/package.json
@@ -39,7 +39,7 @@
     "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
   },
   "devDependencies": {
-    "@kong/kongponents": "^9.56.2",
+    "@kong/kongponents": "9.59.0",
     "vue": "^3.5.35"
   },
   "repository": {
@@ -60,7 +60,7 @@
     "errorLimit": "500KB"
   },
   "peerDependencies": {
-    "@kong/kongponents": "^9.56.2",
+    "@kong/kongponents": "^9.59.0",
     "vue": "^3.5.35"
   },
   "dependencies": {

--- a/packages/core/table-data-grid/sandbox/App.vue
+++ b/packages/core/table-data-grid/sandbox/App.vue
@@ -1,62 +1,709 @@
+<!-- fallow-ignore-file unused-file -->
 <template>
-  <main class="sandbox">
+  <div class="sandbox">
     <header class="sandbox-header">
-      <h1>TableDataGrid</h1>
-      <p>Basic fetcher render example for the initial AG Grid wrapper.</p>
+      <div>
+        <h1>TableDataGrid</h1>
+        <p>Cursor-first infinite loading playground with refresh, states, and fetch history.</p>
+      </div>
+
+      <div class="sandbox-header-actions">
+        <KButton
+          appearance="secondary"
+          @click="clearEventLog"
+        >
+          Clear log
+        </KButton>
+        <KButton
+          appearance="primary"
+          @click="refreshRows"
+        >
+          Refresh rows
+        </KButton>
+      </div>
     </header>
 
-    <TableDataGrid
-      :fetcher="fetchRows"
-      :headers="headers"
-    />
-  </main>
+    <main class="sandbox-main">
+      <section class="table-section">
+        <TableDataGrid
+          :key="tableResetKey"
+          :error="showErrorState"
+          :fetcher="fetchRows"
+          :headers="headers"
+          :page-size="pageSize"
+          :refresh-key="refreshKey"
+          @grid:ready="handleGridReady"
+          @state="handleState"
+        >
+          <template #empty-state>
+            <KEmptyState
+              message="Switch back to the generated dataset or refresh after changing controls."
+              title="No sandbox rows"
+            />
+          </template>
+
+          <template #error-state>
+            <KEmptyState
+              icon-variant="error"
+              message="Turn off the host error state to show the grid again."
+              title="Sandbox error state"
+            />
+          </template>
+        </TableDataGrid>
+      </section>
+
+      <section class="event-log-section">
+        <div class="event-log-header">
+          <h2>Event log</h2>
+          <KButton
+            appearance="tertiary"
+            :disabled="!eventLog.length"
+            size="small"
+            @click="clearEventLog"
+          >
+            Clear
+          </KButton>
+        </div>
+        <pre class="debug-output event-log-output">{{ eventLog.length ? eventLog : 'Interact with the sandbox to see emitted events.' }}</pre>
+      </section>
+    </main>
+
+    <aside class="state-panel">
+      <section class="state-panel-section">
+        <KCollapse
+          v-model="collapsedSections.tableOptions"
+          class="sandbox-section-collapse"
+          title="Table options"
+          @click.capture="toggleSectionOnHeaderClick('tableOptions', $event)"
+        >
+          <div class="control-grid">
+            <label>
+              Dataset
+              <select
+                :value="datasetMode"
+                @change="handleDatasetModeChange"
+              >
+                <option
+                  v-for="option in datasetModeOptions"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </option>
+              </select>
+            </label>
+
+            <label>
+              Page size
+              <select
+                :value="String(pageSize)"
+                @change="handlePageSizeChange"
+              >
+                <option
+                  v-for="size in pageSizeOptions"
+                  :key="size"
+                  :value="String(size)"
+                >
+                  {{ size }}
+                </option>
+              </select>
+            </label>
+
+            <label>
+              Fetch delay
+              <select
+                :value="String(fetchDelayMs)"
+                @change="handleFetchDelayChange"
+              >
+                <option
+                  v-for="delay in fetchDelayOptions"
+                  :key="delay"
+                  :value="String(delay)"
+                >
+                  {{ delay }} ms
+                </option>
+              </select>
+            </label>
+          </div>
+
+          <div class="toggle-list">
+            <KCheckbox
+              v-model="showErrorState"
+              label="Host error state"
+            />
+          </div>
+
+          <div class="sandbox-panel-actions">
+            <KButton
+              appearance="secondary"
+              size="small"
+              @click="refreshRows"
+            >
+              Increment refreshKey
+            </KButton>
+            <KButton
+              appearance="tertiary"
+              size="small"
+              @click="resetSandbox"
+            >
+              Reset sandbox
+            </KButton>
+          </div>
+        </KCollapse>
+      </section>
+
+      <section class="state-panel-section">
+        <KCollapse
+          v-model="collapsedSections.fetchDebug"
+          class="sandbox-section-collapse"
+          title="Fetch debug"
+          @click.capture="toggleSectionOnHeaderClick('fetchDebug', $event)"
+        >
+          <pre class="debug-output">{{ fetchDebug }}</pre>
+
+          <h3>Fetch history</h3>
+          <div class="fetch-history-list">
+            <KCard
+              v-for="entry in fetchHistoryEntries"
+              :key="entry.id"
+              class="fetch-history-card"
+            >
+              <dl class="fetch-history-summary">
+                <div>
+                  <dt>Request</dt>
+                  <dd>{{ entry.fetchCount }}</dd>
+                </div>
+                <div>
+                  <dt>Page size</dt>
+                  <dd>{{ entry.request.pageSize }}</dd>
+                </div>
+                <div>
+                  <dt>Request cursor</dt>
+                  <dd>{{ formatCursor(entry.request.cursor) }}</dd>
+                </div>
+                <div>
+                  <dt>Response cursor</dt>
+                  <dd>{{ formatCursor(entry.responseCursor) }}</dd>
+                </div>
+                <div>
+                  <dt>Rows</dt>
+                  <dd>{{ entry.rowsReturned }}</dd>
+                </div>
+                <div>
+                  <dt>Time</dt>
+                  <dd>{{ entry.time }}</dd>
+                </div>
+              </dl>
+            </KCard>
+
+            <p
+              v-if="!fetchHistoryEntries.length"
+              class="empty-history"
+            >
+              Fetch rows to populate history.
+            </p>
+          </div>
+        </KCollapse>
+      </section>
+
+      <section class="state-panel-section">
+        <KCollapse
+          v-model="collapsedSections.headers"
+          class="sandbox-section-collapse"
+          title="Headers"
+          @click.capture="toggleSectionOnHeaderClick('headers', $event)"
+        >
+          <pre class="debug-output">{{ headers }}</pre>
+        </KCollapse>
+      </section>
+    </aside>
+  </div>
 </template>
 
 <script setup lang="ts">
-import type { TableDataGridFetcher, TableDataGridHeader } from '../src'
+import type {
+  TableDataGridFetcher,
+  TableDataGridHeader,
+  TableDataGridInfiniteFetcherParams,
+  TableDataGridStatePayload,
+} from '../src'
+import type { GridApi } from 'ag-grid-community'
+import { computed, ref } from 'vue'
 import { TableDataGrid } from '../src'
 
 type SandboxRow = {
   id: string
   name: string
   status: string
-  latency: string
+  latency: number
+  region: string
 }
 
-const headers: Array<TableDataGridHeader<SandboxRow>> = [
-  { key: 'name', label: 'Name', width: 220 },
-  { key: 'status', label: 'Status', width: 140 },
-  { key: 'latency', label: 'Latency', width: 160 },
-]
+type DatasetMode = 'generated' | 'empty'
+type SandboxSectionId = 'tableOptions' | 'fetchDebug' | 'headers'
 
-const rows: SandboxRow[] = [
-  { id: 'row-1', name: 'Gateway service', status: 'Active', latency: '42 ms' },
-  { id: 'row-2', name: 'Portal app', status: 'Inactive', latency: '128 ms' },
-  { id: 'row-3', name: 'Analytics API', status: 'Active', latency: '86 ms' },
-]
+type FetchHistoryEntry = {
+  fetchCount: number
+  id: string
+  request: TableDataGridInfiniteFetcherParams
+  responseCursor?: unknown
+  rowsReturned: number
+  time: string
+}
 
-const fetchRows: TableDataGridFetcher<SandboxRow> = async () => ({
-  data: rows,
-  total: rows.length,
+type EventLogEntry = {
+  event: string
+  payload: unknown
+  time: string
+}
+
+const defaultPageSize = 25
+const defaultFetchDelayMs = 350
+const cursorPrefix = 'cursor:'
+const cursorPattern = /^cursor:(\d+)$/
+
+const datasetModeOptions: Array<{ label: string, value: DatasetMode }> = [
+  { label: 'Generated rows', value: 'generated' },
+  { label: 'Empty rows', value: 'empty' },
+]
+const pageSizeOptions = [10, 25, 50, 100]
+const fetchDelayOptions = [0, 150, 350, 800]
+
+const pageSize = ref(defaultPageSize)
+const fetchDelayMs = ref(defaultFetchDelayMs)
+const datasetMode = ref<DatasetMode>('generated')
+const showErrorState = ref(false)
+const refreshKey = ref(0)
+const tableResetKey = ref(0)
+const fetchCount = ref(0)
+const lastRequest = ref<TableDataGridInfiniteFetcherParams>()
+const lastResponseCursor = ref<unknown>()
+const fetchHistory = ref<FetchHistoryEntry[]>([])
+const eventLog = ref<EventLogEntry[]>([])
+const collapsedSections = ref<Record<SandboxSectionId, boolean>>({
+  fetchDebug: false,
+  headers: true,
+  tableOptions: false,
 })
+
+const headers: Array<TableDataGridHeader<SandboxRow>> = [
+  { key: 'name', label: 'Name', width: 240 },
+  { key: 'status', label: 'Status', width: 140 },
+  { key: 'latency', label: 'Latency', width: 140 },
+  { key: 'region', label: 'Region', width: 160 },
+]
+
+const generatedRows: SandboxRow[] = Array.from({ length: 140 }, (_, index) => {
+  const rowNumber = index + 1
+
+  return {
+    id: `row-${rowNumber}`,
+    latency: 35 + ((index * 29) % 800),
+    name: `Service ${rowNumber}`,
+    region: ['us', 'eu', 'au', 'me'][index % 4] ?? 'us',
+    status: ['Active', 'Deploying', 'Inactive'][index % 3] ?? 'Active',
+  }
+})
+
+const activeRows = computed<SandboxRow[]>(() => (
+  datasetMode.value === 'empty'
+    ? []
+    : generatedRows
+))
+
+const fetchDebug = computed(() => ({
+  datasetMode: datasetMode.value,
+  fetchCount: fetchCount.value,
+  fetchDelayMs: fetchDelayMs.value,
+  lastRequest: lastRequest.value,
+  lastResponseCursor: lastResponseCursor.value,
+  pageSize: pageSize.value,
+  refreshKey: refreshKey.value,
+  showErrorState: showErrorState.value,
+}))
+
+const fetchHistoryEntries = computed(() => [...fetchHistory.value].reverse())
+
+const wait = (delayMs: number) => new Promise(resolve => setTimeout(resolve, delayMs))
+
+const createCursor = (offset: number): string | undefined => (
+  offset > 0 ? `${cursorPrefix}${offset}` : undefined
+)
+
+const getOffsetFromCursor = (cursor: unknown): number => {
+  const [, offset = '0'] = cursorPattern.exec(String(cursor ?? '')) ?? []
+
+  return Number(offset)
+}
+
+const formatCursor = (cursor: unknown): string => (
+  cursor === undefined ? 'undefined' : String(cursor)
+)
+
+const logEvent = (event: string, payload: unknown) => {
+  eventLog.value = [
+    {
+      event,
+      payload,
+      time: new Date().toLocaleTimeString(),
+    },
+    ...eventLog.value,
+  ].slice(0, 30)
+}
+
+const clearFetchHistory = () => {
+  fetchCount.value = 0
+  lastRequest.value = undefined
+  lastResponseCursor.value = undefined
+  fetchHistory.value = []
+}
+
+const refreshRows = () => {
+  clearFetchHistory()
+  refreshKey.value += 1
+  logEvent('refreshKey:change', { refreshKey: refreshKey.value })
+}
+
+const resetSandbox = () => {
+  pageSize.value = defaultPageSize
+  fetchDelayMs.value = defaultFetchDelayMs
+  datasetMode.value = 'generated'
+  showErrorState.value = false
+  refreshKey.value = 0
+  tableResetKey.value += 1
+  clearFetchHistory()
+  clearEventLog()
+}
+
+const clearEventLog = () => {
+  eventLog.value = []
+}
+
+const recordFetch = ({
+  request,
+  responseCursor,
+  rowsReturned,
+}: {
+  request: TableDataGridInfiniteFetcherParams
+  responseCursor?: unknown
+  rowsReturned: number
+}) => {
+  const nextFetchCount = fetchCount.value + 1
+  const entry: FetchHistoryEntry = {
+    fetchCount: nextFetchCount,
+    id: `fetch-${nextFetchCount}`,
+    request,
+    responseCursor,
+    rowsReturned,
+    time: new Date().toLocaleTimeString(),
+  }
+
+  fetchCount.value = nextFetchCount
+  lastRequest.value = request
+  lastResponseCursor.value = responseCursor
+  fetchHistory.value = [...fetchHistory.value, entry].slice(-8)
+}
+
+const fetchRows: TableDataGridFetcher<SandboxRow> = async ({ pageSize, cursor }) => {
+  const request: TableDataGridInfiniteFetcherParams = {
+    cursor,
+    mode: 'infinite',
+    pageSize,
+  }
+
+  if (fetchDelayMs.value > 0) {
+    await wait(fetchDelayMs.value)
+  }
+
+  const offset = getOffsetFromCursor(cursor)
+  const data = activeRows.value.slice(offset, offset + pageSize)
+  const nextOffset = offset + data.length
+  const hasMore = nextOffset < activeRows.value.length
+  const responseCursor = hasMore ? createCursor(nextOffset) : undefined
+
+  recordFetch({
+    request,
+    responseCursor,
+    rowsReturned: data.length,
+  })
+
+  return {
+    cursor: responseCursor,
+    data,
+    hasMore,
+  }
+}
+
+const handleState = (payload: TableDataGridStatePayload) => {
+  logEvent('state', payload)
+}
+
+const handleGridReady = (api: GridApi<SandboxRow>) => {
+  logEvent('grid:ready', {
+    displayedRows: api.getDisplayedRowCount(),
+  })
+}
+
+const refreshAfterControlChange = () => {
+  refreshRows()
+}
+
+const handleDatasetModeChange = (event: Event) => {
+  const value = event.target instanceof HTMLSelectElement
+    ? event.target.value
+    : 'generated'
+
+  datasetMode.value = value === 'empty' ? 'empty' : 'generated'
+  refreshAfterControlChange()
+}
+
+const handlePageSizeChange = (event: Event) => {
+  const value = event.target instanceof HTMLSelectElement
+    ? Number(event.target.value)
+    : defaultPageSize
+
+  pageSize.value = pageSizeOptions.includes(value) ? value : defaultPageSize
+  refreshAfterControlChange()
+}
+
+const handleFetchDelayChange = (event: Event) => {
+  const value = event.target instanceof HTMLSelectElement
+    ? Number(event.target.value)
+    : defaultFetchDelayMs
+
+  fetchDelayMs.value = fetchDelayOptions.includes(value) ? value : defaultFetchDelayMs
+  logEvent('fetchDelay:change', { fetchDelayMs: fetchDelayMs.value })
+}
+
+const toggleSectionOnHeaderClick = (sectionId: SandboxSectionId, event: MouseEvent) => {
+  const target = event.target
+
+  if (!(target instanceof Element)) {
+    return
+  }
+
+  const clickedHeader = target.closest('.collapse-heading')
+  const clickedDefaultTrigger = target.closest('.collapse-trigger-content')
+
+  if (!clickedHeader || clickedDefaultTrigger) {
+    return
+  }
+
+  collapsedSections.value[sectionId] = !collapsedSections.value[sectionId]
+}
 </script>
 
 <style lang="scss" scoped>
 .sandbox {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: var(--kui-space-70, $kui-space-70);
-  padding: var(--kui-space-80, $kui-space-80);
+  grid-template-columns: minmax(0, 1fr) 360px;
+  padding: var(--kui-space-70, $kui-space-70);
 }
 
 .sandbox-header {
+  align-items: center;
   display: flex;
-  flex-direction: column;
-  gap: var(--kui-space-20, $kui-space-20);
+  gap: var(--kui-space-50, $kui-space-50);
+  grid-column: 1 / -1;
+  justify-content: space-between;
+
+  h1 {
+    font-size: 28px;
+    margin: 0 0 var(--kui-space-20, $kui-space-20);
+  }
+
+  p {
+    color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+    margin: 0;
+  }
 }
 
-.sandbox-header h1,
-.sandbox-header p {
+.sandbox-header-actions,
+.sandbox-panel-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--kui-space-30, $kui-space-30);
+}
+
+.sandbox-header-actions {
+  justify-content: flex-end;
+}
+
+.sandbox-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-50, $kui-space-50);
+  grid-column: 1;
+  min-width: 0;
+}
+
+.table-section {
+  display: flex;
+  min-width: 0;
+
+  :deep(.kong-ui-public-table-data-grid) {
+    flex: 0 0 760px;
+    height: 760px;
+    min-height: 0;
+  }
+}
+
+.event-log-section {
+  min-width: 0;
+
+  h2 {
+    font-size: 16px;
+    margin: 0;
+  }
+}
+
+.event-log-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: var(--kui-space-30, $kui-space-30);
+}
+
+.state-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-50, $kui-space-50);
+  grid-column: 2;
+
+  h3 {
+    font-size: 14px;
+    margin: var(--kui-space-40, $kui-space-40) 0 var(--kui-space-30, $kui-space-30);
+  }
+}
+
+.sandbox-section-collapse {
+  :deep(.collapse-heading) {
+    cursor: pointer;
+  }
+}
+
+.control-grid {
+  display: grid;
+  gap: var(--kui-space-40, $kui-space-40);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.control-grid,
+.toggle-list {
+  label {
+    color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+    display: flex;
+    flex-direction: column;
+    font-size: var(--kui-font-size-20, $kui-font-size-20);
+    gap: var(--kui-space-20, $kui-space-20);
+  }
+}
+
+.control-grid {
+  select {
+    border: 1px solid var(--kui-color-border, $kui-color-border);
+    border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
+    color: var(--kui-color-text, $kui-color-text);
+    min-height: 32px;
+    min-width: 0;
+    padding: 0 var(--kui-space-30, $kui-space-30);
+    width: 100%;
+  }
+}
+
+.toggle-list {
+  display: grid;
+  gap: var(--kui-space-30, $kui-space-30);
+  margin-top: var(--kui-space-40, $kui-space-40);
+
+  label {
+    align-items: center;
+    color: var(--kui-color-text, $kui-color-text);
+    flex-direction: row;
+  }
+}
+
+.sandbox-panel-actions {
+  margin-top: var(--kui-space-40, $kui-space-40);
+}
+
+.debug-output {
+  background: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
+  border: 1px solid var(--kui-color-border, $kui-color-border);
+  border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
+  font-size: 12px;
   margin: 0;
+  max-height: 340px;
+  overflow: auto;
+  padding: var(--kui-space-40, $kui-space-40);
+  white-space: pre-wrap;
+}
+
+.event-log-output {
+  max-height: 300px;
+}
+
+.fetch-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-30, $kui-space-30);
+  max-height: 420px;
+  overflow: auto;
+  padding-right: var(--kui-space-20, $kui-space-20);
+}
+
+.fetch-history-card {
+  :deep(.k-card-content) {
+    padding: var(--kui-space-40, $kui-space-40);
+  }
+}
+
+.fetch-history-summary {
+  display: grid;
+  gap: var(--kui-space-30, $kui-space-30);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+
+  div {
+    min-width: 0;
+  }
+
+  dt {
+    color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+    font-size: var(--kui-font-size-20, $kui-font-size-20);
+  }
+
+  dd {
+    color: var(--kui-color-text, $kui-color-text);
+    font-size: var(--kui-font-size-30, $kui-font-size-30);
+    margin: var(--kui-space-10, $kui-space-10) 0 0;
+    overflow-wrap: anywhere;
+  }
+}
+
+.empty-history {
+  color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+  margin: 0;
+}
+
+@media (max-width: 980px) {
+  .sandbox {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sandbox-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .sandbox-header-actions {
+    justify-content: flex-start;
+  }
+
+  .state-panel {
+    grid-column: 1;
+  }
 }
 </style>

--- a/packages/core/table-data-grid/sandbox/App.vue
+++ b/packages/core/table-data-grid/sandbox/App.vue
@@ -168,32 +168,37 @@
               :key="entry.id"
               class="fetch-history-card"
             >
-              <dl class="fetch-history-summary">
-                <div>
-                  <dt>Request</dt>
-                  <dd>{{ entry.fetchCount }}</dd>
-                </div>
-                <div>
-                  <dt>Page size</dt>
-                  <dd>{{ entry.request.pageSize }}</dd>
-                </div>
-                <div>
-                  <dt>Request cursor</dt>
-                  <dd>{{ formatCursor(entry.request.cursor) }}</dd>
-                </div>
-                <div>
-                  <dt>Response cursor</dt>
-                  <dd>{{ formatCursor(entry.responseCursor) }}</dd>
-                </div>
-                <div>
-                  <dt>Rows</dt>
-                  <dd>{{ entry.rowsReturned }}</dd>
-                </div>
-                <div>
-                  <dt>Time</dt>
-                  <dd>{{ entry.time }}</dd>
-                </div>
-              </dl>
+              <KCollapse
+                v-model="collapsedFetchHistoryItems[entry.id]"
+                :title="entry.title"
+              >
+                <dl class="fetch-history-summary">
+                  <div>
+                    <dt>Request</dt>
+                    <dd>{{ entry.fetchCount }}</dd>
+                  </div>
+                  <div>
+                    <dt>Page size</dt>
+                    <dd>{{ entry.request.pageSize }}</dd>
+                  </div>
+                  <div>
+                    <dt>Request cursor</dt>
+                    <dd>{{ formatCursor(entry.request.cursor) }}</dd>
+                  </div>
+                  <div>
+                    <dt>Response cursor</dt>
+                    <dd>{{ formatCursor(entry.responseCursor) }}</dd>
+                  </div>
+                  <div>
+                    <dt>Rows</dt>
+                    <dd>{{ entry.rowsReturned }}</dd>
+                  </div>
+                  <div>
+                    <dt>Time</dt>
+                    <dd>{{ entry.time }}</dd>
+                  </div>
+                </dl>
+              </KCollapse>
             </KCard>
 
             <p
@@ -248,6 +253,7 @@ type FetchHistoryEntry = {
   request: TableDataGridInfiniteFetcherParams
   responseCursor?: unknown
   rowsReturned: number
+  title: string
   time: string
 }
 
@@ -279,6 +285,7 @@ const fetchCount = ref(0)
 const lastRequest = ref<TableDataGridInfiniteFetcherParams>()
 const lastResponseCursor = ref<unknown>()
 const fetchHistory = ref<FetchHistoryEntry[]>([])
+const collapsedFetchHistoryItems = ref<Record<string, boolean>>({})
 const eventLog = ref<EventLogEntry[]>([])
 const collapsedSections = ref<Record<SandboxSectionId, boolean>>({
   fetchDebug: false,
@@ -356,6 +363,7 @@ const clearFetchHistory = () => {
   lastRequest.value = undefined
   lastResponseCursor.value = undefined
   fetchHistory.value = []
+  collapsedFetchHistoryItems.value = {}
 }
 
 const refreshRows = () => {
@@ -395,13 +403,22 @@ const recordFetch = ({
     request,
     responseCursor,
     rowsReturned,
+    title: `Fetch ${nextFetchCount} - cursor ${formatCursor(request.cursor)}`,
     time: new Date().toLocaleTimeString(),
   }
+  const nextFetchHistory = [...fetchHistory.value, entry].slice(-8)
+  const nextFetchHistoryIds = new Set(nextFetchHistory.map(entry => entry.id))
 
   fetchCount.value = nextFetchCount
   lastRequest.value = request
   lastResponseCursor.value = responseCursor
-  fetchHistory.value = [...fetchHistory.value, entry].slice(-8)
+  collapsedFetchHistoryItems.value = Object.fromEntries(
+    Object.entries({
+      ...collapsedFetchHistoryItems.value,
+      [entry.id]: true,
+    }).filter(([entryId]) => nextFetchHistoryIds.has(entryId)),
+  )
+  fetchHistory.value = nextFetchHistory
 }
 
 const fetchRows: TableDataGridFetcher<SandboxRow> = async ({ pageSize, cursor }) => {

--- a/packages/core/table-data-grid/sandbox/App.vue
+++ b/packages/core/table-data-grid/sandbox/App.vue
@@ -294,10 +294,10 @@ const collapsedSections = ref<Record<SandboxSectionId, boolean>>({
 })
 
 const headers: Array<TableDataGridHeader<SandboxRow>> = [
-  { key: 'name', label: 'Name', width: 240 },
-  { key: 'status', label: 'Status', width: 140 },
-  { key: 'latency', label: 'Latency', width: 140 },
-  { key: 'region', label: 'Region', width: 160 },
+  { key: 'name', label: 'Name', minWidth: 220 },
+  { key: 'status', label: 'Status', minWidth: 140 },
+  { key: 'latency', label: 'Latency', minWidth: 140 },
+  { key: 'region', label: 'Region', minWidth: 140 },
 ]
 
 const generatedRows: SandboxRow[] = Array.from({ length: 140 }, (_, index) => {

--- a/packages/core/table-data-grid/sandbox/index.ts
+++ b/packages/core/table-data-grid/sandbox/index.ts
@@ -1,4 +1,11 @@
+// fallow-ignore-file unused-file
 import { createApp } from 'vue'
 import App from './App.vue'
+import Kongponents from '@kong/kongponents'
+import '@kong/kongponents/dist/style.css'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+
+app.use(Kongponents)
+
+app.mount('#app')

--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -82,6 +82,24 @@ const mountTestTableDataGrid = ({
   }
 }
 
+const scrollToSecondBlock = ({
+  fetcher,
+  onState,
+}: {
+  fetcher: TableDataGridFetcher<TestRow>
+  onState?: (payload: TableDataGridStatePayload) => void
+}) => {
+  mountTestTableDataGrid({
+    fetcher,
+    onState,
+    pageSize: 15,
+  })
+
+  cy.contains('.ag-cell', 'Service 1').should('be.visible')
+  cy.get('.ag-body-viewport').scrollTo('bottom')
+  cy.wrap(fetcher).should('have.been.calledTwice')
+}
+
 describe('<TableDataGrid />', () => {
   it('fetches the first infinite block and renders AG Grid headers and data', () => {
     const fetcher = cy.stub().resolves({
@@ -129,18 +147,7 @@ describe('<TableDataGrid />', () => {
         hasMore: true,
       })
 
-    cy.mount(TestTableDataGrid, {
-      props: {
-        fetcher,
-        headers,
-        pageSize: 15,
-      },
-    })
-
-    cy.contains('.ag-cell', 'Service 1').should('be.visible')
-    cy.get('.ag-body-viewport').scrollTo('bottom')
-
-    cy.wrap(fetcher).should('have.been.calledTwice')
+    scrollToSecondBlock({ fetcher })
     cy.then(() => {
       const firstParams = fetcher.firstCall.args[0]
       const secondParams = fetcher.secondCall.args[0]
@@ -315,6 +322,53 @@ describe('<TableDataGrid />', () => {
     cy.get('@state').should('have.been.calledWithMatch', {
       state: 'success',
       hasData: true,
+    })
+  })
+
+  it('emits loading and success state for later infinite blocks', () => {
+    const firstBlockRows = createRows(1, 15)
+    const secondBlockRows = createRows(16, 15)
+    const onState = cy.stub().as('state')
+    let resolveSecondBlock: (result: {
+      data: TestRow[]
+      hasMore: boolean
+    }) => void
+    const secondBlockPromise = new Promise<{
+      data: TestRow[]
+      hasMore: boolean
+    }>((resolve) => {
+      resolveSecondBlock = resolve
+    })
+    const fetcher = cy.stub()
+      .onFirstCall()
+      .resolves({
+        cursor: 'next-cursor',
+        data: firstBlockRows,
+        hasMore: true,
+      })
+      .onSecondCall()
+      .returns(secondBlockPromise)
+
+    scrollToSecondBlock({ fetcher, onState })
+    cy.get('@state').should('have.been.calledWithMatch', {
+      state: 'loading',
+      hasData: true,
+    })
+
+    cy.then(() => {
+      resolveSecondBlock({
+        data: secondBlockRows,
+        hasMore: false,
+      })
+    })
+
+    cy.contains('.ag-cell', 'Service 16').should('be.visible')
+    cy.get('@state').should((state) => {
+      const successEvents = state.getCalls().filter(call => (
+        call.args[0].state === 'success' && call.args[0].hasData === true
+      ))
+
+      expect(successEvents).to.have.length.greaterThan(1)
     })
   })
 

--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -409,6 +409,26 @@ describe('<TableDataGrid />', () => {
     })
   })
 
+  it('uses unconstrained columns to fill space left by fixed-width columns', () => {
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+    const getGridApi = mountTableWithGridApi({
+      fetcher,
+      headers: [
+        { key: 'name', label: 'Name', width: 240 },
+        { key: 'status', label: 'Status' },
+      ],
+    })
+
+    expectRenderedColumnWidths(getGridApi, ({ gridApi, widthsByColumn }) => {
+      expect(widthsByColumn.name).to.equal(240)
+      expect(widthsByColumn.status).to.be.greaterThan(240)
+      expectColumnsToFillGrid(gridApi!)
+    })
+  })
+
   it('does not apply default flex sizing to columns with maxWidth', () => {
     const fetcher = cy.stub().resolves({
       data: rows,

--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -3,6 +3,7 @@ import type {
   TableDataGridHeader,
   TableDataGridStatePayload,
 } from '../types'
+import type { GridApi } from 'ag-grid-community'
 import type { DefineComponent } from 'vue'
 import { h } from 'vue'
 import TableDataGrid from './TableDataGrid.vue'
@@ -13,18 +14,20 @@ type TestRow = {
   status: string
 }
 
-type TestTableDataGridProps = {
-  headers: Array<TableDataGridHeader<TestRow>>
-  fetcher: TableDataGridFetcher<TestRow>
-  error?: boolean
-  onState?: (payload: TableDataGridStatePayload) => void
-  pageSize?: number
-  refreshKey?: string | number | boolean
-}
-
 type TestTableDataGridSlots = {
   'empty-state'?: () => unknown
   'error-state'?: () => unknown
+}
+
+type MountTableOptions = {
+  fetcher: TableDataGridFetcher<TestRow>
+  headers?: Array<TableDataGridHeader<TestRow>>
+  error?: boolean
+  onGridReady?: (api: GridApi<TestRow>) => void
+  onState?: (payload: TableDataGridStatePayload) => void
+  pageSize?: number
+  refreshKey?: string | number | boolean
+  slots?: TestTableDataGridSlots
 }
 
 type TestVueWrapper = {
@@ -59,17 +62,20 @@ const createResetFetcher = () => cy.stub().callsFake(({ pageSize }) => Promise.r
   hasMore: false,
 }))
 
-const TestTableDataGrid = TableDataGrid as unknown as DefineComponent<TestTableDataGridProps>
+const TestTableDataGrid = TableDataGrid as unknown as DefineComponent
 
 const mountTestTableDataGrid = ({
+  headers: tableHeaders = headers,
+  onGridReady,
   slots,
   ...props
-}: Omit<TestTableDataGridProps, 'headers'> & { slots?: TestTableDataGridSlots }) => {
+}: MountTableOptions) => {
   let vueWrapper: TestVueWrapper
 
   cy.mount(TestTableDataGrid, {
     props: {
-      headers,
+      headers: tableHeaders,
+      'onGrid:ready': onGridReady,
       ...props,
     },
     slots,
@@ -80,6 +86,70 @@ const mountTestTableDataGrid = ({
   return {
     setProps: (nextProps: Record<string, unknown>) => cy.then(() => vueWrapper.setProps(nextProps)),
   }
+}
+
+const getDisplayedColumnWidth = (api: GridApi<TestRow>) => api.getColumnState()
+  .filter(column => !column.hide)
+  .reduce((total, column) => total + (column.width ?? 0), 0)
+
+const getColumnWidthsById = (api: GridApi<TestRow> | undefined) => Object.fromEntries(
+  api?.getColumnState().map(column => [column.colId, column.width]) ?? [],
+) as Record<string, number | undefined>
+
+const expectColumnsToFillGrid = (api: GridApi<TestRow>) => {
+  cy.get('.table-data-grid-grid .ag-header').then(($header) => {
+    const displayedColumnWidth = getDisplayedColumnWidth(api)
+
+    expect(displayedColumnWidth).to.be.greaterThan($header[0].clientWidth - 20)
+    expect(displayedColumnWidth).to.be.lessThan($header[0].clientWidth + 20)
+  })
+}
+
+const expectHorizontalOverflow = () => {
+  cy.get('.table-data-grid-grid .ag-center-cols-viewport').then(($viewport) => {
+    expect($viewport[0].scrollWidth).to.be.greaterThan($viewport[0].clientWidth)
+  })
+}
+
+const mountTableWithGridApi = ({
+  fetcher,
+  headers: tableHeaders,
+}: {
+  fetcher: TableDataGridFetcher<TestRow>
+  headers: Array<TableDataGridHeader<TestRow>>
+}) => {
+  let gridApi: GridApi<TestRow> | undefined
+
+  mountTestTableDataGrid({
+    fetcher,
+    headers: tableHeaders,
+    onGridReady: (api) => {
+      gridApi = api
+    },
+  })
+
+  return () => gridApi
+}
+
+const expectRenderedColumnWidths = (
+  getGridApi: () => GridApi<TestRow> | undefined,
+  assertWidths: ({
+    gridApi,
+    widthsByColumn,
+  }: {
+    gridApi: GridApi<TestRow> | undefined
+    widthsByColumn: Record<string, number | undefined>
+  }) => void,
+) => {
+  cy.contains('.ag-cell', 'Gateway service').should('be.visible')
+  cy.then(() => {
+    const gridApi = getGridApi()
+
+    assertWidths({
+      gridApi,
+      widthsByColumn: getColumnWidthsById(gridApi),
+    })
+  })
 }
 
 const scrollToSecondBlock = ({
@@ -284,6 +354,78 @@ describe('<TableDataGrid />', () => {
 
     cy.getTestId('custom-error-state').should('contain.text', 'Try again later')
     cy.getTestId('table-error-state').should('contain.text', 'Try again later')
+  })
+
+  it('fits columns to available width when headers do not configure width constraints', () => {
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+    const getGridApi = mountTableWithGridApi({ fetcher, headers })
+
+    expectRenderedColumnWidths(getGridApi, ({ gridApi }) => {
+      expect(gridApi).to.not.equal(undefined)
+      expectColumnsToFillGrid(gridApi!)
+    })
+  })
+
+  it('preserves explicit column widths and allows horizontal overflow', () => {
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+    const getGridApi = mountTableWithGridApi({
+      fetcher,
+      headers: [
+        { key: 'name', label: 'Name', width: 900 },
+        { key: 'status', label: 'Status', width: 600 },
+      ],
+    })
+
+    expectRenderedColumnWidths(getGridApi, ({ widthsByColumn }) => {
+      expect(widthsByColumn.name).to.equal(900)
+      expect(widthsByColumn.status).to.equal(600)
+    })
+    expectHorizontalOverflow()
+  })
+
+  it('uses minWidth as a lower bound without disabling default column fill', () => {
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+    const getGridApi = mountTableWithGridApi({
+      fetcher,
+      headers: [
+        { key: 'name', label: 'Name', minWidth: 280 },
+        { key: 'status', label: 'Status', minWidth: 160 },
+      ],
+    })
+
+    expectRenderedColumnWidths(getGridApi, ({ gridApi, widthsByColumn }) => {
+      expect(widthsByColumn.name).to.be.at.least(280)
+      expect(widthsByColumn.status).to.be.at.least(160)
+      expectColumnsToFillGrid(gridApi!)
+    })
+  })
+
+  it('does not apply default flex sizing to columns with maxWidth', () => {
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+    const getGridApi = mountTableWithGridApi({
+      fetcher,
+      headers: [
+        { key: 'name', label: 'Name', maxWidth: 600 },
+        { key: 'status', label: 'Status' },
+      ],
+    })
+
+    expectRenderedColumnWidths(getGridApi, ({ gridApi, widthsByColumn }) => {
+      expect(widthsByColumn.name).to.equal(200)
+      expectColumnsToFillGrid(gridApi!)
+    })
   })
 
   it('emits error state for a failed first block without rendering visible error UI', () => {

--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -8,6 +8,17 @@ type TestRow = {
   status: string
 }
 
+type TestTableDataGridProps = {
+  headers: Array<TableDataGridHeader<TestRow>>
+  fetcher: TableDataGridFetcher<TestRow>
+  pageSize?: number
+  refreshKey?: string | number | boolean
+}
+
+type TestVueWrapper = {
+  setProps: (props: Record<string, unknown>) => Promise<void>
+}
+
 const headers: Array<TableDataGridHeader<TestRow>> = [
   { key: 'name', label: 'Name' },
   { key: 'status', label: 'Status' },
@@ -18,14 +29,45 @@ const rows: TestRow[] = [
   { id: 'row-2', name: 'Portal app', status: 'Inactive' },
 ]
 
-const TestTableDataGrid = TableDataGrid as unknown as DefineComponent<{
-  headers: Array<TableDataGridHeader<TestRow>>
-  fetcher: TableDataGridFetcher<TestRow>
-  pageSize?: number
-}>
+const createRows = (startIndex: number, count: number): TestRow[] => (
+  Array.from({ length: count }, (_, index) => {
+    const rowIndex = startIndex + index
+
+    return {
+      id: `row-${rowIndex}`,
+      name: `Service ${rowIndex}`,
+      status: rowIndex % 2 === 0 ? 'Inactive' : 'Active',
+    }
+  })
+)
+
+const createResetFetcher = () => cy.stub().callsFake(({ pageSize }) => Promise.resolve({
+  cursor: 'next-cursor',
+  data: createRows(1, pageSize),
+  hasMore: false,
+}))
+
+const TestTableDataGrid = TableDataGrid as unknown as DefineComponent<TestTableDataGridProps>
+
+const mountTestTableDataGrid = (props: Omit<TestTableDataGridProps, 'headers'>) => {
+  let vueWrapper: TestVueWrapper
+
+  cy.mount(TestTableDataGrid, {
+    props: {
+      headers,
+      ...props,
+    },
+  }).then(({ wrapper }) => {
+    vueWrapper = wrapper
+  })
+
+  return {
+    setProps: (nextProps: Record<string, unknown>) => cy.then(() => vueWrapper.setProps(nextProps)),
+  }
+}
 
 describe('<TableDataGrid />', () => {
-  it('fetches rows and renders AG Grid headers and data', () => {
+  it('fetches the first infinite block and renders AG Grid headers and data', () => {
     const fetcher = cy.stub().resolves({
       data: rows,
       total: rows.length,
@@ -50,6 +92,100 @@ describe('<TableDataGrid />', () => {
     cy.wrap(fetcher).should('have.been.calledOnceWith', {
       mode: 'infinite',
       pageSize: 15,
+      cursor: undefined,
+    })
+  })
+
+  it('uses response cursors for later blocks without leaking AG Grid ranges', () => {
+    const firstBlockRows = createRows(1, 15)
+    const secondBlockRows = createRows(16, 15)
+    const fetcher = cy.stub()
+      .onFirstCall()
+      .resolves({
+        cursor: 'next-cursor',
+        data: firstBlockRows,
+        hasMore: true,
+      })
+      .onSecondCall()
+      .resolves({
+        cursor: 'last-cursor',
+        data: secondBlockRows,
+        hasMore: true,
+      })
+
+    cy.mount(TestTableDataGrid, {
+      props: {
+        fetcher,
+        headers,
+        pageSize: 15,
+      },
+    })
+
+    cy.contains('.ag-cell', 'Service 1').should('be.visible')
+    cy.get('.ag-body-viewport').scrollTo('bottom')
+
+    cy.wrap(fetcher).should('have.been.calledTwice')
+    cy.then(() => {
+      const firstParams = fetcher.firstCall.args[0]
+      const secondParams = fetcher.secondCall.args[0]
+
+      expect(firstParams).to.deep.equal({
+        mode: 'infinite',
+        pageSize: 15,
+        cursor: undefined,
+      })
+      expect(secondParams).to.deep.equal({
+        mode: 'infinite',
+        pageSize: 15,
+        cursor: 'next-cursor',
+      })
+
+      for (const params of [firstParams, secondParams]) {
+        expect(params).not.to.have.property('startRow')
+        expect(params).not.to.have.property('endRow')
+        expect(params).not.to.have.property('offset')
+      }
+    })
+  })
+
+  it('resets the cursor chain when refreshKey changes', () => {
+    const fetcher = createResetFetcher()
+    const tableDataGrid = mountTestTableDataGrid({
+      fetcher,
+      pageSize: 15,
+      refreshKey: 0,
+    })
+
+    cy.contains('.ag-cell', 'Service 1').should('be.visible')
+    tableDataGrid.setProps({ refreshKey: 1 })
+
+    cy.wrap(fetcher).should('have.been.calledTwice')
+    cy.then(() => {
+      expect(fetcher.secondCall.args[0]).to.deep.equal({
+        mode: 'infinite',
+        pageSize: 15,
+        cursor: undefined,
+      })
+    })
+  })
+
+  it('resets the cursor chain and cache block size when pageSize changes', () => {
+    const fetcher = createResetFetcher()
+    const tableDataGrid = mountTestTableDataGrid({
+      fetcher,
+      pageSize: 15,
+    })
+
+    cy.contains('.ag-cell', 'Service 1').should('be.visible')
+    tableDataGrid.setProps({ pageSize: 10 })
+
+    cy.wrap(fetcher).should((stub) => {
+      expect(stub.callCount).to.be.greaterThan(1)
+      expect(stub.secondCall.args[0]).to.deep.equal({
+        mode: 'infinite',
+        pageSize: 10,
+        cursor: undefined,
+      })
     })
   })
 })

--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -17,7 +17,6 @@ type TestTableDataGridProps = {
   headers: Array<TableDataGridHeader<TestRow>>
   fetcher: TableDataGridFetcher<TestRow>
   error?: boolean
-  loading?: boolean
   onState?: (payload: TableDataGridStatePayload) => void
   pageSize?: number
   refreshKey?: string | number | boolean
@@ -206,23 +205,7 @@ describe('<TableDataGrid />', () => {
     })
   })
 
-  it('renders host loading as a full table replacement', () => {
-    const fetcher = cy.stub().resolves({
-      data: rows,
-      total: rows.length,
-    })
-
-    mountTestTableDataGrid({
-      fetcher,
-      loading: true,
-    })
-
-    cy.getTestId('table-data-grid-loading').should('be.visible')
-    cy.get('.table-data-grid-grid').should('not.exist')
-    cy.wrap(fetcher).should('not.have.been.called')
-  })
-
-  it('renders host error ahead of host loading', () => {
+  it('renders host error as a full table replacement', () => {
     const fetcher = cy.stub().resolves({
       data: rows,
       total: rows.length,
@@ -231,13 +214,11 @@ describe('<TableDataGrid />', () => {
     mountTestTableDataGrid({
       error: true,
       fetcher,
-      loading: true,
     })
 
     cy.getTestId('table-error-state')
       .should('contain.text', 'An error occurred')
       .and('contain.text', 'Data cannot be displayed due to an error.')
-    cy.getTestId('table-data-grid-loading').should('not.exist')
     cy.get('.table-data-grid-grid').should('not.exist')
   })
 
@@ -334,6 +315,32 @@ describe('<TableDataGrid />', () => {
     cy.get('@state').should('have.been.calledWithMatch', {
       state: 'success',
       hasData: true,
+    })
+  })
+
+  it('does not emit loading while waiting for the first fetch to start', () => {
+    const eventOrder: string[] = []
+    const onState = cy.stub().callsFake(() => {
+      eventOrder.push('state')
+    }).as('state')
+    const fetcher = cy.stub().callsFake(() => {
+      eventOrder.push('fetcher')
+
+      return new Promise(() => undefined)
+    })
+
+    mountTestTableDataGrid({
+      fetcher,
+      onState,
+    })
+
+    cy.wrap(fetcher).should('have.been.calledOnce')
+    cy.get('@state').should('have.been.calledWithMatch', {
+      state: 'loading',
+      hasData: false,
+    })
+    cy.then(() => {
+      expect(eventOrder).to.deep.equal(['fetcher', 'state'])
     })
   })
 })

--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -1,5 +1,10 @@
-import type { TableDataGridFetcher, TableDataGridHeader } from '../types'
+import type {
+  TableDataGridFetcher,
+  TableDataGridHeader,
+  TableDataGridStatePayload,
+} from '../types'
 import type { DefineComponent } from 'vue'
+import { h } from 'vue'
 import TableDataGrid from './TableDataGrid.vue'
 
 type TestRow = {
@@ -11,8 +16,16 @@ type TestRow = {
 type TestTableDataGridProps = {
   headers: Array<TableDataGridHeader<TestRow>>
   fetcher: TableDataGridFetcher<TestRow>
+  error?: boolean
+  loading?: boolean
+  onState?: (payload: TableDataGridStatePayload) => void
   pageSize?: number
   refreshKey?: string | number | boolean
+}
+
+type TestTableDataGridSlots = {
+  'empty-state'?: () => unknown
+  'error-state'?: () => unknown
 }
 
 type TestVueWrapper = {
@@ -49,7 +62,10 @@ const createResetFetcher = () => cy.stub().callsFake(({ pageSize }) => Promise.r
 
 const TestTableDataGrid = TableDataGrid as unknown as DefineComponent<TestTableDataGridProps>
 
-const mountTestTableDataGrid = (props: Omit<TestTableDataGridProps, 'headers'>) => {
+const mountTestTableDataGrid = ({
+  slots,
+  ...props
+}: Omit<TestTableDataGridProps, 'headers'> & { slots?: TestTableDataGridSlots }) => {
   let vueWrapper: TestVueWrapper
 
   cy.mount(TestTableDataGrid, {
@@ -57,6 +73,7 @@ const mountTestTableDataGrid = (props: Omit<TestTableDataGridProps, 'headers'>) 
       headers,
       ...props,
     },
+    slots,
   }).then(({ wrapper }) => {
     vueWrapper = wrapper
   })
@@ -186,6 +203,137 @@ describe('<TableDataGrid />', () => {
         pageSize: 10,
         cursor: undefined,
       })
+    })
+  })
+
+  it('renders host loading as a full table replacement', () => {
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+
+    mountTestTableDataGrid({
+      fetcher,
+      loading: true,
+    })
+
+    cy.getTestId('table-data-grid-loading').should('be.visible')
+    cy.get('.table-data-grid-grid').should('not.exist')
+    cy.wrap(fetcher).should('not.have.been.called')
+  })
+
+  it('renders host error ahead of host loading', () => {
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+
+    mountTestTableDataGrid({
+      error: true,
+      fetcher,
+      loading: true,
+    })
+
+    cy.getTestId('table-error-state')
+      .should('contain.text', 'An error occurred')
+      .and('contain.text', 'Data cannot be displayed due to an error.')
+    cy.getTestId('table-data-grid-loading').should('not.exist')
+    cy.get('.table-data-grid-grid').should('not.exist')
+  })
+
+  it('renders an empty state after the first block succeeds with no rows', () => {
+    const onState = cy.stub().as('state')
+    const fetcher = cy.stub().resolves({
+      data: [],
+      hasMore: false,
+    })
+
+    mountTestTableDataGrid({
+      fetcher,
+      onState,
+    })
+
+    cy.getTestId('table-empty-state')
+      .should('be.visible')
+      .and('contain.text', 'No Data')
+      .and('contain.text', 'There is no data to display.')
+    cy.get('@state').should('have.been.calledWithMatch', {
+      state: 'success',
+      hasData: false,
+    })
+  })
+
+  it('renders a custom empty state slot', () => {
+    const fetcher = cy.stub().resolves({
+      data: [],
+      hasMore: false,
+    })
+
+    mountTestTableDataGrid({
+      fetcher,
+      slots: {
+        'empty-state': () => h('div', { 'data-testid': 'custom-empty-state' }, 'Nothing matched'),
+      },
+    })
+
+    cy.getTestId('custom-empty-state').should('contain.text', 'Nothing matched')
+    cy.getTestId('table-empty-state').should('contain.text', 'Nothing matched')
+  })
+
+  it('renders a custom error state slot', () => {
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+
+    mountTestTableDataGrid({
+      error: true,
+      fetcher,
+      slots: {
+        'error-state': () => h('div', { 'data-testid': 'custom-error-state' }, 'Try again later'),
+      },
+    })
+
+    cy.getTestId('custom-error-state').should('contain.text', 'Try again later')
+    cy.getTestId('table-error-state').should('contain.text', 'Try again later')
+  })
+
+  it('emits error state for a failed first block without rendering visible error UI', () => {
+    const onState = cy.stub().as('state')
+    const fetcher = cy.stub().rejects(new Error('failed'))
+
+    mountTestTableDataGrid({
+      fetcher,
+      onState,
+    })
+
+    cy.getTestId('table-error-state').should('not.exist')
+    cy.get('@state').should('have.been.calledWithMatch', {
+      state: 'error',
+      hasData: false,
+    })
+  })
+
+  it('emits loading and success state for fetched rows', () => {
+    const onState = cy.stub().as('state')
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+
+    mountTestTableDataGrid({
+      fetcher,
+      onState,
+    })
+
+    cy.contains('.ag-cell', 'Gateway service').should('be.visible')
+    cy.get('@state').should('have.been.calledWithMatch', {
+      state: 'loading',
+      hasData: false,
+    })
+    cy.get('@state').should('have.been.calledWithMatch', {
+      state: 'success',
+      hasData: true,
     })
   })
 })

--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -49,7 +49,6 @@ describe('<TableDataGrid />', () => {
     cy.contains('.ag-cell', 'Inactive').should('be.visible')
     cy.wrap(fetcher).should('have.been.calledOnceWith', {
       mode: 'infinite',
-      offset: 0,
       pageSize: 15,
     })
   })

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -62,7 +62,8 @@ import {
   ModuleRegistry,
   themeQuartz,
 } from 'ag-grid-community'
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
+import { useEmitState } from '../composables/useEmitState'
 import { useFetchInfinite } from '../composables/useFetchInfinite'
 import useFetchState from '../composables/useFetchState'
 
@@ -130,51 +131,11 @@ const shouldShowEmptyState = computed<boolean>(() => (
   && !hasData.value
 ))
 
-watch(
-  () => ({
-    hasData: hasData.value,
-    hostError,
-    state: fetchLifecycleState.value,
-  }),
-  ({ hasData, hostError, state }) => {
-    if (hostError) {
-      emit('state', {
-        hasData,
-        state: 'error',
-      })
-
-      return
-    }
-
-    if (state === fetchState.PENDING) {
-      return
-    }
-
-    if (state === fetchState.LOADING) {
-      emit('state', {
-        hasData,
-        state: 'loading',
-      })
-
-      return
-    }
-
-    if (state === fetchState.ERROR) {
-      emit('state', {
-        hasData,
-        state: 'error',
-      })
-
-      return
-    }
-
-    emit('state', {
-      hasData,
-      state: 'success',
-    })
-  },
-  { immediate: true },
-)
+useEmitState({
+  emitState: payload => emit('state', payload),
+  fetchLifecycleState,
+  hasData,
+})
 
 const onGridReady = (event: GridReadyEvent<Row>) => {
   emit('grid:ready', event.api)

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -11,8 +11,8 @@
       <slot name="error-state">
         <KEmptyState
           icon-variant="error"
-          message="Data cannot be displayed due to an error."
-          title="An error occurred"
+          :message="t('errorState.message')"
+          :title="t('errorState.title')"
         />
       </slot>
     </div>
@@ -24,8 +24,8 @@
     >
       <slot name="empty-state">
         <KEmptyState
-          message="There is no data to display."
-          title="No Data"
+          :message="t('emptyState.message')"
+          :title="t('emptyState.title')"
         />
       </slot>
     </div>
@@ -64,6 +64,7 @@ import {
 import { computed } from 'vue'
 import { useEmitState } from '../composables/useEmitState'
 import { useFetchInfinite } from '../composables/useFetchInfinite'
+import useI18n from '../composables/useI18n'
 import useFetchState from '../composables/useFetchState'
 
 ModuleRegistry.registerModules([AllCommunityModule, InfiniteRowModelModule])
@@ -91,6 +92,8 @@ const emit = defineEmits<{
   (e: 'grid:ready', api: GridReadyEvent<Row>['api']): void
   (e: 'state', payload: TableDataGridStatePayload): void
 }>()
+
+const { i18n: { t } } = useI18n()
 
 const defaultColDef: ColDef<Row> = {
   resizable: false,

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -101,6 +101,7 @@ const defaultColDef: ColDef<Row> = {
 const columnDefs = computed<Array<ColDef<Row>>>(() => headers.map((header) => {
   const columnDef: ColDef<Row> = {
     colId: header.key,
+    flex: !header.width && !header.maxWidth ? 1 : undefined,
     headerName: header.label,
     maxWidth: header.maxWidth,
     minWidth: header.minWidth,

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -36,7 +36,7 @@
       class="table-data-grid-grid"
       :column-defs="columnDefs"
       :datasource="datasource"
-      :grid-options="agGridOptions"
+      :default-col-def="defaultColDef"
       :infinite-initial-row-count="1"
       :loading="isFetching"
       row-model-type="infinite"
@@ -50,7 +50,6 @@
 <script setup lang="ts" generic="Row extends object">
 import type {
   TableDataGridFetcher,
-  TableDataGridGridOptions,
   TableDataGridHeader,
   TableDataGridStatePayload,
 } from '../types'
@@ -70,7 +69,6 @@ import useFetchState from '../composables/useFetchState'
 ModuleRegistry.registerModules([AllCommunityModule, InfiniteRowModelModule])
 
 const {
-  agGridOptions = {},
   error: hostError = false,
   fetcher,
   headers,
@@ -82,7 +80,6 @@ const {
   error?: boolean
   pageSize?: number
   refreshKey?: string | number | boolean
-  agGridOptions?: TableDataGridGridOptions<Row>
 }>()
 
 defineSlots<{
@@ -94,6 +91,12 @@ const emit = defineEmits<{
   (e: 'grid:ready', api: GridReadyEvent<Row>['api']): void
   (e: 'state', payload: TableDataGridStatePayload): void
 }>()
+
+const defaultColDef: ColDef<Row> = {
+  resizable: false,
+  sortable: false,
+  suppressMovable: true,
+}
 
 const columnDefs = computed<Array<ColDef<Row>>>(() => headers.map((header) => {
   const columnDef: ColDef<Row> = {

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -17,12 +17,6 @@
       </slot>
     </div>
 
-    <KSkeleton
-      v-else-if="loading"
-      data-testid="table-data-grid-loading"
-      type="table"
-    />
-
     <div
       v-else-if="shouldShowEmptyState"
       class="table-empty-state"
@@ -58,7 +52,6 @@ import type {
   TableDataGridFetcher,
   TableDataGridGridOptions,
   TableDataGridHeader,
-  TableDataGridState,
   TableDataGridStatePayload,
 } from '../types'
 import type { ColDef, GridReadyEvent } from 'ag-grid-community'
@@ -80,13 +73,11 @@ const {
   error: hostError = false,
   fetcher,
   headers,
-  loading = false,
   pageSize = 25,
   refreshKey,
 } = defineProps<{
   headers: Array<TableDataGridHeader<Row>>
   fetcher: TableDataGridFetcher<Row>
-  loading?: boolean
   error?: boolean
   pageSize?: number
   refreshKey?: string | number | boolean
@@ -133,28 +124,8 @@ const {
   state: fetchLifecycleState,
 } = useFetchState(data, fetchError, isFetching)
 
-const publicState = computed<TableDataGridState>(() => {
-  if (hostError) {
-    return 'error'
-  }
-
-  if (
-    loading
-    || fetchLifecycleState.value === fetchState.PENDING
-    || fetchLifecycleState.value === fetchState.LOADING
-  ) {
-    return 'loading'
-  }
-
-  if (fetchLifecycleState.value === fetchState.ERROR) {
-    return 'error'
-  }
-
-  return 'success'
-})
-
 const shouldShowEmptyState = computed<boolean>(() => (
-  publicState.value === 'success'
+  fetchLifecycleState.value === fetchState.SUCCESS
   && data.value !== undefined
   && !hasData.value
 ))
@@ -162,9 +133,46 @@ const shouldShowEmptyState = computed<boolean>(() => (
 watch(
   () => ({
     hasData: hasData.value,
-    state: publicState.value,
+    hostError,
+    state: fetchLifecycleState.value,
   }),
-  payload => emit('state', payload),
+  ({ hasData, hostError, state }) => {
+    if (hostError) {
+      emit('state', {
+        hasData,
+        state: 'error',
+      })
+
+      return
+    }
+
+    if (state === fetchState.PENDING) {
+      return
+    }
+
+    if (state === fetchState.LOADING) {
+      emit('state', {
+        hasData,
+        state: 'loading',
+      })
+
+      return
+    }
+
+    if (state === fetchState.ERROR) {
+      emit('state', {
+        hasData,
+        state: 'error',
+      })
+
+      return
+    }
+
+    emit('state', {
+      hasData,
+      state: 'success',
+    })
+  },
   { immediate: true },
 )
 

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -67,7 +67,6 @@ const fetchRows = async () => {
   try {
     const result = await fetcher({
       mode: 'infinite',
-      offset: 0,
       pageSize,
     })
 

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -101,6 +101,7 @@ const defaultColDef: ColDef<Row> = {
 const columnDefs = computed<Array<ColDef<Row>>>(() => headers.map((header) => {
   const columnDef: ColDef<Row> = {
     colId: header.key,
+    // Headers without explicit width constraints should fill available space.
     flex: !header.width && !header.maxWidth ? 1 : undefined,
     headerName: header.label,
     maxWidth: header.maxWidth,

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -127,7 +127,6 @@ const {
 
 const shouldShowEmptyState = computed<boolean>(() => (
   fetchLifecycleState.value === fetchState.SUCCESS
-  && data.value !== undefined
   && !hasData.value
 ))
 

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -117,14 +117,13 @@ const columnDefs = computed<Array<ColDef<Row>>>(() => headers.map((header) => {
 }))
 
 const resetKey = computed(() => [fetcher, pageSize, refreshKey])
-const fetchRows: TableDataGridFetcher<Row> = params => fetcher(params)
 const {
   data,
   datasource,
   error: fetchError,
   isFetching,
 } = useFetchInfinite({
-  fetcher: fetchRows,
+  fetcher,
   resetKey,
 })
 

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -3,7 +3,41 @@
     class="kong-ui-public-table-data-grid"
     data-testid="table-data-grid"
   >
+    <div
+      v-if="hostError"
+      class="table-error-state"
+      data-testid="table-error-state"
+    >
+      <slot name="error-state">
+        <KEmptyState
+          icon-variant="error"
+          message="Data cannot be displayed due to an error."
+          title="An error occurred"
+        />
+      </slot>
+    </div>
+
+    <KSkeleton
+      v-else-if="loading"
+      data-testid="table-data-grid-loading"
+      type="table"
+    />
+
+    <div
+      v-else-if="shouldShowEmptyState"
+      class="table-empty-state"
+      data-testid="table-empty-state"
+    >
+      <slot name="empty-state">
+        <KEmptyState
+          message="There is no data to display."
+          title="No Data"
+        />
+      </slot>
+    </div>
+
     <AgGridVue
+      v-else
       :cache-block-size="pageSize"
       class="table-data-grid-grid"
       :column-defs="columnDefs"
@@ -24,6 +58,8 @@ import type {
   TableDataGridFetcher,
   TableDataGridGridOptions,
   TableDataGridHeader,
+  TableDataGridState,
+  TableDataGridStatePayload,
 } from '../types'
 import type { ColDef, GridReadyEvent } from 'ag-grid-community'
 import { AgGridVue } from 'ag-grid-vue3'
@@ -33,7 +69,7 @@ import {
   ModuleRegistry,
   themeQuartz,
 } from 'ag-grid-community'
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useFetchInfinite } from '../composables/useFetchInfinite'
 import useFetchState from '../composables/useFetchState'
 
@@ -41,20 +77,30 @@ ModuleRegistry.registerModules([AllCommunityModule, InfiniteRowModelModule])
 
 const {
   agGridOptions = {},
+  error: hostError = false,
   fetcher,
   headers,
+  loading = false,
   pageSize = 25,
   refreshKey,
 } = defineProps<{
   headers: Array<TableDataGridHeader<Row>>
   fetcher: TableDataGridFetcher<Row>
+  loading?: boolean
+  error?: boolean
   pageSize?: number
   refreshKey?: string | number | boolean
   agGridOptions?: TableDataGridGridOptions<Row>
 }>()
 
+defineSlots<{
+  'empty-state': () => unknown
+  'error-state': () => unknown
+}>()
+
 const emit = defineEmits<{
   (e: 'grid:ready', api: GridReadyEvent<Row>['api']): void
+  (e: 'state', payload: TableDataGridStatePayload): void
 }>()
 
 const columnDefs = computed<Array<ColDef<Row>>>(() => headers.map((header) => {
@@ -75,14 +121,53 @@ const fetchRows: TableDataGridFetcher<Row> = params => fetcher(params)
 const {
   data,
   datasource,
-  error,
+  error: fetchError,
   isFetching,
 } = useFetchInfinite({
   fetcher: fetchRows,
   resetKey,
 })
 
-useFetchState(data, error, isFetching)
+const {
+  fetchState,
+  hasData,
+  state: fetchLifecycleState,
+} = useFetchState(data, fetchError, isFetching)
+
+const publicState = computed<TableDataGridState>(() => {
+  if (hostError) {
+    return 'error'
+  }
+
+  if (
+    loading
+    || fetchLifecycleState.value === fetchState.PENDING
+    || fetchLifecycleState.value === fetchState.LOADING
+  ) {
+    return 'loading'
+  }
+
+  if (fetchLifecycleState.value === fetchState.ERROR) {
+    return 'error'
+  }
+
+  return 'success'
+})
+
+const shouldShowEmptyState = computed<boolean>(() => (
+  publicState.value === 'success'
+  && data.value !== undefined
+  && !hasData.value
+))
+
+watch(
+  () => ({
+    hasData: hasData.value,
+    state: publicState.value,
+  }),
+  payload => emit('state', payload),
+  { immediate: true },
+)
 
 const onGridReady = (event: GridReadyEvent<Row>) => {
   emit('grid:ready', event.api)

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -4,10 +4,14 @@
     data-testid="table-data-grid"
   >
     <AgGridVue
+      :cache-block-size="pageSize"
       class="table-data-grid-grid"
       :column-defs="columnDefs"
+      :datasource="datasource"
       :grid-options="agGridOptions"
-      :row-data="rowData"
+      :infinite-initial-row-count="1"
+      :loading="isFetching"
+      row-model-type="infinite"
       :suppress-cell-focus="true"
       :theme="themeQuartz"
       @grid-ready="onGridReady"
@@ -23,29 +27,35 @@ import type {
 } from '../types'
 import type { ColDef, GridReadyEvent } from 'ag-grid-community'
 import { AgGridVue } from 'ag-grid-vue3'
-import { AllCommunityModule, ModuleRegistry, themeQuartz } from 'ag-grid-community'
-import { computed, ref, shallowRef, toRef, watch } from 'vue'
+import {
+  AllCommunityModule,
+  InfiniteRowModelModule,
+  ModuleRegistry,
+  themeQuartz,
+} from 'ag-grid-community'
+import { computed } from 'vue'
+import { useFetchInfinite } from '../composables/useFetchInfinite'
+import useFetchState from '../composables/useFetchState'
 
-ModuleRegistry.registerModules([AllCommunityModule])
+ModuleRegistry.registerModules([AllCommunityModule, InfiniteRowModelModule])
 
 const {
   agGridOptions = {},
   fetcher,
   headers,
   pageSize = 25,
+  refreshKey,
 } = defineProps<{
   headers: Array<TableDataGridHeader<Row>>
   fetcher: TableDataGridFetcher<Row>
   pageSize?: number
+  refreshKey?: string | number | boolean
   agGridOptions?: TableDataGridGridOptions<Row>
 }>()
 
 const emit = defineEmits<{
   (e: 'grid:ready', api: GridReadyEvent<Row>['api']): void
 }>()
-
-const rowData = shallowRef<Row[]>([])
-const latestFetchId = ref(0)
 
 const columnDefs = computed<Array<ColDef<Row>>>(() => headers.map((header) => {
   const columnDef: ColDef<Row> = {
@@ -60,41 +70,23 @@ const columnDefs = computed<Array<ColDef<Row>>>(() => headers.map((header) => {
   return columnDef
 }))
 
-const fetchRows = async () => {
-  const fetchId = latestFetchId.value + 1
-  latestFetchId.value = fetchId
+const resetKey = computed(() => [fetcher, pageSize, refreshKey])
+const fetchRows: TableDataGridFetcher<Row> = params => fetcher(params)
+const {
+  data,
+  datasource,
+  error,
+  isFetching,
+} = useFetchInfinite({
+  fetcher: fetchRows,
+  resetKey,
+})
 
-  try {
-    const result = await fetcher({
-      mode: 'infinite',
-      pageSize,
-    })
-
-    if (fetchId === latestFetchId.value) {
-      rowData.value = result.data
-    }
-  } catch (error) {
-    if (fetchId === latestFetchId.value) {
-      rowData.value = []
-    }
-    console.error(error)
-  }
-}
+useFetchState(data, error, isFetching)
 
 const onGridReady = (event: GridReadyEvent<Row>) => {
   emit('grid:ready', event.api)
 }
-
-watch(
-  [
-    toRef(() => fetcher),
-    toRef(() => pageSize),
-  ],
-  () => {
-    fetchRows()
-  },
-  { immediate: true },
-)
 </script>
 
 <style lang="scss" scoped>

--- a/packages/core/table-data-grid/src/composables/useEmitState.spec.ts
+++ b/packages/core/table-data-grid/src/composables/useEmitState.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { useEmitState } from './useEmitState'
+import { fetchState } from './useFetchState'
+
+describe('useEmitState', () => {
+  it('skips pending state and emits public fetch states', async () => {
+    const emitState = vi.fn()
+    const hasData = ref(false)
+    const fetchLifecycleState = ref(fetchState.PENDING)
+
+    useEmitState({
+      emitState,
+      fetchLifecycleState,
+      hasData,
+    })
+
+    expect(emitState).not.toHaveBeenCalled()
+
+    fetchLifecycleState.value = fetchState.LOADING
+    await nextTick()
+    expect(emitState).toHaveBeenLastCalledWith({
+      hasData: false,
+      state: 'loading',
+    })
+
+    hasData.value = true
+    fetchLifecycleState.value = fetchState.SUCCESS
+    await nextTick()
+    expect(emitState).toHaveBeenLastCalledWith({
+      hasData: true,
+      state: 'success',
+    })
+
+    fetchLifecycleState.value = fetchState.ERROR
+    await nextTick()
+    expect(emitState).toHaveBeenLastCalledWith({
+      hasData: true,
+      state: 'error',
+    })
+  })
+
+  it('does not emit the current state during setup', () => {
+    const emitState = vi.fn()
+    const hasData = ref(true)
+    const fetchLifecycleState = ref(fetchState.SUCCESS)
+
+    useEmitState({
+      emitState,
+      fetchLifecycleState,
+      hasData,
+    })
+
+    expect(emitState).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/table-data-grid/src/composables/useEmitState.ts
+++ b/packages/core/table-data-grid/src/composables/useEmitState.ts
@@ -1,0 +1,51 @@
+import type { TableDataGridStatePayload } from '../types'
+import type { Ref } from 'vue'
+import { watch } from 'vue'
+import { fetchState } from './useFetchState'
+
+type UseEmitStateOptions = {
+  emitState: (payload: TableDataGridStatePayload) => void
+  fetchLifecycleState: Readonly<Ref<fetchState>>
+  hasData: Readonly<Ref<boolean>>
+}
+
+export const useEmitState = ({
+  emitState,
+  fetchLifecycleState,
+  hasData,
+}: UseEmitStateOptions) => {
+  watch(
+    () => ({
+      hasData: hasData.value,
+      state: fetchLifecycleState.value,
+    }),
+    ({ hasData, state }) => {
+      if (state === fetchState.PENDING) {
+        return
+      }
+
+      if (state === fetchState.LOADING) {
+        emitState({
+          hasData,
+          state: 'loading',
+        })
+
+        return
+      }
+
+      if (state === fetchState.ERROR) {
+        emitState({
+          hasData,
+          state: 'error',
+        })
+
+        return
+      }
+
+      emitState({
+        hasData,
+        state: 'success',
+      })
+    },
+  )
+}

--- a/packages/core/table-data-grid/src/composables/useFetchInfinite.spec.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchInfinite.spec.ts
@@ -220,7 +220,7 @@ describe('useFetchInfinite', () => {
 
     expect(staleSuccessCallback).not.toHaveBeenCalled()
     expect(staleFailCallback).not.toHaveBeenCalled()
-    expect(data.value).toEqual([])
+    expect(data.value).toBeUndefined()
     expect(error.value).toBeUndefined()
     expect(isFetching.value).toBe(true)
 

--- a/packages/core/table-data-grid/src/composables/useFetchInfinite.spec.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchInfinite.spec.ts
@@ -1,0 +1,238 @@
+import type { TableDataGridFetcher } from '../types'
+import type { IDatasource, IGetRowsParams } from 'ag-grid-community'
+import { describe, expect, it, vi } from 'vitest'
+import { isReadonly, nextTick, ref } from 'vue'
+import { useFetchInfinite } from './useFetchInfinite'
+
+type TestRow = {
+  id: string
+}
+
+const createRows = (prefix: string, length: number): TestRow[] => (
+  Array.from({ length }, (_, index) => ({ id: `${prefix}-${index + 1}` }))
+)
+
+const createDeferred = <Value>() => {
+  let deferredResolve!: (value: Value) => void
+  let deferredReject!: (reason?: unknown) => void
+  const promise = new Promise<Value>((resolve, reject) => {
+    deferredResolve = resolve
+    deferredReject = reject
+  })
+
+  return {
+    promise,
+    reject: deferredReject,
+    resolve: deferredResolve,
+  }
+}
+
+const createGetRowsParams = ({
+  endRow,
+  failCallback = vi.fn(),
+  startRow,
+  successCallback = vi.fn(),
+}: {
+  endRow: number
+  failCallback?: IGetRowsParams['failCallback']
+  startRow: number
+  successCallback?: IGetRowsParams['successCallback']
+}): IGetRowsParams => ({
+  context: undefined,
+  endRow,
+  failCallback,
+  filterModel: undefined,
+  sortModel: [],
+  startRow,
+  successCallback,
+})
+
+const expectDatasource = (datasource: IDatasource | undefined): IDatasource => {
+  expect(datasource).toBeDefined()
+
+  return datasource as IDatasource
+}
+
+const getDatasourceRows = async (
+  datasource: IDatasource,
+  range: { endRow: number, startRow: number },
+): Promise<{ lastRow?: number, rows: TestRow[] }> => new Promise((resolve, reject) => {
+  datasource.getRows(createGetRowsParams({
+    ...range,
+    failCallback: reject,
+    successCallback: (rowsThisBlock, lastRow) => {
+      resolve({
+        lastRow,
+        rows: rowsThisBlock as TestRow[],
+      })
+    },
+  }))
+})
+
+const createInfiniteFetch = (fetcher: TableDataGridFetcher<TestRow>) => {
+  const resetKey = ref(0)
+  const infiniteFetch = useFetchInfinite({
+    fetcher,
+    resetKey,
+  })
+
+  return {
+    ...infiniteFetch,
+    resetKey,
+  }
+}
+
+describe('useFetchInfinite', () => {
+  it('returns readonly fetch state refs', () => {
+    const fetcher = vi.fn().mockResolvedValue({ data: [] })
+    const { data, datasource, error, isFetching } = createInfiniteFetch(fetcher)
+
+    expect(isReadonly(data)).toBe(true)
+    expect(isReadonly(datasource)).toBe(true)
+    expect(isReadonly(error)).toBe(true)
+    expect(isReadonly(isFetching)).toBe(true)
+  })
+
+  it('uses the previous block cursor when fetching the next block', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ data: [{ id: 'one' }], cursor: 'cursor-1', hasMore: true })
+      .mockResolvedValueOnce({ data: [{ id: 'two' }], hasMore: false })
+    const { data, datasource } = createInfiniteFetch(fetcher)
+    const activeDatasource = expectDatasource(datasource.value)
+
+    const firstBlock = await getDatasourceRows(activeDatasource, { startRow: 0, endRow: 100 })
+    const secondBlock = await getDatasourceRows(activeDatasource, { startRow: 100, endRow: 200 })
+
+    expect(fetcher).toHaveBeenNthCalledWith(1, {
+      mode: 'infinite',
+      pageSize: 100,
+      cursor: undefined,
+    })
+    expect(fetcher).toHaveBeenNthCalledWith(2, {
+      mode: 'infinite',
+      pageSize: 100,
+      cursor: 'cursor-1',
+    })
+    expect(firstBlock.rows).toEqual([{ id: 'one' }])
+    expect(firstBlock.lastRow).toBeUndefined()
+    expect(secondBlock.rows).toEqual([{ id: 'two' }])
+    expect(secondBlock.lastRow).toBe(101)
+    expect(data.value).toEqual([{ id: 'one' }])
+  })
+
+  it('fails an out-of-order block until the previous block completes, then allows retry', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ data: createRows('block-1', 15), cursor: 'cursor-1', hasMore: true })
+      .mockResolvedValueOnce({ data: createRows('block-2', 15), hasMore: false })
+    const { datasource } = createInfiniteFetch(fetcher)
+    const activeDatasource = expectDatasource(datasource.value)
+    const failCallback = vi.fn()
+
+    // AG Grid can request block 0, then determine it should load block 1 before
+    // block 0 resolves due to viewport size, row buffering, scroll position, or
+    // cache preloading. Cursor-backed APIs need block 0's response cursor before
+    // fetching block 1, so fail this attempt and let AG Grid retry after the
+    // prior block completes.
+    await (activeDatasource.getRows(createGetRowsParams({
+      startRow: 15,
+      endRow: 30,
+      failCallback,
+    })) as Promise<void>)
+
+    expect(fetcher).not.toHaveBeenCalled()
+    expect(failCallback).toHaveBeenCalledOnce()
+
+    await getDatasourceRows(activeDatasource, { startRow: 0, endRow: 15 })
+    const secondBlock = await getDatasourceRows(activeDatasource, { startRow: 15, endRow: 30 })
+
+    expect(fetcher).toHaveBeenNthCalledWith(2, {
+      mode: 'infinite',
+      pageSize: 15,
+      cursor: 'cursor-1',
+    })
+    expect(secondBlock.lastRow).toBe(30)
+  })
+
+  it('continues sequential infinite fetches when the previous cursor is undefined', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ data: createRows('block-1', 15), cursor: undefined, hasMore: true })
+      .mockResolvedValueOnce({ data: createRows('block-2', 15), hasMore: false })
+    const { datasource } = createInfiniteFetch(fetcher)
+    const activeDatasource = expectDatasource(datasource.value)
+
+    await getDatasourceRows(activeDatasource, { startRow: 0, endRow: 15 })
+    await getDatasourceRows(activeDatasource, { startRow: 15, endRow: 30 })
+
+    expect(fetcher).toHaveBeenNthCalledWith(2, {
+      mode: 'infinite',
+      pageSize: 15,
+      cursor: undefined,
+    })
+  })
+
+  it('tracks failures and calls AG Grid failCallback', async () => {
+    const thrownError = new Error('failed')
+    const fetcher = vi.fn().mockRejectedValue(thrownError)
+    const { datasource, error, isFetching } = createInfiniteFetch(fetcher)
+    const activeDatasource = expectDatasource(datasource.value)
+    const failCallback = vi.fn()
+
+    await (activeDatasource.getRows(createGetRowsParams({
+      startRow: 0,
+      endRow: 15,
+      failCallback,
+    })) as Promise<void>)
+
+    expect(failCallback).toHaveBeenCalledOnce()
+    expect(error.value).toBe(thrownError)
+    expect(isFetching.value).toBe(false)
+  })
+
+  it('ignores stale datasource results after resetKey changes', async () => {
+    const staleRequest = createDeferred<{ data: TestRow[], cursor: string, hasMore: boolean }>()
+    const latestRequest = createDeferred<{ data: TestRow[], cursor: string, hasMore: boolean }>()
+    const fetcher = vi.fn()
+      .mockReturnValueOnce(staleRequest.promise)
+      .mockReturnValueOnce(latestRequest.promise)
+    const { data, datasource, error, isFetching, resetKey } = createInfiniteFetch(fetcher)
+    const staleDatasource = expectDatasource(datasource.value)
+    const staleSuccessCallback = vi.fn()
+    const staleFailCallback = vi.fn()
+    const staleGetRows = staleDatasource.getRows(createGetRowsParams({
+      startRow: 0,
+      endRow: 15,
+      successCallback: staleSuccessCallback,
+      failCallback: staleFailCallback,
+    })) as Promise<void>
+
+    resetKey.value += 1
+    await nextTick()
+
+    const latestDatasource = expectDatasource(datasource.value)
+    const latestRows = getDatasourceRows(latestDatasource, { startRow: 0, endRow: 15 })
+
+    staleRequest.resolve({
+      data: createRows('stale-block', 15),
+      cursor: 'stale-cursor',
+      hasMore: true,
+    })
+    await staleGetRows
+
+    expect(staleSuccessCallback).not.toHaveBeenCalled()
+    expect(staleFailCallback).not.toHaveBeenCalled()
+    expect(data.value).toEqual([])
+    expect(error.value).toBeUndefined()
+    expect(isFetching.value).toBe(true)
+
+    latestRequest.resolve({
+      data: createRows('latest-block', 15),
+      cursor: 'latest-cursor',
+      hasMore: false,
+    })
+    const latestBlock = await latestRows
+
+    expect(latestBlock.rows).toEqual(createRows('latest-block', 15))
+    expect(data.value).toEqual(createRows('latest-block', 15))
+    expect(isFetching.value).toBe(false)
+  })
+})

--- a/packages/core/table-data-grid/src/composables/useFetchInfinite.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchInfinite.ts
@@ -37,11 +37,20 @@ interface UseFetchInfiniteOptions<Row extends object = TableDataGridRow> {
  * block completion gates, pending counts, and stale datasource guards stay
  * private to this composable so component code cannot mutate fetch lifecycle
  * state directly.
+ *
+ * @param fetcher Host-supplied fetcher that uses TableDataGrid's cursor-first
+ * infinite mode contract.
+ * @param resetKey Optional reactive invalidation key that rebuilds the
+ * datasource and restarts the cursor chain.
+ * @returns Readonly datasource, first-block data, error, and fetching state
+ * refs for the active AG Grid infinite datasource.
  */
 export const useFetchInfinite = <Row extends object = TableDataGridRow>({
   fetcher,
   resetKey,
 }: UseFetchInfiniteOptions<Row>) => {
+  // AG Grid thinks in row ranges; the public TableDataGrid fetcher thinks in a
+  // cursor chain. These maps keep that translation internal to the datasource.
   const cursorMap = new Map<number, unknown>()
   const blockCompletionMap = new Map<number, BlockCompletion>()
   const latestDatasourceId = ref(0)
@@ -76,6 +85,8 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
       return existingCompletion
     }
 
+    // Later blocks await this promise so they do not call a cursor-backed API
+    // before the previous block has had a chance to return its next cursor.
     let resolveCurrentBlock!: (completed: boolean) => void
     const completion: BlockCompletion = {
       promise: new Promise<boolean>((resolve) => {
@@ -96,6 +107,21 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
     }
   }
 
+  /**
+   * Gates later blocks on the previous block's completion.
+   *
+   * Cursor-backed blocks are sequential even if AG Grid requests them
+   * concurrently. A later block can only fetch after the previous block has
+   * either produced the cursor it needs or failed.
+   *
+   * @param blockIndex Current AG Grid block index derived from the row range.
+   * @param currentBlockCompletion Completion gate registered for the current
+   * block.
+   * @param datasourceId Identifier for the datasource instance that started the
+   * request.
+   * @returns Whether the current block is ready to fetch, failed dependency
+   * gating, or became stale after a datasource reset.
+   */
   const waitForPreviousBlockCompletion = async ({
     blockIndex,
     currentBlockCompletion,
@@ -105,15 +131,15 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
     currentBlockCompletion: BlockCompletion
     datasourceId: number
   }): Promise<InfiniteBlockGateResult> => {
-    // Cursor-backed blocks are sequential even if AG Grid requests them
-    // concurrently. A later block can only fetch after the previous block has
-    // either produced the cursor it needs or failed.
     if (blockIndex === 0) {
       return 'ready'
     }
 
     const previousBlockCompletion = blockCompletionMap.get(blockIndex - 1)
     if (!previousBlockCompletion) {
+      // AG Grid can ask for block N before it has asked for block N - 1. That
+      // is valid for range-based APIs, but not for a cursor chain, so fail this
+      // attempt and let AG Grid retry according to its normal block policy.
       rejectBlockCompletion(blockIndex, currentBlockCompletion)
       return 'failed'
     }
@@ -132,6 +158,22 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
     return 'ready'
   }
 
+  /**
+   * Completes AG Grid's datasource request for a successfully fetched block.
+   *
+   * The cursor is stored on the block that produced it so the next block can
+   * continue the chain, while AG Grid receives only rows and its `lastRow`
+   * signal through `successCallback`.
+   *
+   * @param blockIndex Current AG Grid block index derived from the row range.
+   * @param currentBlockCompletion Completion gate registered for the current
+   * block.
+   * @param getRowsParams AG Grid datasource request parameters and callbacks.
+   * @param pageSize Requested block size derived from AG Grid's row range.
+   * @param result Rows and pagination metadata returned by the TableDataGrid
+   * fetcher.
+   * @returns Nothing. Completes the AG Grid datasource request via callback.
+   */
   const handleSuccessfulBlock = ({
     blockIndex,
     currentBlockCompletion,
@@ -151,6 +193,9 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
       cursorMap.set(blockIndex, result.cursor)
     }
 
+    // AG Grid only considers this block loaded after one datasource callback is
+    // invoked. `lastRow` is optional; undefined means the grid may ask for the
+    // next block later.
     getRowsParams.successCallback(result.data, resolveInfiniteLastRow({
       startRow: getRowsParams.startRow,
       rowsLength: result.data.length,
@@ -159,12 +204,27 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
       hasMore: result.hasMore,
     }))
 
+    // The first block is enough for component-level empty/data state. Later
+    // blocks are owned by AG Grid's row cache and should not replace that state.
     if (getRowsParams.startRow === 0) {
       data.value = result.data
     }
     currentBlockCompletion.resolve(true)
   }
 
+  /**
+   * Completes AG Grid's datasource request for a failed block.
+   *
+   * Failed blocks must unblock any dependent later block and notify AG Grid
+   * through its datasource callback so it can retry according to grid policy.
+   *
+   * @param blockIndex Current AG Grid block index derived from the row range.
+   * @param currentBlockCompletion Completion gate registered for the current
+   * block.
+   * @param fetchError Error thrown by the TableDataGrid fetcher.
+   * @param getRowsParams AG Grid datasource request parameters and callbacks.
+   * @returns Nothing. Completes the AG Grid datasource request via callback.
+   */
   const handleFailedBlock = ({
     blockIndex,
     currentBlockCompletion,
@@ -176,17 +236,21 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
     fetchError: unknown
     getRowsParams: IGetRowsParams
   }) => {
-    // Failed blocks must unblock any dependent later block and notify AG Grid
-    // through its datasource callback so it can retry according to grid policy.
     error.value = fetchError
     getRowsParams.failCallback()
     rejectBlockCompletion(blockIndex, currentBlockCompletion)
   }
 
+  /**
+   * Creates a new AG Grid datasource and resets cursor-chain state.
+   *
+   * A new datasource is a fresh cursor chain. Incrementing the id lets in-flight
+   * requests from an older datasource resolve without mutating current state or
+   * calling callbacks on the replaced datasource.
+   *
+   * @returns AG Grid datasource for the latest cursor chain.
+   */
   const buildDatasource = (): IDatasource => {
-    // A new datasource is a fresh cursor chain. Incrementing the id lets
-    // in-flight requests from an older datasource resolve without mutating the
-    // current state or calling callbacks on the replaced datasource.
     const datasourceId = latestDatasourceId.value + 1
     latestDatasourceId.value = datasourceId
     cursorMap.clear()
@@ -209,6 +273,8 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
           endRow: getRowsParams.endRow,
         })
 
+        // Register the current block before waiting so any following block can
+        // find a completion promise instead of treating this request as missing.
         const currentBlockCompletion = createBlockCompletion(blockIndex)
         const blockGateResult = await waitForPreviousBlockCompletion({
           blockIndex,
@@ -226,6 +292,12 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
 
         markFetchStarted()
         try {
+          // AG Grid schedules blocks by row range, so `blockIndex` is this
+          // composable's range-to-cursor bridge: range 0-25 maps to block 0,
+          // range 25-50 maps to block 1, and so on. Block 0 starts the public
+          // fetcher with no cursor. Every later block reads the cursor stored
+          // for the previous block, because that previous AG Grid range is what
+          // produced the backend cursor needed to continue the chain.
           const cursor = blockIndex > 0 ? cursorMap.get(blockIndex - 1) : undefined
           const result = await fetcher({
             mode: 'infinite',
@@ -234,6 +306,8 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
           })
 
           if (!isLatestDatasource(datasourceId)) {
+            // A reset replaced the datasource while this request was in flight.
+            // Do not call callbacks on the old datasource or mutate current state.
             rejectBlockCompletion(blockIndex, currentBlockCompletion)
             return
           }
@@ -247,6 +321,8 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
           })
         } catch (fetchError) {
           if (!isLatestDatasource(datasourceId)) {
+            // The latest datasource will issue its own requests; the stale
+            // failure should not surface as a current-grid error.
             rejectBlockCompletion(blockIndex, currentBlockCompletion)
             return
           }

--- a/packages/core/table-data-grid/src/composables/useFetchInfinite.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchInfinite.ts
@@ -46,7 +46,7 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
   const blockCompletionMap = new Map<number, BlockCompletion>()
   const latestDatasourceId = ref(0)
   const datasource = shallowRef<IDatasource>()
-  const data = shallowRef<Row[]>([])
+  const data = shallowRef<Row[] | undefined>()
   const error = shallowRef<unknown>()
   const pendingFetchCount = ref(0)
   const isFetching = ref(false)
@@ -191,7 +191,7 @@ export const useFetchInfinite = <Row extends object = TableDataGridRow>({
     latestDatasourceId.value = datasourceId
     cursorMap.clear()
     blockCompletionMap.clear()
-    data.value = []
+    data.value = undefined
     error.value = undefined
     pendingFetchCount.value = 0
     syncIsFetching()

--- a/packages/core/table-data-grid/src/composables/useFetchInfinite.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchInfinite.ts
@@ -1,0 +1,291 @@
+import type {
+  TableDataGridFetcher,
+  TableDataGridFetcherResult,
+  TableDataGridRow,
+} from '../types'
+import type { IDatasource, IGetRowsParams } from 'ag-grid-community'
+import type { Ref } from 'vue'
+import { readonly, ref, shallowRef, watch } from 'vue'
+import { getCursorBlock, resolveInfiniteLastRow } from '../utils/fetchers'
+
+type BlockCompletion = {
+  promise: Promise<boolean>
+  resolve: (completed: boolean) => void
+}
+
+type InfiniteBlockGateResult = 'ready' | 'failed' | 'stale'
+
+interface UseFetchInfiniteOptions<Row extends object = TableDataGridRow> {
+  /**
+   * Public row fetcher supplied by the host. The composable keeps AG Grid row
+   * ranges internal and calls this with the cursor-first TableDataGrid contract.
+   */
+  fetcher: TableDataGridFetcher<Row>
+  /**
+   * Reactive invalidation input from the component layer. Any change rebuilds
+   * the datasource and clears cursor/block state back to block 0.
+   */
+  resetKey?: Readonly<Ref<unknown>>
+}
+
+/**
+ * Owns AG Grid infinite datasource creation and cursor-backed fetch
+ * orchestration for TableDataGrid.
+ *
+ * Callers provide the public fetcher and an optional reset key, then observe
+ * readonly fetch state and pass the returned datasource to AG Grid. Cursor maps,
+ * block completion gates, pending counts, and stale datasource guards stay
+ * private to this composable so component code cannot mutate fetch lifecycle
+ * state directly.
+ */
+export const useFetchInfinite = <Row extends object = TableDataGridRow>({
+  fetcher,
+  resetKey,
+}: UseFetchInfiniteOptions<Row>) => {
+  const cursorMap = new Map<number, unknown>()
+  const blockCompletionMap = new Map<number, BlockCompletion>()
+  const latestDatasourceId = ref(0)
+  const datasource = shallowRef<IDatasource>()
+  const data = shallowRef<Row[]>([])
+  const error = shallowRef<unknown>()
+  const pendingFetchCount = ref(0)
+  const isFetching = ref(false)
+
+  const isLatestDatasource = (datasourceId: number): boolean => (
+    datasourceId === latestDatasourceId.value
+  )
+
+  const syncIsFetching = () => {
+    isFetching.value = pendingFetchCount.value > 0
+  }
+
+  const markFetchStarted = () => {
+    error.value = undefined
+    pendingFetchCount.value += 1
+    syncIsFetching()
+  }
+
+  const markFetchFinished = () => {
+    pendingFetchCount.value = Math.max(0, pendingFetchCount.value - 1)
+    syncIsFetching()
+  }
+
+  const createBlockCompletion = (blockIndex: number): BlockCompletion => {
+    const existingCompletion = blockCompletionMap.get(blockIndex)
+    if (existingCompletion) {
+      return existingCompletion
+    }
+
+    let resolveCurrentBlock!: (completed: boolean) => void
+    const completion: BlockCompletion = {
+      promise: new Promise<boolean>((resolve) => {
+        resolveCurrentBlock = resolve
+      }),
+      resolve: completed => resolveCurrentBlock(completed),
+    }
+
+    blockCompletionMap.set(blockIndex, completion)
+
+    return completion
+  }
+
+  const rejectBlockCompletion = (blockIndex: number, completion: BlockCompletion) => {
+    completion.resolve(false)
+    if (blockCompletionMap.get(blockIndex) === completion) {
+      blockCompletionMap.delete(blockIndex)
+    }
+  }
+
+  const waitForPreviousBlockCompletion = async ({
+    blockIndex,
+    currentBlockCompletion,
+    datasourceId,
+  }: {
+    blockIndex: number
+    currentBlockCompletion: BlockCompletion
+    datasourceId: number
+  }): Promise<InfiniteBlockGateResult> => {
+    // Cursor-backed blocks are sequential even if AG Grid requests them
+    // concurrently. A later block can only fetch after the previous block has
+    // either produced the cursor it needs or failed.
+    if (blockIndex === 0) {
+      return 'ready'
+    }
+
+    const previousBlockCompletion = blockCompletionMap.get(blockIndex - 1)
+    if (!previousBlockCompletion) {
+      rejectBlockCompletion(blockIndex, currentBlockCompletion)
+      return 'failed'
+    }
+
+    const previousBlockCompleted = await previousBlockCompletion.promise
+    if (!isLatestDatasource(datasourceId)) {
+      rejectBlockCompletion(blockIndex, currentBlockCompletion)
+      return 'stale'
+    }
+
+    if (!previousBlockCompleted) {
+      rejectBlockCompletion(blockIndex, currentBlockCompletion)
+      return 'failed'
+    }
+
+    return 'ready'
+  }
+
+  const handleSuccessfulBlock = ({
+    blockIndex,
+    currentBlockCompletion,
+    getRowsParams,
+    pageSize,
+    result,
+  }: {
+    blockIndex: number
+    currentBlockCompletion: BlockCompletion
+    getRowsParams: IGetRowsParams
+    pageSize: number
+    result: TableDataGridFetcherResult<Row>
+  }) => {
+    // Store each response cursor on the block that produced it so the next
+    // block can use that cursor instead of exposing AG Grid ranges publicly.
+    if (result.cursor !== undefined) {
+      cursorMap.set(blockIndex, result.cursor)
+    }
+
+    getRowsParams.successCallback(result.data, resolveInfiniteLastRow({
+      startRow: getRowsParams.startRow,
+      rowsLength: result.data.length,
+      pageSize,
+      total: result.total,
+      hasMore: result.hasMore,
+    }))
+
+    if (getRowsParams.startRow === 0) {
+      data.value = result.data
+    }
+    currentBlockCompletion.resolve(true)
+  }
+
+  const handleFailedBlock = ({
+    blockIndex,
+    currentBlockCompletion,
+    fetchError,
+    getRowsParams,
+  }: {
+    blockIndex: number
+    currentBlockCompletion: BlockCompletion
+    fetchError: unknown
+    getRowsParams: IGetRowsParams
+  }) => {
+    // Failed blocks must unblock any dependent later block and notify AG Grid
+    // through its datasource callback so it can retry according to grid policy.
+    error.value = fetchError
+    getRowsParams.failCallback()
+    rejectBlockCompletion(blockIndex, currentBlockCompletion)
+  }
+
+  const buildDatasource = (): IDatasource => {
+    // A new datasource is a fresh cursor chain. Incrementing the id lets
+    // in-flight requests from an older datasource resolve without mutating the
+    // current state or calling callbacks on the replaced datasource.
+    const datasourceId = latestDatasourceId.value + 1
+    latestDatasourceId.value = datasourceId
+    cursorMap.clear()
+    blockCompletionMap.clear()
+    data.value = []
+    error.value = undefined
+    pendingFetchCount.value = 0
+    syncIsFetching()
+
+    return {
+      async getRows(getRowsParams) {
+        // AG Grid owns block scheduling and supplies zero-based row ranges.
+        // This layer converts those ranges into cursor-chain blocks before
+        // calling the public fetcher.
+        const {
+          blockIndex,
+          pageSize,
+        } = getCursorBlock({
+          startRow: getRowsParams.startRow,
+          endRow: getRowsParams.endRow,
+        })
+
+        const currentBlockCompletion = createBlockCompletion(blockIndex)
+        const blockGateResult = await waitForPreviousBlockCompletion({
+          blockIndex,
+          currentBlockCompletion,
+          datasourceId,
+        })
+
+        if (blockGateResult !== 'ready') {
+          if (blockGateResult === 'failed') {
+            getRowsParams.failCallback()
+          }
+
+          return
+        }
+
+        markFetchStarted()
+        try {
+          const cursor = blockIndex > 0 ? cursorMap.get(blockIndex - 1) : undefined
+          const result = await fetcher({
+            mode: 'infinite',
+            pageSize,
+            cursor,
+          })
+
+          if (!isLatestDatasource(datasourceId)) {
+            rejectBlockCompletion(blockIndex, currentBlockCompletion)
+            return
+          }
+
+          handleSuccessfulBlock({
+            blockIndex,
+            currentBlockCompletion,
+            getRowsParams,
+            pageSize,
+            result,
+          })
+        } catch (fetchError) {
+          if (!isLatestDatasource(datasourceId)) {
+            rejectBlockCompletion(blockIndex, currentBlockCompletion)
+            return
+          }
+
+          handleFailedBlock({
+            blockIndex,
+            currentBlockCompletion,
+            fetchError,
+            getRowsParams,
+          })
+        } finally {
+          if (isLatestDatasource(datasourceId)) {
+            markFetchFinished()
+          }
+        }
+      },
+    }
+  }
+
+  const resetDatasource = () => {
+    // In infinite cursor mode, reset means starting over from block 0. Cursors
+    // are only valid relative to the response/query chain that produced them, so
+    // parent invalidation or request-shape changes must clear the cursor chain
+    // instead of reusing later block cursors from the previous datasource.
+    datasource.value = buildDatasource()
+  }
+
+  watch(
+    () => resetKey?.value,
+    () => {
+      resetDatasource()
+    },
+    { immediate: true },
+  )
+
+  return {
+    datasource: readonly(datasource),
+    data: readonly(data),
+    error: readonly(error),
+    isFetching: readonly(isFetching),
+  }
+}

--- a/packages/core/table-data-grid/src/composables/useFetchState.spec.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchState.spec.ts
@@ -1,0 +1,165 @@
+import type { Ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { isReadonly, ref } from 'vue'
+import useFetchState, { fetchState } from './useFetchState'
+
+type TestRow = {
+  id: string
+  visible?: boolean
+}
+
+type TestCase = {
+  data?: TestRow[]
+  error?: unknown
+  expectedHasData: boolean
+  expected: fetchState
+  isFetching: boolean
+  name: string
+}
+
+const createRows = (length: number): TestRow[] => (
+  Array.from({ length }, (_, index) => ({ id: `${index + 1}` }))
+)
+
+const stateCases: TestCase[] = [
+  {
+    name: 'no data, no error, not fetching',
+    expectedHasData: false,
+    expected: fetchState.PENDING,
+    isFetching: false,
+  },
+  {
+    name: 'no data, no error, fetching',
+    expectedHasData: false,
+    expected: fetchState.LOADING,
+    isFetching: true,
+  },
+  {
+    name: 'no data, error, not fetching',
+    error: new Error('failed'),
+    expectedHasData: false,
+    expected: fetchState.ERROR,
+    isFetching: false,
+  },
+  {
+    name: 'empty data, no error, not fetching',
+    data: [],
+    expectedHasData: false,
+    expected: fetchState.SUCCESS,
+    isFetching: false,
+  },
+  {
+    name: 'empty data, no error, fetching',
+    data: [],
+    expectedHasData: false,
+    expected: fetchState.LOADING,
+    isFetching: true,
+  },
+  {
+    name: 'data, no error, not fetching',
+    data: createRows(1),
+    expectedHasData: true,
+    expected: fetchState.SUCCESS,
+    isFetching: false,
+  },
+  {
+    name: 'data, no error, fetching',
+    data: createRows(1),
+    expectedHasData: true,
+    expected: fetchState.SUCCESS,
+    isFetching: true,
+  },
+  {
+    name: 'data, error, not fetching',
+    data: createRows(1),
+    error: new Error('failed'),
+    expectedHasData: true,
+    expected: fetchState.SUCCESS,
+    isFetching: false,
+  },
+]
+
+describe('useFetchState', () => {
+  it.each(stateCases)('returns $expected for $name', ({
+    data: initialData,
+    error: initialError,
+    expectedHasData,
+    expected,
+    isFetching: initialIsFetching,
+  }) => {
+    const data = ref<TestRow[] | undefined>(initialData)
+    const error = ref<unknown>(initialError)
+    const isFetching = ref(initialIsFetching)
+
+    const { hasData, state } = useFetchState(data, error, isFetching)
+
+    expect(hasData.value).toBe(expectedHasData)
+    expect(state.value).toBe(expected)
+  })
+
+  it('derives state reactively from data, error, and isFetching refs', () => {
+    const data = ref<TestRow[] | undefined>(undefined)
+    const error = ref<unknown>(undefined)
+    const isFetching = ref(false)
+
+    const { state } = useFetchState(data, error, isFetching)
+
+    expect(state.value).toBe(fetchState.PENDING)
+
+    isFetching.value = true
+    expect(state.value).toBe(fetchState.LOADING)
+
+    data.value = [{ id: 'one' }]
+    expect(state.value).toBe(fetchState.SUCCESS)
+
+    isFetching.value = false
+    expect(state.value).toBe(fetchState.SUCCESS)
+
+    error.value = new Error('failed')
+    expect(state.value).toBe(fetchState.SUCCESS)
+  })
+
+  it('supports a custom data detector without owning fetch lifecycle state', () => {
+    const data = ref<TestRow[] | undefined>([{ id: 'one', visible: false }])
+    const error = ref<unknown>(undefined)
+    const isFetching = ref(false)
+    const hasVisibleData = (rows: TestRow[] | undefined): boolean => (
+      rows?.some(row => row.visible === true) ?? false
+    )
+
+    const { hasData, state } = useFetchState(data, error, isFetching, hasVisibleData)
+
+    expect(hasData.value).toBe(false)
+    expect(state.value).toBe(fetchState.SUCCESS)
+
+    data.value = [{ id: 'one', visible: true }]
+    expect(hasData.value).toBe(true)
+    expect(state.value).toBe(fetchState.SUCCESS)
+  })
+
+  it('returns readonly state and hasData refs to callers', () => {
+    const data = ref<TestRow[] | undefined>(undefined)
+    const error = ref<unknown>(undefined)
+    const isFetching = ref(false)
+
+    const { hasData, state } = useFetchState(data, error, isFetching)
+    const assertReadonlyState = (stateRef: Readonly<Ref<fetchState>>) => {
+      expect(stateRef.value).toBe(fetchState.PENDING)
+    }
+    const assertReadonlyHasData = (hasDataRef: Readonly<Ref<boolean>>) => {
+      expect(hasDataRef.value).toBe(false)
+    }
+    const assertReadonlyAssignment = () => {
+      // @ts-expect-error state is derived and readonly to callers.
+      state.value = fetchState.ERROR
+      // @ts-expect-error hasData is derived and readonly to callers.
+      hasData.value = true
+    }
+
+    assertReadonlyState(state)
+    assertReadonlyHasData(hasData)
+    expect(assertReadonlyAssignment).toBeTypeOf('function')
+    expect(isReadonly(state)).toBe(true)
+    expect(isReadonly(hasData)).toBe(true)
+  })
+})

--- a/packages/core/table-data-grid/src/composables/useFetchState.spec.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchState.spec.ts
@@ -22,8 +22,9 @@ const createRows = (length: number): TestRow[] => (
 )
 
 // Documents state precedence for a derived fetch-state helper:
-// meaningful data wins over loading/error, fetching wins before first data,
-// and resolved empty data still means the fetch completed successfully.
+// active fetches report loading even when rows already exist, meaningful data
+// still wins over later errors, and resolved empty data still means the fetch
+// completed successfully.
 const stateCases: TestCase[] = [
   {
     name: 'nothing has resolved and no request is pending',
@@ -69,7 +70,7 @@ const stateCases: TestCase[] = [
     name: 'rows exist and another request is pending',
     data: createRows(1),
     expectedHasData: true,
-    expectedState: fetchState.SUCCESS,
+    expectedState: fetchState.LOADING,
     isFetching: true,
   },
   {
@@ -113,7 +114,7 @@ describe('useFetchState', () => {
     expect(state.value).toBe(fetchState.LOADING)
 
     data.value = [{ id: 'one' }]
-    expect(state.value).toBe(fetchState.SUCCESS)
+    expect(state.value).toBe(fetchState.LOADING)
 
     isFetching.value = false
     expect(state.value).toBe(fetchState.SUCCESS)

--- a/packages/core/table-data-grid/src/composables/useFetchState.spec.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchState.spec.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { describe, expect, it } from 'vitest'
-import { isReadonly, ref } from 'vue'
+import { isReadonly, ref, shallowRef } from 'vue'
 import useFetchState, { fetchState } from './useFetchState'
 
 type TestRow = {
@@ -12,7 +12,7 @@ type TestCase = {
   data?: TestRow[]
   error?: unknown
   expectedHasData: boolean
-  expected: fetchState
+  expectedState: fetchState
   isFetching: boolean
   name: string
 }
@@ -21,70 +21,73 @@ const createRows = (length: number): TestRow[] => (
   Array.from({ length }, (_, index) => ({ id: `${index + 1}` }))
 )
 
+// Documents state precedence for a derived fetch-state helper:
+// meaningful data wins over loading/error, fetching wins before first data,
+// and resolved empty data still means the fetch completed successfully.
 const stateCases: TestCase[] = [
   {
-    name: 'no data, no error, not fetching',
+    name: 'nothing has resolved and no request is pending',
     expectedHasData: false,
-    expected: fetchState.PENDING,
+    expectedState: fetchState.PENDING,
     isFetching: false,
   },
   {
-    name: 'no data, no error, fetching',
+    name: 'nothing has resolved and a request is pending',
     expectedHasData: false,
-    expected: fetchState.LOADING,
+    expectedState: fetchState.LOADING,
     isFetching: true,
   },
   {
-    name: 'no data, error, not fetching',
+    name: 'nothing has resolved and the latest request failed',
     error: new Error('failed'),
     expectedHasData: false,
-    expected: fetchState.ERROR,
+    expectedState: fetchState.ERROR,
     isFetching: false,
   },
   {
-    name: 'empty data, no error, not fetching',
+    name: 'an empty result has resolved',
     data: [],
     expectedHasData: false,
-    expected: fetchState.SUCCESS,
+    expectedState: fetchState.SUCCESS,
     isFetching: false,
   },
   {
-    name: 'empty data, no error, fetching',
+    name: 'an empty result exists but a request is pending',
     data: [],
     expectedHasData: false,
-    expected: fetchState.LOADING,
+    expectedState: fetchState.LOADING,
     isFetching: true,
   },
   {
-    name: 'data, no error, not fetching',
+    name: 'rows have resolved',
     data: createRows(1),
     expectedHasData: true,
-    expected: fetchState.SUCCESS,
+    expectedState: fetchState.SUCCESS,
     isFetching: false,
   },
   {
-    name: 'data, no error, fetching',
+    name: 'rows exist and another request is pending',
     data: createRows(1),
     expectedHasData: true,
-    expected: fetchState.SUCCESS,
+    expectedState: fetchState.SUCCESS,
     isFetching: true,
   },
   {
-    name: 'data, error, not fetching',
+    name: 'rows exist and a later request failed',
     data: createRows(1),
     error: new Error('failed'),
     expectedHasData: true,
-    expected: fetchState.SUCCESS,
+    expectedState: fetchState.SUCCESS,
     isFetching: false,
   },
 ]
 
 describe('useFetchState', () => {
-  it.each(stateCases)('returns $expected for $name', ({
+  it.each(stateCases)('classifies fetch state as $expectedState when $name', ({
     data: initialData,
     error: initialError,
     expectedHasData,
-    expected,
+    expectedState,
     isFetching: initialIsFetching,
   }) => {
     const data = ref<TestRow[] | undefined>(initialData)
@@ -94,10 +97,10 @@ describe('useFetchState', () => {
     const { hasData, state } = useFetchState(data, error, isFetching)
 
     expect(hasData.value).toBe(expectedHasData)
-    expect(state.value).toBe(expected)
+    expect(state.value).toBe(expectedState)
   })
 
-  it('derives state reactively from data, error, and isFetching refs', () => {
+  it('updates the derived state when source refs change', () => {
     const data = ref<TestRow[] | undefined>(undefined)
     const error = ref<unknown>(undefined)
     const isFetching = ref(false)
@@ -119,7 +122,7 @@ describe('useFetchState', () => {
     expect(state.value).toBe(fetchState.SUCCESS)
   })
 
-  it('supports a custom data detector without owning fetch lifecycle state', () => {
+  it('uses a custom hasData detector without owning fetch lifecycle state', () => {
     const data = ref<TestRow[] | undefined>([{ id: 'one', visible: false }])
     const error = ref<unknown>(undefined)
     const isFetching = ref(false)
@@ -129,6 +132,8 @@ describe('useFetchState', () => {
 
     const { hasData, state } = useFetchState(data, error, isFetching, hasVisibleData)
 
+    // The custom detector only controls hasData. The fetch state is still
+    // SUCCESS because a result has resolved and there is no pending request.
     expect(hasData.value).toBe(false)
     expect(state.value).toBe(fetchState.SUCCESS)
 
@@ -137,7 +142,21 @@ describe('useFetchState', () => {
     expect(state.value).toBe(fetchState.SUCCESS)
   })
 
-  it('returns readonly state and hasData refs to callers', () => {
+  it('accepts readonly row data refs returned by fetch composables', () => {
+    // Fetch orchestration composables return readonly row refs so callers can
+    // observe rows without mutating fetch-owned data.
+    const data = shallowRef<readonly TestRow[] | undefined>([{ id: 'one' }])
+    const error = ref<unknown>(undefined)
+    const isFetching = ref(false)
+    const hasOneRow = (rows: readonly TestRow[] | undefined): boolean => rows?.length === 1
+
+    const { hasData, state } = useFetchState(data, error, isFetching, hasOneRow)
+
+    expect(hasData.value).toBe(true)
+    expect(state.value).toBe(fetchState.SUCCESS)
+  })
+
+  it('exposes readonly derived refs to callers', () => {
     const data = ref<TestRow[] | undefined>(undefined)
     const error = ref<unknown>(undefined)
     const isFetching = ref(false)

--- a/packages/core/table-data-grid/src/composables/useFetchState.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchState.ts
@@ -1,0 +1,72 @@
+import type { Ref } from 'vue'
+import { computed } from 'vue'
+
+export enum fetchState {
+  PENDING = 'PENDING',
+  LOADING = 'LOADING',
+  SUCCESS = 'SUCCESS',
+  ERROR = 'ERROR',
+}
+
+type UseFetchStateResult = {
+  fetchState: typeof fetchState
+  hasData: Readonly<Ref<boolean>>
+  state: Readonly<Ref<fetchState>>
+}
+
+const defaultHasData = <Row>(data: Row[] | undefined): boolean => (
+  Boolean(data?.length)
+)
+
+/**
+ * Derives TableDataGrid fetch state from fetch lifecycle refs.
+ *
+ * `data`, `error`, and `isFetching` are owned by the fetch orchestration
+ * composable. This helper only reads those refs and exposes a readonly derived
+ * state without owning mutation or request lifecycle behavior.
+ *
+ * @param data Current rows from the active fetch chain, or `undefined` before
+ * the first fetch result resolves.
+ * @param error Current fetch error, if one exists.
+ * @param isFetching Whether at least one fetch request is currently pending.
+ * @param hasDataCallback Optional row detector for callers that need a custom
+ * definition of meaningful data.
+ */
+export default function useFetchState<Row>(
+  data: Readonly<Ref<Row[] | undefined>>,
+  error: Readonly<Ref<unknown>>,
+  isFetching: Readonly<Ref<boolean>>,
+  hasDataCallback: (data: Row[] | undefined) => boolean = defaultHasData,
+): UseFetchStateResult {
+  const hasData = computed<boolean>(() => hasDataCallback(data.value))
+
+  const state = computed<fetchState>(() => {
+    const dataValue = data.value
+    const hasResolvedData = dataValue !== undefined
+    const hasError = error.value !== undefined && error.value !== null
+
+    if (hasData.value) {
+      return fetchState.SUCCESS
+    }
+
+    if (isFetching.value) {
+      return fetchState.LOADING
+    }
+
+    if (hasError) {
+      return fetchState.ERROR
+    }
+
+    if (hasResolvedData) {
+      return fetchState.SUCCESS
+    }
+
+    return fetchState.PENDING
+  })
+
+  return {
+    fetchState,
+    hasData,
+    state,
+  }
+}

--- a/packages/core/table-data-grid/src/composables/useFetchState.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchState.ts
@@ -14,7 +14,9 @@ type UseFetchStateResult = {
   state: Readonly<Ref<fetchState>>
 }
 
-const defaultHasData = <Row>(data: Row[] | undefined): boolean => (
+type FetchStateData<Row> = readonly Row[] | undefined
+
+const defaultHasData = <Row>(data: FetchStateData<Row>): boolean => (
   Boolean(data?.length)
 )
 
@@ -33,10 +35,10 @@ const defaultHasData = <Row>(data: Row[] | undefined): boolean => (
  * definition of meaningful data.
  */
 export default function useFetchState<Row>(
-  data: Readonly<Ref<Row[] | undefined>>,
+  data: Readonly<Ref<FetchStateData<Row>>>,
   error: Readonly<Ref<unknown>>,
   isFetching: Readonly<Ref<boolean>>,
-  hasDataCallback: (data: Row[] | undefined) => boolean = defaultHasData,
+  hasDataCallback: (data: FetchStateData<Row>) => boolean = defaultHasData,
 ): UseFetchStateResult {
   const hasData = computed<boolean>(() => hasDataCallback(data.value))
 

--- a/packages/core/table-data-grid/src/composables/useFetchState.ts
+++ b/packages/core/table-data-grid/src/composables/useFetchState.ts
@@ -47,12 +47,12 @@ export default function useFetchState<Row>(
     const hasResolvedData = dataValue !== undefined
     const hasError = error.value !== undefined && error.value !== null
 
-    if (hasData.value) {
-      return fetchState.SUCCESS
-    }
-
     if (isFetching.value) {
       return fetchState.LOADING
+    }
+
+    if (hasData.value) {
+      return fetchState.SUCCESS
     }
 
     if (hasError) {

--- a/packages/core/table-data-grid/src/composables/useI18n.ts
+++ b/packages/core/table-data-grid/src/composables/useI18n.ts
@@ -1,0 +1,16 @@
+import { createI18n, i18nTComponent } from '@kong-ui-public/i18n'
+import english from '../locales/en.json'
+
+interface UseI18nReturn {
+  i18n: ReturnType<typeof createI18n<typeof english>>
+  i18nT: ReturnType<typeof i18nTComponent<typeof english>>
+}
+
+export default function useI18n(): UseI18nReturn {
+  const i18n = createI18n<typeof english>('en-us', english)
+
+  return {
+    i18n,
+    i18nT: i18nTComponent<typeof english>(i18n), // Translation component <i18n-t>
+  }
+}

--- a/packages/core/table-data-grid/src/global-components.d.ts
+++ b/packages/core/table-data-grid/src/global-components.d.ts
@@ -1,0 +1,2 @@
+// Import globally available components.
+import '@kong/kongponents/dist/types/global-components'

--- a/packages/core/table-data-grid/src/locales/en.json
+++ b/packages/core/table-data-grid/src/locales/en.json
@@ -1,0 +1,10 @@
+{
+  "emptyState": {
+    "title": "No Data",
+    "message": "There is no data to display."
+  },
+  "errorState": {
+    "title": "An error occurred",
+    "message": "Data cannot be displayed due to an error."
+  }
+}

--- a/packages/core/table-data-grid/src/types/index.ts
+++ b/packages/core/table-data-grid/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { GridApi, GridOptions } from 'ag-grid-community'
+import type { GridApi } from 'ag-grid-community'
 
 export type TableDataGridMode = 'infinite'
 export type TableDataGridRow = Record<string, unknown>
@@ -33,7 +33,5 @@ export type TableDataGridFetcherResult<Row extends object = TableDataGridRow> = 
 export type TableDataGridFetcher<Row extends object = TableDataGridRow> = (
   params: TableDataGridInfiniteFetcherParams,
 ) => Promise<TableDataGridFetcherResult<Row>>
-
-export type TableDataGridGridOptions<Row extends object = TableDataGridRow> = GridOptions<Row>
 
 export type TableDataGridReadyPayload<Row extends object = TableDataGridRow> = GridApi<Row>

--- a/packages/core/table-data-grid/src/types/index.ts
+++ b/packages/core/table-data-grid/src/types/index.ts
@@ -1,8 +1,9 @@
 import type { GridApi, GridOptions } from 'ag-grid-community'
 
 export type TableDataGridMode = 'infinite'
+export type TableDataGridRow = Record<string, unknown>
 
-export type TableDataGridHeader<Row extends object = Record<string, unknown>> = {
+export type TableDataGridHeader<Row extends object = TableDataGridRow> = {
   key: Extract<keyof Row, string>
   label: string
   width?: number
@@ -10,30 +11,23 @@ export type TableDataGridHeader<Row extends object = Record<string, unknown>> = 
   maxWidth?: number
 }
 
-type TableDataGridCursorParams = {
-  cursor?: unknown
-  offset?: never
-}
-
-type TableDataGridOffsetParams = {
-  cursor?: never
-  offset?: number
-}
-
-export type TableDataGridFetcherParams = {
-  mode: TableDataGridMode
+export interface TableDataGridInfiniteFetcherParams {
+  mode: 'infinite'
   pageSize: number
-} & (TableDataGridCursorParams | TableDataGridOffsetParams)
-
-export type TableDataGridFetcherResult<Row extends object = Record<string, unknown>> = {
-  data: Row[]
-  total?: number
+  cursor?: unknown
 }
 
-export type TableDataGridFetcher<Row extends object = Record<string, unknown>> = (
-  params: TableDataGridFetcherParams,
+export type TableDataGridFetcherResult<Row extends object = TableDataGridRow> = {
+  data: Row[]
+  cursor?: unknown
+  total?: number
+  hasMore?: boolean
+}
+
+export type TableDataGridFetcher<Row extends object = TableDataGridRow> = (
+  params: TableDataGridInfiniteFetcherParams,
 ) => Promise<TableDataGridFetcherResult<Row>>
 
-export type TableDataGridGridOptions<Row extends object = Record<string, unknown>> = GridOptions<Row>
+export type TableDataGridGridOptions<Row extends object = TableDataGridRow> = GridOptions<Row>
 
-export type TableDataGridReadyPayload<Row extends object = Record<string, unknown>> = GridApi<Row>
+export type TableDataGridReadyPayload<Row extends object = TableDataGridRow> = GridApi<Row>

--- a/packages/core/table-data-grid/src/types/index.ts
+++ b/packages/core/table-data-grid/src/types/index.ts
@@ -2,6 +2,12 @@ import type { GridApi, GridOptions } from 'ag-grid-community'
 
 export type TableDataGridMode = 'infinite'
 export type TableDataGridRow = Record<string, unknown>
+export type TableDataGridState = 'loading' | 'success' | 'error'
+
+export type TableDataGridStatePayload = {
+  state: TableDataGridState
+  hasData: boolean
+}
 
 export type TableDataGridHeader<Row extends object = TableDataGridRow> = {
   key: Extract<keyof Row, string>

--- a/packages/core/table-data-grid/src/utils/fetchers.spec.ts
+++ b/packages/core/table-data-grid/src/utils/fetchers.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { getCursorBlock, resolveInfiniteLastRow } from './fetchers'
+
+describe('fetcher utilities', () => {
+  it('resolves cursor block details from AG Grid row ranges', () => {
+    expect(getCursorBlock({ startRow: 0, endRow: 100 })).toEqual({
+      blockIndex: 0,
+      pageSize: 100,
+    })
+    expect(getCursorBlock({ startRow: 200, endRow: 300 })).toEqual({
+      blockIndex: 2,
+      pageSize: 100,
+    })
+  })
+
+  it('resolves infinite last row values from result metadata and block size', () => {
+    // AG Grid uses `lastRow` to stop asking for more blocks. A short block with
+    // no explicit `hasMore` is treated as the terminal block.
+    expect(resolveInfiniteLastRow({
+      startRow: 0,
+      rowsLength: 25,
+      pageSize: 100,
+    })).toBe(25)
+    // A full block without total/hasMore metadata is inconclusive, so AG Grid
+    // should keep requesting more blocks.
+    expect(resolveInfiniteLastRow({
+      startRow: 100,
+      rowsLength: 100,
+      pageSize: 100,
+    })).toBeUndefined()
+    // When the backend explicitly says there is no next page, the current block
+    // end becomes AG Grid's terminal row.
+    expect(resolveInfiniteLastRow({
+      startRow: 100,
+      rowsLength: 100,
+      pageSize: 100,
+      hasMore: false,
+    })).toBe(200)
+    // A known total is the strongest signal and should win over block shape.
+    expect(resolveInfiniteLastRow({
+      startRow: 100,
+      rowsLength: 100,
+      pageSize: 100,
+      total: 250,
+    })).toBe(250)
+  })
+})

--- a/packages/core/table-data-grid/src/utils/fetchers.ts
+++ b/packages/core/table-data-grid/src/utils/fetchers.ts
@@ -1,0 +1,50 @@
+interface GridRowRange {
+  startRow: number
+  endRow: number
+}
+
+interface CursorBlock {
+  blockIndex: number
+  pageSize: number
+}
+
+export const getCursorBlock = ({ startRow, endRow }: GridRowRange): CursorBlock => {
+  // AG Grid uses zero-based, half-open row ranges: startRow is inclusive and
+  // endRow is exclusive. A 100-row block is 0-100, then 100-200.
+  const pageSize = endRow - startRow
+
+  return {
+    blockIndex: pageSize > 0 ? Math.floor(startRow / pageSize) : 0,
+    pageSize,
+  }
+}
+
+// Translate TableDataGrid fetch metadata into AG Grid's `lastRow` signal. An
+// undefined value tells AG Grid to keep requesting more blocks.
+export const resolveInfiniteLastRow = ({
+  startRow,
+  rowsLength,
+  pageSize,
+  total,
+  hasMore,
+}: {
+  startRow: number
+  rowsLength: number
+  pageSize: number
+  total?: number
+  hasMore?: boolean
+}): number | undefined => {
+  if (typeof total === 'number') {
+    return total
+  }
+
+  if (hasMore === true) {
+    return undefined
+  }
+
+  if (hasMore === false || rowsLength < pageSize) {
+    return startRow + rowsLength
+  }
+
+  return undefined
+}

--- a/packages/core/table-data-grid/src/utils/fetchers.ts
+++ b/packages/core/table-data-grid/src/utils/fetchers.ts
@@ -8,9 +8,18 @@ interface CursorBlock {
   pageSize: number
 }
 
+/**
+ * Resolves AG Grid's zero-based, half-open row range into a cursor block.
+ *
+ * AG Grid passes `startRow` as inclusive and `endRow` as exclusive. It does not
+ * pass a block index directly, so derive it from the range before calling
+ * TableDataGrid's cursor-based fetcher.
+ *
+ * @param startRow AG Grid's inclusive row start for the requested block.
+ * @param endRow AG Grid's exclusive row end for the requested block.
+ * @returns Cursor block index and page size derived from AG Grid's row range.
+ */
 export const getCursorBlock = ({ startRow, endRow }: GridRowRange): CursorBlock => {
-  // AG Grid uses zero-based, half-open row ranges: startRow is inclusive and
-  // endRow is exclusive. A 100-row block is 0-100, then 100-200.
   const pageSize = endRow - startRow
 
   return {
@@ -19,8 +28,19 @@ export const getCursorBlock = ({ startRow, endRow }: GridRowRange): CursorBlock 
   }
 }
 
-// Translate TableDataGrid fetch metadata into AG Grid's `lastRow` signal. An
-// undefined value tells AG Grid to keep requesting more blocks.
+/**
+ * Translates TableDataGrid fetch metadata into AG Grid's `lastRow` signal.
+ *
+ * An undefined value tells AG Grid to keep requesting more blocks. A number
+ * tells AG Grid the absolute row index where the dataset ends.
+ *
+ * @param startRow AG Grid's inclusive row start for the fetched block.
+ * @param rowsLength Number of rows returned by the TableDataGrid fetcher.
+ * @param pageSize Requested block size derived from AG Grid's row range.
+ * @param total Optional known total row count from the backend.
+ * @param hasMore Optional backend signal for whether another block exists.
+ * @returns AG Grid `lastRow` value, or undefined when more blocks may exist.
+ */
 export const resolveInfiniteLastRow = ({
   startRow,
   rowsLength,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,7 +826,7 @@ importers:
     devDependencies:
       '@kong/kongponents':
         specifier: ^9.56.2
-        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 9.59.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
       vue:
         specifier: 3.5.35
         version: 3.5.35(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,6 +824,9 @@ importers:
         specifier: ^34.3.1
         version: 34.3.1(vue@3.5.35(typescript@5.9.3))
     devDependencies:
+      '@kong/kongponents':
+        specifier: ^9.56.2
+        version: 9.56.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       vue:
         specifier: 3.5.35
         version: 3.5.35(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,6 +824,9 @@ importers:
         specifier: ^34.3.1
         version: 34.3.1(vue@3.5.35(typescript@5.9.3))
     devDependencies:
+      '@kong-ui-public/i18n':
+        specifier: workspace:^
+        version: link:../i18n
       '@kong/kongponents':
         specifier: 9.59.0
         version: 9.59.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3)))(vite@8.0.16(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,8 +825,8 @@ importers:
         version: 34.3.1(vue@3.5.35(typescript@5.9.3))
     devDependencies:
       '@kong/kongponents':
-        specifier: ^9.56.2
-        version: 9.59.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3)))(vite@5.4.21(@types/node@24.12.4)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1))(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
+        specifier: 9.59.0
+        version: 9.59.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3)))(vite@8.0.16(@types/node@25.9.0)(jiti@2.5.1)(sass-embedded@1.80.3)(sass@1.99.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
       vue:
         specifier: 3.5.35
         version: 3.5.35(typescript@5.9.3)


### PR DESCRIPTION
## Summary

This branch adds cursor-first infinite scrolling support to `@kong-ui-public/table-data-grid` and updates the surrounding component behavior, docs, and sandbox examples.

- define the public cursor-first infinite fetcher contract
- add `useFetchInfinite` for AG Grid infinite datasource wiring, cursor chaining, refresh invalidation, and stale request guards
- add fetch lifecycle state derivation and public `state` emits, including later-block loading and success transitions
- wire `TableDataGrid` to AG Grid infinite row model with `pageSize`, `refreshKey`, host error handling, empty state handling, and `grid:ready`
- add default and slotted empty/error presentation states backed by Kongponents
- document usage, fetcher behavior, refresh invalidation, internal fetch state, state emits, slots, column sizing, and host setup expectations
- rebuild the sandbox into a reference-style infinite-fetch playground with dataset controls, fetch delay, host error, refresh, state logs, and fetch history
- make unconstrained columns fill available table width by default while preserving explicit width and max-width constraints
- declare Kongponents as a package peer/dev dependency

## Cursor-based infinite fetching state model

AG Grid’s infinite row model is range-based: it calls the datasource with row windows like `0-25`, `25-50`, and `50-75`. TableDataGrid translates those ranges into cursor-backed blocks while keeping `startRow` / `endRow` internal.

State flow:

1. AG Grid requests a range through `getRows({ startRow, endRow })`.
2. TableDataGrid derives:
   - `pageSize = endRow - startRow`
   - `blockIndex = startRow / pageSize`
3. Block `0` calls the public fetcher with `cursor: undefined`.
4. The fetcher response returns `{ data, cursor, total?, hasMore? }`.
5. TableDataGrid passes `data` back to AG Grid with `successCallback`.
6. If the response includes a cursor, TableDataGrid stores it in an internal `cursorMap` keyed by the block that produced it.
7. When AG Grid later requests the next range, TableDataGrid derives the next `blockIndex`.
8. Before fetching that next block, TableDataGrid reads the cursor stored for `blockIndex - 1`.
9. The next fetcher call receives that cursor:
   - block `0` -> `cursor: undefined`
   - block `1` -> cursor returned by block `0`
   - block `2` -> cursor returned by block `1`
10. Response metadata is translated back into AG Grid’s `lastRow` signal so AG Grid knows whether to keep requesting more blocks.

## Notes

This slice stays scoped to the current infinite-fetch surface. Pagination, filters, selection, configurable/resizable columns, toolbar behavior, and table-config persistence are left for later work.