### PR TITLE
fix(analytics): display empty rows without entity links [MA-5070]

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
@@ -276,7 +276,13 @@
         title="Top 5 Routes"
       >
         <template #name="{ record }">
-          <a href="#">{{ record.name }}</a>
+          <a
+            v-if="record.name !== 'empty'"
+            href="#"
+          >
+            {{ record.name }}
+          </a>
+          <span v-else><i>{{ record.name }}</i></span>
         </template>
       </TopNTable>
     </div>
@@ -334,6 +340,7 @@ const topNRouteDisplay = {
   'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:8b1db7eb-5c3c-489c-9344-eb0b272019ca': { name: '8b1db (default)', deleted: false },
   'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:8f3f6808-a723-4793-8444-f2046961226b': { name: 'dp-mock-us-dev (default)', deleted: false },
   'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:2a3e9d21-804b-4b3b-ab7e-c6f002dadbf4': { name: 'dp-mock-msg-per-sec-us-dev (default)', deleted: false },
+  'empty': { name: 'empty', deleted: false },
 }
 
 const topNGatewayServiceDisplay = {
@@ -353,31 +360,31 @@ const topNMetricScenarios: MetricScenario[] = [
     kind: 'count',
     metricKey: 'request_count',
     unit: 'count',
-    values: [9_483, 5_587, 5_583, 1_485, 309],
+    values: [9_483, 5_587, 5_583, 1_485, 309, 9_001],
   },
   {
     kind: 'ms',
     metricKey: 'response_latency_average',
     unit: 'ms',
-    values: [12.345, 9.8, 7.23, 3.456, 1.001],
+    values: [12.345, 9.8, 7.23, 3.456, 1.001, 9.001],
   },
   {
     kind: 'bytes',
     metricKey: 'response_size_average',
     unit: 'bytes',
-    values: [1_048_576, 512_000, 2_048, 128, 1],
+    values: [1_048_576, 512_000, 2_048, 128, 1, 9_001],
   },
   {
     kind: 'usd',
     metricKey: 'cost',
     unit: 'usd',
-    values: [12.3, 3.99, 0.00005, 0.42, 0.1],
+    values: [12.3, 3.99, 0.00005, 0.42, 0.1, 90.01],
   },
   {
     kind: 'rpm',
     metricKey: 'requests_per_minute',
     unit: 'count/minute',
-    values: [98_765, 43_210, 2_100, 987, 12],
+    values: [98_765, 43_210, 2_100, 987, 12, 9_001],
   },
 ]
 

--- a/packages/analytics/analytics-chart/src/components/TopNTable.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/TopNTable.cy.ts
@@ -1,4 +1,3 @@
-import { h } from 'vue'
 import TopNTable from './TopNTable.vue'
 
 const ROUTE_ID = 'b486fb30-e058-4b5f-85c2-495ec26ba522:09ba7bc7-58d6-42d5-b9c0-3ffb28b307e6'
@@ -209,6 +208,67 @@ const THREE_DIMENSION_TABLE_DATA = {
       },
     }
   }),
+}
+
+const EMPTY_ROUTE_DISPLAY = {
+  ...ROUTE_DISPLAY_V2,
+  empty: {
+    name: 'empty',
+    deleted: false,
+  },
+}
+
+const EMPTY_ROW_TABLE_DATA = {
+  ...TABLE_DATA_V2,
+  meta: {
+    ...TABLE_DATA_V2.meta,
+    display: {
+      ROUTE: EMPTY_ROUTE_DISPLAY,
+    },
+  },
+  data: [
+    {
+      event: {
+        REQUEST_COUNT: 9483,
+        ROUTE: ROUTE_ID,
+      },
+      timestamp: '2023-08-17T17:55:53.000Z',
+    },
+    {
+      event: {
+        REQUEST_COUNT: 9001,
+        ROUTE: 'empty',
+      },
+      timestamp: '2023-08-17T17:55:53.000Z',
+    },
+  ],
+}
+
+const EMPTY_DIMENSION_TABLE_DATA = {
+  ...MULTI_DIMENSION_TABLE_DATA,
+  meta: {
+    ...MULTI_DIMENSION_TABLE_DATA.meta,
+    display: {
+      ROUTE: ROUTE_DISPLAY_V2,
+      GATEWAY_SERVICE: {
+        ...SERVICE_DISPLAY,
+        empty: {
+          name: 'empty',
+          deleted: false,
+        },
+      },
+    },
+  },
+  data: [
+    {
+      event: {
+        REQUEST_COUNT: 9483,
+        ROUTE: ROUTE_ID,
+        GATEWAY_SERVICE: 'empty',
+      },
+      timestamp: '2023-08-17T17:55:53.000Z',
+    },
+  ],
 }
 
 const TITLE = 'Top 5 Routes'
@@ -592,6 +652,48 @@ describe('<TopNTable />', () => {
         cy.get('td').eq(2).should('contain.text', '1')
         cy.get('td').eq(3).should('contain.text', '0')
         cy.get('td').eq(4).should('contain.text', '100 ms')
+      })
+    })
+  })
+
+  describe('empty rows', () => {
+    it('flags the primary dimension cell as empty for an "empty" id', () => {
+      cy.mount(TopNTable, {
+        props: {
+          data: EMPTY_ROW_TABLE_DATA,
+          title: TITLE,
+          description: DESCRIPTION,
+        },
+        slots: {
+          name: `<template #name="params">
+                  {{ params.record.isEmpty }}
+                 </template>
+          `,
+        },
+      })
+
+      cy.get(`[data-testid="row-${ROUTE_ID}"]`).should('contain.text', 'false')
+      cy.get('[data-testid="row-empty"]').should('contain.text', 'true')
+    })
+
+    it('flags an additional dimension cell as empty for an "empty" id', () => {
+      cy.mount(TopNTable, {
+        props: {
+          data: EMPTY_DIMENSION_TABLE_DATA,
+          title: TITLE,
+          description: DESCRIPTION,
+        },
+        slots: {
+          name: `<template #name="params">
+                  {{ params.record.dimension }}={{ params.record.isEmpty }}
+                 </template>
+          `,
+        },
+      })
+
+      cy.get('tbody tr').first().within(() => {
+        cy.get('td').eq(0).should('contain.text', 'ROUTE=false')
+        cy.get('td').eq(1).should('contain.text', 'GATEWAY_SERVICE=true')
       })
     })
   })

--- a/packages/analytics/analytics-chart/src/components/TopNTable.vue
+++ b/packages/analytics/analytics-chart/src/components/TopNTable.vue
@@ -105,6 +105,7 @@
                     deleted: row.deleted,
                     dimension: displayKey,
                     dimensions: row.dimensions,
+                    isEmpty: row.id === 'empty',
                   }"
                 >
                   {{ row.name }}
@@ -487,6 +488,7 @@ const getDimensionSlotRecord = (row: TopNRow, key: string) => {
     deleted: dimension?.deleted || false,
     dimension: key,
     dimensions: row.dimensions,
+    isEmpty: dimension?.id === 'empty',
   }
 }
 

--- a/packages/analytics/analytics-chart/src/types/chart-data.ts
+++ b/packages/analytics/analytics-chart/src/types/chart-data.ts
@@ -200,6 +200,7 @@ export interface TopNTableRecord {
     name: string
     deleted: boolean
   }>
+  isEmpty?: boolean
 }
 
 export interface SparklineDataset {

--- a/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
@@ -484,6 +484,7 @@ export const routeExploreResponse: ExploreResultV4 = {
         'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:8b1db7eb-5c3c-489c-9344-eb0b272019ca': { name: '8b1db (default)', deleted: false },
         'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:8f3f6808-a723-4793-8444-f2046961226b': { name: 'dp-mock-us-dev (default)', deleted: false },
         'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:b4cd1c10-d77f-41b0-a84d-31fc0d99f0d9': { name: 'GetMeASongRoute (default)', deleted: false },
+        'empty': { name: 'empty', deleted: false },
       },
     },
     end: '2023-08-17T18:00:53.000Z',
@@ -531,6 +532,13 @@ export const routeExploreResponse: ExploreResultV4 = {
       event: {
         request_count: 309,
         route: 'd5ac5d88-efed-4e10-9dfe-0b0a6646c219:2a3e9d21-804b-4b3b-ab7e-c6f002dadbf4',
+      },
+      timestamp: '2023-08-17T17:55:53.000Z',
+    },
+    {
+      event: {
+        request_count: 9001,
+        route: 'empty',
       },
       timestamp: '2023-08-17T17:55:53.000Z',
     },

--- a/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/TopNTableRenderer.vue
@@ -15,7 +15,7 @@
         #name="{ record }"
       >
         <AsyncEntityLink
-          v-if="getEntityLink(record)"
+          v-if="!record.isEmpty && getEntityLink(record)"
           :entity-link-data="{
             id: record.id,
             label: record.name,
@@ -24,7 +24,8 @@
           :external-link="parseLink(record)"
         />
         <template v-else>
-          {{ record.name }}
+          <i v-if="record.name === 'empty'">{{ record.name }}</i>
+          <span v-else>{{ record.name }}</span>
         </template>
       </template>
     </TopNTable>


### PR DESCRIPTION
# Summary

Fix [MA-5070](https://konghq.atlassian.net/browse/MA-5070)

This will ensure that "empty" rows are displayed properly in a TopN table without generating an entity link by providing the `isEmpty` prop which can be used in the TopN renderer.

If the `record.name` is `empty`, the entity link will no longer be generated, instead a simple italicized "_empty_" will be displayed.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


<details open>
<summary>analytics-chart topn with an empty row example</summary>

<img width="1085" height="454" alt="analytics-chart-topn-empty" src="https://github.com/user-attachments/assets/4ad5d4b6-1819-49ca-ba70-916a0edca2d1" />


</details>


<details open>
<summary>dashboard-renderer with an empty row in a topn table example</summary>

<img width="570" height="372" alt="dashboard-topn-empty" src="https://github.com/user-attachments/assets/8e6ac773-7c5c-4208-9f62-d271b7bd44f3" />


</details>

[MA-5070]: https://konghq.atlassian.net/browse/MA-5070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ