### PR TITLE
feat(analytics): support single result in trend queries [MA-5139]

### DIFF
--- a/packages/analytics/analytics-chart/package.json
+++ b/packages/analytics/analytics-chart/package.json
@@ -76,6 +76,7 @@
     "@types/lodash.pick": "^4.4.9",
     "@types/lodash.pickby": "^4.6.9",
     "@types/papaparse": "^5.5.2",
+    "@vueuse/core": "^14.3.0",
     "approximate-number": "^3.0.1",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
@@ -131,9 +131,9 @@ describe('<SingleValue />', () => {
       .should('be.visible')
       .contains('-')
 
-    // cy.getTestId('single-value-trend').should('be.visible')
-    // cy.get('.trend-change').should('have.class', 'neutral').and('have.text', 'Not available')
-    // cy.get('.trend-change .trend-up-icon').should('exist')
+    cy.getTestId('single-value-trend').should('be.visible')
+    cy.get('.trend-change').should('have.class', 'negative').and('have.text', '100.00%')
+    cy.get('.trend-change .trend-down-icon').should('exist')
   })
 
   it('treats a non-numeric value as empty and shows the error state', () => {

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
@@ -82,6 +82,60 @@ describe('<SingleValue />', () => {
     cy.getTestId('single-value-trend').should('be.visible')
   })
 
+  it('when showing trend and only have a current result, displays that value and show indeterminate change', () => {
+    const exploreResult = buildExploreResult({ previous: 100, current: 250 })
+    const resultOneValue = {
+      ...exploreResult,
+      data: [
+        exploreResult.data[1], // the current data
+      ],
+    }
+
+    cy.mount(SingleValue, {
+      props: {
+        data: resultOneValue,
+        showTrend: true,
+      },
+    })
+
+    const expected = parseFloat(
+      exploreResult.data[1].event.request_per_minute.toFixed(2),
+    )
+
+    cy.getTestId('single-value-chart')
+      .should('be.visible')
+      .contains(expected)
+
+    cy.getTestId('single-value-trend').should('be.visible')
+    cy.get('.trend-change').should('have.class', 'neutral').and('have.text', 'Not available')
+    cy.get('.trend-change .indeterminate-small-icon').should('exist')
+  })
+
+  it('when showing trend and only have a previous result, display - and show -100% change', () => {
+    const exploreResult = buildExploreResult({ previous: 100, current: 250 })
+    const resultOneValue = {
+      ...exploreResult,
+      data: [
+        exploreResult.data[0], // the previous data
+      ],
+    }
+
+    cy.mount(SingleValue, {
+      props: {
+        data: resultOneValue,
+        showTrend: true,
+      },
+    })
+
+    cy.getTestId('single-value-chart')
+      .should('be.visible')
+      .contains('-')
+
+    // cy.getTestId('single-value-trend').should('be.visible')
+    // cy.get('.trend-change').should('have.class', 'neutral').and('have.text', 'Not available')
+    // cy.get('.trend-change .trend-up-icon').should('exist')
+  })
+
   it('treats a non-numeric value as empty and shows the error state', () => {
     const exploreResult = buildExploreResult({ previous: 100, current: 250 })
     // @ts-expect-error - this is intentionally invalid for the test

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
@@ -5,7 +5,7 @@
     data-testid="single-value-parent"
   >
     <KEmptyState
-      v-if="singleValue === null"
+      v-if="invalidState"
       class="single-value-error"
       data-testid="single-value-error"
       icon-variant="error"
@@ -45,7 +45,7 @@
         >
           <component
             :is="trendIcon"
-            v-if="polarity !== 0"
+            v-if="noTrendButShowTrend || polarity !== 0"
             :color="colorAttribute(polarity)"
             :size="`var(--kui-icon-size-30, ${KUI_ICON_SIZE_30})`"
           />
@@ -74,7 +74,7 @@ import type { AnalyticsExploreRecord, ExploreResultV4, AllAggregations } from '@
 
 import { computed, onMounted } from 'vue'
 import { unitFormatter } from '@kong-ui-public/analytics-utilities'
-import { changePolarity, metricChange, defineIcon, calculateChange, useTrendRange } from '@kong-ui-public/analytics-metric-provider'
+import { changePolarity, metricChange, defineIcon, calculateChange, useTrendRange, buildDeltaMapping } from '@kong-ui-public/analytics-metric-provider'
 import { EqualIcon } from '@kong/icons'
 import {
   KUI_COLOR_TEXT_DANGER_STRONG,
@@ -121,6 +121,20 @@ const props = defineProps({
 
 const alignmentClass = computed(() => `align-${props.leftAlign ? 'left' : props.alignX}`)
 
+const topLevelKey = 't1'
+const secondLevelKey = 't2'
+const trendData = computed(() => {
+  return buildDeltaMapping(props.data, props.showTrend, { topLevelKey, secondLevelKey })
+})
+
+const trendPrevious = computed<undefined | number>(() => {
+  return trendData.value?.previous?.[topLevelKey]?.[secondLevelKey]
+})
+
+const trendCurrent = computed<undefined | number>(() => {
+  return trendData.value?.current?.[topLevelKey]?.[secondLevelKey]
+})
+
 const records = computed<AnalyticsExploreRecord[]>(() => props.data.data)
 const metricName = computed((): AllAggregations | undefined => props.data.meta?.metric_names?.[0])
 const formattedMetricName = computed((): string => {
@@ -137,13 +151,18 @@ const metricUnit = computed((): string | undefined => {
 
   return undefined
 })
+
 // by default, display metric units for requests per minute, latency
 const displayMetricUnit = computed((): boolean => metricName.value === 'request_per_minute'
   || !!metricName.value?.includes('_latency_')
   || metricName.value === 'error_rate')
 
 const previousValue = computed<number | null>(() => {
-  if (!props.showTrend || records.value.length < 2 || !metricName.value) {
+  if (props.showTrend) {
+    return trendPrevious.value ?? null
+  }
+
+  if (records.value.length < 2 || !metricName.value) {
     return null
   }
 
@@ -157,20 +176,15 @@ const previousValue = computed<number | null>(() => {
 })
 
 const singleValue = computed<number | null>(() => {
-  if (!metricName.value) {
+  if (props.showTrend) {
+    return trendCurrent.value ?? null
+  }
+
+  if (records.value.length < 1 || !metricName.value) {
     return null
   }
 
-  // With trend: need 2 records (previous at [0], current at [1])
-  // Without trend: need 1 record (current at [0])
-  const requiredRecords = props.showTrend ? 2 : 1
-  const currentIndex = props.showTrend ? 1 : 0
-
-  if (records.value.length < requiredRecords) {
-    return null
-  }
-
-  const value = records.value[currentIndex].event[metricName.value]
+  const value = records.value[0].event[metricName.value]
 
   // Check if value is actually a number
   if (typeof value !== 'number' || isNaN(value)) {
@@ -180,11 +194,18 @@ const singleValue = computed<number | null>(() => {
   return value
 })
 
+const invalidState = computed<boolean>(() => {
+  return props.data?.data?.length === undefined // no data defined
+    || props.data?.data?.length === 0 // no data at all
+    || (!props.showTrend && singleValue.value === null) // not trend and doesn't have single value
+    || (props.showTrend && previousValue.value === null && singleValue.value === null) // trend and doesn't have any value
+})
+
 const formattedValue = computed((): string => {
   const value = singleValue.value
 
   if (value === null) {
-    return ''
+    return '-'
   }
 
   const rawUnit = metricName.value ? props.data.meta?.metric_units?.[metricName.value] : undefined
@@ -212,10 +233,38 @@ const formattedValue = computed((): string => {
   return value.toLocaleString('en-US', { maximumFractionDigits: decimalPoints })
 })
 
+const noTrendButShowTrend = computed(() => props.showTrend && props.data?.data?.length < 2)
 const change = computed(() => calculateChange(singleValue.value ?? 0, previousValue.value ?? 0) || 0)
-const polarity = computed(() => changePolarity(change.value, true, props.increaseIsBad)) // Assume hasTrendAccess=true
+const polarity = computed(() => {
+  if (!props.showTrend) {
+    return 0 // not relevant unless we're showing a trend
+  }
+
+  if (props.data?.data?.length < 2) {
+    if (trendPrevious.value === undefined) {
+      return 0 // we can't determine the polarity change because we had no previous data
+    }
+
+    if (trendCurrent.value === undefined) {
+      return props.increaseIsBad ? 1 : -1 // we have previous data, but no current, so it dropped 100%
+    }
+  }
+
+  return changePolarity(change.value, true, props.increaseIsBad)
+})
 const trendIcon = computed(() => defineIcon(polarity.value, props.increaseIsBad))
-const formattedChange = computed(() => metricChange(change.value, true, i18n.t('singleValue.trend.not_available')))
+const formattedChange = computed(() => {
+  if (props.showTrend && props.data?.data?.length < 2) {
+    if (trendPrevious.value === undefined) {
+      return i18n.t('singleValue.trend.not_available')
+    }
+
+    if (trendCurrent.value === undefined) {
+      return metricChange(-1, true, i18n.t('singleValue.trend.not_available'))
+    }
+  }
+  return metricChange(change.value, props.data?.data?.length === 2, i18n.t('singleValue.trend.not_available'))
+})
 const trendRange = useTrendRange(computed(() => props.showTrend), undefined, computed(() => props.data.meta))
 
 const textColor = (polarityNum: number) => {
@@ -246,8 +295,9 @@ const colorAttribute = (polarityNum: number) => {
 onMounted(() => {
   if (!props.showTrend && props.data?.data?.length > 1) {
     console.warn('SingleValue chart should only be used with a single data point. Data length:', props.data.data.length)
-  } else if (props.showTrend && props.data?.data?.length !== 2) {
-    console.warn('SingleValue with trend expects exactly 2 data points. Data length:', props.data.data.length)
+  } else if (props.showTrend && props.data?.data?.length > 2) {
+    // because 1 data point is when we don't have any previous data to compare against
+    console.warn('SingleValue with trend expects at least 1 data point, usually 2. Data length:', props.data.data.length)
   }
 })
 </script>

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
@@ -158,21 +158,10 @@ const displayMetricUnit = computed((): boolean => metricName.value === 'request_
   || metricName.value === 'error_rate')
 
 const previousValue = computed<number | null>(() => {
-  if (props.showTrend) {
-    return trendPrevious.value ?? null
+  if (props.showTrend && trendPrevious.value !== undefined) {
+    return trendPrevious.value
   }
-
-  if (records.value.length < 2 || !metricName.value) {
-    return null
-  }
-
-  const value = records.value[0].event[metricName.value]
-
-  if (typeof value !== 'number' || isNaN(value)) {
-    return null
-  }
-
-  return value
+  return null
 })
 
 const singleValue = computed<number | null>(() => {
@@ -296,8 +285,7 @@ onMounted(() => {
   if (!props.showTrend && props.data?.data?.length > 1) {
     console.warn('SingleValue chart should only be used with a single data point. Data length:', props.data.data.length)
   } else if (props.showTrend && props.data?.data?.length > 2) {
-    // because 1 data point is when we don't have any previous data to compare against
-    console.warn('SingleValue with trend expects at least 1 data point, usually 2. Data length:', props.data.data.length)
+    console.warn('SingleValue with trend expects 2 or fewer data points. Instead got:', props.data.data.length)
   }
 })
 </script>

--- a/packages/analytics/analytics-metric-provider/src/composables/useMetricCardBuilder.ts
+++ b/packages/analytics/analytics-metric-provider/src/composables/useMetricCardBuilder.ts
@@ -1,9 +1,8 @@
-import type { MetricCardDef } from '../types'
+import type { MetricCardDef, ChronologicalMappedMetrics } from '../types'
 import type { MetricCardType } from '../enums'
 import type { Ref } from 'vue'
 import { computed } from 'vue'
-import type { ChronologicalMappedMetrics } from './useMetricFetcher'
-import { DEFAULT_KEY } from './useMetricFetcher'
+import { DEFAULT_KEY } from '../constants'
 
 export interface BuilderOptions {
   cardType: MetricCardType

--- a/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.spec.ts
+++ b/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.spec.ts
@@ -1,5 +1,6 @@
 import { vi, describe, expect } from 'vitest'
-import useMetricFetcher, { buildDeltaMapping, DEFAULT_KEY } from './useMetricFetcher'
+import useMetricFetcher from './useMetricFetcher'
+import { DEFAULT_KEY } from '../constants'
 import { ref } from 'vue'
 import type { ExploreResultV4 } from '@kong-ui-public/analytics-utilities'
 import type { MetricFetcherOptions } from '../types'
@@ -72,56 +73,6 @@ const EXPLORE_RESULT_NO_TREND: ExploreResultV4 = {
   },
 }
 
-const EXPLORE_RESULT_PREVIOUS_DATA_ONLY: ExploreResultV4 = {
-  data: [
-    {
-      version: 'v1',
-      timestamp: deltaStart.toISOString(),
-      event: {
-        request_count: 10,
-      },
-    },
-  ],
-  meta: {
-    start: deltaStart.toISOString(),
-    end: timeRange.end.toISOString(),
-    granularity_ms: 86400000,
-    query_id: '',
-    metric_names: [
-      'request_count',
-    ],
-    metric_units: {
-      request_count: 'count',
-    },
-    display: {},
-  },
-}
-
-const EXPLORE_RESULT_CURRENT_DATA_ONLY: ExploreResultV4 = {
-  data: [
-    {
-      version: 'v1',
-      timestamp: timeRange.start.toISOString(),
-      event: {
-        request_count: 20,
-      },
-    },
-  ],
-  meta: {
-    start: deltaStart.toISOString(),
-    end: timeRange.end.toISOString(),
-    granularity_ms: 86400000,
-    query_id: '',
-    metric_names: [
-      'request_count',
-    ],
-    metric_units: {
-      request_count: 'count',
-    },
-    display: {},
-  },
-}
-
 const EXPLORE_RESULT_NO_RECORDS: ExploreResultV4 = {
   data: [],
   meta: {
@@ -139,165 +90,6 @@ const EXPLORE_RESULT_NO_RECORDS: ExploreResultV4 = {
   },
 }
 
-const EXPLORE_RESULT_CURRENT_DATA_MULTI_DIMENSION: ExploreResultV4 = {
-  data: [
-    {
-      version: 'v1',
-      timestamp: addDays(deltaStart, 1).toISOString(),
-      event: {
-        route: 'route1',
-        request_count: 20,
-        status_code_grouped: '2XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: addDays(deltaStart, 1).toISOString(),
-      event: {
-        route: 'route1',
-        request_count: 10,
-        status_code_grouped: '5XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: addDays(deltaStart, 1).toISOString(),
-      event: {
-        route: 'route2',
-        request_count: 20,
-        status_code_grouped: '2XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: addDays(deltaStart, 1).toISOString(),
-      event: {
-        route: 'route2',
-        request_count: 10,
-        status_code_grouped: '5XX',
-      },
-    },
-  ],
-  meta: {
-    start: deltaStart.toISOString(),
-    end: timeRange.end.toISOString(),
-    granularity_ms: 86400000,
-    query_id: '',
-    metric_names: [
-      'request_count',
-    ],
-    metric_units: {
-      request_count: 'count',
-    },
-    display: {
-      status_code_grouped: {
-        '2XX': { name: '2XX' }, '5XX': { name: '5XX' },
-      },
-      route: {
-        route1: { name: 'route1' },
-        route2: { name: 'route2' },
-      },
-    },
-  },
-}
-
-const EXPLORE_RESULT_TREND_DATA_MULTI_DIMENSION: ExploreResultV4 = {
-  data: [
-    {
-      version: 'v1',
-      timestamp: deltaStart.toISOString(),
-      event: {
-        request_count: 20,
-        route: 'route1',
-        status_code_grouped: '2XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: deltaStart.toISOString(),
-      event: {
-        request_count: 10,
-        route: 'route1',
-        status_code_grouped: '5XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: deltaStart.toISOString(),
-      event: {
-        request_count: 25,
-        route: 'route2',
-        status_code_grouped: '2XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: deltaStart.toISOString(),
-      event: {
-        request_count: 15,
-        route: 'route2',
-        status_code_grouped: '5XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: addDays(deltaStart, 1).toISOString(),
-      event: {
-        request_count: 40,
-        route: 'route1',
-        status_code_grouped: '2XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: addDays(deltaStart, 1).toISOString(),
-      event: {
-        request_count: 20,
-        route: 'route1',
-        status_code_grouped: '5XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: addDays(deltaStart, 1).toISOString(),
-      event: {
-        request_count: 45,
-        route: 'route2',
-        status_code_grouped: '2XX',
-      },
-    },
-    {
-      version: 'v1',
-      timestamp: addDays(deltaStart, 1).toISOString(),
-      event: {
-        request_count: 25,
-        route: 'route2',
-        status_code_grouped: '5XX',
-      },
-    },
-  ],
-  meta: {
-    start: deltaStart.toISOString(),
-    end: timeRange.end.toISOString(),
-    granularity_ms: 86400000,
-    query_id: '',
-    metric_names: [
-      'request_count',
-    ],
-    metric_units: {
-      request_count: 'count',
-    },
-    display: {
-      route: {
-        route1: { name: 'route1' }, route2: { name: 'route2' },
-      },
-      status_code_grouped: {
-        '2XX': { name: '2XX' }, '5XX': { name: '5XX' },
-      },
-    },
-  },
-}
-
 describe('useMetricFetcher', () => {
 
   afterEach(() => {
@@ -307,18 +99,16 @@ describe('useMetricFetcher', () => {
   it('can get metric data with trend', () => {
 
     const fetcherOptions: MetricFetcherOptions = {
-      metrics: [
+      metrics: ref([
         'request_count',
-      ],
+      ]),
       timeRange: ref({
         type: 'relative',
         time_range: '24h',
       }),
-      loading: ref(true),
-      hasError: ref(false),
       withTrend: ref(true),
       refreshInterval: CHART_REFRESH_INTERVAL_MS,
-    }
+    } as any
 
     // @ts-ignore
     vi.spyOn(composables, 'useRequest').mockReturnValue({ response: ref(EXPLORE_RESULT_TREND), error: {}, isValidating: ref(false) })
@@ -345,18 +135,16 @@ describe('useMetricFetcher', () => {
   it('handles empty result', () => {
 
     const fetcherOptions: MetricFetcherOptions = {
-      metrics: [
+      metrics: ref([
         'request_count',
-      ],
+      ]),
       timeRange: ref({
         type: 'relative',
         time_range: '24h',
       }),
-      loading: ref(true),
-      hasError: ref(false),
       withTrend: ref(true),
       refreshInterval: CHART_REFRESH_INTERVAL_MS,
-    }
+    } as any
 
     // @ts-ignore
     vi.spyOn(composables, 'useRequest').mockReturnValue({ response: ref({}), error: {}, isValidating: ref(false) })
@@ -378,18 +166,16 @@ describe('useMetricFetcher', () => {
   it('handles no records and no trend', () => {
 
     const fetcherOptions: MetricFetcherOptions = {
-      metrics: [
+      metrics: ref([
         'request_count',
-      ],
+      ]),
       timeRange: ref({
         type: 'relative',
         time_range: '24h',
       }),
-      loading: ref(true),
-      hasError: ref(false),
       withTrend: ref(true),
       refreshInterval: CHART_REFRESH_INTERVAL_MS,
-    }
+    } as any
 
     // @ts-ignore
     vi.spyOn(composables, 'useRequest').mockReturnValue({ response: ref(EXPLORE_RESULT_NO_RECORDS), error: {}, isValidating: ref(false) })
@@ -409,19 +195,16 @@ describe('useMetricFetcher', () => {
   it('handles no records, no trend, and no dimensions', () => {
 
     const fetcherOptions: MetricFetcherOptions = {
-      metrics: [
+      metrics: ref([
         'request_count',
-      ],
-      filterValues: ['test-org-uuid'],
+      ]),
       timeRange: ref({
         type: 'relative',
         time_range: '24h',
       }),
-      loading: ref(true),
-      hasError: ref(false),
       withTrend: ref(false),
       refreshInterval: CHART_REFRESH_INTERVAL_MS,
-    }
+    } as any
 
     // @ts-ignore
     vi.spyOn(composables, 'useRequest').mockReturnValue({ response: ref(EXPLORE_RESULT_NO_RECORDS), error: {}, isValidating: ref(false) })
@@ -440,20 +223,17 @@ describe('useMetricFetcher', () => {
 
   it('properly calculates descriptions for custom timeperiods with trend', () => {
     const fetcherOptionsTrend: MetricFetcherOptions = {
-      metrics: [
+      metrics: ref([
         'request_count',
-      ],
-      filterValues: ['test-org-uuid'],
+      ]),
       timeRange: ref({
         type: 'absolute',
         start: new Date('2024-01-01T00:00:00Z'),
         end: new Date('2024-01-02T00:00:00Z'),
       }),
-      loading: ref(true),
-      hasError: ref(false),
       withTrend: ref(true),
       refreshInterval: CHART_REFRESH_INTERVAL_MS,
-    }
+    } as any
 
     // @ts-ignore
     vi.spyOn(composables, 'useRequest').mockReturnValue({ response: ref(EXPLORE_RESULT_TREND), error: {}, isValidating: ref(false) })
@@ -467,20 +247,17 @@ describe('useMetricFetcher', () => {
 
   it('properly calculates descriptions for custom timeperiods without trend', () => {
     const fetcherOptionsTrend: MetricFetcherOptions = {
-      metrics: [
+      metrics: ref([
         'request_count',
-      ],
-      filterValues: ['test-org-uuid'],
+      ]),
       timeRange: ref({
         type: 'absolute',
         start: new Date('2024-01-01T00:00:00Z'),
         end: new Date('2024-01-02T00:00:00Z'),
       }),
-      loading: ref(true),
-      hasError: ref(false),
       withTrend: ref(false),
       refreshInterval: CHART_REFRESH_INTERVAL_MS,
-    }
+    } as any
 
     // @ts-ignore
     vi.spyOn(composables, 'useRequest').mockReturnValue({ response: ref(EXPLORE_RESULT_NO_TREND), error: {}, isValidating: ref(false) })
@@ -492,130 +269,4 @@ describe('useMetricFetcher', () => {
     expect(trafficData.trendRange.value).toEqual('vs previous day')
   })
 
-})
-
-describe('buildDeltaMapping', () => {
-  it('can get metric data without trend', () => {
-    const trafficData = buildDeltaMapping(EXPLORE_RESULT_NO_TREND, false)
-
-    const expected = {
-      current: {
-        [DEFAULT_KEY]: {
-          [DEFAULT_KEY]: 20,
-        },
-      },
-      previous: {},
-    }
-
-    expect(trafficData).toEqual(expected)
-  })
-
-  it('can get metric data when there is only previous data', () => {
-    const trafficData = buildDeltaMapping(EXPLORE_RESULT_PREVIOUS_DATA_ONLY, true)
-
-    const expected = {
-      current: {},
-      previous: {
-        [DEFAULT_KEY]: {
-          [DEFAULT_KEY]: 10,
-        },
-      },
-    }
-    expect(trafficData).toEqual(expected)
-  })
-
-  it('can get metric data when there is only current data', () => {
-    const trafficData = buildDeltaMapping(EXPLORE_RESULT_CURRENT_DATA_ONLY, true)
-
-    console.log(trafficData)
-
-    const expected = {
-      current: {
-        [DEFAULT_KEY]: {
-          [DEFAULT_KEY]: 20,
-        },
-      },
-      previous: {},
-    }
-
-    expect(trafficData).toEqual(expected)
-  })
-
-  it('handles current record only, trend, and no dimensions', () => {
-    const trafficData = buildDeltaMapping(EXPLORE_RESULT_CURRENT_DATA_ONLY, true)
-
-    const expected = {
-      current: {
-        [DEFAULT_KEY]: {
-          [DEFAULT_KEY]: 20,
-        },
-      },
-      previous: {},
-    }
-
-    expect(trafficData).toEqual(expected)
-  })
-
-  it('handles current record only, no trend', () => {
-    const trafficData = buildDeltaMapping(EXPLORE_RESULT_CURRENT_DATA_ONLY, true)
-
-    const expected = {
-      current: {
-        [DEFAULT_KEY]: {
-          [DEFAULT_KEY]: 20,
-        },
-      },
-      previous: {},
-    }
-    expect(trafficData).toEqual(expected)
-  })
-
-  it('can get metric data when there is only current data for multi-dimensional result', () => {
-    const trafficData = buildDeltaMapping(EXPLORE_RESULT_CURRENT_DATA_MULTI_DIMENSION, true)
-
-    const expected = {
-      current: {
-        route1: {
-          '2XX': 20,
-          '5XX': 10,
-        },
-        route2: {
-          '2XX': 20,
-          '5XX': 10,
-        },
-      },
-      previous: {},
-    }
-
-    expect(trafficData).toEqual(expected)
-  })
-
-  it('can get metric data with trend for multi-dimensional result', () => {
-    const trafficData = buildDeltaMapping(EXPLORE_RESULT_TREND_DATA_MULTI_DIMENSION, true)
-
-    const expected = {
-      current: {
-        route1: {
-          '2XX': 40,
-          '5XX': 20,
-        },
-        route2: {
-          '2XX': 45,
-          '5XX': 25,
-        },
-      },
-      previous: {
-        route1: {
-          '2XX': 20,
-          '5XX': 10,
-        },
-        route2: {
-          '2XX': 25,
-          '5XX': 15,
-        },
-      },
-    }
-
-    expect(trafficData).toEqual(expected)
-  })
 })

--- a/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
+++ b/packages/analytics/analytics-metric-provider/src/composables/useMetricFetcher.ts
@@ -2,25 +2,13 @@ import type { Ref } from 'vue'
 import { computed } from 'vue'
 import type {
   ExploreQuery,
-  QueryableExploreDimensions,
   ExploreResultV4,
 } from '@kong-ui-public/analytics-utilities'
-import type { MetricFetcherOptions } from '../types'
+import type { ChronologicalMappedMetrics, MetricFetcherOptions } from '../types'
 import { MAX_ANALYTICS_REQUEST_RETRIES } from '../constants'
 import composables from '.'
 import { useSwrvState } from '@kong-ui-public/core'
-
-export const DEFAULT_KEY = Symbol('default')
-export type MappedMetrics = Record<string | typeof DEFAULT_KEY, Record<string | typeof DEFAULT_KEY, number>>
-
-// This dimension is special: metric cards are never going to group on this dimension
-// except in order to determine traffic and error rate information.
-const ERROR_RATE_DIMENSION: QueryableExploreDimensions = 'status_code_grouped'
-
-export interface ChronologicalMappedMetrics {
-  current: MappedMetrics
-  previous: MappedMetrics
-}
+import { buildDeltaMapping } from '../utilities'
 
 export interface FetcherResult {
   isLoading: Ref<boolean>
@@ -28,64 +16,6 @@ export interface FetcherResult {
   raw: Ref<ExploreResultV4 | undefined>
   mapped: Ref<ChronologicalMappedMetrics>
   trendRange: Ref<string>
-}
-
-const setMetric = (result: ChronologicalMappedMetrics, time: 'previous' | 'current', topLevelKey: string | typeof DEFAULT_KEY, secondLevelKey: string | typeof DEFAULT_KEY, metricValue: number) => {
-  if (!result[time][topLevelKey]) {
-    result[time][topLevelKey] = {} as Record<string | typeof DEFAULT_KEY, number>
-  }
-  result[time][topLevelKey][secondLevelKey] = metricValue
-}
-
-export function buildDeltaMapping(result: ExploreResultV4, withTrend: boolean): ChronologicalMappedMetrics {
-  // We should always have metric names in the result; if they're not present, just pick something that won't crash.
-  const metricName = result.meta.metric_names?.[0] || ''
-
-  // Figure out the first expected timestamp.
-  const queriedStartTime = new Date(result.meta.start).getTime()
-
-  // We only ever have 2 dimensions in the response if the second dimension is STATUS_CODE_GROUPED.
-  // TIME doesn't show up in the response.
-  // Assert that this is the case; raise a reportable error if not.
-  const dimensionNames = Object.keys(result.meta.display || {})
-  const hasErrorRateDimension = !!dimensionNames.find(k => k === ERROR_RATE_DIMENSION)
-  const keyDimension = dimensionNames.find(k => k !== ERROR_RATE_DIMENSION)
-
-  if (dimensionNames.length > 2 || (dimensionNames.length > 1 && !hasErrorRateDimension)) {
-    console.error("Don't know how to work with provided dimensions:", dimensionNames)
-    return {
-      previous: { [DEFAULT_KEY]: { [DEFAULT_KEY]: 0 } },
-      current: { [DEFAULT_KEY]: { [DEFAULT_KEY]: 0 } },
-    }
-  }
-
-  // Go through each record and add it to the correct group.
-  // Explore always returns results sorted in ascending order by time.
-  return result.data.reduce<ChronologicalMappedMetrics>((result, record) => {
-    const metricValue = record.event[metricName] as number
-
-    // If we have dimensions, then index the results based on the dimension name.
-    // If we don't have dimensions, insert a synthetic key (DEFAULT_KEY).
-    const topLevelKey = keyDimension ? record.event[keyDimension] as string : DEFAULT_KEY
-
-    // If we have the error rate key, then index the 2nd level results based on that.
-    // Otherwise, insert a synthetic key (DEFAULT_KEY).
-    const secondLevelKey = hasErrorRateDimension ? record.event[ERROR_RATE_DIMENSION] as string : DEFAULT_KEY
-
-    // The records are in ascending order, so the first record is the earliest.
-    // If the timestamp of the current record is the same as the query start date, it belongs to
-    // the previous group, otherwise it belongs to the current group.
-    if (new Date(record.timestamp).getTime() === queriedStartTime && withTrend) {
-      setMetric(result, 'previous', topLevelKey, secondLevelKey, metricValue)
-    } else {
-      setMetric(result, 'current', topLevelKey, secondLevelKey, metricValue)
-    }
-
-    return result
-  }, {
-    previous: {},
-    current: {},
-  } as ChronologicalMappedMetrics)
 }
 
 export default function useMetricFetcher(opts: MetricFetcherOptions): FetcherResult {

--- a/packages/analytics/analytics-metric-provider/src/constants.ts
+++ b/packages/analytics/analytics-metric-provider/src/constants.ts
@@ -1,6 +1,14 @@
+import type { QueryableExploreDimensions } from '@kong-ui-public/analytics-utilities'
+
 export const MAX_ANALYTICS_REQUEST_RETRIES = 2
 export const ALL_STATUS_CODE_GROUPS = ['1XX', '2XX', '3XX', '4XX', '5XX']
 export const STATUS_CODES_FAILED = ['4XX', '5XX']
 export const STATUS_CODES_SUCCESS = ['1XX', '2XX', '3XX']
 export const DEFAULT_REFRESH_INTERVAL = 30 * 1000
 export const INJECT_QUERY_PROVIDER = 'analytics-query-provider'
+
+// This dimension is special: metric cards are never going to group on this dimension
+// except in order to determine traffic and error rate information.
+export const ERROR_RATE_DIMENSION: QueryableExploreDimensions = 'status_code_grouped'
+export const DEFAULT_KEY = Symbol('default')
+

--- a/packages/analytics/analytics-metric-provider/src/types/fetcher-types.ts
+++ b/packages/analytics/analytics-metric-provider/src/types/fetcher-types.ts
@@ -5,6 +5,15 @@ import type {
 } from '@kong-ui-public/analytics-utilities'
 import type { Ref } from 'vue'
 
+import type { DEFAULT_KEY } from '../constants'
+
+export type MappedMetrics = Record<string | typeof DEFAULT_KEY, Record<string | typeof DEFAULT_KEY, number>>
+
+export interface ChronologicalMappedMetrics {
+  current: MappedMetrics
+  previous: MappedMetrics
+}
+
 export interface MetricFetcherOptions {
   datasource: Ref<QueryDatasource>
   metrics: Ref<ExploreAggregations[]>

--- a/packages/analytics/analytics-metric-provider/src/utilities/trend-display.spec.ts
+++ b/packages/analytics/analytics-metric-provider/src/utilities/trend-display.spec.ts
@@ -1,0 +1,373 @@
+import { describe, expect } from 'vitest'
+import { buildDeltaMapping } from './trend-display'
+import type { ExploreResultV4 } from '@kong-ui-public/analytics-utilities'
+import { addDays } from '../mockExploreResponse'
+import { DEFAULT_KEY } from '../constants'
+
+const timeRange = {
+  start: addDays(new Date(), -1),
+  end: new Date(),
+}
+
+const deltaStart = addDays(timeRange.start, -1)
+
+const EXPLORE_RESULT_NO_TREND: ExploreResultV4 = {
+  data: [
+    {
+      version: 'v1',
+      timestamp: timeRange.start.toISOString(),
+      event: {
+        request_count: 20,
+      },
+    },
+  ],
+  meta: {
+    start: timeRange.start.toISOString(),
+    end: timeRange.end.toISOString(),
+    granularity_ms: 86400000,
+    query_id: '',
+    metric_names: [
+      'request_count',
+    ],
+    metric_units: {
+      request_count: 'count',
+    },
+    display: {},
+  },
+}
+
+const EXPLORE_RESULT_PREVIOUS_DATA_ONLY: ExploreResultV4 = {
+  data: [
+    {
+      version: 'v1',
+      timestamp: deltaStart.toISOString(),
+      event: {
+        request_count: 10,
+      },
+    },
+  ],
+  meta: {
+    start: deltaStart.toISOString(),
+    end: timeRange.end.toISOString(),
+    granularity_ms: 86400000,
+    query_id: '',
+    metric_names: [
+      'request_count',
+    ],
+    metric_units: {
+      request_count: 'count',
+    },
+    display: {},
+  },
+}
+
+const EXPLORE_RESULT_CURRENT_DATA_ONLY: ExploreResultV4 = {
+  data: [
+    {
+      version: 'v1',
+      timestamp: timeRange.start.toISOString(),
+      event: {
+        request_count: 20,
+      },
+    },
+  ],
+  meta: {
+    start: deltaStart.toISOString(),
+    end: timeRange.end.toISOString(),
+    granularity_ms: 86400000,
+    query_id: '',
+    metric_names: [
+      'request_count',
+    ],
+    metric_units: {
+      request_count: 'count',
+    },
+    display: {},
+  },
+}
+
+const EXPLORE_RESULT_CURRENT_DATA_MULTI_DIMENSION: ExploreResultV4 = {
+  data: [
+    {
+      version: 'v1',
+      timestamp: addDays(deltaStart, 1).toISOString(),
+      event: {
+        route: 'route1',
+        request_count: 20,
+        status_code_grouped: '2XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: addDays(deltaStart, 1).toISOString(),
+      event: {
+        route: 'route1',
+        request_count: 10,
+        status_code_grouped: '5XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: addDays(deltaStart, 1).toISOString(),
+      event: {
+        route: 'route2',
+        request_count: 20,
+        status_code_grouped: '2XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: addDays(deltaStart, 1).toISOString(),
+      event: {
+        route: 'route2',
+        request_count: 10,
+        status_code_grouped: '5XX',
+      },
+    },
+  ],
+  meta: {
+    start: deltaStart.toISOString(),
+    end: timeRange.end.toISOString(),
+    granularity_ms: 86400000,
+    query_id: '',
+    metric_names: [
+      'request_count',
+    ],
+    metric_units: {
+      request_count: 'count',
+    },
+    display: {
+      status_code_grouped: {
+        '2XX': { name: '2XX' }, '5XX': { name: '5XX' },
+      },
+      route: {
+        route1: { name: 'route1' },
+        route2: { name: 'route2' },
+      },
+    },
+  },
+}
+
+const EXPLORE_RESULT_TREND_DATA_MULTI_DIMENSION: ExploreResultV4 = {
+  data: [
+    {
+      version: 'v1',
+      timestamp: deltaStart.toISOString(),
+      event: {
+        request_count: 20,
+        route: 'route1',
+        status_code_grouped: '2XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: deltaStart.toISOString(),
+      event: {
+        request_count: 10,
+        route: 'route1',
+        status_code_grouped: '5XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: deltaStart.toISOString(),
+      event: {
+        request_count: 25,
+        route: 'route2',
+        status_code_grouped: '2XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: deltaStart.toISOString(),
+      event: {
+        request_count: 15,
+        route: 'route2',
+        status_code_grouped: '5XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: addDays(deltaStart, 1).toISOString(),
+      event: {
+        request_count: 40,
+        route: 'route1',
+        status_code_grouped: '2XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: addDays(deltaStart, 1).toISOString(),
+      event: {
+        request_count: 20,
+        route: 'route1',
+        status_code_grouped: '5XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: addDays(deltaStart, 1).toISOString(),
+      event: {
+        request_count: 45,
+        route: 'route2',
+        status_code_grouped: '2XX',
+      },
+    },
+    {
+      version: 'v1',
+      timestamp: addDays(deltaStart, 1).toISOString(),
+      event: {
+        request_count: 25,
+        route: 'route2',
+        status_code_grouped: '5XX',
+      },
+    },
+  ],
+  meta: {
+    start: deltaStart.toISOString(),
+    end: timeRange.end.toISOString(),
+    granularity_ms: 86400000,
+    query_id: '',
+    metric_names: [
+      'request_count',
+    ],
+    metric_units: {
+      request_count: 'count',
+    },
+    display: {
+      route: {
+        route1: { name: 'route1' }, route2: { name: 'route2' },
+      },
+      status_code_grouped: {
+        '2XX': { name: '2XX' }, '5XX': { name: '5XX' },
+      },
+    },
+  },
+}
+
+describe('buildDeltaMapping', () => {
+  it('can get metric data without trend', () => {
+    const trafficData = buildDeltaMapping(EXPLORE_RESULT_NO_TREND, false)
+
+    const expected = {
+      current: {
+        [DEFAULT_KEY]: {
+          [DEFAULT_KEY]: 20,
+        },
+      },
+      previous: {},
+    }
+
+    expect(trafficData).toEqual(expected)
+  })
+
+  it('can get metric data when there is only previous data', () => {
+    const trafficData = buildDeltaMapping(EXPLORE_RESULT_PREVIOUS_DATA_ONLY, true)
+
+    const expected = {
+      current: {},
+      previous: {
+        [DEFAULT_KEY]: {
+          [DEFAULT_KEY]: 10,
+        },
+      },
+    }
+    expect(trafficData).toEqual(expected)
+  })
+
+  it('can get metric data when there is only current data', () => {
+    const trafficData = buildDeltaMapping(EXPLORE_RESULT_CURRENT_DATA_ONLY, true)
+
+    console.log(trafficData)
+
+    const expected = {
+      current: {
+        [DEFAULT_KEY]: {
+          [DEFAULT_KEY]: 20,
+        },
+      },
+      previous: {},
+    }
+
+    expect(trafficData).toEqual(expected)
+  })
+
+  it('handles current record only, trend, and no dimensions', () => {
+    const trafficData = buildDeltaMapping(EXPLORE_RESULT_CURRENT_DATA_ONLY, true)
+
+    const expected = {
+      current: {
+        [DEFAULT_KEY]: {
+          [DEFAULT_KEY]: 20,
+        },
+      },
+      previous: {},
+    }
+
+    expect(trafficData).toEqual(expected)
+  })
+
+  it('handles current record only, no trend', () => {
+    const trafficData = buildDeltaMapping(EXPLORE_RESULT_CURRENT_DATA_ONLY, true)
+
+    const expected = {
+      current: {
+        [DEFAULT_KEY]: {
+          [DEFAULT_KEY]: 20,
+        },
+      },
+      previous: {},
+    }
+    expect(trafficData).toEqual(expected)
+  })
+
+  it('can get metric data when there is only current data for multi-dimensional result', () => {
+    const trafficData = buildDeltaMapping(EXPLORE_RESULT_CURRENT_DATA_MULTI_DIMENSION, true)
+
+    const expected = {
+      current: {
+        route1: {
+          '2XX': 20,
+          '5XX': 10,
+        },
+        route2: {
+          '2XX': 20,
+          '5XX': 10,
+        },
+      },
+      previous: {},
+    }
+
+    expect(trafficData).toEqual(expected)
+  })
+
+  it('can get metric data with trend for multi-dimensional result', () => {
+    const trafficData = buildDeltaMapping(EXPLORE_RESULT_TREND_DATA_MULTI_DIMENSION, true)
+
+    const expected = {
+      current: {
+        route1: {
+          '2XX': 40,
+          '5XX': 20,
+        },
+        route2: {
+          '2XX': 45,
+          '5XX': 25,
+        },
+      },
+      previous: {
+        route1: {
+          '2XX': 20,
+          '5XX': 10,
+        },
+        route2: {
+          '2XX': 25,
+          '5XX': 15,
+        },
+      },
+    }
+
+    expect(trafficData).toEqual(expected)
+  })
+})
+

--- a/packages/analytics/analytics-metric-provider/src/utilities/trend-display.ts
+++ b/packages/analytics/analytics-metric-provider/src/utilities/trend-display.ts
@@ -6,6 +6,11 @@ import {
 import type {
   IndeterminateSmallIcon as GenericIcon,
 } from '@kong/icons'
+import { DEFAULT_KEY, ERROR_RATE_DIMENSION } from '../constants'
+import type { ChronologicalMappedMetrics } from '../types'
+import type {
+  ExploreResultV4,
+} from '@kong-ui-public/analytics-utilities'
 
 // Used to render a percentage display (eg: 30.97%)
 export const DECIMAL_DISPLAY = 2
@@ -71,3 +76,68 @@ export const defineIcon = (polarity: number, thisIsBad: boolean = false): typeof
       ? TrendDownIcon
       : IndeterminateSmallIcon
 }
+
+const setMetric = (result: ChronologicalMappedMetrics, time: 'previous' | 'current', topLevelKey: string | typeof DEFAULT_KEY, secondLevelKey: string | typeof DEFAULT_KEY, metricValue: number) => {
+  if (!result[time][topLevelKey]) {
+    result[time][topLevelKey] = {} as Record<string | typeof DEFAULT_KEY, number>
+  }
+  result[time][topLevelKey][secondLevelKey] = metricValue
+}
+
+export function buildDeltaMapping(result: ExploreResultV4, withTrend: boolean, {
+  topLevelKey = DEFAULT_KEY,
+  secondLevelKey = DEFAULT_KEY,
+}: {
+  topLevelKey?: string | typeof DEFAULT_KEY
+  secondLevelKey?: string | typeof DEFAULT_KEY
+} = {}): ChronologicalMappedMetrics {
+  // We should always have metric names in the result; if they're not present, just pick something that won't crash.
+  const metricName = result.meta.metric_names?.[0] || ''
+
+  // Figure out the first expected timestamp.
+  const queriedStartTime = new Date(result.meta.start).getTime()
+
+  // We only ever have 2 dimensions in the response if the second dimension is STATUS_CODE_GROUPED.
+  // TIME doesn't show up in the response.
+  // Assert that this is the case; raise a reportable error if not.
+  const dimensionNames = Object.keys(result.meta.display || {})
+  const hasErrorRateDimension = !!dimensionNames.find(k => k === ERROR_RATE_DIMENSION)
+  const keyDimension = dimensionNames.find(k => k !== ERROR_RATE_DIMENSION)
+
+  if (dimensionNames.length > 2 || (dimensionNames.length > 1 && !hasErrorRateDimension)) {
+    console.error("Don't know how to work with provided dimensions:", dimensionNames)
+    return {
+      previous: { [topLevelKey]: { [secondLevelKey]: 0 } },
+      current: { [topLevelKey]: { [secondLevelKey]: 0 } },
+    } as ChronologicalMappedMetrics
+  }
+
+  // Go through each record and add it to the correct group.
+  // Explore always returns results sorted in ascending order by time.
+  return result.data.reduce<ChronologicalMappedMetrics>((result, record) => {
+    const metricValue = record.event[metricName] as number
+
+    // If we have dimensions, then index the results based on the dimension name.
+    // If we don't have dimensions, insert a synthetic key (DEFAULT_KEY).
+    const newTopLevelKey = keyDimension ? record.event[keyDimension] as string : topLevelKey
+
+    // If we have the error rate key, then index the 2nd level results based on that.
+    // Otherwise, insert a synthetic key (DEFAULT_KEY).
+    const newSecondLevelKey = hasErrorRateDimension ? record.event[ERROR_RATE_DIMENSION] as string : secondLevelKey
+
+    // The records are in ascending order, so the first record is the earliest.
+    // If the timestamp of the current record is the same as the query start date, it belongs to
+    // the previous group, otherwise it belongs to the current group.
+    if (new Date(record.timestamp).getTime() === queriedStartTime && withTrend) {
+      setMetric(result, 'previous', newTopLevelKey, newSecondLevelKey, metricValue)
+    } else {
+      setMetric(result, 'current', newTopLevelKey, newSecondLevelKey, metricValue)
+    }
+
+    return result
+  }, {
+    previous: {},
+    current: {},
+  } as ChronologicalMappedMetrics)
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       '@types/papaparse':
         specifier: ^5.5.2
         version: 5.5.2
+      '@vueuse/core':
+        specifier: ^14.3.0
+        version: 14.3.0(vue@3.5.35(typescript@5.9.3))
       approximate-number:
         specifier: ^3.0.1
         version: 3.0.1


### PR DESCRIPTION
# Summary

We want single value chart to display trends. However, its current implementation was unique from how analytics-metric-provider did it. So, we're updating single value chart to implement trends the same way. To do this, we had to:

1. refactor analytics metric provider so that `buildDeltaMapping` was exported. This is the function that does all the calculation given a query result for determining if a value is the "previous" or "current" value.
2. update single value chart to use `buildDeltaMapping`
3. update the tests to reflect the new (old) logic

I also ended up needing to fix a minor build issue due to a missing dependency in the analytics chart package.json.

### Screenshots

**show trend, but no previous value exists**
<img width="266" height="124" alt="Screenshot 2026-06-22 at 5 56 46 PM" src="https://github.com/user-attachments/assets/ff345c27-9947-4118-8255-87eef28aebcd" />

**show trend, but no current value exists**
<img width="266" height="121" alt="Screenshot 2026-06-22 at 5 56 32 PM" src="https://github.com/user-attachments/assets/63b3197f-9638-4ec5-a234-0bd84b123f75" />
