### PR TITLE
fix(page-layout): add tab link styles

### DIFF
--- a/packages/core/page-layout/src/components/PageLayoutTabs.vue
+++ b/packages/core/page-layout/src/components/PageLayoutTabs.vue
@@ -258,22 +258,26 @@ watch(() => tabs, () => {
         gap: var(--kui-space-30, $kui-space-30);
         line-height: var(--kui-line-height-30, $kui-line-height-30);
         padding: var(--kui-space-30, $kui-space-30) var(--kui-space-0, $kui-space-0);
+        text-decoration: none;
         transition: color 0.2s ease-in, border-color 0.2s ease-in, font-weight 0.2s ease-in;
         white-space: nowrap;
 
         &:hover {
           border-bottom: var(--kui-border-width-20, $kui-border-width-20) solid var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
           color: var(--kui-color-text, $kui-color-text);
+          text-decoration: none;
         }
 
         &:focus-visible {
           box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
+          text-decoration: none;
         }
 
         &.active {
           border-bottom: var(--kui-border-width-20, $kui-border-width-20) solid var(--kui-color-border-primary, $kui-color-border-primary);
           color: var(--kui-color-text-primary, $kui-color-text-primary) !important;
           font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+          text-decoration: none;
         }
 
         &.overflow-dropdown-trigger {


### PR DESCRIPTION
# Summary

Ensure the page layout tabs do not have `text-decoration: underline` applied.