### PR TITLE
fix(ci): trigger full build/test on pnpm-workspace.yaml changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
           echo "run-tests=${{ (github.event_name == 'push' && steps.up-to-date.outputs.status == 'true') && 'false' || 'true' }}"
           echo "run-tests=${{ (github.event_name == 'push' && steps.up-to-date.outputs.status == 'true') && 'false' || 'true' }}" >> $GITHUB_OUTPUT
 
-      # If we detect changes in any of the config files (e.g. lockfile, shared cypress configs, etc.), we need to build every package
+      # If we detect changes in any of the config files (e.g. pnpm-workspace.yaml, shared cypress configs, etc.), we need to build every package
       # See 'changed_packages' below
       - name: Check for config file changes
         id: config-files-changed
@@ -82,6 +82,7 @@ jobs:
             ./cypress.config.ts
             ./cypress/**
             ./package.json
+            ./pnpm-workspace.yaml
             ./eslintrc.cjs
             ./.stylelintrc.js
             ./.github/**
@@ -94,7 +95,7 @@ jobs:
           # we execute lerna changed to grab all the packages changed
           lernaCommand="changed"
 
-          # if config-files-changed detects the change of pnpm-lock.yaml file - we will grab all the packages
+          # if config-files-changed detects a change in any of the watched config files - we will grab all the packages
           if [[ "${{ steps.config-files-changed.outputs.any_modified }}" == "true" ]]; then
             lernaCommand="ls"
           fi
@@ -133,7 +134,7 @@ jobs:
           # we execute lerna changed to grab all the packages changed
           lernaCommand="changed"
 
-          # if config-files-changed detects the change of pnpm-lock.yaml file - we will grab all the packages
+          # if config-files-changed detects a change in any of the watched config files - we will grab all the packages
           if [[ "${{ steps.config-files-changed.outputs.any_modified }}" == "true" ]]; then
             lernaCommand="ls"
           fi


### PR DESCRIPTION
## Summary

CI's `Check for config file changes` step (`config-files-changed`) expands the build/test scope to **all** packages (`lerna ls`) when a watched root config file changes. `pnpm-workspace.yaml` — which now holds catalog/overrides/pnpm config — was missing from the watched list, so PRs that touch only it (e.g. `chore: pnpm audit fix`) compute an empty changed-package set and skip lint/build/test/preview entirely.

## Changes

- Add `./pnpm-workspace.yaml` to the `config-files-changed` watched `files:` list.
- Fix misleading comments that referenced `pnpm-lock.yaml` (the lockfile was never actually watched); they now describe "any watched config file".
