### PR TITLE
fix(analytics): use correct method to determine legend visibility [MA-5104]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.spec.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.spec.ts
@@ -1,0 +1,117 @@
+import type { EnhancedLegendItem } from 'src/types'
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+
+import ChartLegend from './ChartLegend.vue'
+import { ChartLegendPosition } from '../../enums'
+
+const legendItem = (overrides: Partial<EnhancedLegendItem> = {}): EnhancedLegendItem => ({
+  text: 'Dataset A',
+  datasetIndex: 0,
+  index: 0,
+  fillStyle: '#000',
+  strokeStyle: '#000',
+  value: { raw: 0, formatted: '' },
+  ...overrides,
+})
+
+const createChart = (overrides: {
+  isDatasetVisible?: (i: number) => boolean
+  getDataVisibility?: (i: number) => boolean
+  datasetMeta?: { dataset?: object, data?: any[] }
+} = {}) => ({
+  isDatasetVisible: overrides.isDatasetVisible ?? (() => true),
+  getDataVisibility: overrides.getDataVisibility ?? (() => true),
+  getDatasetMeta: () => ({
+    dataset: overrides.datasetMeta?.dataset,
+    data: overrides.datasetMeta?.data ?? [],
+  }),
+})
+
+const wrapChart = (chart: any) => chart === null ? null : { chart }
+
+const mountLegend = (items: EnhancedLegendItem[], chartInstance: any, { wrap = true } = {}) => {
+  return mount(ChartLegend, {
+    props: {
+      id: 'test-legend',
+      items,
+      chartInstance: (wrap ? wrapChart(chartInstance) : chartInstance) as Record<string, any>,
+    },
+    global: {
+      provide: {
+        legendPosition: ref(ChartLegendPosition.Bottom),
+        showLegendValues: false,
+      },
+      stubs: {
+        KTooltip: { template: '<div><slot /><slot name="content" /></div>' },
+      },
+    },
+  })
+}
+
+describe('ChartLegend', () => {
+  describe('isDatasetVisible', () => {
+    it('returns true when chartInstance is null', () => {
+      const wrapper = mountLegend([legendItem()], null)
+      expect(wrapper.find('.strike-through').exists()).toBe(false)
+    })
+
+    it('returns true when chartInstance.chart is null', () => {
+      const wrapper = mountLegend([legendItem()], { chart: null }, { wrap: false })
+      expect(wrapper.find('.strike-through').exists()).toBe(false)
+    })
+
+    it('delegates to isDatasetVisible for line charts', () => {
+      const chart = createChart({
+        isDatasetVisible: () => false,
+        datasetMeta: { dataset: {}, data: [] },
+      })
+      const wrapper = mountLegend([legendItem()], chart)
+      expect(wrapper.find('.strike-through').exists()).toBe(true)
+    })
+
+    it('delegates to isDatasetVisible when segmentIndex is undefined', () => {
+      const chart = createChart({
+        isDatasetVisible: () => false,
+        datasetMeta: { dataset: undefined, data: [] },
+      })
+      const wrapper = mountLegend([legendItem({ index: undefined })], chart)
+      expect(wrapper.find('.strike-through').exists()).toBe(true)
+    })
+
+    it('delegates to getDataVisibility for visible doughnut segments', () => {
+      const chart = createChart({
+        getDataVisibility: () => true,
+        datasetMeta: { dataset: undefined, data: [{}] },
+      })
+      const wrapper = mountLegend([legendItem({ index: 0 })], chart)
+      expect(wrapper.find('.strike-through').exists()).toBe(false)
+    })
+
+    it('delegates to getDataVisibility for hidden doughnut segments', () => {
+      const chart = createChart({
+        getDataVisibility: () => false,
+        datasetMeta: { dataset: undefined, data: [{}] },
+      })
+      const wrapper = mountLegend([legendItem({ index: 0 })], chart)
+      expect(wrapper.find('.strike-through').exists()).toBe(true)
+    })
+
+    it('delegates to getDataVisibility instead of indexing datasetMeta.data when segmentIndex is out of bounds', () => {
+      const calledWith: number[] = []
+      const chart = createChart({
+        getDataVisibility: (i: number) => {
+          calledWith.push(i)
+
+          return true
+        },
+        datasetMeta: { dataset: undefined, data: [{}] },
+      })
+
+      expect(() => mountLegend([legendItem({ index: 5 })], chart)).not.toThrow()
+      expect(calledWith).toEqual([5])
+    })
+  })
+})

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -103,7 +103,7 @@ const isDatasetVisible = (datasetIndex: number = 0, segmentIndex: number): boole
   if (datasetMeta.dataset || segmentIndex === undefined) {
     return chart.isDatasetVisible(datasetIndex)
   } else {
-    return !(datasetMeta.data.length && datasetMeta.data[segmentIndex].hidden)
+    return chart.getDataVisibility(segmentIndex)
   }
 }
 </script>


### PR DESCRIPTION
# Summary

Fix [MA-5104](https://konghq.atlassian.net/browse/MA-5104)

This will fix an issue when determining if a dataset is visible within the ChartLegend. It was caused by improperly checking for a `hidden` property on the segment metadata, which doesn't exist! According to Chart.js there is a method for this exact purpose ([getDataVisibility](https://www.chartjs.org/docs/latest/developers/api.html#getdatavisibility-index)). 

I also added a unit test for the ChartLegend.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-5104]: https://konghq.atlassian.net/browse/MA-5104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ