### PR TITLE
feat(entities-plugins): migrate confluent and kafka plugins to freeform

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -93,13 +93,17 @@ useProvideExperimentalFreeForms([
   'exit-transformer',
   'file-log',
   'http-log',
+  'kafka-log',
   'request-transformer-advanced',
   'response-transformer',
   'response-transformer-advanced',
   'correlation-id',
   'solace-consume',
+  'confluent-consume',
+  'kafka-consume',
   'solace-log',
   'solace-upstream',
+  'kafka-upstream',
   'opentelemetry',
   'acl',
   'request-transformer',
@@ -114,6 +118,7 @@ useProvideExperimentalFreeForms([
   'mtls-auth',
   'basic-auth',
   'key-auth',
+  'confluent',
 ])
 
 const enableDeckConfigCustomization = ref(false)

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/confluent-consume.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/confluent-consume.ts
@@ -1,0 +1,16 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+import StringField from '../shared/StringField.vue'
+
+export default definePluginConfig({
+  experimental: true,
+  fieldRenderers: [
+    {
+      match: 'config.message_by_lua_functions.*',
+      component: StringField,
+      propsOverrides: {
+        multiline: true,
+        rows: 3,
+      },
+    },
+  ],
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/confluent.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/confluent.ts
@@ -1,0 +1,16 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+import StringField from '../shared/StringField.vue'
+
+export default definePluginConfig({
+  experimental: true,
+  fieldRenderers: [
+    {
+      match: 'config.message_by_lua_functions.*',
+      component: StringField,
+      propsOverrides: {
+        multiline: true,
+        rows: 3,
+      },
+    },
+  ],
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/kafka-consume.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/kafka-consume.ts
@@ -1,0 +1,16 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+import StringField from '../shared/StringField.vue'
+
+export default definePluginConfig({
+  experimental: true,
+  fieldRenderers: [
+    {
+      match: ({ genericPath }) => genericPath === 'config.message_by_lua_functions.*',
+      component: StringField,
+      propsOverrides: {
+        multiline: true,
+        rows: 3,
+      },
+    },
+  ],
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/kafka-log.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/kafka-log.ts
@@ -1,0 +1,15 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+import MapField from '../shared/MapField.vue'
+
+export default definePluginConfig({
+  experimental: true,
+  fieldRenderers: [
+    {
+      match: 'config.custom_fields_by_lua',
+      component: MapField,
+      propsOverrides: {
+        appearance: { string: { multiline: true } },
+      },
+    },
+  ],
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/kafka-upstream.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/kafka-upstream.ts
@@ -1,0 +1,16 @@
+import { definePluginConfig } from '../shared/define-plugin-config'
+import StringField from '../shared/StringField.vue'
+
+export default definePluginConfig({
+  experimental: true,
+  fieldRenderers: [
+    {
+      match: ({ genericPath }) => genericPath === 'config.message_by_lua_functions.*',
+      component: StringField,
+      propsOverrides: {
+        multiline: true,
+        rows: 3,
+      },
+    },
+  ],
+})


### PR DESCRIPTION
## Summary
KM-2708

Freeform rendering is now enabled for a focused Confluent/Kafka plugin group split out from the broader migration PRs.

This picks the target plugin configs from Kong/public-ui-components#3382, Kong/public-ui-components#3383, Kong/public-ui-components#3389, and Kong/public-ui-components#3392 for:

- `confluent`
- `confluent-consume`
- `kafka-consume`
- `kafka-log`
- `kafka-upstream`

The entities-plugins sandbox allowlist is updated so these plugin forms can be exercised with the freeform engine locally.
