### PR TITLE
feat(entities-plugins): support multi-section config layout in free-form StandardLayout

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.cy.ts
@@ -264,6 +264,63 @@ describe('<StandardLayout />', () => {
     cy.getTestId('custom-config-extra').should('contain.text', 'Extra action')
   })
 
+  describe('Multi-section configuration (configSections)', () => {
+    const mountMultiSection = () => {
+      cy.mount(StandardLayout as any, {
+        props: {
+          schema: createBaseSchema(),
+          formSchema: createFormSchema(),
+          model: createBaseModel(),
+          formModel: { enabled: true },
+          isEditing: false,
+          onFormChange: cy.spy(),
+          pluginName: 'test-plugin',
+          configSections: [
+            { name: 'configuration', title: 'Plugin configuration', description: 'First section' },
+            { name: 'governance', title: 'Governance settings', description: 'Second section' },
+          ],
+        },
+        slots: {
+          'section-configuration': () => h('div', { 'data-testid': 'section-configuration-content' }, 'Configuration fields'),
+          'section-governance': () => h('div', { 'data-testid': 'section-governance-content' }, 'Governance fields'),
+        },
+      })
+    }
+
+    it('should render one numbered step block per section', () => {
+      mountMultiSection()
+
+      // The default single config block must NOT render
+      cy.getTestId('form-section-plugin-config').should('not.exist')
+
+      // Each section renders its own block with content from its slot
+      cy.getTestId('form-section-configuration').should('exist')
+        .find('[data-testid="form-block-step"]').should('contain.text', '2')
+      cy.getTestId('section-configuration-content').should('contain.text', 'Configuration fields')
+
+      cy.getTestId('form-section-governance').should('exist')
+        .find('[data-testid="form-block-step"]').should('contain.text', '3')
+      cy.getTestId('section-governance-content').should('contain.text', 'Governance fields')
+    })
+
+    it('should renumber the General Info step after the configured sections', () => {
+      mountMultiSection()
+
+      // 2 sections -> General Info is step 4
+      cy.getTestId('form-section-general-info')
+        .find('[data-testid="form-block-step"]').should('contain.text', '4')
+    })
+
+    it('should keep the default single config block and step 3 General Info when configSections is omitted', () => {
+      mountStandardLayout()
+
+      cy.getTestId('form-section-plugin-config').should('exist')
+        .find('[data-testid="form-block-step"]').should('contain.text', '2')
+      cy.getTestId('form-section-general-info')
+        .find('[data-testid="form-block-step"]').should('contain.text', '3')
+    })
+  })
+
   it('should show code editor and hide form sections when editorMode is code', () => {
     cy.mount(StandardLayout as any, {
       props: {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -109,8 +109,23 @@
       </template>
     </EntityFormBlock>
 
+    <!-- Multi-section plugin configuration: one numbered step block per section -->
+    <template v-if="editorMode === 'form' && configSections?.length">
+      <EntityFormBlock
+        v-for="(section, index) in configSections"
+        :key="section.name"
+        :data-testid="`form-section-${section.name}`"
+        :description="section.description"
+        :step="2 + index"
+        :title="section.title"
+      >
+        <slot :name="`section-${section.name}`" />
+      </EntityFormBlock>
+    </template>
+
+    <!-- Default single plugin configuration step (back-compatible) -->
     <EntityFormBlock
-      v-if="editorMode === 'form'"
+      v-else-if="editorMode === 'form'"
       data-testid="form-section-plugin-config"
       :description="pluginConfigDescription ?? t('plugins.form.sections.plugin_config.description')"
       :step="2"
@@ -144,7 +159,7 @@
       v-if="editorMode === 'form'"
       data-testid="form-section-general-info"
       :description="t('plugins.form.sections.plugin_general_info.description')"
-      :step="3"
+      :step="generalInfoStep"
       :title="t('plugins.form.sections.general_info.title')"
     >
       <SwitchField
@@ -300,7 +315,15 @@ const slots = defineSlots<{
   'plugin-config-description'?: () => any
   'plugin-config-extra'?: () => any
   'field-renderers'?: () => any
+  /** Content slots for multi-section layouts (`configSections`) */
+  [sectionSlot: `section-${string}`]: (() => any) | undefined
 }>()
+
+/**
+ * General Info is the last numbered step. In default single-config mode it is
+ * step 3; in multi-section mode it follows the configured sections.
+ */
+const generalInfoStep = computed(() => 2 + (props.configSections?.length ?? 1))
 
 const scopeWrapperAttrs = computed(() => {
   if (scopeSchema.value?.disabled) {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/types.ts
@@ -218,9 +218,32 @@ export type PluginConfigurationBaseProps<T extends Record<string, any> = Record<
   isKonnectManagedRedisEnabled?: boolean
 }
 
+/**
+ * Describes one numbered configuration step in a multi-section plugin layout.
+ * Content for each section is provided by the layout consumer via a
+ * `#section-<name>` slot.
+ */
+export interface ConfigSection {
+  /** Unique section key; the layout renders content from the `#section-<name>` slot */
+  name: string
+  /** Step block title */
+  title?: string
+  /** Step block description */
+  description?: string
+}
+
 export type PluginFormLayoutProps<T extends FreeFormPluginData = FreeFormPluginData> = PluginConfigurationBaseProps<T> & {
   onValidityChange?: (event: { model: string, valid: boolean, error?: Error | string }) => void
   isEditing: boolean
+  /**
+   * Optional multi-section configuration layout. When provided, the single
+   * "Plugin Configuration" step is replaced by one numbered step block per
+   * section (steps 2..N), each rendered via its `#section-<name>` slot, and the
+   * General Info step is renumbered to `2 + configSections.length`. When
+   * omitted, the layout renders the default single config step (step 2) using
+   * the default slot — i.e. existing plugins are unaffected.
+   */
+  configSections?: ConfigSection[]
   /**
    * Hide the built-in form/code switcher. Plugins that own a custom switcher
    * (e.g. Datakit's flow/code control) should set this to true to avoid


### PR DESCRIPTION
## What

Generalizes `StandardLayout`'s single **Plugin Configuration** step into *N* numbered sections via an optional `configSections` prop.

- Each section renders its own numbered `EntityFormBlock` with content from a `#section-<name>` slot.
- General Info is renumbered to `2 + configSections.length`.
- **Fully back-compatible:** when `configSections` is omitted, the layout is byte-for-byte unchanged (single config step at step 2, General Info at step 3) — existing plugins are unaffected.

## Why

Unblocks plugin forms (e.g. the upcoming `governance` plugin) that need more than one top-level numbered configuration step, while reusing the shared Scope / General-Info / Code-mode scaffolding.

## Changes
- `shared/types.ts` — add `ConfigSection` type + `configSections` prop to `PluginFormLayoutProps`.
- `shared/layout/StandardLayout.vue` — multi-section rendering + computed General-Info step.
- `StandardLayout.cy.ts` — tests for multi-section rendering, step renumbering, and the unchanged default path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)