### PR TITLE
fix: audit GHSA-gv7w-rqvm-qjhr breaking build

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "auditConfig": {
       "ignoreGhsas": [
         "GHSA-p9ff-h696-f583",
-        "GHSA-5xrq-8626-4rwp"
+        "GHSA-5xrq-8626-4rwp",
+        "GHSA-gv7w-rqvm-qjhr"
       ]
     },
     "overrides": {


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/KHCP-20873


Addressing https://github.com/advisories/GHSA-gv7w-rqvm-qjhr breaks build. 

```
[vite:esbuild-transpile] Transform failed with 3 errors:
ERROR: Transforming destructuring to the configured target environment (...) is not supported yet
...
at .../node_modules/.pnpm/esbuild@0.28.1/node_modules/esbuild/...
```

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
