### PR TITLE
fix(entities-plugins): fix freeform autofiller

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
@@ -358,6 +358,68 @@ describe('Filler - Cypress', () => {
       cy.get('[data-testid="ff-map-container-functions.1"] [data-testid^="ff-functions.kid:"]').should('have.value', 'line1\nline2\nline3')
     })
 
+    it('enum: scoped selection ignores identically-named options from other enum fields', () => {
+      // Two enum fields each having 'openai' as a valid value — the old global
+      // selector would match 2 elements and throw "can only be called on a single element".
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            format: {
+              type: 'string',
+              one_of: ['openai', 'ollama'],
+              default: 'openai',
+            },
+          },
+          {
+            provider: {
+              type: 'string',
+              one_of: ['openai', 'cohere'],
+              default: 'openai',
+            },
+          },
+        ],
+      }
+
+      cy.mount(() => h('div', { style: 'padding: 20px' }, h(Form, { schema })))
+
+      const filler = createFiller(schema)
+      // Selecting 'ollama' on the first field must not accidentally hit 'openai'
+      // in the second field's popover.
+      filler.fillField('format', 'ollama')
+      filler.fillField('provider', 'cohere')
+
+      cy.getTestId('ff-format').should('have.value', 'ollama')
+      cy.getTestId('ff-provider').should('have.value', 'cohere')
+    })
+
+    it('array: add-item button click succeeds even when sticky tabs cover the button', () => {
+      // The hosts array has default items; fillField adds new ones via the
+      // add-item button. With scrollIntoView + force:true this works even when
+      // a sticky header overlaps the button center.
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            hosts: {
+              type: 'array',
+              elements: {
+                type: 'string',
+              },
+            },
+          },
+        ],
+      }
+
+      cy.mount(() => h('div', { style: 'padding: 20px' }, h(Form, { schema })))
+
+      const filler = createFiller(schema)
+      filler.fillField('hosts', ['alpha.example.com', 'beta.example.com'])
+
+      cy.getTestId('ff-hosts.0').should('have.value', 'alpha.example.com')
+      cy.getTestId('ff-hosts.1').should('have.value', 'beta.example.com')
+    })
+
     it('should fill json field', () => {
       const schema: FormSchema = {
         type: 'record',

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/array.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/array.ts
@@ -33,9 +33,11 @@ export function fillArray(option: ArrayHandlerOption): void {
 
       // Add items and fill each one
       for (let i = 0; i < value.length; i++) {
-        // Click add button to add more items
+        // Click add button to add more items; scrollIntoView + force:true prevents
+        // sticky-tabs headers from blocking the click.
         const addBtnSelector = selectors.arrayAddBtn(fieldKey)
-        cy.get(addBtnSelector).click()
+        cy.get(addBtnSelector).scrollIntoView()
+        cy.get(addBtnSelector).click({ force: true })
 
         // Fill the item
         onFillItem(i, value[i])

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
@@ -15,6 +15,10 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
   cy.get(fieldSelector).scrollIntoView()
   cy.get(fieldSelector).click(actionOptions.click)
 
+  // Scope all option interactions to this field's own popover to avoid matching
+  // identically-named options from other enum fields on the same form.
+  const popoverSelector = selectors.selectTrigger(fieldKey)
+
   // Select each value within the dropdown
   for (const optionValue of fieldSchema.one_of ?? (fieldSchema as SetFieldSchema).elements?.one_of ?? []) {
     if (optionValue !== undefined && optionValue !== null) {
@@ -24,7 +28,7 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
 
       // clear default value
       if (isMulti) {
-        cy.get(itemSelector).within(($el) => {
+        cy.get(popoverSelector).find(itemSelector).within(($el) => {
           if ($el.find('button.selected').length > 0) {
             cy.get('button').click() // Value can't be selected when force: true is set, not sure why
           }
@@ -32,7 +36,7 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
       }
 
       if (values.includes(optionValue)) {
-        cy.get(itemSelector).click() // Value can't be selected when force: true is set, not sure why
+        cy.get(popoverSelector).find(itemSelector).click() // Value can't be selected when force: true is set, not sure why
       }
     }
   }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
@@ -332,6 +332,65 @@ test.describe('Filler - Playwright', () => {
       await expect(page.locator('[data-testid="ff-map-container-functions.1"] [data-testid^="ff-functions.kid:"]')).toHaveValue('line1\nline2\nline3')
     })
 
+    test('enum: scoped selection ignores identically-named options from other enum fields', async ({ mount, page }) => {
+      // Two enum fields each having 'openai' as a valid value — the old global
+      // selector would match 2 elements and cause a strict-mode violation.
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            format: {
+              type: 'string',
+              one_of: ['openai', 'ollama'],
+              default: 'openai',
+            },
+          },
+          {
+            provider: {
+              type: 'string',
+              one_of: ['openai', 'cohere'],
+              default: 'openai',
+            },
+          },
+        ],
+      }
+
+      await mount(FormWrapper, { props: { schema } })
+
+      const filler = createFiller(page, schema)
+      await filler.fillField('format', 'ollama')
+      await filler.fillField('provider', 'cohere')
+
+      await expect(page.getByTestId('ff-format')).toHaveValue('ollama')
+      await expect(page.getByTestId('ff-provider')).toHaveValue('cohere')
+    })
+
+    test('array: add-item button click succeeds even when sticky tabs cover the button', async ({ mount, page }) => {
+      // scrollIntoViewIfNeeded + force:true lets the click through even when
+      // a sticky header overlaps the button center.
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            hosts: {
+              type: 'array',
+              elements: {
+                type: 'string',
+              },
+            },
+          },
+        ],
+      }
+
+      await mount(FormWrapper, { props: { schema } })
+
+      const filler = createFiller(page, schema)
+      await filler.fillField('hosts', ['alpha.example.com', 'beta.example.com'])
+
+      await expect(page.locator('[data-testid="ff-hosts.0"]')).toHaveValue('alpha.example.com')
+      await expect(page.locator('[data-testid="ff-hosts.1"]')).toHaveValue('beta.example.com')
+    })
+
     test('should fill json field', async ({ mount, page }) => {
       const schema: FormSchema = {
         type: 'record',

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/array.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/array.ts
@@ -30,9 +30,11 @@ export async function fillArray(option: ArrayHandlerOption): Promise<void> {
 
     // Add items and fill each one
     for (let i = 0; i < value.length; i++) {
-      // Click add button to add more items
+      // Click add button to add more items; scrollIntoView + force:true prevents
+      // sticky-tabs headers from blocking the click.
       const addBtnSelector = selectors.arrayAddBtn(fieldKey)
-      await page.locator(addBtnSelector).click()
+      await page.locator(addBtnSelector).scrollIntoViewIfNeeded()
+      await page.locator(addBtnSelector).click({ force: true })
 
       await onFillItem(i, value[i])
     }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/enum.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/enum.ts
@@ -13,7 +13,11 @@ export async function fillEnum(option: HandlerOption<StringFieldSchema | NumberL
   const fieldSelector = selectors.field(fieldKey)
   await page.locator(fieldSelector).click()
 
-  // Select each value
+  // Scope all option interactions to this field's own popover to avoid matching
+  // identically-named options from other enum fields on the same form.
+  const popoverSelector = selectors.selectTrigger(fieldKey)
+
+  // Select each value within the dropdown
   for (const optionValue of fieldSchema.one_of ?? (fieldSchema as SetFieldSchema).elements?.one_of ?? []) {
     if (optionValue !== undefined && optionValue !== null) {
       const itemSelector = isMulti
@@ -22,14 +26,14 @@ export async function fillEnum(option: HandlerOption<StringFieldSchema | NumberL
 
       // clear default value
       if (isMulti) {
-        const isSelected = await page.locator(`${itemSelector} button.selected`).count() > 0
+        const isSelected = await page.locator(popoverSelector).locator(`${itemSelector} button.selected`).count() > 0
         if (isSelected) {
-          await page.locator(itemSelector).click()
+          await page.locator(popoverSelector).locator(itemSelector).click()
         }
       }
 
       if (values.includes(optionValue)) {
-        await page.locator(itemSelector).click()
+        await page.locator(popoverSelector).locator(itemSelector).click()
       }
     }
   }


### PR DESCRIPTION
The freeform test filler picked enum options with a global `select-item-<value>` selector. When two enum fields on the same form share an option value — e.g. `config.llm_format` + `config.model.provider` in ai-proxy, or the embeddings/targets provider selects in ai-proxy-advanced — that matches 2 elements and the click fails. It now scopes the lookup to the field's own popover (`ff-enum-<path>-items`).

Also `scrollIntoView` + force the array add-item click so sticky-tab arrays (e.g. ai-proxy-advanced `targets`) don't block it.

Same fixes mirrored to the Playwright filler. Added Cypress and Playwright tests for both cases.
