### PR TITLE
fix(analytics): let single value chart determine error cases for itself [MA-5154]

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -20,6 +20,20 @@ export default defineConfig({
   includeShadowDom: true,
   fixturesFolder: 'cypress/fixtures',
   screenshotsFolder: 'cypress/screenshots',
+  setupNodeEvents(on: Cypress.PluginEvents) {
+    on('before:browser:launch', (browser, launchOptions) => {
+      if (browser.name === 'chrome') {
+        // CrowdStrike disables CDP/CRI when Cypress tries to connect to the
+        // Chrome instance's websocket. This only matters when you're running
+        // it locally with the browser open (i.e. not headless). This
+        // disconnect causes the browser window to spin forever depending on
+        // how fast things connect/disconnect. Disabling all extensions (only
+        // in the Chrome profile used by Cypress) dodges the issue.
+        launchOptions.args.push('--disable-extensions')
+        return launchOptions
+      }
+    })
+  },
   video: true,
   videosFolder: 'cypress/videos',
   retries: {

--- a/packages/analytics/analytics-chart/src/components/SimpleChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/SimpleChart.cy.ts
@@ -8,25 +8,20 @@ const exploreResultTruncated = {
     {
       timestamp: '2023-05-30T13:09:00.987Z',
       event: {
-        StatusCode: '200',
         TotalRequests: 255.49999999999997,
       },
     },
     {
-      timestamp: '2023-05-30T13:09:00.987Z',
+      timestamp: '2023-05-30T14:09:00.987Z',
       event: {
-        StatusCode: '300',
         TotalRequests: 182.5,
       },
     },
   ],
   meta: {
     start: '2023-05-30T13:09:00.987Z',
-    end: '2023-05-30T19:09:00.987Z',
+    end: '2023-05-30T15:09:00.987Z',
     query_id: '12346',
-    display: {
-      StatusCode: { 200: { name: '200' }, 300: { name: '300' } },
-    },
     metric_names: ['TotalRequests'],
     metric_units: {
       TotalRequests: 'requests',
@@ -113,6 +108,66 @@ describe('<SimpleChart />', () => {
 
     const value = parseFloat(exploreResultTruncated.data[0].event.TotalRequests.toFixed(2))
 
+    cy.getTestId('single-value-chart').should('be.visible')
+    cy.getTestId('single-value-chart').contains(value)
+  })
+
+  it('renders Single Value chart with a trend', () => {
+    cy.mount(SimpleChart, {
+      props: {
+        chartData: exploreResultTruncated,
+        chartOptions: {
+          type: 'single_value',
+          showTrend: true,
+        },
+      },
+    })
+
+    const value = parseFloat(exploreResultTruncated.data[1].event.TotalRequests.toFixed(2))
+
+    cy.getTestId('single-value-chart').should('be.visible')
+    cy.getTestId('single-value-chart').contains(value)
+  })
+
+  it('renders Single Value chart with a trend with only previous datapoint', () => {
+    const oneResult = {
+      ...exploreResultTruncated,
+      data: [
+        exploreResultTruncated.data[0],
+      ],
+    }
+    cy.mount(SimpleChart, {
+      props: {
+        chartData: oneResult,
+        chartOptions: {
+          type: 'single_value',
+          showTrend: true,
+        },
+      },
+    })
+
+    cy.getTestId('single-value-chart').should('be.visible')
+    cy.getTestId('single-value-chart').contains('-')
+  })
+
+  it('renders Single Value chart with a trend with only current datapoint', () => {
+    const oneResult = {
+      ...exploreResultTruncated,
+      data: [
+        exploreResultTruncated.data[1],
+      ],
+    }
+    cy.mount(SimpleChart, {
+      props: {
+        chartData: oneResult,
+        chartOptions: {
+          type: 'single_value',
+          showTrend: true,
+        },
+      },
+    })
+
+    const value = parseFloat(exploreResultTruncated.data[1].event.TotalRequests.toFixed(2))
     cy.getTestId('single-value-chart').should('be.visible')
     cy.getTestId('single-value-chart').contains(value)
   })

--- a/packages/analytics/analytics-chart/src/components/SimpleChart.vue
+++ b/packages/analytics/analytics-chart/src/components/SimpleChart.vue
@@ -119,10 +119,6 @@ const hasValidChartData = computed(() => {
   // for single value chart, show empty state if the metric value is null
   if (isSingleValueChart.value) {
     const metricName = props.chartData.meta?.metric_names?.[0]
-    if (props.chartOptions.showTrend) {
-      // For trend, expect exactly 2 records, and check current (last) is not null
-      return hasChartData && props.chartData.data.length >= 2 && props.chartData.data[1].event[metricName!] !== null
-    }
 
     // ignore the scenario where the metric name is undefined or metric value is not a number, the chart will handle it (display error message)
     return hasChartData && props.chartData.data[0].event[metricName!] !== null


### PR DESCRIPTION
Satisfies [MA-5154](https://konghq.atlassian.net/browse/MA-5154)

related to https://github.com/Kong/public-ui-components/pull/3464

# Summary

In the [previous PR](https://github.com/Kong/public-ui-components/pull/3464) we handled data that has fewer than 2 data points for trend. Unfortunately, `SimpleChart` _also_ had a datapoints restriction that was no longer relevant. This removes that restriction and adds more tests around it.

### screenshots

**Previously for both a trend with JUST current data and a trend JUST with previous data**

<img width="356" height="135" alt="Screenshot 2026-06-24 at 11 53 28 AM" src="https://github.com/user-attachments/assets/61465118-cc3c-4f1b-97e3-1dc137c7f1de" />

**After for a trend with JUST current data**

<img width="271" height="128" alt="Screenshot 2026-06-24 at 11 56 32 AM" src="https://github.com/user-attachments/assets/c2d2c31e-a6bf-4b86-93f3-d7fa55b8cfd7" />

**After for a trend with JUST previous data**

<img width="245" height="119" alt="Screenshot 2026-06-24 at 11 53 49 AM" src="https://github.com/user-attachments/assets/f7604305-1199-457d-8704-1746d4d2d387" />

---

will update:

@kong-ui-public/analytics-chart@latest
@kong-ui-public/dashboard-renderer@latest

[MA-5154]: https://konghq.atlassian.net/browse/MA-5154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ