### PR TITLE
feat(entities-plugins): add Kong Identity principals creation guide

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -25,7 +25,7 @@
         :plugin-name="formModel.name"
         :render-rules="pluginConfig?.renderRules"
         :schema="freeformSchema"
-        @click:create-principal="() => $emit('click:create-principal')"
+        @click:create-entity="(payload: EntityCreateEvent) => $emit('click:create-entity', payload)"
         @click:learn-more="(entity: string) => $emit('click:learn-more', entity)"
         @global-action="(name: GlobalAction, payload: any) => $emit('globalAction', name, payload)"
       >
@@ -140,7 +140,7 @@ import composables from '../composables'
 import useI18n from '../composables/useI18n'
 import { PLUGIN_METADATA } from '../definitions/metadata'
 import endpoints from '../plugins-endpoints'
-import type { KongManagerPluginFormConfig, KonnectPluginFormConfig, PluginEntityInfo, PluginValidityChangeEvent } from '../types'
+import type { EntityCreateEvent, KongManagerPluginFormConfig, KonnectPluginFormConfig, PluginEntityInfo, PluginValidityChangeEvent } from '../types'
 import PluginFieldRuleAlerts from './PluginFieldRuleAlerts.vue'
 import CommonForm from './free-form/Common'
 import type { GlobalAction } from './free-form/shared/types'
@@ -161,7 +161,7 @@ const emit = defineEmits<{
   (e: 'showNewPartialModal', redisType: string): void
   (e: 'globalAction', name: GlobalAction, payload: any): void
   (e: 'click:learn-more', entity: string): void
-  (e: 'click:create-principal'): void
+  (e: 'click:create-entity', payload: EntityCreateEvent): void
   (e: 'validity-change', payload: PluginValidityChangeEvent): void
 }>()
 

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -25,6 +25,8 @@
         :plugin-name="formModel.name"
         :render-rules="pluginConfig?.renderRules"
         :schema="freeformSchema"
+        @click:create-principal="() => $emit('click:create-principal')"
+        @click:learn-more="(entity: string) => $emit('click:learn-more', entity)"
         @global-action="(name: GlobalAction, payload: any) => $emit('globalAction', name, payload)"
       >
         <template
@@ -158,6 +160,8 @@ const emit = defineEmits<{
   ): void
   (e: 'showNewPartialModal', redisType: string): void
   (e: 'globalAction', name: GlobalAction, payload: any): void
+  (e: 'click:learn-more', entity: string): void
+  (e: 'click:create-principal'): void
   (e: 'validity-change', payload: PluginValidityChangeEvent): void
 }>()
 

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -56,7 +56,7 @@
         :raw-schema="loadedSchema"
         :record="record"
         :schema="finalSchema"
-        @click:create-principal="() => $emit('click:create-principal')"
+        @click:create-entity="(payload: EntityCreateEvent) => $emit('click:create-entity', payload)"
         @click:learn-more="(entity: string) => $emit('click:learn-more', entity)"
         @global-action="(name: GlobalAction, payload: any) => $emit('globalAction', name, payload)"
         @loading="(val: boolean) => formLoading = val"
@@ -215,6 +215,7 @@ import {
   type PluginOrdering,
   type CustomSchemas,
   type PluginValidityChangeEvent,
+  type EntityCreateEvent,
 } from '../types'
 import PluginEntityForm from './PluginEntityForm.vue'
 import PluginFormActionsWrapper from './PluginFormActionsWrapper.vue'
@@ -252,7 +253,7 @@ const emit = defineEmits<{
   (e: 'showNewPartialModal', redisType: string): void
   (e: 'globalAction', name: GlobalAction, payload: any): void
   (e: 'click:learn-more', entity: string): void
-  (e: 'click:create-principal'): void
+  (e: 'click:create-entity', payload: EntityCreateEvent): void
 }>()
 
 // Component props - This structure must exist in ALL entity components, with the exclusion of unneeded action props (e.g. if you don't need `canDelete`, just exclude it)

--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -56,6 +56,8 @@
         :raw-schema="loadedSchema"
         :record="record"
         :schema="finalSchema"
+        @click:create-principal="() => $emit('click:create-principal')"
+        @click:learn-more="(entity: string) => $emit('click:learn-more', entity)"
         @global-action="(name: GlobalAction, payload: any) => $emit('globalAction', name, payload)"
         @loading="(val: boolean) => formLoading = val"
         @model-updated="handleUpdate"
@@ -249,6 +251,8 @@ const emit = defineEmits<{
   ): void
   (e: 'showNewPartialModal', redisType: string): void
   (e: 'globalAction', name: GlobalAction, payload: any): void
+  (e: 'click:learn-more', entity: string): void
+  (e: 'click:create-principal'): void
 }>()
 
 // Component props - This structure must exist in ALL entity components, with the exclusion of unneeded action props (e.g. if you don't need `canDelete`, just exclude it)

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -796,13 +796,29 @@ describe('ConfigFormContent', () => {
         cy.getTestId('kong-identity-principals-panel').should('not.exist')
       })
 
-      it('emits "click:create-principal" when the create button is clicked', () => {
+      it('emits "click:create-principal" only after confirming the leave-page prompt', () => {
         mountContent(schemaWithoutRealms, { isKonnect: true, hasPrincipals: false }, { config: { principals: { enabled: false } } })
 
         selectKongIdentity()
 
+        // Clicking opens the leave-page confirmation; the event must not fire yet
         cy.getTestId('kong-identity-create-principal').should('not.be.disabled').click()
+        cy.getTestId('kong-identity-create-principal-prompt').should('be.visible')
+        cy.get('@onCreatePrincipalSpy').should('not.have.been.called')
+
+        // Proceeding through the prompt emits the event
+        cy.getTestId('modal-action-button').click()
         cy.get('@onCreatePrincipalSpy').should('have.been.calledOnce')
+      })
+
+      it('does not emit "click:create-principal" when the leave-page prompt is cancelled', () => {
+        mountContent(schemaWithoutRealms, { isKonnect: true, hasPrincipals: false }, { config: { principals: { enabled: false } } })
+
+        selectKongIdentity()
+
+        cy.getTestId('kong-identity-create-principal').click()
+        cy.getTestId('modal-cancel-button').click()
+        cy.get('@onCreatePrincipalSpy').should('not.have.been.called')
       })
 
       it('emits "click:learn-more" to open the Learning Hub when "Learn more" is clicked', () => {

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -803,7 +803,7 @@ describe('ConfigFormContent', () => {
 
         // Clicking opens the leave-page confirmation; the event must not fire yet
         cy.getTestId('kong-identity-create-principal').should('not.be.disabled').click()
-        cy.getTestId('kong-identity-create-principal-prompt').should('be.visible')
+        cy.getTestId('modal-action-button').should('be.visible')
         cy.get('@onCreatePrincipalSpy').should('not.have.been.called')
 
         // Proceeding through the prompt emits the event

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -237,8 +237,20 @@ const schemaWithoutPrincipals: FormSchema = {
   ],
 }
 
-function mountContent(schema: FormSchema, options: { isKonnect: boolean, hasExistingRealms?: boolean }, data?: Record<string, any>) {
+function mountContent(
+  schema: FormSchema,
+  options: {
+    isKonnect: boolean
+    hasExistingRealms?: boolean
+    hasDefaultDirectory?: boolean
+    hasPrincipals?: boolean
+    lookupDelay?: number
+  },
+  data?: Record<string, any>,
+) {
   const onChangeSpy = cy.spy().as('onChangeSpy')
+  const onLearnMoreSpy = cy.spy().as('onLearnMoreSpy')
+  const onCreatePrincipalSpy = cy.spy().as('onCreatePrincipalSpy')
   const formsConfig = options.isKonnect
     ? { app: 'konnect', apiBaseUrl: 'https://us.api.konghq.com' }
     : { app: 'kongManager' }
@@ -250,6 +262,16 @@ function mountContent(schema: FormSchema, options: { isKonnect: boolean, hasExis
   cy.intercept('GET', '**/v1/realms*', { body: realmsResponse }).as('fetchRealms')
 
   const beforeSaveCallbacks: Array<() => boolean> = []
+  // Mock the Kong Identity directories + principals APIs
+  const directoriesResponse = options.hasDefaultDirectory !== false
+    ? { data: [{ id: 'dir-default', name: 'default' }] }
+    : { data: [] }
+  cy.intercept('GET', '**/v2/directories*', { body: directoriesResponse, delay: options.lookupDelay }).as('fetchDirectories')
+
+  const principalsResponse = options.hasPrincipals
+    ? { data: [{ id: 'principal-1' }] }
+    : { data: [] }
+  cy.intercept('GET', '**/v2/directories/*/principals*', { body: principalsResponse }).as('fetchPrincipals')
 
   cy.mount(() =>
     h('div', { style: 'padding: 20px' },
@@ -258,7 +280,10 @@ function mountContent(schema: FormSchema, options: { isKonnect: boolean, hasExis
         data,
         onChange: onChangeSpy,
       }, {
-        default: () => h(ConfigFormContent),
+        default: () => h(ConfigFormContent, {
+          'onClick:learn-more': onLearnMoreSpy,
+          'onClick:create-principal': onCreatePrincipalSpy,
+        }),
       }),
     ), {
     global: {
@@ -540,6 +565,44 @@ describe('ConfigFormContent', () => {
         cy.getTestId('principals-error-on-miss-false').should('exist')
       })
 
+      it('disables error_on_miss while the "create principal" panel is shown (no stored principals)', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, hasPrincipals: false }, {
+          config: { principals: { enabled: true, directory: 'default', error_on_miss: true }, identity_realms: null },
+        })
+
+        cy.wait('@fetchDirectories')
+        cy.wait('@fetchPrincipals')
+        cy.getTestId('kong-identity-principals-panel').should('be.visible')
+        cy.getTestId('principals-error-on-miss-true').should('be.disabled')
+        cy.getTestId('principals-error-on-miss-false').should('be.disabled')
+      })
+
+      it('disables error_on_miss while the principals lookup is loading, then enables it once principals are found', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, hasPrincipals: true, lookupDelay: 500 }, {
+          config: { principals: { enabled: true, directory: 'default', error_on_miss: true }, identity_realms: null },
+        })
+
+        // While the lookup is in flight the skeleton shows and the field stays disabled
+        cy.getTestId('kong-identity-principals-loading').should('be.visible')
+        cy.getTestId('principals-error-on-miss-true').should('be.disabled')
+
+        // Once the default directory is confirmed to have principals, it becomes enabled
+        cy.wait('@fetchPrincipals')
+        cy.getTestId('principals-error-on-miss-true').should('be.enabled')
+      })
+
+      it('keeps error_on_miss enabled when the default directory already has principals', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, hasPrincipals: true }, {
+          config: { principals: { enabled: true, directory: 'default', error_on_miss: true }, identity_realms: null },
+        })
+
+        cy.wait('@fetchDirectories')
+        cy.wait('@fetchPrincipals')
+        cy.getTestId('kong-identity-principals-panel').should('not.exist')
+        cy.getTestId('principals-error-on-miss-true').should('be.enabled')
+        cy.getTestId('principals-error-on-miss-false').should('be.enabled')
+      })
+
       it('hides error_on_miss group when consumers mode is active', () => {
         mountContent(schemaWithRealms, { isKonnect: true }, {
           config: { principals: null, identity_realms: null },
@@ -569,10 +632,11 @@ describe('ConfigFormContent', () => {
       })
 
       it('clicking reject radio sets error_on_miss to true', () => {
-        mountContent(schemaWithRealms, { isKonnect: true }, {
+        mountContent(schemaWithRealms, { isKonnect: true, hasPrincipals: true }, {
           config: { principals: { enabled: true, directory: 'default', error_on_miss: false }, identity_realms: null },
         })
 
+        cy.wait('@fetchPrincipals')
         cy.getTestId('principals-error-on-miss-true').click({ force: true })
 
         cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
@@ -581,10 +645,11 @@ describe('ConfigFormContent', () => {
       })
 
       it('clicking continue radio sets error_on_miss to false', () => {
-        mountContent(schemaWithRealms, { isKonnect: true }, {
+        mountContent(schemaWithRealms, { isKonnect: true, hasPrincipals: true }, {
           config: { principals: { enabled: true, directory: 'default', error_on_miss: true }, identity_realms: null },
         })
 
+        cy.wait('@fetchPrincipals')
         cy.getTestId('principals-error-on-miss-false').click({ force: true })
 
         cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
@@ -686,6 +751,67 @@ describe('ConfigFormContent', () => {
         })
 
         cy.getTestId('identity-realms-validation-error').should('exist')
+      })
+    })
+    describe('Kong Identity principals panel', () => {
+    // Switch to Kong Identity mode, which is what reveals the principals panel
+      const selectKongIdentity = () => {
+        cy.getTestId('kong-identity-mode-kong-identity').closest('.k-radio').click()
+      }
+
+      it('shows the empty-state panel when the default directory has no principals', () => {
+        mountContent(schemaWithoutRealms, { isKonnect: true, hasPrincipals: false }, { config: { principals: { enabled: false } } })
+
+        selectKongIdentity()
+
+        cy.wait('@fetchDirectories')
+        cy.wait('@fetchPrincipals')
+        cy.getTestId('kong-identity-principals-panel').should('be.visible')
+        cy.getTestId('kong-identity-create-principal').should('exist')
+      })
+
+      it('shows the empty-state panel when there is no default directory', () => {
+        mountContent(schemaWithoutRealms, { isKonnect: true, hasDefaultDirectory: false }, { config: { principals: { enabled: false } } })
+
+        selectKongIdentity()
+
+        cy.wait('@fetchDirectories')
+        cy.getTestId('kong-identity-principals-panel').should('be.visible')
+      })
+
+      it('hides the panel when the default directory already has principals', () => {
+        mountContent(schemaWithoutRealms, { isKonnect: true, hasPrincipals: true }, { config: { principals: { enabled: false } } })
+
+        selectKongIdentity()
+
+        cy.wait('@fetchDirectories')
+        cy.wait('@fetchPrincipals')
+        cy.getTestId('kong-identity-principals-panel').should('not.exist')
+      })
+
+      it('does not show the panel unless Kong Identity mode is selected', () => {
+        mountContent(schemaWithoutRealms, { isKonnect: true, hasPrincipals: false })
+
+        cy.getTestId('ff-kong-identity-field').should('exist')
+        cy.getTestId('kong-identity-principals-panel').should('not.exist')
+      })
+
+      it('emits "click:create-principal" when the create button is clicked', () => {
+        mountContent(schemaWithoutRealms, { isKonnect: true, hasPrincipals: false }, { config: { principals: { enabled: false } } })
+
+        selectKongIdentity()
+
+        cy.getTestId('kong-identity-create-principal').should('not.be.disabled').click()
+        cy.get('@onCreatePrincipalSpy').should('have.been.calledOnce')
+      })
+
+      it('emits "click:learn-more" to open the Learning Hub when "Learn more" is clicked', () => {
+        mountContent(schemaWithoutRealms, { isKonnect: true, hasPrincipals: false }, { config: { principals: { enabled: false } } })
+
+        selectKongIdentity()
+
+        cy.getTestId('kong-identity-principals-learn-more').click()
+        cy.get('@onLearnMoreSpy').should('have.been.calledOnceWith', 'kong-identity')
       })
     })
   })

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -282,7 +282,7 @@ function mountContent(
       }, {
         default: () => h(ConfigFormContent, {
           'onClick:learn-more': onLearnMoreSpy,
-          'onClick:create-principal': onCreatePrincipalSpy,
+          'onClick:create-entity': onCreatePrincipalSpy,
         }),
       }),
     ), {
@@ -796,7 +796,7 @@ describe('ConfigFormContent', () => {
         cy.getTestId('kong-identity-principals-panel').should('not.exist')
       })
 
-      it('emits "click:create-principal" only after confirming the leave-page prompt', () => {
+      it('emits "click:create-entity" only after confirming the leave-page prompt', () => {
         mountContent(schemaWithoutRealms, { isKonnect: true, hasPrincipals: false }, { config: { principals: { enabled: false } } })
 
         selectKongIdentity()
@@ -811,7 +811,7 @@ describe('ConfigFormContent', () => {
         cy.get('@onCreatePrincipalSpy').should('have.been.calledOnce')
       })
 
-      it('does not emit "click:create-principal" when the leave-page prompt is cancelled', () => {
+      it('does not emit "click:create-entity" when the leave-page prompt is cancelled', () => {
         mountContent(schemaWithoutRealms, { isKonnect: true, hasPrincipals: false }, { config: { principals: { enabled: false } } })
 
         selectKongIdentity()

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -142,44 +142,8 @@ const principalsPanelVisible = computed(() =>
 type ListResponse<T> = { data?: T[] }
 type Directory = { id: string, name: string }
 
-// `setDirectory` is only true on a genuine switch into Kong Identity mode (create flow);
-// on edit-load the directory is already stored and must not be overwritten.
-const fetchPrincipalsState = async ({ setDirectory }: { setDirectory: boolean }) => {
-  // Kong Identity directories are a Konnect-only concept.
-  if (appConfig?.app !== 'konnect') return
-
-  try {
-    principalsLoading.value = true
-    const dirResp = await axiosInstance.get<ListResponse<Directory>>(
-      `${appConfig.apiBaseUrl}/v2/directories`,
-      { params: { 'page[size]': 1 } },
-    )
-    const directory = dirResp?.data?.data?.[0]
-
-    if (!directory) {
-      principalsHasPrincipals.value = false
-      return
-    }
-
-    // Store the resolved directory name so it matches the directory we check principals
-    // against (the two can no longer disagree).
-    if (setDirectory && formData.config?.principals) {
-      formData.config.principals.directory = directory.name
-    }
-
-    // Only need to know whether at least one principal exists, so request a single item.
-    const principalsResp = await axiosInstance.get<ListResponse<unknown>>(
-      `${appConfig.apiBaseUrl}/v2/directories/${directory.id}/principals`,
-      { params: { 'page[size]': 1 } },
-    )
-    principalsHasPrincipals.value = (principalsResp?.data?.data?.length ?? 0) > 0
-  } catch {
-    // On failure fall back to the empty state so the user can still create a principal.
-    principalsHasPrincipals.value = false
-  } finally {
-    principalsLoading.value = false
-  }
-}
+// Cached after the first fetch so mode switches never trigger a second network request.
+const cachedDirectory = ref<Directory | null>(null)
 
 const principalsErrorOnMiss = computed(() => formData.config?.principals?.error_on_miss ?? true)
 
@@ -253,18 +217,67 @@ function hasActualRealm(realms: any[] | null | undefined): boolean {
 
 const selectedMode = ref<'consumers' | 'kong-identity' | 'centrally-managed'>(detectInitialMode())
 
-// Run the directory/principals lookup each time the user enters Kong Identity mode.
-// `prev === false` means a real user switch (create flow) so we adopt the directory name;
-// the immediate run (`prev` is undefined, i.e. edit-load) only checks principals and leaves
-// the stored directory intact. Declared after `selectedMode`/`hasPrincipals` because the
-// immediate run reads them synchronously during setup.
-watch(
-  () => isKonnect.value && hasPrincipals.value && selectedMode.value === 'kong-identity',
-  (active, prev) => {
-    if (active) fetchPrincipalsState({ setDirectory: prev === false })
-  },
-  { immediate: true },
-)
+// True when the form loads with an existing kong-identity config (edit flow).
+// Captured synchronously so the async fetch can decide whether to overwrite the saved directory.
+const isEditLoadKongIdentity = selectedMode.value === 'kong-identity'
+
+const fetchPrincipalsState = async () => {
+  if (appConfig?.app !== 'konnect') return
+  try {
+    // Only show the loading skeleton on the first fetch; background refreshes are silent.
+    if (!cachedDirectory.value) {
+      principalsLoading.value = true
+    }
+    const dirResp = await axiosInstance.get<ListResponse<Directory>>(
+      `${appConfig.apiBaseUrl}/v2/directories`,
+      { params: { 'page[size]': 1 } },
+    )
+    const directory = dirResp?.data?.data?.[0]
+    if (!directory) {
+      principalsHasPrincipals.value = false
+      return
+    }
+
+    cachedDirectory.value = directory
+
+    // Apply the directory name if the user is currently in Kong Identity mode and this
+    // is not an edit-load (where the saved directory value must be preserved).
+    if (!isEditLoadKongIdentity && selectedMode.value === 'kong-identity' && formData.config?.principals) {
+      formData.config.principals.directory = directory.name
+    }
+
+    const principalsResp = await axiosInstance.get<ListResponse<unknown>>(
+      `${appConfig.apiBaseUrl}/v2/directories/${directory.id}/principals`,
+      { params: { 'page[size]': 1 } },
+    )
+    principalsHasPrincipals.value = (principalsResp?.data?.data?.length ?? 0) > 0
+  } catch {
+    principalsHasPrincipals.value = false
+  } finally {
+    principalsLoading.value = false
+  }
+}
+
+// Fetch on mount — covers edit-load (already in kong-identity) and pre-warms the
+// cache for create-flow so switching into kong-identity shows data without a second request.
+onMounted(() => {
+  if (isKonnect.value && hasPrincipals.value) {
+    fetchPrincipalsState()
+  }
+})
+
+// When the user switches into Kong Identity, optimistically apply the cached directory
+// name then always re-fetch to refresh the principals status. Skip the fetch only if
+// the mount fetch is still in flight (it will apply the result when it completes).
+watch(selectedMode, (mode) => {
+  if (!isKonnect.value || !hasPrincipals.value || mode !== 'kong-identity') return
+  if (cachedDirectory.value && formData.config?.principals) {
+    formData.config.principals.directory = cachedDirectory.value.name
+  }
+  if (!principalsLoading.value) {
+    fetchPrincipalsState()
+  }
+})
 
 // Show validation error when centrally-managed mode is active but no real realm is selected
 const realmValidationError = computed(() =>

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -34,6 +34,14 @@
       {{ i18n.t('custom_field.kong_identity.identity_realms_required') }}
     </p>
   </div>
+  <PrincipalsCreationGuide
+    v-if="isKonnect && hasPrincipals && selectedMode === 'kong-identity'"
+    class="kong-identity-principals-section"
+    :loading="principalsLoading"
+    :show-panel="principalsShowPanel"
+    @click:create-principal="emit('click:create-principal')"
+    @click:learn-more="(entity: string) => emit('click:learn-more', entity)"
+  />
 
   <AdvancedFields
     class="ff-advanced-fields-container"
@@ -50,6 +58,7 @@
       <KRadio
         data-testid="principals-error-on-miss-true"
         :description="i18n.t('custom_field.kong_identity.error_on_miss_reject_description')"
+        :disabled="principalsPanelVisible"
         :label="i18n.t('custom_field.kong_identity.error_on_miss_reject_label')"
         :model-value="principalsErrorOnMiss"
         :selected-value="true"
@@ -58,6 +67,7 @@
       <KRadio
         data-testid="principals-error-on-miss-false"
         :description="i18n.t('custom_field.kong_identity.error_on_miss_continue_description')"
+        :disabled="principalsPanelVisible"
         :label="i18n.t('custom_field.kong_identity.error_on_miss_continue_label')"
         :model-value="principalsErrorOnMiss"
         :selected-value="false"
@@ -79,6 +89,7 @@ import ObjectField from '../../free-form/shared/ObjectField.vue'
 import AdvancedFields from '../../free-form/shared/AdvancedFields.vue'
 import KongIdentityField from './KongIdentityField.vue'
 import IdentityRealmsField from '../../free-form/plugins/key-auth/IdentityRealmsField.vue'
+import PrincipalsCreationGuide from './PrincipalsCreationGuide.vue'
 import { useFormShared } from '../../free-form/shared/composables'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import { useAxios } from '@kong-ui-public/entities-shared'
@@ -91,6 +102,11 @@ import type { KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-
 import type { MultiselectItem } from '@kong/kongponents'
 import type { AxiosResponse } from 'axios'
 
+const emit = defineEmits<{
+  'click:learn-more': [entity: string]
+  'click:create-principal': []
+}>()
+
 const registerBeforeSave = inject(BEFORE_SAVE_KEY)
 
 const { i18n } = composables.useI18n()
@@ -102,6 +118,67 @@ const { axiosInstance } = useAxios(appConfig?.axiosRequestConfig)
 const { formData, getSchema } = useFormShared()
 
 const hasPrincipalsErrorOnMiss = computed(() => !!getSchema('$.config.principals.error_on_miss'))
+
+// Kong Identity directory lookup (Konnect only). A single /v2/directories call drives two
+// things: the directory NAME is stored on config.principals.directory, and the directory ID
+// is used to check whether any principals already exist. When none do we show the "create
+// your first principal" panel; while that panel is shown (or the lookup is still loading)
+// there are no principals to configure, so error_on_miss is meaningless and must be disabled.
+const principalsLoading = ref(false)
+const principalsHasPrincipals = ref(false)
+
+const principalsShowPanel = computed(() => !principalsLoading.value && !principalsHasPrincipals.value)
+
+// True whenever the field renders something (skeleton or empty-state panel), i.e. there
+// are no confirmed stored principals yet — used to disable error_on_miss.
+const principalsPanelVisible = computed(() =>
+  isKonnect.value
+  && hasPrincipals.value
+  && selectedMode.value === 'kong-identity'
+  && (principalsLoading.value || principalsShowPanel.value),
+)
+
+type ListResponse<T> = { data?: T[] }
+type Directory = { id: string, name: string }
+
+// `setDirectory` is only true on a genuine switch into Kong Identity mode (create flow);
+// on edit-load the directory is already stored and must not be overwritten.
+const fetchPrincipalsState = async ({ setDirectory }: { setDirectory: boolean }) => {
+  // Kong Identity directories are a Konnect-only concept.
+  if (appConfig?.app !== 'konnect') return
+
+  try {
+    principalsLoading.value = true
+    const dirResp = await axiosInstance.get<ListResponse<Directory>>(
+      `${appConfig.apiBaseUrl}/v2/directories`,
+      { params: { 'page[size]': 1 } },
+    )
+    const directory = dirResp?.data?.data?.[0]
+
+    if (!directory) {
+      principalsHasPrincipals.value = false
+      return
+    }
+
+    // Store the resolved directory name so it matches the directory we check principals
+    // against (the two can no longer disagree).
+    if (setDirectory && formData.config?.principals) {
+      formData.config.principals.directory = directory.name
+    }
+
+    // Only need to know whether at least one principal exists, so request a single item.
+    const principalsResp = await axiosInstance.get<ListResponse<unknown>>(
+      `${appConfig.apiBaseUrl}/v2/directories/${directory.id}/principals`,
+      { params: { 'page[size]': 1 } },
+    )
+    principalsHasPrincipals.value = (principalsResp?.data?.data?.length ?? 0) > 0
+  } catch {
+    // On failure fall back to the empty state so the user can still create a principal.
+    principalsHasPrincipals.value = false
+  } finally {
+    principalsLoading.value = false
+  }
+}
 
 const principalsErrorOnMiss = computed(() => formData.config?.principals?.error_on_miss ?? true)
 
@@ -174,6 +251,19 @@ function hasActualRealm(realms: any[] | null | undefined): boolean {
 }
 
 const selectedMode = ref<'consumers' | 'kong-identity' | 'centrally-managed'>(detectInitialMode())
+
+// Run the directory/principals lookup each time the user enters Kong Identity mode.
+// `prev === false` means a real user switch (create flow) so we adopt the directory name;
+// the immediate run (`prev` is undefined, i.e. edit-load) only checks principals and leaves
+// the stored directory intact. Declared after `selectedMode`/`hasPrincipals` because the
+// immediate run reads them synchronously during setup.
+watch(
+  () => isKonnect.value && hasPrincipals.value && selectedMode.value === 'kong-identity',
+  (active, prev) => {
+    if (active) fetchPrincipalsState({ setDirectory: prev === false })
+  },
+  { immediate: true },
+)
 
 // Show validation error when centrally-managed mode is active but no real realm is selected
 const realmValidationError = computed(() =>
@@ -293,6 +383,11 @@ const advancedOmit = computed(() => {
   display: flex;
   flex-direction: column;
   gap: var(--kui-space-40, $kui-space-40);
+}
+
+.kong-identity-principals-section + .ff-advanced-fields-container {
+  border-top: none;
+  padding-top: 0;
 }
 
 .ff-advanced-fields-container {

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -39,7 +39,7 @@
     class="kong-identity-principals-section"
     :loading="principalsLoading"
     :show-panel="principalsShowPanel"
-    @click:create-principal="emit('click:create-principal')"
+    @click:create-entity="(payload) => emit('click:create-entity', payload)"
     @click:learn-more="(entity: string) => emit('click:learn-more', entity)"
   />
 
@@ -101,10 +101,11 @@ import composables from '../../../composables'
 import type { KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
 import type { MultiselectItem } from '@kong/kongponents'
 import type { AxiosResponse } from 'axios'
+import type { EntityCreateEvent } from '../../../types'
 
 const emit = defineEmits<{
   'click:learn-more': [entity: string]
-  'click:create-principal': []
+  'click:create-entity': [payload: EntityCreateEvent]
 }>()
 
 const registerBeforeSave = inject(BEFORE_SAVE_KEY)

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormWithIdentity.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormWithIdentity.vue
@@ -1,6 +1,9 @@
 <template>
   <DynamicLayout v-bind="props">
-    <ConfigFormContent />
+    <ConfigFormContent
+      @click:create-principal="emit('click:create-principal')"
+      @click:learn-more="(entity: string) => emit('click:learn-more', entity)"
+    />
   </DynamicLayout>
 </template>
 
@@ -13,6 +16,11 @@ import ConfigFormContent from './ConfigFormContent.vue'
 import type { PluginFormLayoutProps as Props } from '../../free-form/shared/layout/provider'
 
 const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'click:learn-more': [entity: string]
+  'click:create-principal': []
+}>()
 
 const slots = defineSlots<{
   [K in typeof AUTOFILL_SLOT_NAME]: () => any

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormWithIdentity.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormWithIdentity.vue
@@ -1,7 +1,7 @@
 <template>
   <DynamicLayout v-bind="props">
     <ConfigFormContent
-      @click:create-principal="emit('click:create-principal')"
+      @click:create-entity="(payload) => emit('click:create-entity', payload)"
       @click:learn-more="(entity: string) => emit('click:learn-more', entity)"
     />
   </DynamicLayout>
@@ -14,12 +14,13 @@ import DynamicLayout from '../../free-form/shared/layout/DynamicLayout.vue'
 import ConfigFormContent from './ConfigFormContent.vue'
 
 import type { PluginFormLayoutProps as Props } from '../../free-form/shared/layout/provider'
+import type { EntityCreateEvent } from '../../../types'
 
 const props = defineProps<Props>()
 
 const emit = defineEmits<{
   'click:learn-more': [entity: string]
-  'click:create-principal': []
+  'click:create-entity': [payload: EntityCreateEvent]
 }>()
 
 const slots = defineSlots<{

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
@@ -129,7 +129,9 @@ function handleModeChange(mode: AuthMode) {
   model.value = mode
 
   switch (mode) {
-    case 'kong-identity':
+    case 'kong-identity': {
+      // `directory` is a placeholder; ConfigFormContent resolves the real directory name
+      // from the shared /v2/directories lookup and overwrites it on entering this mode.
       formData.config.principals = { ...getEmptyOrDefault('$.config.principals'), enabled: true, directory: 'default' }
       if (identityRealmsInSchema.value) {
         formData.config.identity_realms = []
@@ -138,6 +140,7 @@ function handleModeChange(mode: AuthMode) {
         formData.config.realm = null
       }
       break
+    }
     case 'consumers': {
       const principalsRequired = !!getSchema('$.config.principals')?.required
       formData.config.principals = principalsRequired ? getEmptyOrDefault('$.config.principals') : null

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/PrincipalsCreationGuide.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/PrincipalsCreationGuide.vue
@@ -65,7 +65,7 @@ defineProps<{
 const emit = defineEmits<{
   'click:learn-more': [entity: string]
   /** Emitted when the user clicks "Create principal"; the consuming app owns navigation */
-  'click:create-principal': []
+  'click:create-entity': [payload: { type: 'principal' }]
 }>()
 
 const { i18n } = composables.useI18n()
@@ -76,7 +76,7 @@ const showLeavePrompt = ref(false)
 
 const handleCreatePrincipal = () => {
   showLeavePrompt.value = false
-  emit('click:create-principal')
+  emit('click:create-entity', { type: 'principal' })
 }
 </script>
 

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/PrincipalsCreationGuide.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/PrincipalsCreationGuide.vue
@@ -18,7 +18,7 @@
       <KButton
         appearance="primary"
         data-testid="kong-identity-create-principal"
-        @click="emit('click:create-principal')"
+        @click="showLeavePrompt = true"
       >
         <AddIcon decorative />
         {{ t('custom_field.kong_identity.create_principal') }}
@@ -35,10 +35,21 @@
       </KButton>
     </template>
   </KEmptyState>
+
+  <KPrompt
+    :action-button-text="t('custom_field.kong_identity.leave_prompt_action')"
+    data-testid="kong-identity-create-principal-prompt"
+    :message="t('custom_field.kong_identity.leave_prompt_message')"
+    :title="t('custom_field.kong_identity.leave_prompt_title')"
+    :visible="showLeavePrompt"
+    @cancel="showLeavePrompt = false"
+    @proceed="handleCreatePrincipal"
+  />
 </template>
 
 <script lang="ts" setup>
-import { KButton, KEmptyState } from '@kong/kongponents'
+import { ref } from 'vue'
+import { KButton, KEmptyState, KPrompt } from '@kong/kongponents'
 import { AddIcon, BookIcon } from '@kong/icons'
 import composables from '../../../composables'
 
@@ -59,6 +70,14 @@ const emit = defineEmits<{
 
 const { i18n } = composables.useI18n()
 const { t } = i18n
+
+// Creating a principal navigates away from the form; confirm before losing unsaved changes.
+const showLeavePrompt = ref(false)
+
+const handleCreatePrincipal = () => {
+  showLeavePrompt.value = false
+  emit('click:create-principal')
+}
 </script>
 
 <style lang="scss" scoped>

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/PrincipalsCreationGuide.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/PrincipalsCreationGuide.vue
@@ -1,0 +1,95 @@
+<template>
+  <KSkeleton
+    v-if="loading"
+    class="kong-identity-principals-skeleton"
+    data-testid="kong-identity-principals-loading"
+  />
+
+  <KEmptyState
+    v-else-if="showPanel"
+    class="kong-identity-principals"
+    data-testid="kong-identity-principals-panel"
+    :message="t('custom_field.kong_identity.configure_description')"
+    :title="t('custom_field.kong_identity.configure_title')"
+  >
+    <template #icon />
+
+    <template #action>
+      <KButton
+        appearance="primary"
+        data-testid="kong-identity-create-principal"
+        @click="emit('click:create-principal')"
+      >
+        <AddIcon decorative />
+        {{ t('custom_field.kong_identity.create_principal') }}
+      </KButton>
+
+      <KButton
+        appearance="secondary"
+        class="open-learning-hub"
+        data-testid="kong-identity-principals-learn-more"
+        @click="emit('click:learn-more', 'kong-identity')"
+      >
+        <BookIcon decorative />
+        {{ t('custom_field.kong_identity.configure_learn_more') }}
+      </KButton>
+    </template>
+  </KEmptyState>
+</template>
+
+<script lang="ts" setup>
+import { KButton, KEmptyState } from '@kong/kongponents'
+import { AddIcon, BookIcon } from '@kong/icons'
+import composables from '../../../composables'
+
+defineOptions({ name: 'PrincipalsCreationGuide' })
+
+defineProps<{
+  /** Whether the directory/principal lookup is still in flight */
+  loading?: boolean
+  /** Whether to show the "create your first principal" empty-state panel */
+  showPanel?: boolean
+}>()
+
+const emit = defineEmits<{
+  'click:learn-more': [entity: string]
+  /** Emitted when the user clicks "Create principal"; the consuming app owns navigation */
+  'click:create-principal': []
+}>()
+
+const { i18n } = composables.useI18n()
+const { t } = i18n
+</script>
+
+<style lang="scss" scoped>
+.kong-identity-principals-skeleton {
+  margin-top: var(--kui-space-50, $kui-space-50);
+
+  // KSkeletonBox caps its own width (80px) and height (8/16px) via its own
+  // scoped rules; override both to roughly match the empty-state panel so the
+  // loading state doesn't flash as a thin sliver.
+  &.skeleton-box {
+    border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
+    height: 240px !important;
+    width: 100% !important;
+  }
+}
+
+.kong-identity-principals {
+  background-color: var(--kui-color-background-decorative-purple-weakest, $kui-color-background-decorative-purple-weakest);
+  border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
+  margin-top: var(--kui-space-50, $kui-space-50);
+  padding: var(--kui-space-80, $kui-space-80);
+
+  // No icon in this empty state
+  :deep(.empty-state-icon) {
+    display: none;
+  }
+
+  // Render the two action buttons (Create principal + Learn more) side by side
+  :deep(.empty-state-action) {
+    display: flex;
+    gap: var(--kui-space-40, $kui-space-40);
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/basic-auth/index.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/basic-auth/index.ts
@@ -1,4 +1,5 @@
 import ConfigFormWithIdentity from '../../../fields/kong-identity/ConfigFormWithIdentity.vue'
+import StringField from '../../shared/StringField.vue'
 import { definePluginConfig } from '../../shared/define-plugin-config'
 
 export default definePluginConfig({
@@ -9,4 +10,13 @@ export default definePluginConfig({
       'config.brute_force_protection.redis': ['config.brute_force_protection.strategy', 'redis'],
     },
   },
+  fieldRenderers: [
+    {
+      match: 'config.anonymous',
+      component: StringField,
+      propsOverrides: {
+        placeholder: 'e.g., 00000000-0000-0000-0000-000000000001',
+      },
+    },
+  ],
 })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/key-auth/index.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/key-auth/index.ts
@@ -1,5 +1,6 @@
 import ConfigFormWithIdentity from '../../../fields/kong-identity/ConfigFormWithIdentity.vue'
 import IdentityRealmsField from './IdentityRealmsField.vue'
+import StringField from '../../shared/StringField.vue'
 import { definePluginConfig } from '../../shared/define-plugin-config'
 
 export default definePluginConfig({
@@ -9,6 +10,20 @@ export default definePluginConfig({
     {
       match: ({ path }) => path === 'config.identity_realms',
       component: IdentityRealmsField,
+    },
+    {
+      match: 'config.anonymous',
+      component: StringField,
+      propsOverrides: {
+        placeholder: 'e.g., 00000000-0000-0000-0000-000000000001',
+      },
+    },
+    {
+      match: 'config.realm',
+      component: StringField,
+      propsOverrides: {
+        placeholder: 'e.g., my-api',
+      },
     },
   ],
 })

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -1209,7 +1209,11 @@
       "error_on_miss_reject_label": "Reject the request",
       "error_on_miss_reject_description": "Treat the request as unauthenticated if Kong Identity cannot resolve the principal.",
       "error_on_miss_continue_label": "Continue without a principal",
-      "error_on_miss_continue_description": "Allow the request to continue without resolving a principal."
+      "error_on_miss_continue_description": "Allow the request to continue without resolving a principal.",
+      "configure_title": "Configure Kong Identity",
+      "configure_description": "Kong Identity uses principals to represent authenticated users, services, or applications. Create your first principal in Kong Identity to start using principal-based authentication.",
+      "create_principal": "Create principal",
+      "configure_learn_more": "Learn more"
     }
   },
   "sp": {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -1213,7 +1213,10 @@
       "configure_title": "Configure Kong Identity",
       "configure_description": "Kong Identity uses principals to represent authenticated users, services, or applications. Create your first principal in Kong Identity to start using principal-based authentication.",
       "create_principal": "Create principal",
-      "configure_learn_more": "Learn more"
+      "configure_learn_more": "Learn more",
+      "leave_prompt_title": "Leave this page?",
+      "leave_prompt_message": "Your unsaved changes will be lost if you continue.",
+      "leave_prompt_action": "Leave page"
     }
   },
   "sp": {

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -87,6 +87,20 @@ export interface KonnectPluginFormConfig extends BasePluginFormConfig, KonnectBa
 /** Kong Manager Plugin form config */
 export interface KongManagerPluginFormConfig extends BasePluginFormConfig, KongManagerBaseFormConfig { }
 
+/**
+ * Payload for the `click:create-entity` event emitted from the Kong Identity principals UI.
+ * The consuming app navigates to the matching create page; `authServerId` is provided when
+ * creating a client (scoped to the selected auth server).
+ */
+export type EntityCreateEvent = {
+  type: 'principal'
+} | {
+  type: 'auth-server'
+} | {
+  type: 'client'
+  authServerId?: string
+}
+
 export interface PluginFormFields {
   enabled: boolean
   name?: string


### PR DESCRIPTION
# Summary

Adds a **Principals Creation Guide** to the Kong Identity section of the plugin config form (Konnect only). When a plugin is set to use Kong Identity (principal-based auth) but no principals exist yet, the form surfaces an empty-state panel guiding the user to create their first principal, and emits events so the consuming app owns navigation.

## What's new

**`PrincipalsCreationGuide.vue`** (new field) — presentational empty-state panel shown when Kong Identity mode is selected and the directory has no principals. Shows a loading skeleton during lookup, then a "Create principal" + "Learn more" panel. Pure props-in / events-out:
- props: `loading`, `showPanel`
- emits: `click:create-principal`, `click:learn-more`

**Directory & principals lookup (`ConfigFormContent.vue`)** — on entering Kong Identity mode, a single `GET /v2/directories?pageSize=1` call:
- stores the resolved directory **name** on `config.principals.directory`,
- uses the directory **id** to check `GET /v2/directories/{id}/principals` for existing principals,
- shows the guide when none exist, hides it once principals are confirmed,
- disables the `error_on_miss` radios while the guide is visible (nothing to configure yet).
- On edit-load the stored directory is preserved; it's only adopted from the lookup on a genuine user switch into the mode.

**Event propagation** — `click:create-principal` / `click:learn-more` bubble `PrincipalsCreationGuide → ConfigFormContent → ConfigFormWithIdentity → PluginForm`/`PluginEntityForm`, so the host app handles navigation.

**i18n** — new strings: `configure_title`, `configure_description`, `create_principal`, `configure_learn_more`.

## Consuming app integration

```vue
<PluginForm
  :config="config"
  @click:create-principal="() => router.push(/* your principal-create route */)"
  @click:learn-more="(entity) => /* open docs for `entity`, e.g. 'kong-identity' */"
/>
```

Both events are optional; bind `@click:create-principal` wherever the guide can appear so the button is actionable.

## Tests

`ConfigFormContent.cy.ts` (+134): guide shown/hidden by principals existence, loading skeleton, `error_on_miss` disabled while the guide is visible, and `click:create-principal` emission.
