### PR TITLE
fix: cap undici override at <8.0.0 to fix jsdom unit test failures

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
   tmp@<0.2.6: '>=0.2.7'
   shell-quote@>=1.1.0 <=1.8.3: '>=1.8.4'
   ws@>=8.0.0 <8.21.0: '>=8.21.0'
-  undici@>=7.0.0 <7.28.0: '>=7.28.0'
+  undici@>=7.0.0 <7.28.0: '>=7.28.0 <8.0.0'
 
 importers:
 
@@ -10746,9 +10746,9 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
-    engines: {node: '>=22.19.0'}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -18608,7 +18608,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 8.5.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -22230,7 +22230,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.5.0: {}
+  undici@7.28.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ overrides:
   tmp@<0.2.6: '>=0.2.7'
   shell-quote@>=1.1.0 <=1.8.3: '>=1.8.4'
   ws@>=8.0.0 <8.21.0: '>=8.21.0'
-  undici@>=7.0.0 <7.28.0: '>=7.28.0'
+  undici@>=7.0.0 <7.28.0: '>=7.28.0 <8.0.0'
 
 onlyBuiltDependencies:
   - '@evilmartians/lefthook'


### PR DESCRIPTION
## Problem

The security override in `pnpm-workspace.yaml` had no upper bound:

```yaml
undici@>=7.0.0 <7.28.0: '>=7.28.0'
```

`jsdom@29.1.1` declares `undici@^7.25.0` as a dependency. The partial overlap with the override range caused pnpm to resolve undici to the latest `8.5.0`. However, jsdom uses the internal path `undici/lib/handler/wrap-handler.js`, which was removed in undici 8.x — causing all vitest test files to fail initialization in CI (13 unhandled errors, 0 tests ran).

## Fix

Cap the override at `<8.0.0`:

```diff
- undici@>=7.0.0 <7.28.0: '>=7.28.0'
+ undici@>=7.0.0 <7.28.0: '>=7.28.0 <8.0.0'
```

undici `8.5.0` → `7.28.0`. The security requirement (`>=7.28.0`) is still satisfied.