### PR TITLE
chore(entities-plugins): kong identity updates

### DIFF
--- a/packages/core/forms/src/components/forms/OIDCPrincipals.vue
+++ b/packages/core/forms/src/components/forms/OIDCPrincipals.vue
@@ -791,11 +791,7 @@ export default {
     gap: var(--kui-space-70, $kui-space-70);
   }
 
-  .principals-lookup-method-select :deep(.k-label) {
-    margin-top: 0;
-  }
-
-  .k-label {
+  :deep(.k-label) {
     margin-top: var(--kui-space-0, $kui-space-0);
   }
 }

--- a/packages/core/forms/src/components/forms/PrincipalLookupSettings.vue
+++ b/packages/core/forms/src/components/forms/PrincipalLookupSettings.vue
@@ -40,6 +40,16 @@
         </template>
       </KSelect>
 
+      <KInput
+        data-testid="principals-identifier-claim"
+        :disabled="fieldsDisabled"
+        :help="identifierClaimHelp"
+        label="Identifier claim"
+        :model-value="getIdentifierClaimInputValue()"
+        placeholder="e.g., user.employee_id"
+        @update:model-value="handleIdentifierClaimChange($event)"
+      />
+
       <template v-if="selectedLookupMethod === 'custom-identity'">
         <KInput
           data-testid="principals-custom-identity-name"
@@ -49,15 +59,6 @@
           :model-value="formModel['config-principals-principal_by']"
           placeholder="e.g., Customer_ID"
           @update:model-value="updateField('config-principals-principal_by', $event)"
-        />
-        <KInput
-          data-testid="principals-identifier-claim"
-          :disabled="fieldsDisabled"
-          help="Enter the token claim used to identify the principal. Use dot notation for nested claims (for example, workload.id). Escape periods in claim names with \ (for example, workload\.id)."
-          label="Identifier claim"
-          :model-value="getIdentifierClaimInputValue()"
-          placeholder="e.g., user.employee_id"
-          @update:model-value="handleIdentifierClaimChange($event)"
         />
       </template>
     </div>
@@ -132,7 +133,7 @@ const lookupMethodItems = [
   {
     label: 'Kong Identity client',
     value: 'kong-identity',
-    description: 'Match principals using the client ID from the token subject (sub) claim.',
+    description: 'Match principals using a token claim, defaulting to the subject (sub) claim.',
   },
   {
     label: 'Custom claim',
@@ -154,7 +155,10 @@ const hasValue = value => {
 }
 
 const inferInitialLookupMethod = (formModel) => {
-  if (hasValue(formModel['config-principals-principal_claim']) || hasValue(formModel['config-principals-principal_by'])) {
+  // principal_by is the true discriminator: it's only set for a custom-identity
+  // (type=custom) lookup. A principal_claim on its own is just an OIDC lookup
+  // against a non-`sub` claim, which is still the kong-identity method.
+  if (hasValue(formModel['config-principals-principal_by'])) {
     return 'custom-identity'
   }
 
@@ -204,6 +208,15 @@ export default {
     // Fields are inert when lookup is off, and otherwise follow the directory/principals gate.
     fieldsDisabled() {
       return this.disabled || !this.lookupEnabled
+    },
+    // principal_claim is the value source in both modes (default `sub`), but in
+    // custom-identity mode that value is matched against the Custom Identity name,
+    // so call out the pairing there.
+    identifierClaimHelp() {
+      const lead = this.selectedLookupMethod === 'custom-identity'
+        ? 'The token claim whose value is matched against the Custom Identity name below.'
+        : 'The token claim used to look up the principal.'
+      return `${lead} Leave empty to use the subject (sub) claim. Use dot notation for nested claims (for example, workload.id); escape literal periods with \\ (for example, workload\\.id).`
     },
   },
   methods: {

--- a/packages/core/forms/src/components/forms/PrincipalLookupSettings.vue
+++ b/packages/core/forms/src/components/forms/PrincipalLookupSettings.vue
@@ -41,6 +41,7 @@
       </KSelect>
 
       <KInput
+        class="principals-identifier-claim-input"
         data-testid="principals-identifier-claim"
         :disabled="fieldsDisabled"
         :help="identifierClaimHelp"
@@ -52,6 +53,7 @@
 
       <template v-if="selectedLookupMethod === 'custom-identity'">
         <KInput
+          class="principals-custom-identity-name-input"
           data-testid="principals-custom-identity-name"
           :disabled="fieldsDisabled"
           help="Enter the custom identity name used to look up the principal. Kong matches the value from the token claim to a principal with the same custom identity name and value."
@@ -282,16 +284,17 @@ export default {
   .principals-lookup-method-select :deep(.k-label) {
     margin-top: 0;
   }
-
-  .k-label {
-    margin-top: var(--kui-space-0, $kui-space-0);
-  }
 }
 
 .principals-field-group {
   display: flex;
   flex-direction: column;
   gap: var(--kui-space-40, $kui-space-40);
+
+  .principals-identifier-claim-input,
+  .principals-custom-identity-name-input {
+    margin-top: var(--kui-space-40, $kui-space-40);
+  }
 }
 
 .lookup-method-item {

--- a/packages/core/forms/src/components/forms/__tests__/PrincipalLookupSettings.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/PrincipalLookupSettings.spec.ts
@@ -36,12 +36,21 @@ describe('PrincipalLookupSettings', () => {
       expect((wrapper.vm as any).selectedLookupMethod).toBe('kong-identity')
     })
 
-    it('infers custom-identity when principal_by or principal_claim is set', () => {
+    it('infers custom-identity when principal_by is set', () => {
       const wrapper = mountComponent({
         'config-principals-principal_by': 'Customer_ID',
       })
 
       expect((wrapper.vm as any).selectedLookupMethod).toBe('custom-identity')
+    })
+
+    it('infers kong-identity when only principal_claim is set (OIDC lookup against a non-sub claim)', () => {
+      const wrapper = mountComponent({
+        'config-principals-principal_by': null,
+        'config-principals-principal_claim': ['user', 'employee_id'],
+      })
+
+      expect((wrapper.vm as any).selectedLookupMethod).toBe('kong-identity')
     })
   })
 

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -329,12 +329,13 @@ describe('ConfigFormContent', () => {
         cy.getTestId('kong-identity-mode-centrally-managed').should('not.exist')
       })
 
-      it('hides centrally managed when schema has identity_realms but no realms exist', () => {
+      it('shows centrally managed when schema has identity_realms even if no realms exist yet', () => {
+        // Launch decision: the option is shown unconditionally; hiding it is a fast-follow.
         mountContent(schemaWithRealms, { isKonnect: true, hasExistingRealms: false })
 
         cy.getTestId('kong-identity-mode-kong-identity').should('exist')
         cy.getTestId('kong-identity-mode-consumers').should('exist')
-        cy.getTestId('kong-identity-mode-centrally-managed').should('not.exist')
+        cy.getTestId('kong-identity-mode-centrally-managed').should('exist')
       })
 
       it('does not show Kong Identity selector when schema has no principals (backward compat)', () => {

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -11,7 +11,6 @@
     v-if="isKonnect && hasPrincipals"
     v-model="selectedMode"
     class="kong-identity-section"
-    :has-existing-realms="hasExistingRealms"
     :identity-realms-in-schema="identityRealmsInSchema"
     :loading-realms="isLoadingRealms"
   />
@@ -158,7 +157,6 @@ function handleErrorOnMissChange(value: boolean) {
 type KonnectRealmResponse = { data: Array<{ id: string, name: string }>, meta: { next: string | null } }
 
 const fetchedRealms = ref<MultiselectItem[]>([])
-const hasExistingRealms = ref(false)
 const isLoadingRealms = ref(false)
 
 const fetchRealms = async () => {
@@ -181,9 +179,8 @@ const fetchRealms = async () => {
     } while (nextUrl)
 
     fetchedRealms.value = items
-    hasExistingRealms.value = items.length > 0
   } catch {
-    hasExistingRealms.value = false
+    fetchedRealms.value = []
   } finally {
     isLoadingRealms.value = false
   }

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
@@ -84,7 +84,6 @@ defineOptions({ name: 'KongIdentityField' })
 
 const props = defineProps<{
   identityRealmsInSchema?: boolean
-  hasExistingRealms?: boolean
   loadingRealms?: boolean
 }>()
 const { i18n } = composables.useI18n()
@@ -100,8 +99,7 @@ const identityRealmsInSchema = computed(() => {
 
 // Launch decision: Centrally Managed is shown unconditionally whenever the schema
 // supports identity_realms — we intentionally do NOT hide it when no realms exist yet.
-// Hiding it (platform-wide) is deferred to a fast-follow; `hasExistingRealms` is kept
-// wired up so that follow-up can re-gate without re-plumbing the realm fetch.
+// Hiding it (platform-wide) is deferred to a fast-follow.
 const showCentrallyManaged = computed(() => identityRealmsInSchema.value)
 
 const descriptionText = computed(() => {

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
@@ -98,7 +98,11 @@ const identityRealmsInSchema = computed(() => {
   return !!getSchema('$.config.identity_realms')
 })
 
-const showCentrallyManaged = computed(() => identityRealmsInSchema.value && !!props.hasExistingRealms)
+// Launch decision: Centrally Managed is shown unconditionally whenever the schema
+// supports identity_realms — we intentionally do NOT hide it when no realms exist yet.
+// Hiding it (platform-wide) is deferred to a fast-follow; `hasExistingRealms` is kept
+// wired up so that follow-up can re-gate without re-plumbing the realm fetch.
+const showCentrallyManaged = computed(() => identityRealmsInSchema.value)
 
 const descriptionText = computed(() => {
   return identityRealmsInSchema.value


### PR DESCRIPTION
## Summary
- **forms**: Show the Identifier claim input in both principal lookup modes (`principal_claim` is used by the gateway in both OIDC and custom-identity lookups). Infer the initial mode from `principal_by` alone, make the help text mode-aware, and drop the `sub`-only wording.
- **entities-plugins**: Always show the Centrally Managed option when the schema supports `identity_realms`, even with no realms yet. Hiding it is deferred to a platform-wide fast-follow.

## Tests
- Updated `PrincipalLookupSettings.spec.ts` (new `principal_claim`-only → kong-identity case).
- Updated `ConfigFormContent.cy.ts` to assert Centrally Managed shows with no existing realms.
