### PR TITLE
fix: table tiles encoded as chart tile types

### DIFF
--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -251,23 +251,6 @@ describe('dashboardSchema.v2', () => {
     })).toBe(false)
   })
 
-  it('rejects the old top-level table tile encoding', () => {
-    expect(validateDashboardConfigSchema({
-      tiles: [
-        {
-          ...tableChartTile,
-          type: 'table',
-          definition: {
-            query: tableChartTile.definition.query,
-            config: {
-              title: 'Routes',
-            },
-          },
-        },
-      ],
-    })).toBe(false)
-  })
-
   it('accepts table chart tiles with only the platform datasource', () => {
     expect(validateDashboardConfigSchema({
       tiles: [
@@ -284,41 +267,6 @@ describe('dashboardSchema.v2', () => {
         },
       ],
     })).toBe(true)
-  })
-
-  it('rejects table chart fields other than chart_title', () => {
-    expect(validateDashboardConfigSchema({
-      tiles: [
-        {
-          ...tableChartTile,
-          definition: {
-            ...tableChartTile.definition,
-            chart: {
-              type: 'table',
-              chart_title: 'Routes',
-              description: 'Extra table chart field is not supported',
-            },
-          },
-        },
-      ],
-    })).toBe(false)
-  })
-
-  it('rejects table chart title fields that do not use chart_title', () => {
-    expect(validateDashboardConfigSchema({
-      tiles: [
-        {
-          ...tableChartTile,
-          definition: {
-            ...tableChartTile.definition,
-            chart: {
-              type: 'table',
-              title: 'Routes',
-            },
-          },
-        },
-      ],
-    })).toBe(false)
   })
 
   it('rejects table chart tiles with a top-level query', () => {

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -58,7 +58,7 @@ describe('dashboardSchema.v2', () => {
     ]),
   ]
 
-  const platformQuery = {
+  const platformChartQuery = {
     datasource: 'platform',
     metrics: ['custom_metric_name'],
     dimensions: ['custom_dimension_name'],
@@ -77,7 +77,7 @@ describe('dashboardSchema.v2', () => {
         type: 'chart',
         definition: {
           query: {
-            ...platformQuery,
+            ...platformChartQuery,
           },
           chart: {
             type: 'horizontal_bar',
@@ -195,8 +195,8 @@ describe('dashboardSchema.v2', () => {
   }
 
   it('accepts platform queries with arbitrary strings at runtime', () => {
-    expect(validatePlatformQuerySchema(platformQuery)).toBe(true)
-    expect(validateValidDashboardQuery(platformQuery)).toBe(true)
+    expect(validatePlatformQuerySchema(platformChartQuery)).toBe(true)
+    expect(validateValidDashboardQuery(platformChartQuery)).toBe(true)
     expect(validateDashboardConfigSchema(dashboardConfig)).toBe(true)
     expect(validateDashboardConfigSchema(mixedDashboardConfig)).toBe(true)
   })
@@ -213,7 +213,7 @@ describe('dashboardSchema.v2', () => {
   })
 
   it('rejects non-table chart tiles with tabular explore query shape', () => {
-    expect(validateValidDashboardTableQuery(platformQuery)).toBe(false)
+    expect(validateValidDashboardTableQuery(platformChartQuery)).toBe(false)
 
     expect(validateDashboardConfigSchema({
       tiles: [
@@ -232,15 +232,15 @@ describe('dashboardSchema.v2', () => {
   })
 
   it('rejects table chart tiles with chart query shape', () => {
-    expect(validateValidDashboardChartQuery(platformQuery)).toBe(true)
-    expect(validateValidDashboardTableQuery(platformQuery)).toBe(false)
+    expect(validateValidDashboardChartQuery(platformChartQuery)).toBe(true)
+    expect(validateValidDashboardTableQuery(platformChartQuery)).toBe(false)
 
     expect(validateDashboardConfigSchema({
       tiles: [
         {
           ...tableChartTile,
           definition: {
-            query: platformQuery,
+            query: platformChartQuery,
             chart: {
               type: 'table',
               title: 'Routes',

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -179,7 +179,7 @@ describe('dashboardSchema.v2', () => {
       },
       chart: {
         type: 'table',
-        title: 'Routes',
+        chart_title: 'Routes',
       },
     },
     layout: {
@@ -243,7 +243,7 @@ describe('dashboardSchema.v2', () => {
             query: platformChartQuery,
             chart: {
               type: 'table',
-              title: 'Routes',
+              chart_title: 'Routes',
             },
           },
         },
@@ -286,7 +286,25 @@ describe('dashboardSchema.v2', () => {
     })).toBe(true)
   })
 
-  it('rejects table chart fields other than title', () => {
+  it('rejects table chart fields other than chart_title', () => {
+    expect(validateDashboardConfigSchema({
+      tiles: [
+        {
+          ...tableChartTile,
+          definition: {
+            ...tableChartTile.definition,
+            chart: {
+              type: 'table',
+              chart_title: 'Routes',
+              description: 'Extra table chart field is not supported',
+            },
+          },
+        },
+      ],
+    })).toBe(false)
+  })
+
+  it('rejects table chart title fields that do not use chart_title', () => {
     expect(validateDashboardConfigSchema({
       tiles: [
         {
@@ -296,7 +314,6 @@ describe('dashboardSchema.v2', () => {
             chart: {
               type: 'table',
               title: 'Routes',
-              description: 'Extra table chart field is not supported',
             },
           },
         },

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -154,8 +154,8 @@ describe('dashboardSchema.v2', () => {
     ],
   }
 
-  const tableDataGridTile = {
-    type: 'table',
+  const tableChartTile = {
+    type: 'chart',
     id: 'routes-table',
     definition: {
       query: {
@@ -177,7 +177,8 @@ describe('dashboardSchema.v2', () => {
         cursor: 'eyJh',
         page_size: 50,
       },
-      config: {
+      chart: {
+        type: 'table',
         title: 'Routes',
       },
     },
@@ -200,27 +201,27 @@ describe('dashboardSchema.v2', () => {
     expect(validateDashboardConfigSchema(mixedDashboardConfig)).toBe(true)
   })
 
-  it('accepts table tiles with tabular explore query shape', () => {
-    expect(validateValidDashboardQuery(tableDataGridTile.definition.query)).toBe(true)
-    expect(validateValidDashboardTableQuery(tableDataGridTile.definition.query)).toBe(true)
-    expect(validateValidDashboardChartQuery(tableDataGridTile.definition.query)).toBe(false)
+  it('accepts table chart tiles with tabular explore query shape', () => {
+    expect(validateValidDashboardQuery(tableChartTile.definition.query)).toBe(true)
+    expect(validateValidDashboardTableQuery(tableChartTile.definition.query)).toBe(true)
+    expect(validateValidDashboardChartQuery(tableChartTile.definition.query)).toBe(false)
     expect(validateDashboardConfigSchema({
       tiles: [
-        tableDataGridTile,
+        tableChartTile,
       ],
     })).toBe(true)
   })
 
-  it('rejects chart tiles with tabular explore query shape', () => {
+  it('rejects non-table chart tiles with tabular explore query shape', () => {
     expect(validateValidDashboardTableQuery(platformQuery)).toBe(false)
 
     expect(validateDashboardConfigSchema({
       tiles: [
         {
-          ...tableDataGridTile,
+          ...tableChartTile,
           type: 'chart',
           definition: {
-            query: tableDataGridTile.definition.query,
+            query: tableChartTile.definition.query,
             chart: {
               type: 'horizontal_bar',
             },
@@ -230,32 +231,19 @@ describe('dashboardSchema.v2', () => {
     })).toBe(false)
   })
 
-  it('accepts table tiles with only the platform datasource', () => {
-    expect(validateDashboardConfigSchema({
-      tiles: [
-        {
-          ...tableDataGridTile,
-          definition: {
-            query: {
-              datasource: 'platform',
-            },
-            config: {},
-          },
-        },
-      ],
-    })).toBe(true)
-  })
+  it('rejects table chart tiles with chart query shape', () => {
+    expect(validateValidDashboardChartQuery(platformQuery)).toBe(true)
+    expect(validateValidDashboardTableQuery(platformQuery)).toBe(false)
 
-  it('rejects table tile config fields other than title', () => {
     expect(validateDashboardConfigSchema({
       tiles: [
         {
-          ...tableDataGridTile,
+          ...tableChartTile,
           definition: {
-            ...tableDataGridTile.definition,
-            config: {
+            query: platformQuery,
+            chart: {
+              type: 'table',
               title: 'Routes',
-              description: 'Extra config is not supported',
             },
           },
         },
@@ -263,11 +251,64 @@ describe('dashboardSchema.v2', () => {
     })).toBe(false)
   })
 
-  it('rejects table tiles with a top-level query', () => {
+  it('rejects the old top-level table tile encoding', () => {
     expect(validateDashboardConfigSchema({
       tiles: [
         {
-          ...tableDataGridTile,
+          ...tableChartTile,
+          type: 'table',
+          definition: {
+            query: tableChartTile.definition.query,
+            config: {
+              title: 'Routes',
+            },
+          },
+        },
+      ],
+    })).toBe(false)
+  })
+
+  it('accepts table chart tiles with only the platform datasource', () => {
+    expect(validateDashboardConfigSchema({
+      tiles: [
+        {
+          ...tableChartTile,
+          definition: {
+            query: {
+              datasource: 'platform',
+            },
+            chart: {
+              type: 'table',
+            },
+          },
+        },
+      ],
+    })).toBe(true)
+  })
+
+  it('rejects table chart fields other than title', () => {
+    expect(validateDashboardConfigSchema({
+      tiles: [
+        {
+          ...tableChartTile,
+          definition: {
+            ...tableChartTile.definition,
+            chart: {
+              type: 'table',
+              title: 'Routes',
+              description: 'Extra table chart field is not supported',
+            },
+          },
+        },
+      ],
+    })).toBe(false)
+  })
+
+  it('rejects table chart tiles with a top-level query', () => {
+    expect(validateDashboardConfigSchema({
+      tiles: [
+        {
+          ...tableChartTile,
           query: {
             entity: 'route',
             columns: ['name', 'control_plane'],
@@ -287,20 +328,20 @@ describe('dashboardSchema.v2', () => {
     ['invalid page size', { page_size: '50' }],
     ['invalid cursor', { cursor: 50 }],
     ['invalid filter', { filters: [{ field: 'env', value: ['prod'] }] }],
-  ])('rejects table tiles with %s', (_description, queryOverrides) => {
+  ])('rejects table chart tiles with %s', (_description, queryOverrides) => {
     expect(validateValidDashboardTableQuery({
-      ...tableDataGridTile.definition.query,
+      ...tableChartTile.definition.query,
       ...queryOverrides,
     })).toBe(false)
 
     expect(validateDashboardConfigSchema({
       tiles: [
         {
-          ...tableDataGridTile,
+          ...tableChartTile,
           definition: {
-            config: tableDataGridTile.definition.config,
+            chart: tableChartTile.definition.chart,
             query: {
-              ...tableDataGridTile.definition.query,
+              ...tableChartTile.definition.query,
               ...queryOverrides,
             },
           },
@@ -309,13 +350,13 @@ describe('dashboardSchema.v2', () => {
     })).toBe(false)
   })
 
-  it('rejects table tiles without config definitions', () => {
+  it('rejects table tile definitions without chart definitions', () => {
     expect(validateDashboardConfigSchema({
       tiles: [
         {
-          ...tableDataGridTile,
+          ...tableChartTile,
           definition: {
-            query: tableDataGridTile.definition.query,
+            query: tableChartTile.definition.query,
           },
         },
       ],

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -228,7 +228,7 @@ export const tableChartSchema = {
       type: 'string',
       enum: ['table'],
     },
-    title: chartTitle,
+    chart_title: chartTitle,
   },
   required: ['type'],
   additionalProperties: false,

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -31,6 +31,7 @@ export const dashboardTileTypes = [
   'timeseries_bar',
   'golden_signals',
   'top_n',
+  'table',
   'slottable',
   'single_value',
   'choropleth_map',
@@ -220,15 +221,20 @@ export const topNTableSchema = {
 
 export type TopNTableOptions = FromSchemaWithOptions<typeof topNTableSchema>
 
-export const tableDataGridConfigSchema = {
+export const tableChartSchema = {
   type: 'object',
   properties: {
+    type: {
+      type: 'string',
+      enum: ['table'],
+    },
     title: chartTitle,
   },
+  required: ['type'],
   additionalProperties: false,
 } as const satisfies JSONSchema
 
-export type TableDataGridConfigOptions = FromSchemaWithOptions<typeof tableDataGridConfigSchema>
+export type TableChartOptions = FromSchemaWithOptions<typeof tableChartSchema>
 
 export const metricCardSchema = {
   type: 'object',
@@ -712,22 +718,22 @@ const chartTileDefinitionSchema = {
 
 export type ChartTileDefinition = FromSchemaWithOptions<typeof chartTileDefinitionSchema>
 
-const tableTileDefinitionSchema = {
+const tableChartTileDefinitionSchema = {
   type: 'object',
   properties: {
     query: validDashboardTableQuery,
-    config: tableDataGridConfigSchema,
+    chart: tableChartSchema,
   },
-  required: ['query', 'config'],
+  required: ['query', 'chart'],
   additionalProperties: false,
 } as const satisfies JSONSchema
 
-export type TableTileDefinition = FromSchemaWithOptions<typeof tableTileDefinitionSchema>
+export type TableChartTileDefinition = FromSchemaWithOptions<typeof tableChartTileDefinitionSchema>
 
 export const tileDefinitionSchema = {
   anyOf: [
     chartTileDefinitionSchema,
-    tableTileDefinitionSchema,
+    tableChartTileDefinitionSchema,
   ],
 } as const satisfies JSONSchema
 
@@ -782,7 +788,7 @@ export const chartTileConfigSchema = {
       type: 'string',
       enum: ['chart'],
     },
-    definition: chartTileDefinitionSchema,
+    definition: tileDefinitionSchema,
     layout: tileLayoutSchema,
     id: {
       type: 'string',
@@ -793,30 +799,7 @@ export const chartTileConfigSchema = {
   additionalProperties: false,
 } as const satisfies JSONSchema
 
-export const tableTileConfigSchema = {
-  type: 'object',
-  properties: {
-    type: {
-      type: 'string',
-      enum: ['table'],
-    },
-    definition: tableTileDefinitionSchema,
-    layout: tileLayoutSchema,
-    id: {
-      type: 'string',
-      description: 'Unique identifier for the tile.  If not provided, one will be generated.',
-    },
-  },
-  required: ['type', 'definition', 'layout'],
-  additionalProperties: false,
-} as const satisfies JSONSchema
-
-export const tileConfigSchema = {
-  anyOf: [
-    chartTileConfigSchema,
-    tableTileConfigSchema,
-  ],
-} as const satisfies JSONSchema
+export const tileConfigSchema = chartTileConfigSchema
 
 export type TileConfig = FromSchemaWithOptions<typeof tileConfigSchema>
 

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -16,7 +16,7 @@ Render Analytics charts on a page from a JSON definition.
   - [Tile Definition](#tile-definition)
   - [Chart Options](#chart-options)
   - [Chart Types](#chart-types)
-  - [Table Tile Configuration](#table-tile-configuration)
+  - [Table Chart Configuration](#table-chart-configuration)
   - [Common Chart Properties](#common-chart-properties)
   - [Query Configuration](#query-configuration)
   - [Time Range Configuration](#time-range-configuration)
@@ -29,7 +29,7 @@ Render Analytics charts on a page from a JSON definition.
 - A plugin providing an `AnalyticsBridge` must be installed in the root of the application.
   - This plugin must `provide` the necessary methods to adhere to the [AnalyticsBridge](https://github.com/Kong/public-ui-components/blob/main/packages/analytics/analytics-utilities/src/types/query-bridge.ts) interface defined in `@kong-ui-public/analytics-utilities`.
   - The plugin's query method is in charge of passing the query to the correct API for the host app's environment.
-  - For `table` tiles, the plugin must provide `tabularQueryFn`; the renderer passes a datasource-aware tabular query to that function and renders the returned records.
+  - For table chart tiles, the plugin must provide `tabularQueryFn`; the renderer passes a datasource-aware tabular query to that function and renders the returned records.
   - See the sandbox plugin [sandbox-query-provider.ts](https://github.com/Kong/public-ui-components/blob/main/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts) for an example that simply returns static data rather than consuming an API.
 - The host application must supply peer dependencies for:
   - `@kong-ui-public/analytics-chart`
@@ -437,7 +437,7 @@ Configuration for individual dashboard tiles.
 
 ```typescript
 interface TileConfig {
-  type: 'chart' | 'table'      // The top-level tile kind
+  type: 'chart'                // The top-level tile kind
   definition: TileDefinition   // The tile's renderer-specific definition
   layout: TileLayout           // The tile's position and size in the grid
   id?: string                  // Optional unique identifier (required for editable dashboards)
@@ -448,15 +448,15 @@ interface TileConfig {
 Configuration for the renderer and query within a tile.
 
 ```typescript
-type TileDefinition = ChartTileDefinition | TableTileDefinition
+type TileDefinition = ChartTileDefinition | TableChartTileDefinition
 
 interface ChartTileDefinition {
-  chart: ChartOptions         // Configuration for the chart type and options
+  chart: ChartOptions         // Configuration for a non-table chart type and options
   query: ValidDashboardChartQuery  // Configuration for the chart data query
 }
 
-interface TableTileDefinition {
-  config: TableTileConfig     // Configuration for the table tile
+interface TableChartTileDefinition {
+  chart: TableChartOptions    // Configuration for the table chart
   query: PlatformTabularQuery & { datasource: 'platform' } // Configuration for the platform tabular query
 }
 ```
@@ -489,12 +489,13 @@ The following chart types are supported:
 
 Each chart type has its own configuration schema with specific options.
 
-### Table Tile Configuration
+### Table Chart Configuration
 
-Table tiles use `type: 'table'` on the tile itself. They are not chart tiles, so their definition uses `config` instead of `chart`.
+Table visuals are chart tiles with `type: 'chart'` on the tile itself and `definition.chart.type: 'table'`. Their `definition.query` uses the platform tabular query shape and renders through `TableDataGridRenderer`.
 
 ```typescript
-interface TableTileConfig {
+interface TableChartOptions {
+  type: 'table'
   title?: string
 }
 
@@ -507,17 +508,20 @@ interface PlatformTabularQuery {
 }
 ```
 
-`definition.query.columns` controls the visible table columns. If columns are omitted, the renderer can fall back to response `meta.columns` after the first tabular response. `definition.config.title` controls the tile title.
+`definition.query.columns` controls the visible table columns. If columns are omitted, the renderer can fall back to response `meta.columns` after the first tabular response. `definition.chart.title` controls the tile title.
 
 The dashboard config query includes `datasource: 'platform'`. The host application's `AnalyticsBridge.tabularQueryFn` receives a datasource-aware tabular query, currently `{ datasource: 'platform', query: { entity, columns, filters, page_size, cursor } }`.
 
 The renderer replaces raw record values with display labels when the tabular response includes a matching `meta.display[column][value].name`. Missing display entries and `null` values are rendered unchanged.
 
+Table charts do not expose CSV export or API Requests links. They may expose Explore links when the host application provides the Explore context-link bridge.
+
 ```typescript
 const tableTile: TileConfig = {
-  type: 'table',
+  type: 'chart',
   definition: {
-    config: {
+    chart: {
+      type: 'table',
       title: 'Platform routes',
     },
     query: {
@@ -575,7 +579,7 @@ Chart query fields include:
 - `granularity`: Time bucket size for temporal queries
 - `limit`: Number of results to return
 
-Table tile queries use the platform tabular query shape:
+Table chart queries use the platform tabular query shape:
 - `datasource`: Must be `platform`
 - `entity`: Entity collection to query, such as `route`
 - `columns`: Ordered table columns to request and render

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -496,7 +496,7 @@ Table visuals are chart tiles with `type: 'chart'` on the tile itself and `defin
 ```typescript
 interface TableChartOptions {
   type: 'table'
-  title?: string
+  chart_title?: string
 }
 
 interface PlatformTabularQuery {
@@ -508,7 +508,7 @@ interface PlatformTabularQuery {
 }
 ```
 
-`definition.query.columns` controls the visible table columns. If columns are omitted, the renderer can fall back to response `meta.columns` after the first tabular response. `definition.chart.title` controls the tile title.
+`definition.query.columns` controls the visible table columns. If columns are omitted, the renderer can fall back to response `meta.columns` after the first tabular response. `definition.chart.chart_title` controls the tile title.
 
 The dashboard config query includes `datasource: 'platform'`. The host application's `AnalyticsBridge.tabularQueryFn` receives a datasource-aware tabular query, currently `{ datasource: 'platform', query: { entity, columns, filters, page_size, cursor } }`.
 
@@ -522,7 +522,7 @@ const tableTile: TileConfig = {
   definition: {
     chart: {
       type: 'table',
-      title: 'Platform routes',
+      chart_title: 'Platform routes',
     },
     query: {
       datasource: 'platform',

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -84,7 +84,7 @@ const dashboardConfig = ref <DashboardConfig>({
       definition: {
         chart: {
           type: 'table',
-          title: 'Platform routes',
+          chart_title: 'Platform routes',
         },
         query: {
           datasource: 'platform',

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -79,10 +79,11 @@ const dashboardConfig = ref <DashboardConfig>({
   tile_height: 167,
   tiles: [
     {
-      type: 'table',
+      type: 'chart',
       id: crypto.randomUUID(),
       definition: {
-        config: {
+        chart: {
+          type: 'table',
           title: 'Platform routes',
         },
         query: {
@@ -228,7 +229,7 @@ const dashboardConfig = ref <DashboardConfig>({
 const onEditTile = (tile: GridTile<TileDefinition>) => {
   console.log('@edit-tile', tile)
 
-  const chartTypeToggleMap: Record<DashboardTileType, DashboardTileType> = {
+  const chartTypeToggleMap: Record<Exclude<DashboardTileType, 'table'>, DashboardTileType> = {
     timeseries_line: 'timeseries_bar',
     timeseries_bar: 'timeseries_line',
     horizontal_bar: 'vertical_bar',
@@ -247,9 +248,13 @@ const onEditTile = (tile: GridTile<TileDefinition>) => {
       return t
     }
 
-    const newType = chartTypeToggleMap[t.definition.chart.type] || t.definition.chart.type
-
     if (t.id === tile.id) {
+      if (t.definition.chart.type === 'table') {
+        return t
+      }
+
+      const newType = chartTypeToggleMap[t.definition.chart.type]
+
       return {
         ...t,
         definition: {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -110,7 +110,7 @@ const dashboardConfig = ref<DashboardConfig>({
       definition: {
         chart: {
           type: 'table',
-          title: 'Platform routes',
+          chart_title: 'Platform routes',
         },
         query: {
           datasource: 'platform',

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -106,9 +106,10 @@ const dashboardConfig = ref<DashboardConfig>({
       },
     } satisfies TileConfig,
     {
-      type: 'table',
+      type: 'chart',
       definition: {
-        config: {
+        chart: {
+          type: 'table',
           title: 'Platform routes',
         },
         query: {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/TilePreviewDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/TilePreviewDemo.vue
@@ -80,7 +80,8 @@ const chartDefinitionExample = {
 }
 
 const tableDefinitionExample = {
-  config: {
+  chart: {
+    type: 'table',
     title: 'Platform routes',
   },
   query: {

--- a/packages/analytics/dashboard-renderer/sandbox/pages/TilePreviewDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/TilePreviewDemo.vue
@@ -4,6 +4,24 @@
     title="Tile Preview"
   >
     <template #controls>
+      <h2>Examples</h2>
+      <div class="example-actions">
+        <KButton
+          appearance="secondary"
+          size="small"
+          @click="loadChartExample"
+        >
+          Chart
+        </KButton>
+        <KButton
+          appearance="secondary"
+          size="small"
+          @click="loadTableExample"
+        >
+          Table
+        </KButton>
+      </div>
+
       <h2>Tile Definition (required)</h2>
       <textarea
         v-model="definitionText"
@@ -47,16 +65,49 @@ import type {
 
 const appLinks: SandboxNavigationItem[] = inject('app-links', [])
 
-const contextText = ref(`{
-  "filters": [],
-  "timeSpec": {
-    type": "relative",
-    time_range": "24h",
+const stringifyExample = (value: unknown): string => JSON.stringify(value, null, 2)
+
+const chartDefinitionExample = {
+  chart: {
+    type: 'vertical_bar',
+    chart_title: 'Chart title (using mock data)',
   },
-  "tz": "utc",
-  "refreshInterval": 0,
-  "editable": true,
-}`)
+  query: {
+    datasource: 'api_usage',
+    dimensions: ['status_code_grouped'],
+    metrics: ['request_count'],
+  },
+}
+
+const tableDefinitionExample = {
+  config: {
+    title: 'Platform routes',
+  },
+  query: {
+    datasource: 'platform',
+    entity: 'route',
+    columns: ['name', 'control_plane', 'gateway_service', 'env', 'team', 'region'],
+    filters: [
+      {
+        field: 'env',
+        operator: 'in',
+        value: ['prod'],
+      },
+    ],
+    page_size: 25,
+  },
+}
+
+const contextText = ref(stringifyExample({
+  filters: [],
+  timeSpec: {
+    type: 'relative',
+    time_range: '24h',
+  },
+  tz: 'utc',
+  refreshInterval: 0,
+  editable: true,
+}))
 const context = computed<DashboardRendererContext>(() => {
   try {
     return JSON.parse(contextText.value)
@@ -67,17 +118,7 @@ const context = computed<DashboardRendererContext>(() => {
   }
 })
 
-const definitionText = ref(`{
-  "chart": {
-    "type": "vertical_bar",
-    "chart_title": "Chart title (using mock data)"
-  },
-  "query": {
-    "datasource": "api_usage",
-    "dimensions": ["status_code_grouped"],
-    "metrics": ["request_count"]
-  }
-}`)
+const definitionText = ref(stringifyExample(chartDefinitionExample))
 const definition = computed<TileDefinition>(() => {
   try {
     return JSON.parse(definitionText.value)
@@ -94,6 +135,14 @@ const globalFilters = computed<AllFilters[]>(() => {
     return []
   }
 })
+
+const loadChartExample = () => {
+  definitionText.value = stringifyExample(chartDefinitionExample)
+}
+
+const loadTableExample = () => {
+  definitionText.value = stringifyExample(tableDefinitionExample)
+}
 </script>
 
 <style lang="scss" scoped>
@@ -101,13 +150,18 @@ const globalFilters = computed<AllFilters[]>(() => {
   height: 500px;
 }
 
+.example-actions {
+  display: flex;
+  gap: var(--kui-space-40, $kui-space-40);
+}
+
 textarea {
-  background-color: $kui-color-background-neutral-weakest;
-  border: 1px solid $kui-color-border-neutral-weak;
+  background-color: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
+  border: 1px solid var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
   border-radius: 4px;
   color: #333333;
   font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
-  font-size: $kui-font-size-20;
+  font-size: var(--kui-font-size-20, $kui-font-size-20);
   line-height: 1.5;
   overflow: auto;
   padding: 10px;

--- a/packages/analytics/dashboard-renderer/sandbox/pages/TilePreviewDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/TilePreviewDemo.vue
@@ -82,7 +82,7 @@ const chartDefinitionExample = {
 const tableDefinitionExample = {
   chart: {
     type: 'table',
-    title: 'Platform routes',
+    chart_title: 'Platform routes',
   },
   query: {
     datasource: 'platform',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
@@ -170,7 +170,7 @@ describe('<DashboardRenderer /> table tiles', () => {
           definition: {
             chart: {
               type: 'table',
-              title: 'Routes',
+              chart_title: 'Routes',
             },
             query: {
               datasource: 'platform',
@@ -218,7 +218,7 @@ describe('<DashboardRenderer /> table tiles', () => {
     expect(model.tiles[1].type).toBe('chart')
     expect(model.tiles[1].definition.chart).toEqual({
       type: 'table',
-      title: 'Copy of Routes',
+      chart_title: 'Copy of Routes',
     })
     expect(model.tiles[1].definition.query).toMatchObject({
       datasource: 'platform',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
@@ -159,16 +159,17 @@ describe('Dashboard schemas', () => {
 })
 
 describe('<DashboardRenderer /> table tiles', () => {
-  it('preserves table tile type when duplicating', async () => {
+  it('preserves table chart shape when duplicating', async () => {
     setupPiniaTestStore()
 
     const model: DashboardConfig = {
       tiles: [
         {
           id: 'table-1',
-          type: 'table',
+          type: 'chart',
           definition: {
-            config: {
+            chart: {
+              type: 'table',
               title: 'Routes',
             },
             query: {
@@ -214,8 +215,9 @@ describe('<DashboardRenderer /> table tiles', () => {
     await wrapper.getTestId('duplicate-dashboard-tile-table-1').trigger('click')
 
     expect(model.tiles).toHaveLength(2)
-    expect(model.tiles[1].type).toBe('table')
-    expect(model.tiles[1].definition.config).toEqual({
+    expect(model.tiles[1].type).toBe('chart')
+    expect(model.tiles[1].definition.chart).toEqual({
+      type: 'table',
       title: 'Copy of Routes',
     })
     expect(model.tiles[1].definition.query).toMatchObject({

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -87,10 +87,7 @@ import {
   INJECT_QUERY_PROVIDER,
   TIMEFRAME_TOKEN,
 } from '../constants'
-import {
-  duplicateChartTile,
-  duplicateTableTile,
-} from '../utils/duplicate-tile'
+import { duplicateChartTile } from '../utils/duplicate-tile'
 import { KUI_SPACE_70 } from '@kong/design-tokens'
 
 const {
@@ -212,9 +209,7 @@ const getSlottableSlotName = (tile: GridTile<TileDefinition>): string | undefine
 
 const onDuplicateTile = (tile: GridTile<TileDefinition>) => {
   try {
-    const newTile = tile.type === 'table'
-      ? duplicateTableTile(tile)
-      : duplicateChartTile(tile)
+    const newTile = duplicateChartTile(tile)
 
     // deep cloning to avoid duplicated references
     model.value.tiles.push(JSON.parse(JSON.stringify(newTile)))

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
@@ -342,7 +342,7 @@ describe('<DashboardTile /> table tiles', () => {
       queryReady: true,
       refreshCounter: 0,
     })
-    expect(wrapper.findComponent(TableDataGridRenderer).props('height')).toBeUndefined()
+    expect(wrapper.findComponent(TableDataGridRenderer).props('height')).toBeGreaterThan(0)
   })
 
   it('shows editable tile actions and explore links for table tiles', async () => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
@@ -289,7 +289,7 @@ describe('<DashboardTile /> table tiles', () => {
     const tableDefinition: TileDefinition = {
       chart: {
         type: 'table',
-        title: 'Table Tile',
+        chart_title: 'Table Tile',
       },
       query: {
         datasource: 'platform',
@@ -349,7 +349,7 @@ describe('<DashboardTile /> table tiles', () => {
     const tableDefinition: TileDefinition = {
       chart: {
         type: 'table',
-        title: 'Table Tile',
+        chart_title: 'Table Tile',
       },
       query: {
         datasource: 'platform',
@@ -394,7 +394,7 @@ describe('<DashboardTile /> table tiles', () => {
     const tableDefinition: TileDefinition = {
       chart: {
         type: 'table',
-        title: 'Table Tile',
+        chart_title: 'Table Tile',
       },
       query: {
         datasource: 'platform',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
@@ -94,6 +94,32 @@ vi.mock('./TableDataGridRenderer.vue', () => ({
   }),
 }))
 
+const dropdownSlotStubs = {
+  // eslint-disable-next-line vue/one-component-per-file
+  KDropdown: defineComponent({
+    setup(_, { slots }) {
+      return () => h('div', [
+        slots.default?.(),
+        slots.items?.(),
+      ])
+    },
+  }),
+  // eslint-disable-next-line vue/one-component-per-file
+  KDropdownItem: defineComponent({
+    props: {
+      item: {
+        type: Object,
+        default: undefined,
+      },
+    },
+    setup(props, { slots }) {
+      return () => h('a', {
+        href: (props.item as { to?: string } | undefined)?.to,
+      }, slots.default?.() ?? (props.item as { label?: string } | undefined)?.label)
+    },
+  }),
+}
+
 const mockQueryProvider = {
   exploreBaseUrl: async () => 'http://test.com/explore',
   requestsBaseUrl: async () => 'http://test.com/requests',
@@ -261,7 +287,8 @@ describe('<DashboardTile /> table tiles', () => {
 
   it('dispatches table tiles to the table data grid renderer', () => {
     const tableDefinition: TileDefinition = {
-      config: {
+      chart: {
+        type: 'table',
         title: 'Table Tile',
       },
       query: {
@@ -295,7 +322,6 @@ describe('<DashboardTile /> table tiles', () => {
         queryReady: true,
         refreshCounter: 0,
         tileId: '1',
-        tileType: 'table',
       },
       shallow: true,
       global: {
@@ -319,9 +345,10 @@ describe('<DashboardTile /> table tiles', () => {
     expect(wrapper.findComponent(TableDataGridRenderer).props('height')).toBeUndefined()
   })
 
-  it('shows editable tile actions for table tiles', () => {
+  it('shows editable tile actions and explore links for table tiles', async () => {
     const tableDefinition: TileDefinition = {
-      config: {
+      chart: {
+        type: 'table',
         title: 'Table Tile',
       },
       query: {
@@ -341,7 +368,6 @@ describe('<DashboardTile /> table tiles', () => {
         queryReady: true,
         refreshCounter: 0,
         tileId: '1',
-        tileType: 'table',
       },
       shallow: true,
       global: {
@@ -349,16 +375,61 @@ describe('<DashboardTile /> table tiles', () => {
           [INJECT_QUERY_PROVIDER]: mockQueryProvider,
         },
         stubs: {
+          ...dropdownSlotStubs,
           TableDataGridRenderer: false,
         },
       },
     })
+    await flushPromises()
 
     expect(wrapper.findTestId('tile-actions-1').exists()).toBe(true)
     expect(wrapper.findTestId('edit-tile-1').exists()).toBe(true)
     expect(wrapper.findTestId('kebab-action-menu-1').exists()).toBe(true)
-    expect(wrapper.findTestId('chart-jump-to-explore-1').exists()).toBe(false)
+    expect(wrapper.findTestId('chart-jump-to-explore-1').exists()).toBe(true)
     expect(wrapper.findTestId('chart-jump-to-requests-1').exists()).toBe(false)
     expect(wrapper.findTestId('chart-csv-export-1').exists()).toBe(false)
+  })
+
+  it('shows explore links for non-editable table tiles', async () => {
+    const tableDefinition: TileDefinition = {
+      chart: {
+        type: 'table',
+        title: 'Table Tile',
+      },
+      query: {
+        datasource: 'platform',
+        entity: 'route',
+        columns: ['control_plane'],
+      },
+    }
+
+    const wrapper = mount(DashboardTile, {
+      props: {
+        context: {
+          ...mockContext,
+          editable: false,
+        },
+        definition: tableDefinition,
+        queryReady: true,
+        refreshCounter: 0,
+        tileId: '1',
+      },
+      shallow: true,
+      global: {
+        provide: {
+          [INJECT_QUERY_PROVIDER]: mockQueryProvider,
+        },
+        stubs: {
+          ...dropdownSlotStubs,
+          TableDataGridRenderer: false,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.findTestId('tile-actions-1').exists()).toBe(true)
+    expect(wrapper.findTestId('edit-tile-1').exists()).toBe(false)
+    expect(wrapper.findTestId('chart-jump-to-explore-1').exists()).toBe(true)
+    expect(wrapper.findTestId('chart-jump-to-requests-1').exists()).toBe(false)
   })
 })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
@@ -390,7 +390,7 @@ describe('<DashboardTile /> table tiles', () => {
     expect(wrapper.findTestId('chart-csv-export-1').exists()).toBe(false)
   })
 
-  it('shows explore links for non-editable table tiles', async () => {
+  it('shows table explore links when edit actions are hidden', async () => {
     const tableDefinition: TileDefinition = {
       chart: {
         type: 'table',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -152,7 +152,7 @@
     </div>
     <div
       class="tile-content"
-      :class="`type-${tileTypeClass}`"
+      :class="`type-${tileType}-${chart.type}`"
       :data-testid="`tile-content-${tileId}`"
     >
       <component
@@ -255,9 +255,8 @@ const chart = computed(() => props.definition.chart)
 const tileTitle = computed<string | undefined>(() => {
   return 'chart_title' in chart.value ? chart.value.chart_title : undefined
 })
-const tileDescription = computed<string | undefined>(() => !isTableChartDefinition(props.definition) && 'description' in chart.value ? chart.value.description : undefined)
-const tileTypeClass = computed<string>(() => isTableChartDefinition(props.definition) ? 'table' : chart.value.type)
-const isSlottableTile = computed<boolean>(() => !isTableChartDefinition(props.definition) && chart.value.type === 'slottable')
+const tileDescription = computed<string | undefined>(() => 'description' in chart.value ? chart.value.description : undefined)
+const isSlottableTile = computed<boolean>(() => chart.value.type === 'slottable')
 const canExportCsv = computed<boolean>(() => {
   if (isTableChartDefinition(props.definition)) {
     return false
@@ -306,14 +305,12 @@ watch(() => props.definition, async (newValue, oldValue) => {
 
 const csvFilename = computed<string>(() => i18n.t('csvExport.defaultFilename'))
 
-const kebabMenuHasItems = computed((): boolean => isTableChartDefinition(props.definition)
-  ? !!exploreLinkKebabMenu.value || props.context.editable
-  : !!exploreLinkKebabMenu.value || canExportCsv.value || props.context.editable)
+const kebabMenuHasItems = computed((): boolean => !!exploreLinkKebabMenu.value || canExportCsv.value || props.context.editable)
 
 // The shared header action container is hidden when tile actions are globally disabled.
 const canShowHeaderActions = computed((): boolean => !props.hideActions && canShowKebabMenu.value && kebabMenuHasItems.value)
 const hasHeaderActions = computed<boolean>(() => canShowHeaderActions.value && kebabMenuHasItems.value && !props.isFullscreen)
-const hasSignalsDescription = computed<boolean>(() => !isTableChartDefinition(props.definition) && chart.value.type === 'golden_signals' && Boolean(tileDescription.value))
+const hasSignalsDescription = computed<boolean>(() => chart.value.type === 'golden_signals' && Boolean(tileDescription.value))
 
 const rendererLookup: Record<Exclude<DashboardTileType, 'table'>, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,
@@ -344,6 +341,7 @@ const componentData = computed(() => {
       component: TableDataGridRenderer,
       rendererProps: {
         context: props.context,
+        height: props.height - PADDING_SIZE * 2,
         query: definition.query,
         queryReady: props.queryReady,
         refreshCounter: refreshCounter.value,
@@ -436,10 +434,11 @@ const chartDataGranularity = computed(() => {
 })
 
 const isTimeSeriesChart = computed(() => {
-  return !isTableChartDefinition(props.definition) && ['timeseries_line', 'timeseries_bar'].includes(chart.value.type)
+  return ['timeseries_line', 'timeseries_bar'].includes(chart.value.type)
 })
 
 const isAgedOutQuery = computed(() => {
+  // Check table definitions first so TypeScript narrows before reading query.granularity.
   if (isTableChartDefinition(props.definition) || !isTimeSeriesChart.value || !props.queryReady || loadingChartData.value) {
     return false
   }
@@ -455,6 +454,7 @@ const isAgedOutQuery = computed(() => {
 
 const agedOutWarning = computed(() => {
   const currentGranularity = msToGranularity(chartData.value?.meta.granularity_ms ?? 0) ?? 'unknown'
+  // Check table definitions first so TypeScript narrows before reading query.granularity.
   const savedGranularity = isTableChartDefinition(props.definition) ? 'unknown' : props.definition.query.granularity ?? 'unknown'
 
   return i18n.t('query_aged_out_warning', {
@@ -465,18 +465,17 @@ const agedOutWarning = computed(() => {
 
 /**
  * Derives the subset of context and tile query filters that is relevant for the tile's datasource.
+ * This is used only for chart range-selection zoom action links. Table fetching and kebab Explore
+ * links apply their own filter handling outside this component helper.
  *
  * @returns Array of scoped filter objects to a datasource
  */
 const datasourceScopedFilters = computed(() => {
-  if (isTableChartDefinition(props.definition)) {
-    return []
-  }
-
-  const filters = [...props.context.filters, ...props.definition.query.filters ?? []] as AllFilters[]
-  const metrics = props.definition.query.metrics
+  const definition = props.definition
+  const filters = [...props.context.filters, ...definition.query.filters ?? []] as AllFilters[]
+  const metrics = 'metrics' in definition.query ? definition.query.metrics : undefined
   // TODO: default to api_usage until datasource is made required
-  const datasource = props.definition.query.datasource ?? 'api_usage'
+  const datasource = definition.query.datasource ?? 'api_usage'
 
   return stripUnknownFilters.value({
     datasource,
@@ -673,13 +672,13 @@ defineExpose({ getExportData })
     overflow: hidden;
     padding: var(--kui-space-20, $kui-space-20) var(--kui-space-60, $kui-space-60) 0 var(--kui-space-60, $kui-space-60);
 
-    &.type-table {
+    &.type-chart-table {
       display: flex;
       flex-direction: column;
       min-height: 0;
     }
 
-    &.type-golden_signals {
+    &.type-chart-golden_signals {
       padding: 0;
     }
   }
@@ -692,7 +691,7 @@ defineExpose({ getExportData })
     .tile-content {
       padding: var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60) 0 var(--kui-space-60, $kui-space-60);
 
-      &.type-golden_signals {
+      &.type-chart-golden_signals {
         padding: 0;
       }
     }

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -313,12 +313,8 @@ const kebabMenuHasItems = computed((): boolean => isTableTile.value
   ? !!exploreLinkKebabMenu.value || props.context.editable
   : !!exploreLinkKebabMenu.value || canExportCsv.value || props.context.editable)
 
-// Chart header actions are driven by chart-only affordances: context links, CSV export, and editable tile controls.
-const canShowChartHeaderActions = computed((): boolean => !isTableTile.value && canShowKebabMenu.value && kebabMenuHasItems.value)
-// Table header actions allow Explore links and editable tile controls, but not API Requests or CSV export.
-const canShowTableHeaderActions = computed((): boolean => isTableTile.value && canShowKebabMenu.value && kebabMenuHasItems.value)
 // The shared header action container is hidden when tile actions are globally disabled.
-const canShowHeaderActions = computed((): boolean => !props.hideActions && (canShowChartHeaderActions.value || canShowTableHeaderActions.value))
+const canShowHeaderActions = computed((): boolean => !props.hideActions && canShowKebabMenu.value && kebabMenuHasItems.value)
 const hasHeaderActions = computed<boolean>(() => canShowHeaderActions.value && kebabMenuHasItems.value && !props.isFullscreen)
 const hasSignalsDescription = computed<boolean>(() => !isTableTile.value && chart.value.type === 'golden_signals' && Boolean(tileDescription.value))
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -101,7 +101,7 @@
               :item="{ label: i18n.t('jumpToExplore'), to: exploreLinkKebabMenu }"
             />
             <KDropdownItem
-              v-if="!isTableTile && !!requestsLinkKebabMenu"
+              v-if="!isTableChartDefinition(definition) && !!requestsLinkKebabMenu"
               :data-testid="`chart-jump-to-requests-${tileId}`"
               :item="{ label: i18n.t('jumpToRequests'), to: requestsLinkKebabMenu }"
             />
@@ -179,8 +179,6 @@ import type {
   AllFilters,
   TileConfig,
   TileDefinition,
-  TableChartTileDefinition,
-  ChartTileDefinition,
 } from '@kong-ui-public/analytics-utilities'
 
 import { type Component, computed, defineAsyncComponent, inject, nextTick, readonly, ref, toRef, watch } from 'vue'
@@ -252,18 +250,16 @@ const exportModalVisible = ref<boolean>(false)
 const titleRef = ref<HTMLElement>()
 const isTitleTruncated = ref(false)
 const loadingChartData = ref(true)
-const isTableTile = computed((): boolean => isTableChartDefinition(props.definition))
 
-const chartDefinition = computed<ChartTileDefinition>(() => props.definition as ChartTileDefinition)
-const tableDefinition = computed<TableChartTileDefinition>(() => props.definition as TableChartTileDefinition)
-const chart = computed(() => chartDefinition.value.chart)
-const chartTitle = computed<string | undefined>(() => 'chart_title' in chart.value ? chart.value.chart_title : undefined)
-const tileTitle = computed<string | undefined>(() => isTableTile.value ? tableDefinition.value.chart.title : chartTitle.value)
-const tileDescription = computed<string | undefined>(() => !isTableTile.value && 'description' in chart.value ? chart.value.description : undefined)
-const tileTypeClass = computed<string>(() => isTableTile.value ? 'table' : chart.value.type)
-const isSlottableTile = computed<boolean>(() => !isTableTile.value && chart.value.type === 'slottable')
+const chart = computed(() => props.definition.chart)
+const tileTitle = computed<string | undefined>(() => {
+  return 'chart_title' in chart.value ? chart.value.chart_title : undefined
+})
+const tileDescription = computed<string | undefined>(() => !isTableChartDefinition(props.definition) && 'description' in chart.value ? chart.value.description : undefined)
+const tileTypeClass = computed<string>(() => isTableChartDefinition(props.definition) ? 'table' : chart.value.type)
+const isSlottableTile = computed<boolean>(() => !isTableChartDefinition(props.definition) && chart.value.type === 'slottable')
 const canExportCsv = computed<boolean>(() => {
-  if (isTableTile.value) {
+  if (isTableChartDefinition(props.definition)) {
     return false
   }
 
@@ -310,14 +306,14 @@ watch(() => props.definition, async (newValue, oldValue) => {
 
 const csvFilename = computed<string>(() => i18n.t('csvExport.defaultFilename'))
 
-const kebabMenuHasItems = computed((): boolean => isTableTile.value
+const kebabMenuHasItems = computed((): boolean => isTableChartDefinition(props.definition)
   ? !!exploreLinkKebabMenu.value || props.context.editable
   : !!exploreLinkKebabMenu.value || canExportCsv.value || props.context.editable)
 
 // The shared header action container is hidden when tile actions are globally disabled.
 const canShowHeaderActions = computed((): boolean => !props.hideActions && canShowKebabMenu.value && kebabMenuHasItems.value)
 const hasHeaderActions = computed<boolean>(() => canShowHeaderActions.value && kebabMenuHasItems.value && !props.isFullscreen)
-const hasSignalsDescription = computed<boolean>(() => !isTableTile.value && chart.value.type === 'golden_signals' && Boolean(tileDescription.value))
+const hasSignalsDescription = computed<boolean>(() => !isTableChartDefinition(props.definition) && chart.value.type === 'golden_signals' && Boolean(tileDescription.value))
 
 const rendererLookup: Record<Exclude<DashboardTileType, 'table'>, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,
@@ -341,12 +337,14 @@ const componentEventHandlers = computed(() => ({
 }))
 
 const componentData = computed(() => {
-  if (isTableTile.value) {
+  const definition = props.definition
+
+  if (isTableChartDefinition(definition)) {
     return {
       component: TableDataGridRenderer,
       rendererProps: {
         context: props.context,
-        query: tableDefinition.value.query,
+        query: definition.query,
         queryReady: props.queryReady,
         refreshCounter: refreshCounter.value,
       },
@@ -361,7 +359,6 @@ const componentData = computed(() => {
 
   // Ideally, Typescript would ensure that the prop types of the renderers match
   // the props that they're going to receive.  Unfortunately, actually doing this seems difficult.
-  const definition = chartDefinition.value
   const component = rendererLookup[definition.chart.type]
 
   const supportsRequests = !!(component as any)?.emits?.includes('select-chart-range')
@@ -390,11 +387,11 @@ const componentData = computed(() => {
 })
 
 const badgeData = computed<string | null>(() => {
-  if (isTableTile.value) {
+  if (isTableChartDefinition(props.definition)) {
     return null
   }
 
-  const query = chartDefinition.value.query
+  const query = props.definition.query
   const timeRange = query?.time_range
 
   // TODO: Temporary until we have more robust solution for non-timeseries "platform analytics" charts
@@ -439,15 +436,15 @@ const chartDataGranularity = computed(() => {
 })
 
 const isTimeSeriesChart = computed(() => {
-  return !isTableTile.value && ['timeseries_line', 'timeseries_bar'].includes(chart.value.type)
+  return !isTableChartDefinition(props.definition) && ['timeseries_line', 'timeseries_bar'].includes(chart.value.type)
 })
 
 const isAgedOutQuery = computed(() => {
-  if (!isTimeSeriesChart.value || !props.queryReady || loadingChartData.value) {
+  if (isTableChartDefinition(props.definition) || !isTimeSeriesChart.value || !props.queryReady || loadingChartData.value) {
     return false
   }
 
-  const savedGranularity = chartDefinition.value.query.granularity
+  const savedGranularity = props.definition.query.granularity
 
   if (!savedGranularity || !chartDataGranularity.value) {
     return false
@@ -458,7 +455,7 @@ const isAgedOutQuery = computed(() => {
 
 const agedOutWarning = computed(() => {
   const currentGranularity = msToGranularity(chartData.value?.meta.granularity_ms ?? 0) ?? 'unknown'
-  const savedGranularity = chartDefinition.value.query.granularity ?? 'unknown'
+  const savedGranularity = isTableChartDefinition(props.definition) ? 'unknown' : props.definition.query.granularity ?? 'unknown'
 
   return i18n.t('query_aged_out_warning', {
     currentGranularity: i18n.t(`granularities.${currentGranularity}` as any),
@@ -472,14 +469,14 @@ const agedOutWarning = computed(() => {
  * @returns Array of scoped filter objects to a datasource
  */
 const datasourceScopedFilters = computed(() => {
-  if (isTableTile.value) {
+  if (isTableChartDefinition(props.definition)) {
     return []
   }
 
-  const filters = [...props.context.filters, ...chartDefinition.value.query.filters ?? []] as AllFilters[]
-  const metrics = chartDefinition.value.query.metrics
+  const filters = [...props.context.filters, ...props.definition.query.filters ?? []] as AllFilters[]
+  const metrics = props.definition.query.metrics
   // TODO: default to api_usage until datasource is made required
-  const datasource = chartDefinition.value.query.datasource ?? 'api_usage'
+  const datasource = props.definition.query.datasource ?? 'api_usage'
 
   return stripUnknownFilters.value({
     datasource,

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -196,6 +196,7 @@ import GoldenSignalsRenderer from './GoldenSignalsRenderer.vue'
 import TopNTableRenderer from './TopNTableRenderer.vue'
 import TableDataGridRenderer from './TableDataGridRenderer.vue'
 import composables from '../composables'
+import { isTableChartDefinition } from '../utils/tile-definition'
 import { useDatasourceConfigStore } from '@kong-ui-public/analytics-config-store'
 import { storeToRefs } from 'pinia'
 import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_40, KUI_ICON_SIZE_60, KUI_ICON_SIZE_20, KUI_SPACE_70 } from '@kong/design-tokens'
@@ -251,7 +252,7 @@ const exportModalVisible = ref<boolean>(false)
 const titleRef = ref<HTMLElement>()
 const isTitleTruncated = ref(false)
 const loadingChartData = ref(true)
-const isTableTile = computed((): boolean => props.definition.chart.type === 'table')
+const isTableTile = computed((): boolean => isTableChartDefinition(props.definition))
 
 const chartDefinition = computed<ChartTileDefinition>(() => props.definition as ChartTileDefinition)
 const tableDefinition = computed<TableChartTileDefinition>(() => props.definition as TableChartTileDefinition)

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -312,7 +312,7 @@ const canShowHeaderActions = computed((): boolean => !props.hideActions && canSh
 const hasHeaderActions = computed<boolean>(() => canShowHeaderActions.value && kebabMenuHasItems.value && !props.isFullscreen)
 const hasSignalsDescription = computed<boolean>(() => chart.value.type === 'golden_signals' && Boolean(tileDescription.value))
 
-const rendererLookup: Record<Exclude<DashboardTileType, 'table'>, Component | undefined> = {
+const rendererLookup: Record<DashboardTileType, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,
   'timeseries_bar': TimeseriesChartRenderer,
   'horizontal_bar': BarChartRenderer,
@@ -321,6 +321,7 @@ const rendererLookup: Record<Exclude<DashboardTileType, 'table'>, Component | un
   'donut': DonutChartRenderer,
   'golden_signals': GoldenSignalsRenderer,
   'top_n': TopNTableRenderer,
+  'table': TableDataGridRenderer,
   'slottable': undefined,
   'single_value': SimpleChartRenderer,
   'choropleth_map': GeoMapRendererAsync,
@@ -335,51 +336,39 @@ const componentEventHandlers = computed(() => ({
 
 const componentData = computed(() => {
   const definition = props.definition
-
-  if (isTableChartDefinition(definition)) {
-    return {
-      component: TableDataGridRenderer,
-      rendererProps: {
-        context: props.context,
-        height: props.height - PADDING_SIZE * 2,
-        query: definition.query,
-        queryReady: props.queryReady,
-        refreshCounter: refreshCounter.value,
-      },
-      rendererEvents: {
-        supportsRequests: false,
-        supportsZoom: false,
-        supportsBounds: false,
-        supportsLoadingChange: true,
-      },
-    }
-  }
+  const component = rendererLookup[definition.chart.type]
+  const isTableChart = isTableChartDefinition(definition)
 
   // Ideally, Typescript would ensure that the prop types of the renderers match
   // the props that they're going to receive.  Unfortunately, actually doing this seems difficult.
-  const component = rendererLookup[definition.chart.type]
-
   const supportsRequests = !!(component as any)?.emits?.includes('select-chart-range')
   const supportsZoom = !!(component as any)?.emits?.includes('zoom-time-range')
   const supportsBounds = definition.chart.type === 'choropleth_map' // can't lookup with emits as this is an async renderer
+  const supportsLoadingChange = !!(component as any)?.emits?.includes('loading-change')
+  const rendererProps = {
+    query: definition.query,
+    context: props.context,
+    queryReady: props.queryReady,
+    height: props.height - PADDING_SIZE * 2,
+    refreshCounter: refreshCounter.value,
+  }
+  const chartRendererProps = {
+    chartOptions: definition.chart,
+    requestsLink: props.hideZoomActions ? undefined : requestsLinkZoomActions.value,
+    exploreLink: props.hideZoomActions ? undefined : exploreLinkZoomActions.value,
+  }
 
   return component && {
     component,
     rendererProps: {
-      query: definition.query,
-      context: props.context,
-      queryReady: props.queryReady,
-      chartOptions: definition.chart,
-      height: props.height - PADDING_SIZE * 2,
-      refreshCounter: refreshCounter.value,
-      requestsLink: props.hideZoomActions ? undefined : requestsLinkZoomActions.value,
-      exploreLink: props.hideZoomActions ? undefined : exploreLinkZoomActions.value,
+      ...rendererProps,
+      ...(!isTableChart ? chartRendererProps : {}),
     },
     rendererEvents: {
       supportsRequests,
       supportsZoom,
       supportsBounds,
-      supportsLoadingChange: false,
+      supportsLoadingChange,
     },
   }
 })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -96,7 +96,7 @@
           />
           <template #items>
             <KDropdownItem
-              v-if="!isTableTile && !!exploreLinkKebabMenu"
+              v-if="!!exploreLinkKebabMenu"
               :data-testid="`chart-jump-to-explore-${tileId}`"
               :item="{ label: i18n.t('jumpToExplore'), to: exploreLinkKebabMenu }"
             />
@@ -179,7 +179,7 @@ import type {
   AllFilters,
   TileConfig,
   TileDefinition,
-  TableTileDefinition,
+  TableChartTileDefinition,
   ChartTileDefinition,
 } from '@kong-ui-public/analytics-utilities'
 
@@ -251,13 +251,13 @@ const exportModalVisible = ref<boolean>(false)
 const titleRef = ref<HTMLElement>()
 const isTitleTruncated = ref(false)
 const loadingChartData = ref(true)
-const isTableTile = computed((): boolean => props.tileType === 'table')
+const isTableTile = computed((): boolean => props.definition.chart.type === 'table')
 
 const chartDefinition = computed<ChartTileDefinition>(() => props.definition as ChartTileDefinition)
-const tableDefinition = computed<TableTileDefinition>(() => props.definition as TableTileDefinition)
+const tableDefinition = computed<TableChartTileDefinition>(() => props.definition as TableChartTileDefinition)
 const chart = computed(() => chartDefinition.value.chart)
 const chartTitle = computed<string | undefined>(() => 'chart_title' in chart.value ? chart.value.chart_title : undefined)
-const tileTitle = computed<string | undefined>(() => isTableTile.value ? tableDefinition.value?.config.title : chartTitle.value)
+const tileTitle = computed<string | undefined>(() => isTableTile.value ? tableDefinition.value.chart.title : chartTitle.value)
 const tileDescription = computed<string | undefined>(() => !isTableTile.value && 'description' in chart.value ? chart.value.description : undefined)
 const tileTypeClass = computed<string>(() => isTableTile.value ? 'table' : chart.value.type)
 const isSlottableTile = computed<boolean>(() => !isTableTile.value && chart.value.type === 'slottable')
@@ -284,7 +284,7 @@ const {
 } = composables.useContextLinks({
   queryBridge,
   chartData: readonly(chartData),
-  definition: readonly(chartDefinition),
+  definition: readonly(toRef(props, 'definition')),
   context: readonly(toRef(props, 'context')),
 })
 
@@ -310,19 +310,19 @@ watch(() => props.definition, async (newValue, oldValue) => {
 const csvFilename = computed<string>(() => i18n.t('csvExport.defaultFilename'))
 
 const kebabMenuHasItems = computed((): boolean => isTableTile.value
-  ? props.context.editable
+  ? !!exploreLinkKebabMenu.value || props.context.editable
   : !!exploreLinkKebabMenu.value || canExportCsv.value || props.context.editable)
 
 // Chart header actions are driven by chart-only affordances: context links, CSV export, and editable tile controls.
 const canShowChartHeaderActions = computed((): boolean => !isTableTile.value && canShowKebabMenu.value && kebabMenuHasItems.value)
-// Table header actions are limited to editable tile controls; table tiles do not expose chart links or CSV export here.
-const canShowTableHeaderActions = computed((): boolean => isTableTile.value && props.context.editable)
+// Table header actions allow Explore links and editable tile controls, but not API Requests or CSV export.
+const canShowTableHeaderActions = computed((): boolean => isTableTile.value && canShowKebabMenu.value && kebabMenuHasItems.value)
 // The shared header action container is hidden when tile actions are globally disabled.
 const canShowHeaderActions = computed((): boolean => !props.hideActions && (canShowChartHeaderActions.value || canShowTableHeaderActions.value))
 const hasHeaderActions = computed<boolean>(() => canShowHeaderActions.value && kebabMenuHasItems.value && !props.isFullscreen)
 const hasSignalsDescription = computed<boolean>(() => !isTableTile.value && chart.value.type === 'golden_signals' && Boolean(tileDescription.value))
 
-const rendererLookup: Record<DashboardTileType, Component | undefined> = {
+const rendererLookup: Record<Exclude<DashboardTileType, 'table'>, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,
   'timeseries_bar': TimeseriesChartRenderer,
   'horizontal_bar': BarChartRenderer,

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -284,7 +284,7 @@ const {
 } = composables.useContextLinks({
   queryBridge,
   chartData: readonly(chartData),
-  definition: readonly(toRef(props, 'definition')),
+  definition: toRef(props, 'definition'),
   context: readonly(toRef(props, 'context')),
 })
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
@@ -180,11 +180,6 @@ describe('<DashboardTilePreview />', () => {
     })
   })
 
-  it('passes chart definitions to DashboardTile without overriding the tile type', () => {
-    setup()
-    expectTilePropIs('tileType', undefined)
-  })
-
   it('shows the "Chart not configured" empty state when metrics are not provided', () => {
     setup({ metrics: [] })
     cy.getTestId('chart-not-configured-empty-state').should('exist')
@@ -232,7 +227,7 @@ describe('<DashboardTilePreview />', () => {
     cy.getTestId('test-stub').should('not.exist')
   })
 
-  it('passes table chart definitions without column preferences to DashboardTile', () => {
+  it('passes table chart definitions that rely on response metadata columns to DashboardTile', () => {
     const definition: TileDefinition = {
       chart: {
         type: 'table',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
@@ -232,6 +232,25 @@ describe('<DashboardTilePreview />', () => {
     cy.getTestId('test-stub').should('not.exist')
   })
 
+  it('passes table chart definitions without column preferences to DashboardTile', () => {
+    const definition: TileDefinition = {
+      chart: {
+        type: 'table',
+        title: 'Routes',
+      },
+      query: {
+        datasource: 'platform',
+        entity: 'route',
+      },
+    }
+
+    setup({ definition })
+
+    cy.getTestId('chart-not-configured-empty-state').should('not.exist')
+    cy.getTestId('test-stub').should('exist')
+    expectTilePropIs('definition', definition)
+  })
+
   it('forwards getExportData to child DashboardTile', () => {
     const mockExportData = {
       data: [{ event: { request_count: 42 }, timestamp: '2024-01-01T00:00:00Z' }],

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
@@ -190,7 +190,7 @@ describe('<DashboardTilePreview />', () => {
     const definition: TileDefinition = {
       chart: {
         type: 'table',
-        title: 'Routes',
+        chart_title: 'Routes',
       },
       query: {
         datasource: 'platform',
@@ -212,7 +212,7 @@ describe('<DashboardTilePreview />', () => {
     const definition: TileDefinition = {
       chart: {
         type: 'table',
-        title: 'Routes',
+        chart_title: 'Routes',
       },
       query: {
         datasource: 'platform',
@@ -231,7 +231,7 @@ describe('<DashboardTilePreview />', () => {
     const definition: TileDefinition = {
       chart: {
         type: 'table',
-        title: 'Routes',
+        chart_title: 'Routes',
       },
       query: {
         datasource: 'platform',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
@@ -16,10 +16,12 @@ describe('<DashboardTilePreview />', () => {
   })
 
   const setup = async ({
+    definition: definitionOverride,
     editable,
     wrappedInDivWithHeight,
     metrics = ['response_size_p99'],
   }: {
+    definition?: TileDefinition
     editable?: boolean
     wrappedInDivWithHeight?: number
     metrics?: any[]
@@ -33,7 +35,7 @@ describe('<DashboardTilePreview />', () => {
       }),
     }
 
-    const definition: TileDefinition = {
+    const definition: TileDefinition = definitionOverride ?? {
       chart: {
         type: 'horizontal_bar',
       },
@@ -178,10 +180,36 @@ describe('<DashboardTilePreview />', () => {
     })
   })
 
+  it('passes chart definitions to DashboardTile as chart tiles', () => {
+    setup()
+    expectTilePropIs('tileType', 'chart')
+  })
+
   it('shows the "Chart not configured" empty state when metrics are not provided', () => {
     setup({ metrics: [] })
     cy.getTestId('chart-not-configured-empty-state').should('exist')
     cy.getTestId('test-stub').should('not.exist')
+  })
+
+  it('passes definitions with config to DashboardTile as table tiles', () => {
+    const definition: TileDefinition = {
+      config: {
+        title: 'Routes',
+      },
+      query: {
+        datasource: 'platform',
+        entity: 'route',
+        columns: ['name', 'control_plane'],
+      },
+    }
+
+    setup({ definition })
+
+    cy.getTestId('chart-not-configured-empty-state').should('not.exist')
+    cy.getTestId('test-stub').should('exist')
+    expectPreviewPropIs('definition', definition)
+    expectTilePropIs('definition', definition)
+    expectTilePropIs('tileType', 'table')
   })
 
   it('forwards getExportData to child DashboardTile', () => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
@@ -180,9 +180,9 @@ describe('<DashboardTilePreview />', () => {
     })
   })
 
-  it('passes chart definitions to DashboardTile as chart tiles', () => {
+  it('passes chart definitions to DashboardTile without overriding the tile type', () => {
     setup()
-    expectTilePropIs('tileType', 'chart')
+    expectTilePropIs('tileType', undefined)
   })
 
   it('shows the "Chart not configured" empty state when metrics are not provided', () => {
@@ -191,9 +191,10 @@ describe('<DashboardTilePreview />', () => {
     cy.getTestId('test-stub').should('not.exist')
   })
 
-  it('passes definitions with config to DashboardTile as table tiles', () => {
+  it('passes table chart definitions to DashboardTile without showing the chart empty state', () => {
     const definition: TileDefinition = {
-      config: {
+      chart: {
+        type: 'table',
         title: 'Routes',
       },
       query: {
@@ -209,7 +210,26 @@ describe('<DashboardTilePreview />', () => {
     cy.getTestId('test-stub').should('exist')
     expectPreviewPropIs('definition', definition)
     expectTilePropIs('definition', definition)
-    expectTilePropIs('tileType', 'table')
+    expectTilePropIs('tileType', undefined)
+  })
+
+  it('shows the "Chart not configured" empty state for table chart definitions without columns', () => {
+    const definition: TileDefinition = {
+      chart: {
+        type: 'table',
+        title: 'Routes',
+      },
+      query: {
+        datasource: 'platform',
+        entity: 'route',
+        columns: [],
+      },
+    }
+
+    setup({ definition })
+
+    cy.getTestId('chart-not-configured-empty-state').should('exist')
+    cy.getTestId('test-stub').should('not.exist')
   })
 
   it('forwards getExportData to child DashboardTile', () => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.vue
@@ -93,7 +93,7 @@ const isTableDefinition = computed((): boolean => definition.chart.type === 'tab
 
 const chartNotConfigured = computed(() => {
   if (isTableDefinition.value) {
-    return !('columns' in definition.query) || !definition.query.columns?.length
+    return 'columns' in definition.query && !definition.query.columns?.length
   }
 
   return !('metrics' in definition.query) || !definition.query.metrics || definition.query.metrics.length === 0

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.vue
@@ -29,7 +29,6 @@
       :query-ready="queryReady"
       show-refresh
       :tile-id="randomId"
-      :tile-type="tileType"
       @chart-data="onChartData"
       @tile-bounds-change="onBoundsChange"
       @tile-time-range-zoom="onZoom"
@@ -90,15 +89,11 @@ const { internalContext, queryReady } = composables.useDashboardInternalContext(
   preview: computed(() => preview),
 })
 
-const isTableDefinition = (definition: TileDefinition): boolean => {
-  return 'config' in definition
-}
-
-const tileType = computed<'chart' | 'table'>(() => isTableDefinition(definition) ? 'table' : 'chart')
+const isTableDefinition = computed((): boolean => definition.chart.type === 'table')
 
 const chartNotConfigured = computed(() => {
-  if (isTableDefinition(definition)) {
-    return false
+  if (isTableDefinition.value) {
+    return !('columns' in definition.query) || !definition.query.columns?.length
   }
 
   return !('metrics' in definition.query) || !definition.query.metrics || definition.query.metrics.length === 0

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.vue
@@ -29,6 +29,7 @@
       :query-ready="queryReady"
       show-refresh
       :tile-id="randomId"
+      :tile-type="tileType"
       @chart-data="onChartData"
       @tile-bounds-change="onBoundsChange"
       @tile-time-range-zoom="onZoom"
@@ -89,7 +90,17 @@ const { internalContext, queryReady } = composables.useDashboardInternalContext(
   preview: computed(() => preview),
 })
 
+const isTableDefinition = (definition: TileDefinition): boolean => {
+  return 'config' in definition
+}
+
+const tileType = computed<'chart' | 'table'>(() => isTableDefinition(definition) ? 'table' : 'chart')
+
 const chartNotConfigured = computed(() => {
+  if (isTableDefinition(definition)) {
+    return false
+  }
+
   return !('metrics' in definition.query) || !definition.query.metrics || definition.query.metrics.length === 0
 })
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.vue
@@ -47,6 +47,7 @@ import type {
 } from '@kong-ui-public/analytics-utilities'
 import composables from '../composables'
 import { DEFAULT_TILE_HEIGHT } from '../constants'
+import { isTableChartDefinition } from '../utils/tile-definition'
 
 const root = useTemplateRef('root')
 const tileRef = useTemplateRef('dashboard-tile')
@@ -89,7 +90,7 @@ const { internalContext, queryReady } = composables.useDashboardInternalContext(
   preview: computed(() => preview),
 })
 
-const isTableDefinition = computed((): boolean => definition.chart.type === 'table')
+const isTableDefinition = computed((): boolean => isTableChartDefinition(definition))
 
 const chartNotConfigured = computed(() => {
   if (isTableDefinition.value) {

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
@@ -289,6 +289,7 @@ describe('useContextLinks', () => {
     }
     const { wrapper } = mountComposable({
       chartType: 'table',
+      contextFilters: [makeFilter('gateway_service')],
       query: tableQuery,
     })
     await flushPromises()
@@ -296,7 +297,10 @@ describe('useContextLinks', () => {
     const params = new URLSearchParams((wrapper.vm.exploreLinkKebabMenu as string).split('?')[1])
     expect(params.get('d')).toBe('platform')
     expect(params.get('c')).toBe('table')
-    expect(JSON.parse(params.get('q')!)).toEqual(tableQuery)
+    expect(JSON.parse(params.get('q')!)).toEqual({
+      ...tableQuery,
+      filters: [makeFilter('gateway_service'), makeFilter('control_plane')],
+    })
     expect(wrapper.vm.canGenerateRequestsLink).toBe(false)
     expect(wrapper.vm.requestsLinkKebabMenu).toBe('')
     expect(wrapper.vm.requestsLinkZoomActions).toBeUndefined()

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
@@ -77,6 +77,7 @@ function mountComposable({
   datasource = 'api_usage',
   metrics = ['request_count'],
   explicitGranularity,
+  query,
   queryFilters = [],
   contextFilters = [],
   timeRange,
@@ -90,6 +91,7 @@ function mountComposable({
   datasource?: string
   metrics?: string[]
   explicitGranularity?: string | undefined
+  query?: Record<string, unknown>
   queryFilters?: any[]
   contextFilters?: any[]
   timeRange?: any
@@ -111,7 +113,7 @@ function mountComposable({
 
   const definition = computed(() => ({
     chart: { type: chartType },
-    query: {
+    query: query ?? {
       datasource,
       metrics,
       dimensions: ['gateway_service'],
@@ -276,6 +278,28 @@ describe('useContextLinks', () => {
 
     const params = new URLSearchParams((wrapper.vm.exploreLinkKebabMenu as string).split('?')[1])
     expect(params.get('d')).toBe('platform')
+  })
+
+  it('builds explore link for table charts with the tabular query shape', async () => {
+    const tableQuery = {
+      datasource: 'platform',
+      entity: 'route',
+      columns: ['name', 'control_plane'],
+      filters: [makeFilter('control_plane')],
+    }
+    const { wrapper } = mountComposable({
+      chartType: 'table',
+      query: tableQuery,
+    })
+    await flushPromises()
+
+    const params = new URLSearchParams((wrapper.vm.exploreLinkKebabMenu as string).split('?')[1])
+    expect(params.get('d')).toBe('platform')
+    expect(params.get('c')).toBe('table')
+    expect(JSON.parse(params.get('q')!)).toEqual(tableQuery)
+    expect(wrapper.vm.canGenerateRequestsLink).toBe(false)
+    expect(wrapper.vm.requestsLinkKebabMenu).toBe('')
+    expect(wrapper.vm.requestsLinkZoomActions).toBeUndefined()
   })
 
   it('does not generate requests drilldown for platform tiles', async () => {

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -3,7 +3,7 @@ import { msToGranularity } from '@kong-ui-public/analytics-utilities'
 import { useAnalyticsConfigStore, useDatasourceConfigStore } from '@kong-ui-public/analytics-config-store'
 import { storeToRefs } from 'pinia'
 import type { DeepReadonly, Ref } from 'vue'
-import type { AiExploreAggregations, AiExploreQuery, AllFilters, AnalyticsBridge, ChartTileDefinition, ExploreAggregations, ExploreQuery, ExploreResultV4, QueryableAiExploreDimensions, QueryableExploreDimensions, TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
+import type { AiExploreAggregations, AiExploreQuery, AllFilters, AnalyticsBridge, ChartTileDefinition, ExploreAggregations, ExploreQuery, ExploreResultV4, QueryableAiExploreDimensions, QueryableExploreDimensions, TableChartTileDefinition, TimeRangeV4, ValidDashboardTableQuery } from '@kong-ui-public/analytics-utilities'
 import type { DashboardRendererContextInternal } from '../types'
 import type { ExternalLink } from '@kong-ui-public/analytics-chart'
 
@@ -25,7 +25,7 @@ export default function useContextLinks(
   }: {
     queryBridge: AnalyticsBridge | undefined
     context: Readonly<Ref<DeepReadonly<DashboardRendererContextInternal>>>
-    definition: Readonly<Ref<DeepReadonly<ChartTileDefinition>>>
+    definition: Readonly<Ref<DeepReadonly<ChartTileDefinition | TableChartTileDefinition>>>
     chartData: Readonly<Ref<DeepReadonly<ExploreResultV4 | undefined>>>
   },
 ) {
@@ -38,6 +38,7 @@ export default function useContextLinks(
   const analyticsConfigStore = useAnalyticsConfigStore()
   const datasourceConfigStore = useDatasourceConfigStore()
   const { stripUnknownFilters, loading: datasourceConfigLoading } = storeToRefs(datasourceConfigStore)
+  const isTableChart = computed(() => definition.value.chart.type === 'table')
 
   onMounted(async () => {
     // Since this is async, it can't be in the `computed`.  Just check once, when the component mounts.
@@ -60,7 +61,7 @@ export default function useContextLinks(
     return true
   })
 
-  const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && definition.value.query.datasource !== 'llm_usage' && definition.value.query.datasource !== 'platform' && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
+  const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && !isTableChart.value && definition.value.query.datasource !== 'llm_usage' && definition.value.query.datasource !== 'platform' && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
   const canGenerateExploreLink = computed(() => exploreBaseUrl.value && definition.value.query && EXPLORE_DATASOURCES.includes(definition.value.query.datasource as any) && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
 
   const chartDataGranularity = computed(() => {
@@ -68,9 +69,14 @@ export default function useContextLinks(
   })
 
   const datasourceScopedFilters = computed(() => {
-    const filters = [...context.value.filters, ...definition.value.query.filters ?? []] as AllFilters[]
-    const metrics = definition.value.query.metrics
-    const datasource = definition.value.query?.datasource ?? 'api_usage'
+    if (isTableChart.value) {
+      return []
+    }
+
+    const chartDefinition = definition.value as DeepReadonly<ChartTileDefinition>
+    const filters = [...context.value.filters, ...chartDefinition.query.filters ?? []] as AllFilters[]
+    const metrics = chartDefinition.query.metrics
+    const datasource = chartDefinition.query?.datasource ?? 'api_usage'
 
     return stripUnknownFilters.value({
       datasource,
@@ -86,21 +92,26 @@ export default function useContextLinks(
       return ''
     }
 
-    const filters = datasourceScopedFilters.value as AllFilters[]
-    const timeRange = definition.value.query.time_range as TimeRangeV4 || context.value.timeSpec
-    const exploreQuery = buildExploreQuery(timeRange, filters)
+    if (isTableChart.value) {
+      return buildExploreLink((definition.value as DeepReadonly<TableChartTileDefinition>).query)
+    }
+
+    const chartDefinition = definition.value as DeepReadonly<ChartTileDefinition>
+    const timeRange = chartDefinition.query.time_range as TimeRangeV4 || context.value.timeSpec
+    const exploreQuery = buildExploreQuery(timeRange, datasourceScopedFilters.value as AllFilters[])
     return buildExploreLink(exploreQuery)
   })
 
   const requestsLinkKebabMenu = computed(() => {
-    if (!canGenerateRequestsLink.value || !canShowKebabMenu.value) {
+    if (isTableChart.value || !canGenerateRequestsLink.value || !canShowKebabMenu.value) {
       return ''
     }
 
     const filters = datasourceScopedFilters.value as AllFilters[]
+    const chartDefinition = definition.value as DeepReadonly<ChartTileDefinition>
 
     const requestsQuery = buildRequestsQueryKebabMenu(
-      definition.value.query.time_range as TimeRangeV4 || context.value.timeSpec,
+      chartDefinition.query.time_range as TimeRangeV4 || context.value.timeSpec,
       filters,
     )
 
@@ -140,19 +151,20 @@ export default function useContextLinks(
   }
 
   const buildExploreQuery = (timeRange: TimeRangeV4, filters: DeepReadonly<AllFilters[]>) => {
-    const dimensions = definition.value.query.dimensions as QueryableExploreDimensions[] | QueryableAiExploreDimensions[] ?? []
+    const chartDefinition = definition.value as DeepReadonly<ChartTileDefinition>
+    const dimensions = chartDefinition.query.dimensions as QueryableExploreDimensions[] | QueryableAiExploreDimensions[] ?? []
     const exploreQuery: ExploreQuery | AiExploreQuery = {
       filters: filters,
-      metrics: definition.value.query.metrics as ExploreAggregations[] | AiExploreAggregations[] ?? [],
+      metrics: chartDefinition.query.metrics as ExploreAggregations[] | AiExploreAggregations[] ?? [],
       dimensions: dimensions,
       time_range: timeRange,
-      granularity: definition.value.query.granularity || chartDataGranularity.value,
+      granularity: chartDefinition.query.granularity || chartDataGranularity.value,
     } as ExploreQuery | AiExploreQuery
 
     return exploreQuery
   }
 
-  const buildExploreLink = (exploreQuery: ExploreQuery | AiExploreQuery) => {
+  const buildExploreLink = (exploreQuery: ExploreQuery | AiExploreQuery | DeepReadonly<ValidDashboardTableQuery>) => {
     if (!canGenerateExploreLink.value) {
       return ''
     }

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -6,6 +6,7 @@ import type { DeepReadonly, Ref } from 'vue'
 import type { AiExploreAggregations, AiExploreQuery, AllFilters, AnalyticsBridge, ChartTileDefinition, ExploreAggregations, ExploreQuery, ExploreResultV4, QueryableAiExploreDimensions, QueryableExploreDimensions, TableChartTileDefinition, TimeRangeV4, ValidDashboardTableQuery } from '@kong-ui-public/analytics-utilities'
 import type { DashboardRendererContextInternal } from '../types'
 import type { ExternalLink } from '@kong-ui-public/analytics-chart'
+import { isTableChartDefinition } from '../utils/tile-definition'
 
 const EXPLORE_DATASOURCES = [
   'basic',
@@ -17,10 +18,6 @@ const EXPLORE_DATASOURCES = [
 ] as const
 
 type ExploreDatasource = typeof EXPLORE_DATASOURCES[number]
-
-const isTableChartDefinition = (
-  currentDefinition: ChartTileDefinition | TableChartTileDefinition,
-): currentDefinition is TableChartTileDefinition => currentDefinition.chart.type === 'table'
 
 const isExploreDatasource = (datasource: unknown): datasource is ExploreDatasource => {
   return EXPLORE_DATASOURCES.includes(datasource as ExploreDatasource)

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -16,6 +16,16 @@ const EXPLORE_DATASOURCES = [
   undefined,
 ] as const
 
+type ExploreDatasource = typeof EXPLORE_DATASOURCES[number]
+
+const isTableChartDefinition = (
+  currentDefinition: ChartTileDefinition | TableChartTileDefinition,
+): currentDefinition is TableChartTileDefinition => currentDefinition.chart.type === 'table'
+
+const isExploreDatasource = (datasource: unknown): datasource is ExploreDatasource => {
+  return EXPLORE_DATASOURCES.includes(datasource as ExploreDatasource)
+}
+
 export default function useContextLinks(
   {
     queryBridge,
@@ -25,7 +35,7 @@ export default function useContextLinks(
   }: {
     queryBridge: AnalyticsBridge | undefined
     context: Readonly<Ref<DeepReadonly<DashboardRendererContextInternal>>>
-    definition: Readonly<Ref<DeepReadonly<ChartTileDefinition | TableChartTileDefinition>>>
+    definition: Readonly<Ref<ChartTileDefinition | TableChartTileDefinition>>
     chartData: Readonly<Ref<DeepReadonly<ExploreResultV4 | undefined>>>
   },
 ) {
@@ -38,7 +48,7 @@ export default function useContextLinks(
   const analyticsConfigStore = useAnalyticsConfigStore()
   const datasourceConfigStore = useDatasourceConfigStore()
   const { stripUnknownFilters, loading: datasourceConfigLoading } = storeToRefs(datasourceConfigStore)
-  const isTableChart = computed(() => definition.value.chart.type === 'table')
+  const isTableChart = computed(() => isTableChartDefinition(definition.value))
 
   onMounted(async () => {
     // Since this is async, it can't be in the `computed`.  Just check once, when the component mounts.
@@ -62,21 +72,21 @@ export default function useContextLinks(
   })
 
   const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && !isTableChart.value && definition.value.query.datasource !== 'llm_usage' && definition.value.query.datasource !== 'platform' && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
-  const canGenerateExploreLink = computed(() => exploreBaseUrl.value && definition.value.query && EXPLORE_DATASOURCES.includes(definition.value.query.datasource as any) && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
+  const canGenerateExploreLink = computed(() => exploreBaseUrl.value && definition.value.query && isExploreDatasource(definition.value.query.datasource) && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
 
   const chartDataGranularity = computed(() => {
     return chartData.value ? msToGranularity(chartData.value.meta.granularity_ms) : undefined
   })
 
-  const datasourceScopedFilters = computed(() => {
-    if (isTableChart.value) {
+  const datasourceScopedFilters = computed<AllFilters[]>(() => {
+    const currentDefinition = definition.value
+    if (isTableChartDefinition(currentDefinition)) {
       return []
     }
 
-    const chartDefinition = definition.value as DeepReadonly<ChartTileDefinition>
-    const filters = [...context.value.filters, ...chartDefinition.query.filters ?? []] as AllFilters[]
-    const metrics = chartDefinition.query.metrics
-    const datasource = chartDefinition.query?.datasource ?? 'api_usage'
+    const filters = [...context.value.filters, ...currentDefinition.query.filters ?? []] as AllFilters[]
+    const metrics = currentDefinition.query.metrics
+    const datasource = currentDefinition.query?.datasource ?? 'api_usage'
 
     return stripUnknownFilters.value({
       datasource,
@@ -92,13 +102,13 @@ export default function useContextLinks(
       return ''
     }
 
-    if (isTableChart.value) {
-      return buildExploreLink((definition.value as DeepReadonly<TableChartTileDefinition>).query)
+    const currentDefinition = definition.value
+    if (isTableChartDefinition(currentDefinition)) {
+      return buildExploreLink(currentDefinition.query)
     }
 
-    const chartDefinition = definition.value as DeepReadonly<ChartTileDefinition>
-    const timeRange = chartDefinition.query.time_range as TimeRangeV4 || context.value.timeSpec
-    const exploreQuery = buildExploreQuery(timeRange, datasourceScopedFilters.value as AllFilters[])
+    const timeRange = currentDefinition.query.time_range as TimeRangeV4 || context.value.timeSpec
+    const exploreQuery = buildExploreQuery(timeRange, datasourceScopedFilters.value)
     return buildExploreLink(exploreQuery)
   })
 
@@ -107,11 +117,14 @@ export default function useContextLinks(
       return ''
     }
 
-    const filters = datasourceScopedFilters.value as AllFilters[]
-    const chartDefinition = definition.value as DeepReadonly<ChartTileDefinition>
+    const filters = datasourceScopedFilters.value
+    const currentDefinition = definition.value
+    if (isTableChartDefinition(currentDefinition)) {
+      return ''
+    }
 
     const requestsQuery = buildRequestsQueryKebabMenu(
-      chartDefinition.query.time_range as TimeRangeV4 || context.value.timeSpec,
+      currentDefinition.query.time_range as TimeRangeV4 || context.value.timeSpec,
       filters,
     )
 
@@ -150,15 +163,20 @@ export default function useContextLinks(
     }
   }
 
-  const buildExploreQuery = (timeRange: TimeRangeV4, filters: DeepReadonly<AllFilters[]>) => {
-    const chartDefinition = definition.value as DeepReadonly<ChartTileDefinition>
-    const dimensions = chartDefinition.query.dimensions as QueryableExploreDimensions[] | QueryableAiExploreDimensions[] ?? []
+  const buildExploreQuery = (timeRange: TimeRangeV4, filters: AllFilters[]): ExploreQuery | AiExploreQuery => {
+    const currentDefinition = definition.value
+    if (isTableChartDefinition(currentDefinition)) {
+      throw new Error('Cannot build a chart explore query for table chart definitions')
+    }
+
+    const dimensions = [...(currentDefinition.query.dimensions ?? [])] as QueryableExploreDimensions[] | QueryableAiExploreDimensions[]
+    const metrics = [...(currentDefinition.query.metrics ?? [])] as ExploreAggregations[] | AiExploreAggregations[]
     const exploreQuery: ExploreQuery | AiExploreQuery = {
-      filters: filters,
-      metrics: chartDefinition.query.metrics as ExploreAggregations[] | AiExploreAggregations[] ?? [],
+      filters,
+      metrics,
       dimensions: dimensions,
       time_range: timeRange,
-      granularity: chartDefinition.query.granularity || chartDataGranularity.value,
+      granularity: currentDefinition.query.granularity || chartDataGranularity.value || undefined,
     } as ExploreQuery | AiExploreQuery
 
     return exploreQuery

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -77,12 +77,8 @@ export default function useContextLinks(
 
   const datasourceScopedFilters = computed<AllFilters[]>(() => {
     const currentDefinition = definition.value
-    if (isTableChartDefinition(currentDefinition)) {
-      return []
-    }
-
     const filters = [...context.value.filters, ...currentDefinition.query.filters ?? []] as AllFilters[]
-    const metrics = currentDefinition.query.metrics
+    const metrics = 'metrics' in currentDefinition.query ? currentDefinition.query.metrics : undefined
     const datasource = currentDefinition.query?.datasource ?? 'api_usage'
 
     return stripUnknownFilters.value({
@@ -101,7 +97,10 @@ export default function useContextLinks(
 
     const currentDefinition = definition.value
     if (isTableChartDefinition(currentDefinition)) {
-      return buildExploreLink(currentDefinition.query)
+      return buildExploreLink({
+        ...currentDefinition.query,
+        filters: datasourceScopedFilters.value as ValidDashboardTableQuery['filters'],
+      })
     }
 
     const timeRange = currentDefinition.query.time_range as TimeRangeV4 || context.value.timeSpec
@@ -110,7 +109,7 @@ export default function useContextLinks(
   })
 
   const requestsLinkKebabMenu = computed(() => {
-    if (isTableChart.value || !canGenerateRequestsLink.value || !canShowKebabMenu.value) {
+    if (!canGenerateRequestsLink.value || !canShowKebabMenu.value) {
       return ''
     }
 

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
@@ -39,6 +39,23 @@ describe('configureAllowedDefinition', () => {
     },
   }
 
+  const mockTableChartTile: TileConfig = {
+    id: 'table_chart_tile_1',
+    type: 'chart',
+    layout: {
+      size: { cols: 3, rows: 2 },
+      position: { col: 0, row: 2 },
+    },
+    definition: {
+      chart: { type: 'table', title: 'Routes' },
+      query: {
+        datasource: 'platform',
+        entity: 'route',
+        columns: ['route'],
+      },
+    },
+  }
+
   const mockTileWithoutQuery: TileConfig = {
     id: 'no_query_tile',
     type: 'chart',
@@ -106,6 +123,18 @@ describe('configureAllowedDefinition', () => {
       expect(result.tiles[1].definition?.query?.datasource).toBe('api_usage')
     })
 
+    it('should preserve table chart tabular queries', () => {
+      const config: DashboardConfig = {
+        tiles: [mockTableChartTile],
+        tile_height: 167,
+      }
+
+      const result = configureAllowedDefinition(config, true)
+
+      expect(result.tiles).toHaveLength(1)
+      expect(result.tiles[0]).toEqual(mockTableChartTile)
+    })
+
     it('should maintain original tile positions', () => {
       const config: DashboardConfig = {
         tiles: [mockBasicTile, mockApiUsageTile],
@@ -154,6 +183,27 @@ describe('configureAllowedDefinition', () => {
 
       expect(result.tiles).toHaveLength(1)
       expect(result.tiles[0].id).toBe('no_query_tile')
+    })
+
+    it('should keep platform table chart tiles', () => {
+      const config: DashboardConfig = {
+        tiles: [mockTableChartTile, mockApiUsageTile],
+        tile_height: 167,
+      }
+
+      const result = configureAllowedDefinition(config, false)
+
+      expect(result.tiles).toHaveLength(1)
+      expect(result.tiles[0]).toEqual({
+        ...mockTableChartTile,
+        layout: {
+          ...mockTableChartTile.layout,
+          position: {
+            col: 0,
+            row: 0,
+          },
+        },
+      })
     })
 
     it('should reposition tiles after filtering', () => {

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
@@ -47,7 +47,7 @@ describe('configureAllowedDefinition', () => {
       position: { col: 0, row: 2 },
     },
     definition: {
-      chart: { type: 'table', title: 'Routes' },
+      chart: { type: 'table', chart_title: 'Routes' },
       query: {
         datasource: 'platform',
         entity: 'route',

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
@@ -4,6 +4,7 @@ import type {
 } from '@kong-ui-public/analytics-utilities'
 
 import { DASHBOARD_COLS } from '../constants'
+import { isTableChartDefinition } from './tile-definition'
 
 /**
  * Filters out `api_usage` datasource tiles for `basic` analytics.
@@ -34,7 +35,7 @@ const processTileForBasicTier = (tile: TileConfig): TileConfig | undefined => {
  * @returns The updated tile configuration object.
  */
 const processTileForAdvancedTier = (tile: TileConfig): TileConfig => {
-  if (tile.definition?.chart.type === 'table') {
+  if (isTableChartDefinition(tile.definition)) {
     // Table chart queries use the platform tabular API, so leave their datasource unchanged.
     return tile
   }

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
@@ -34,8 +34,8 @@ const processTileForBasicTier = (tile: TileConfig): TileConfig | undefined => {
  * @returns The updated tile configuration object.
  */
 const processTileForAdvancedTier = (tile: TileConfig): TileConfig => {
-  if (tile.type === 'table') {
-    // Table tiles use the platform tabular datasource and skip chart datasource migration.
+  if (tile.definition?.chart.type === 'table') {
+    // Table chart queries use the platform tabular API, so leave their datasource unchanged.
     return tile
   }
 

--- a/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.spec.ts
@@ -3,7 +3,6 @@ import type { GridTile } from '../types'
 import type { TileDefinition } from '@kong-ui-public/analytics-utilities'
 import {
   duplicateChartTile,
-  duplicateTableTile,
 } from './duplicate-tile'
 
 afterEach(() => {
@@ -14,7 +13,7 @@ it('duplicates table tiles with a copied title and reset position', () => {
   vi.spyOn(crypto, 'randomUUID').mockReturnValue('table-copy-id')
   const tile: GridTile<TileDefinition> = {
     id: 'table-tile',
-    type: 'table',
+    type: 'chart',
     layout: {
       position: { col: 3, row: 4 },
       size: { cols: 4, rows: 3 },
@@ -24,20 +23,21 @@ it('duplicates table tiles with a copied title and reset position', () => {
         datasource: 'platform',
         entity: 'route',
         columns: ['route'],
-        filters: [],
       },
-      config: {
+      chart: {
+        type: 'table',
         title: 'Routes',
       },
     },
   }
 
-  expect(duplicateTableTile(tile)).toEqual({
+  expect(duplicateChartTile(tile)).toEqual({
     id: 'table-copy-id',
-    type: 'table',
+    type: 'chart',
     definition: {
       query: tile.meta.query,
-      config: {
+      chart: {
+        type: 'table',
         title: 'Copy of Routes',
       },
     },

--- a/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.spec.ts
@@ -26,7 +26,7 @@ it('duplicates table tiles with a copied title and reset position', () => {
       },
       chart: {
         type: 'table',
-        title: 'Routes',
+        chart_title: 'Routes',
       },
     },
   }
@@ -38,7 +38,7 @@ it('duplicates table tiles with a copied title and reset position', () => {
       query: tile.meta.query,
       chart: {
         type: 'table',
-        title: 'Copy of Routes',
+        chart_title: 'Copy of Routes',
       },
     },
     layout: {

--- a/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
@@ -1,10 +1,9 @@
 import type { GridTile } from '../types'
 import type {
-  ChartTileDefinition,
-  TableChartTileDefinition,
   TileConfig,
   TileDefinition,
 } from '@kong-ui-public/analytics-utilities'
+import { isTableChartDefinition } from './tile-definition'
 
 /**
  * Creates a chart tile copy with a new id, origin position, preserved size, and
@@ -14,47 +13,34 @@ import type {
  * @returns A chart tile config ready to be inserted into the dashboard.
  */
 export const duplicateChartTile = (tile: GridTile<TileDefinition>): TileConfig => {
-  const { chart } = tile.meta
-
-  if (chart.type === 'table') {
-    const tableMeta = tile.meta as TableChartTileDefinition
-
-    return {
-      id: crypto.randomUUID(),
-      type: 'chart',
-      definition: {
-        ...tableMeta,
-        chart: {
-          ...chart,
-          title: chart.title ? `Copy of ${chart.title}` : '',
-        },
+  let duplicatedDefinition: TileDefinition
+  if (isTableChartDefinition(tile.meta)) {
+    duplicatedDefinition = {
+      ...tile.meta,
+      chart: {
+        ...tile.meta.chart,
+        title: tile.meta.chart.title ? `Copy of ${tile.meta.chart.title}` : '',
       },
-      layout: {
-        position: {
-          col: 0,
-          row: 0,
-        },
-        size: tile.layout.size,
+    }
+  } else if (tile.meta.chart.type === 'slottable') {
+    duplicatedDefinition = {
+      ...tile.meta,
+      chart: { ...tile.meta.chart },
+    }
+  } else {
+    duplicatedDefinition = {
+      ...tile.meta,
+      chart: {
+        ...tile.meta.chart,
+        chart_title: tile.meta.chart.chart_title ? `Copy of ${tile.meta.chart.chart_title}` : '',
       },
     }
   }
 
-  const chartMeta = tile.meta as ChartTileDefinition
-  const chartTitle = 'chart_title' in chart ? chart.chart_title : undefined
-  const duplicatedChart = chart.type === 'slottable'
-    ? { ...chart }
-    : {
-      ...chart,
-      chart_title: chartTitle ? `Copy of ${chartTitle}` : '',
-    }
-
   return {
     id: crypto.randomUUID(),
     type: 'chart',
-    definition: {
-      ...chartMeta,
-      chart: duplicatedChart,
-    },
+    definition: duplicatedDefinition,
     layout: {
       position: {
         col: 0,

--- a/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
@@ -1,60 +1,51 @@
 import type { GridTile } from '../types'
 import type {
   ChartTileDefinition,
-  TableTileDefinition,
+  TableChartTileDefinition,
   TileConfig,
   TileDefinition,
 } from '@kong-ui-public/analytics-utilities'
 
-const isSlottable = (chart: ChartTileDefinition['chart']) => {
-  return chart.type === 'slottable'
-}
-
-/**
- * Creates a table tile copy with a new id, origin position, preserved size, and
- * a copied table config whose title is prefixed when present.
- *
- * @param tile The existing dashboard grid tile to duplicate.
- * @returns A table tile config ready to be inserted into the dashboard.
- */
-export const duplicateTableTile = (tile: GridTile<TileDefinition>): TileConfig => {
-  const tableMeta = tile.meta as TableTileDefinition
-  const config = {
-    ...tableMeta.config,
-    title: tableMeta.config.title ? `Copy of ${tableMeta.config.title}` : '',
-  }
-
-  return {
-    id: crypto.randomUUID(),
-    type: 'table',
-    definition: {
-      ...tableMeta,
-      config,
-    },
-    layout: {
-      position: {
-        col: 0,
-        row: 0,
-      },
-      size: tile.layout.size,
-    },
-  }
-}
-
 /**
  * Creates a chart tile copy with a new id, origin position, preserved size, and
- * copied chart metadata. Non-slottable chart titles are prefixed when present.
+ * copied chart metadata. Chart titles are prefixed when supported.
  *
  * @param tile The existing dashboard grid tile to duplicate.
  * @returns A chart tile config ready to be inserted into the dashboard.
  */
 export const duplicateChartTile = (tile: GridTile<TileDefinition>): TileConfig => {
+  const { chart } = tile.meta
+
+  if (chart.type === 'table') {
+    const tableMeta = tile.meta as TableChartTileDefinition
+
+    return {
+      id: crypto.randomUUID(),
+      type: 'chart',
+      definition: {
+        ...tableMeta,
+        chart: {
+          ...chart,
+          title: chart.title ? `Copy of ${chart.title}` : '',
+        },
+      },
+      layout: {
+        position: {
+          col: 0,
+          row: 0,
+        },
+        size: tile.layout.size,
+      },
+    }
+  }
+
   const chartMeta = tile.meta as ChartTileDefinition
-  const chart = isSlottable(chartMeta.chart)
-    ? { ...chartMeta.chart }
+  const chartTitle = 'chart_title' in chart ? chart.chart_title : undefined
+  const duplicatedChart = chart.type === 'slottable'
+    ? { ...chart }
     : {
-      ...chartMeta.chart,
-      chart_title: chartMeta.chart.chart_title ? `Copy of ${chartMeta.chart.chart_title}` : '',
+      ...chart,
+      chart_title: chartTitle ? `Copy of ${chartTitle}` : '',
     }
 
   return {
@@ -62,7 +53,7 @@ export const duplicateChartTile = (tile: GridTile<TileDefinition>): TileConfig =
     type: 'chart',
     definition: {
       ...chartMeta,
-      chart,
+      chart: duplicatedChart,
     },
     layout: {
       position: {

--- a/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
@@ -15,25 +15,27 @@ import { isTableChartDefinition } from './tile-definition'
 export const duplicateChartTile = (tile: GridTile<TileDefinition>): TileConfig => {
   let duplicatedDefinition: TileDefinition
   if (isTableChartDefinition(tile.meta)) {
+    const { chart } = tile.meta
+
     duplicatedDefinition = {
       ...tile.meta,
       chart: {
-        ...tile.meta.chart,
-        title: tile.meta.chart.title ? `Copy of ${tile.meta.chart.title}` : '',
+        ...chart,
+        chart_title: chart.chart_title ? `Copy of ${chart.chart_title}` : '',
       },
     }
-  } else if (tile.meta.chart.type === 'slottable') {
-    duplicatedDefinition = {
-      ...tile.meta,
-      chart: { ...tile.meta.chart },
-    }
-  } else {
+  } else if ('chart_title' in tile.meta.chart) {
     duplicatedDefinition = {
       ...tile.meta,
       chart: {
         ...tile.meta.chart,
         chart_title: tile.meta.chart.chart_title ? `Copy of ${tile.meta.chart.chart_title}` : '',
       },
+    }
+  } else {
+    duplicatedDefinition = {
+      ...tile.meta,
+      chart: { ...tile.meta.chart },
     }
   }
 

--- a/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
@@ -3,7 +3,6 @@ import type {
   TileConfig,
   TileDefinition,
 } from '@kong-ui-public/analytics-utilities'
-import { isTableChartDefinition } from './tile-definition'
 
 /**
  * Creates a chart tile copy with a new id, origin position, preserved size, and
@@ -13,30 +12,15 @@ import { isTableChartDefinition } from './tile-definition'
  * @returns A chart tile config ready to be inserted into the dashboard.
  */
 export const duplicateChartTile = (tile: GridTile<TileDefinition>): TileConfig => {
-  let duplicatedDefinition: TileDefinition
-  if (isTableChartDefinition(tile.meta)) {
-    const { chart } = tile.meta
+  const duplicatedDefinition = {
+    ...tile.meta,
+    chart: { ...tile.meta.chart },
+  } as TileDefinition
 
-    duplicatedDefinition = {
-      ...tile.meta,
-      chart: {
-        ...chart,
-        chart_title: chart.chart_title ? `Copy of ${chart.chart_title}` : '',
-      },
-    }
-  } else if ('chart_title' in tile.meta.chart) {
-    duplicatedDefinition = {
-      ...tile.meta,
-      chart: {
-        ...tile.meta.chart,
-        chart_title: tile.meta.chart.chart_title ? `Copy of ${tile.meta.chart.chart_title}` : '',
-      },
-    }
-  } else {
-    duplicatedDefinition = {
-      ...tile.meta,
-      chart: { ...tile.meta.chart },
-    }
+  if ('chart_title' in duplicatedDefinition.chart) {
+    duplicatedDefinition.chart.chart_title = duplicatedDefinition.chart.chart_title
+      ? `Copy of ${duplicatedDefinition.chart.chart_title}`
+      : ''
   }
 
   return {

--- a/packages/analytics/dashboard-renderer/src/utils/tile-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/tile-definition.ts
@@ -1,0 +1,10 @@
+import type {
+  TableChartTileDefinition,
+  TileDefinition,
+} from '@kong-ui-public/analytics-utilities'
+
+export const isTableChartDefinition = (
+  definition: TileDefinition | undefined,
+): definition is TableChartTileDefinition => {
+  return definition?.chart.type === 'table'
+}


### PR DESCRIPTION
# Summary

Jira: MA-5164 - https://konghq.atlassian.net/browse/MA-5164

This pivots the unreleased dashboard table tile contract so table visuals remain dashboard chart tiles. Table rendering is now selected by `definition.chart.type: 'table'`, while the top-level tile `type` stays `'chart'`.

## Shape change

Previous unreleased shape:

```ts
{
  type: 'table',
  definition: {
    config: { title: 'Routes' },
    query: {
      datasource: 'platform',
      entity: 'route',
      columns: ['name', 'control_plane'],
    },
  },
}
```

New shape:

```ts
{
  type: 'chart',
  definition: {
    chart: { type: 'table', title: 'Routes' },
    query: {
      datasource: 'platform',
      entity: 'route',
      columns: ['name', 'control_plane'],
    },
  },
}
```

## Changes

- Updates `analytics-utilities` schema validation so table charts require the platform tabular query shape, while non-table charts keep the existing chart query shape.
- Routes `definition.chart.type === 'table'` through `DashboardTile` to `TableDataGridRenderer`.
- Preserves table chart shape through dashboard grid updates, duplication, and analytics-tier configuration utilities.
- Updates `DashboardTilePreview`, sandbox examples, and README docs to use the chart subtype contract.
- Keeps table charts out of CSV export and API Requests links, while allowing Explore links when context-link prerequisites are met.
- Keeps table previews with explicit `columns: []` in the not-configured state, while allowing omitted columns so `TableDataGridRenderer` can fall back to response metadata.