### PR TITLE
fix(entities-vaults): secret edit in ai gateway

### DIFF
--- a/packages/entities/entities-vaults/src/components/SecretFormInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretFormInner.vue
@@ -191,7 +191,11 @@ const submitData = async (): Promise<void> => {
     if (formType.value === 'create') {
       response = await axiosInstance.post(submitUrl.value, payload.value)
     } else if (formType.value === 'edit') {
-      response = await axiosInstance.put(submitUrl.value, payload.value)
+      // AI Gateway does not allow updating the `key` field, so omit it from the payload
+      const editPayload = props.config.apiType === 'aiGateway'
+        ? { value: payload.value.value }
+        : payload.value
+      response = await axiosInstance.put(submitUrl.value, editPayload)
     }
 
     updateFormValues(response?.data)


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
In AI Gateway, the request payload of updating a secret can only include the `value` field.

<img width="1098" height="336" alt="image" src="https://github.com/user-attachments/assets/762f648c-350e-4cc8-81b9-c7b9c61caa39" />
