### PR TITLE
feat(entities-plugins): gate Kong Identity principals UI behind feature flag

### DIFF
--- a/packages/core/forms/src/components/forms/OIDCForm.vue
+++ b/packages/core/forms/src/components/forms/OIDCForm.vue
@@ -244,6 +244,15 @@ export default {
       type: Boolean,
       default: false,
     },
+    /**
+     * Identity Principals UI feature flag (khcp-20393). When false, behave as if the
+     * `principals` fields aren't in the schema — the Kong Identity principals section is
+     * hidden and the legacy common-fields form renders instead.
+     */
+    identityPrincipalsUiEnabled: {
+      type: Boolean,
+      default: false,
+    },
     showNewPartialModal: {
       type: Function,
       default: () => { },
@@ -288,7 +297,7 @@ export default {
       return (this.formModel.id && this.isEditing) || !this.isEditing
     },
     hasPrincipalsFields() {
-      return this.formSchema.fields?.some(
+      return this.identityPrincipalsUiEnabled && this.formSchema.fields?.some(
         (field) => PRINCIPALS_FIELD_MODELS.has(field.model),
       )
     },

--- a/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCForm.cy.ts
@@ -118,6 +118,8 @@ const requiredProps = {
   isEditing: false,
   onModelUpdated: () => {},
   onPartialToggled: () => {},
+  // khcp-20393 Identity Principals UI flag — on by default so the principals specs render it.
+  identityPrincipalsUiEnabled: true,
 }
 
 describe('<OIDCForm />', () => {
@@ -411,6 +413,58 @@ describe('<OIDCForm />', () => {
 
       cy.getTestId('principals-custom-identity-name').should('exist')
       cy.wrap(formModel).its('config-principals-directory').should('equal', 'default')
+    })
+
+    it('should not render principals section in Konnect when the Identity Principals UI flag is off', () => {
+      cy.mount(OIDCForm, {
+        props: {
+          ...requiredProps,
+          identityPrincipalsUiEnabled: false,
+          formSchema: OIDCFormSchemaWithPrincipals,
+          formModel: OIDCModelWithPrincipals,
+        },
+        global: {
+          provide: {
+            'kong-ui-forms-config': baseConfigKonnect,
+          },
+        },
+      })
+
+      // Legacy rendering: principals section hidden, plain common-fields form shown instead
+      cy.getTestId('oidc-principals-section').should('not.exist')
+      cy.getTestId('oidc-auth-mode-radio-group').should('not.exist')
+    })
+
+    it('preserves an existing modified principals config (does not reset to default) when the flag is off', () => {
+      // Edit-load: principals was customized while the flag was on; flag-off must not clobber it.
+      const formModel = {
+        ...OIDCModelWithPrincipals,
+        id: 'plugin-id',
+        'config-principals-enabled': true,
+        'config-principals-directory': 'my-custom-dir',
+        'config-principals-error_on_miss': true,
+      }
+
+      cy.mount(OIDCForm, {
+        props: {
+          ...requiredProps,
+          identityPrincipalsUiEnabled: false,
+          isEditing: true,
+          formSchema: OIDCFormSchemaWithPrincipals,
+          formModel,
+        },
+        global: {
+          provide: {
+            'kong-ui-forms-config': baseConfigKonnect,
+          },
+        },
+      })
+
+      // UI hidden, but the saved principals values are left untouched in the model.
+      cy.getTestId('oidc-principals-section').should('not.exist')
+      cy.wrap(formModel).its('config-principals-enabled').should('equal', true)
+      cy.wrap(formModel).its('config-principals-directory').should('equal', 'my-custom-dir')
+      cy.wrap(formModel).its('config-principals-error_on_miss').should('equal', true)
     })
 
     it('should not render principals section in Konnect when schema has no principals fields', () => {

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -10,6 +10,21 @@
         v-model="enableDeckCallout"
         label="Show decK config callout above YAML config"
       />
+
+      <!-- One switch per feature flag — choose which to open/close; any change remounts the forms. -->
+      <KCollapse
+        class="feature-flags-collapse"
+        trigger-label="Feature flags"
+      >
+        <div class="feature-flags-list">
+          <KInputSwitch
+            v-for="flagKey in Object.keys(featureFlags)"
+            :key="flagKey"
+            v-model="featureFlags[flagKey]"
+            :label="flagKey"
+          />
+        </div>
+      </KCollapse>
     </div>
 
     <div
@@ -17,35 +32,41 @@
       class="actions"
     />
 
-    <h2>Konnect API</h2>
-    <PluginForm
-      :config="konnectConfig"
-      enable-redis-partial
-      enable-vault-secret-picker
-      :engine="pluginFormEngine"
-      :plugin-id="id"
-      :plugin-type="plugin"
-      use-custom-names-for-plugin
-      @global-action="handleGlobalAction"
-      @update="onUpdate"
-    />
+    <!-- Keyed on the whole flag map so flipping any switch remounts the forms and re-runs `provide`. -->
+    <FeatureFlagProvider
+      :key="JSON.stringify(featureFlags)"
+      :flags="featureFlags"
+    >
+      <h2>Konnect API</h2>
+      <PluginForm
+        :config="konnectConfig"
+        enable-redis-partial
+        enable-vault-secret-picker
+        :engine="pluginFormEngine"
+        :plugin-id="id"
+        :plugin-type="plugin"
+        use-custom-names-for-plugin
+        @global-action="handleGlobalAction"
+        @update="onUpdate"
+      />
 
-    <h2>Kong Manager API</h2>
-    <PluginForm
-      :config="kongManagerConfig"
-      enable-redis-partial
-      enable-vault-secret-picker
-      :engine="pluginFormEngine"
-      :plugin-id="id"
-      :plugin-type="plugin"
-      @global-action="handleGlobalAction"
-      @update="onUpdate"
-    />
+      <h2>Kong Manager API</h2>
+      <PluginForm
+        :config="kongManagerConfig"
+        enable-redis-partial
+        enable-vault-secret-picker
+        :engine="pluginFormEngine"
+        :plugin-id="id"
+        :plugin-type="plugin"
+        @global-action="handleGlobalAction"
+        @update="onUpdate"
+      />
+    </FeatureFlagProvider>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, provide, ref } from 'vue'
+import { computed, defineComponent, provide, ref, type PropType } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { PluginForm, TOASTER_PROVIDER, useProvideExperimentalFreeForms } from '../../src'
@@ -76,11 +97,31 @@ defineProps({
 const router = useRouter()
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 const pluginFormEngine = import.meta.env.VITE_FORCE_PLUGIN_FORM_ENGINE || undefined
-provide(FEATURE_FLAGS.KM_2262_CODE_MODE, true)
-provide(FEATURE_FLAGS.KM_2306_CONDITION_FIELD_314, true)
-provide(FEATURE_FLAGS.KM_2446_DATAKIT_JWT_NODES, true)
-provide(FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM, true)
-provide(FEATURE_FLAGS.KM_2485_CLONED_PLUGINS, true)
+// All feature flags provided to the plugin forms, editable at runtime via the sandbox switches.
+// `provide` captures a plain value once, so to flip any flag live we re-provide on change: the
+// generic FeatureFlagProvider re-runs `provide` in its setup whenever it remounts, and we force
+// that remount by keying it on the whole flag map — so toggling any flag updates the forms.
+const featureFlags = ref<Record<string, boolean>>({
+  [FEATURE_FLAGS.KM_2262_CODE_MODE]: true,
+  [FEATURE_FLAGS.KM_2306_CONDITION_FIELD_314]: true,
+  [FEATURE_FLAGS.KM_2446_DATAKIT_JWT_NODES]: true,
+  [FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM]: true,
+  [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
+  [FEATURE_FLAGS.KHCP_20393_IDENTITY_PRINCIPALS_UI]: true,
+})
+
+const FeatureFlagProvider = defineComponent({
+  name: 'FeatureFlagProvider',
+  props: {
+    flags: { type: Object as PropType<Record<string, boolean>>, default: () => ({}) },
+  },
+  setup(props, { slots }) {
+    for (const [key, value] of Object.entries(props.flags)) {
+      provide(key, value)
+    }
+    return () => slots.default?.()
+  },
+})
 
 provideDeckCommandEditor()
 
@@ -198,10 +239,22 @@ const handleGlobalAction = (action: GlobalAction, payload: any) => {
   }
 
   .sandbox-controls {
+    align-items: flex-start;
     display: flex;
     flex-direction: row;
     gap: 20px;
     margin-bottom: 20px;
+  }
+
+  .feature-flags-collapse {
+    margin: 0;
+  }
+
+  .feature-flags-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-top: 12px;
   }
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -48,6 +48,7 @@
         :form-model="formModel"
         :form-options="formOptions"
         :form-schema="formSchema"
+        :identity-principals-ui-enabled="identityPrincipalsUiEnabled"
         :is-editing="editing"
         :is-konnect-managed-redis-enabled="isKonnectManagedRedisEnabled"
         :on-model-updated="onModelUpdated"
@@ -261,6 +262,11 @@ const isKonnectManagedRedisEnabled = computed<boolean>(() => {
 })
 
 const enableConditionField = inject<boolean>(PLUGIN_FEATURE_FLAGS.KM_2306_CONDITION_FIELD_314, false)
+
+// Identity Principals UI feature flag. Free-form plugins (basic-auth, key-auth) read this
+// directly via inject in ConfigFormContent; OIDC embeds its own VueFormGenerator, so it's
+// passed through as a prop (mirroring is-konnect-managed-redis-enabled).
+const identityPrincipalsUiEnabled = inject<boolean>(PLUGIN_FEATURE_FLAGS.KHCP_20393_IDENTITY_PRINCIPALS_UI, false)
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
 

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -3,6 +3,7 @@ import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import Form from '../../free-form/shared/Form.vue'
 import ConfigFormContent from './ConfigFormContent.vue'
 import { BEFORE_SAVE_KEY } from '../../const'
+import { FEATURE_FLAGS } from '../../../constants'
 import type { FormSchema } from '../../../types/plugins/form-schema'
 
 // Schema with both principals and identity_realms (like key-auth)
@@ -245,6 +246,8 @@ function mountContent(
     hasDefaultDirectory?: boolean
     hasPrincipals?: boolean
     lookupDelay?: number
+    /** khcp-20393 Identity Principals UI flag. Defaults to on so the new-UI specs render it. */
+    identityPrincipalsUiEnabled?: boolean
   },
   data?: Record<string, any>,
 ) {
@@ -289,6 +292,7 @@ function mountContent(
     global: {
       provide: {
         [FORMS_CONFIG]: formsConfig,
+        [FEATURE_FLAGS.KHCP_20393_IDENTITY_PRINCIPALS_UI]: options.identityPrincipalsUiEnabled !== false,
         [BEFORE_SAVE_KEY as symbol]: (cb: () => boolean) => {
           beforeSaveCallbacks.push(cb); return () => {}
         },
@@ -337,6 +341,36 @@ describe('ConfigFormContent', () => {
         mountContent(schemaWithoutPrincipals, { isKonnect: true })
 
         cy.getTestId('ff-kong-identity-field').should('not.exist')
+      })
+
+      it('hides the Kong Identity principals UI when the feature flag is off, even with principals in schema', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, identityPrincipalsUiEnabled: false })
+
+        // Legacy rendering: none of the new principals UI is shown
+        cy.getTestId('ff-kong-identity-field').should('not.exist')
+        cy.getTestId('kong-identity-principals-panel').should('not.exist')
+        cy.getTestId('ff-principals-error-on-miss-label').should('not.exist')
+      })
+
+      it('preserves an existing modified principals config (does not reset to default) when the flag is off', () => {
+        // Edit-load: the plugin was previously configured with Kong Identity principals while
+        // the flag was on. Re-opening it with the flag off must NOT clobber that saved config.
+        mountContent(schemaWithRealms, { isKonnect: true, identityPrincipalsUiEnabled: false }, {
+          config: {
+            principals: { enabled: true, directory: 'my-custom-dir', error_on_miss: false },
+            identity_realms: null,
+          },
+        })
+
+        // The principals UI is hidden...
+        cy.getTestId('ff-kong-identity-field').should('not.exist')
+
+        // ...but the saved principals is emitted unchanged — not replaced with the schema default.
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return val.config?.principals?.enabled === true
+            && val.config?.principals?.directory === 'my-custom-dir'
+            && val.config?.principals?.error_on_miss === false
+        }))
       })
 
       it('defaults to "consumers" mode when no principals data', () => {

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -96,6 +96,7 @@ import { useAxios } from '@kong-ui-public/entities-shared'
 import { KLabel, KRadio } from '@kong/kongponents'
 import { FETCHED_REALMS_KEY } from '../key-auth-identity-realms/const'
 import { BEFORE_SAVE_KEY } from '../../const'
+import { FEATURE_FLAGS } from '../../../constants'
 import composables from '../../../composables'
 
 import type { KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
@@ -196,7 +197,13 @@ provide(FETCHED_REALMS_KEY, fetchedRealms)
 // Auto-detect from schema
 const identityRealmsInSchema = computed(() => !!getSchema('$.config.identity_realms'))
 
-const hasPrincipals = computed(() => !!getSchema('$.config.principals'))
+// Feature-flagged: when the consuming app hasn't enabled the Identity Principals UI,
+// behave as if `principals` isn't in the schema — every piece of the new UI keys off
+// `hasPrincipals`, so the form falls back to the legacy rendering (and `principals`
+// keeps its prefilled schema default, submitted as-is).
+const identityPrincipalsUiEnabled = inject<boolean>(FEATURE_FLAGS.KHCP_20393_IDENTITY_PRINCIPALS_UI, false)
+
+const hasPrincipals = computed(() => identityPrincipalsUiEnabled && !!getSchema('$.config.principals'))
 
 function detectInitialMode(): 'consumers' | 'kong-identity' | 'centrally-managed' {
   if (formData.config?.principals?.enabled) return 'kong-identity'

--- a/packages/entities/entities-plugins/src/constants/index.ts
+++ b/packages/entities/entities-plugins/src/constants/index.ts
@@ -6,6 +6,7 @@ export const FEATURE_FLAGS = {
   KM_2446_DATAKIT_JWT_NODES: 'KM-2446-Datakit-JWT-nodes',
   KM_2503_CUSTOM_PLUGIN_FREEFORM: 'KM-2503-custom-plugin-freeform',
   KM_2485_CLONED_PLUGINS: 'KM-2485-cloned-plugins',
+  KHCP_20393_IDENTITY_PRINCIPALS_UI: 'khcp-20393-identity-principals-ui',
 }
 
 export const TOASTER_PROVIDER = Symbol('TOASTER_PROVIDER')


### PR DESCRIPTION
# Summary

Add the `khcp-20393-identity-principals-ui` feature flag so the consuming app can ship the Identity Principals UI dark. When the flag is off, the forms render as if `principals` weren't in the schema (legacy behavior).

- AND the flag into the two computeds that already gate every piece of the new UI: `hasPrincipals` (free-form basic-auth/key-auth, ConfigFormContent) and `hasPrincipalsFields` (OIDC, OIDCForm).
- Free-form reads the flag via inject directly; OIDC receives it as a prop passed from PluginEntityForm (mirroring is-konnect-managed-redis-enabled).
- Default off: until the app provides the flag, the new selectors/banners/OIDC principals section are hidden and `principals` keeps its schema default on create and its saved value on edit (nothing strips or mutates it).
- Sandbox: per-flag switches in a collapse on PluginFormPage; a generic keyed FeatureFlagProvider re-runs provide() on toggle so any flag updates the forms.
- Tests: gate existing principals specs behind the flag (on by default in the harness) and add flag-off specs covering hidden UI + preserved principals data.
