### PR TITLE
fix(entities-plugins): skip shameful on freeform and fix enum filler

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginForm.vue
@@ -430,6 +430,8 @@ const realEngine = computed<'vfg' | 'freeform' | undefined>(() => {
   return 'freeform'
 })
 
+const isFreeFormEngine = computed(() => isFreeForm(props.pluginType, realEngine.value))
+
 provide(REDIS_PARTIAL_INFO, {
   redisType: pluginPartialType,
   redisPath: pluginRedisPath,
@@ -736,7 +738,7 @@ const buildFormSchema = (parentKey: string, response: Record<string, any>, initi
     // If the field type is 'set', convert it to 'array'
     // Freeform can handle 'set' type with one_of elements as multiselect
     // Todo: create suitable component for 'set' type in freeform and remove this conversion
-    if (scheme.type === 'set' && !(isFreeForm(props.pluginType, realEngine.value) && scheme.elements.one_of)) {
+    if (scheme.type === 'set' && !(isFreeFormEngine.value && scheme.elements.one_of)) {
       scheme.type = 'array'
     }
     const field = parentKey ? `${parentKey}-${key}` : `${key}`
@@ -1501,7 +1503,7 @@ const saveFormData = async (): Promise<void> => {
 
     const payload = JSON.parse(JSON.stringify(getRequestBody.value))
     const customSchema = customSchemas[effectivePluginType.value as keyof CustomSchemas]
-    if (typeof customSchema?.shamefullyTransformPayload === 'function') {
+    if (!isFreeFormEngine.value && typeof customSchema?.shamefullyTransformPayload === 'function') {
       customSchema.shamefullyTransformPayload({
         originalModel: formFieldsOriginal,
         model: form.fields,

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
@@ -18,6 +18,7 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
   // Scope all option interactions to this field's own popover to avoid matching
   // identically-named options from other enum fields on the same form.
   const popoverSelector = selectors.selectTrigger(fieldKey)
+  cy.get(popoverSelector).scrollIntoView()
 
   // Select each value within the dropdown
   for (const optionValue of fieldSchema.one_of ?? (fieldSchema as SetFieldSchema).elements?.one_of ?? []) {
@@ -30,12 +31,14 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
       if (isMulti) {
         cy.get(popoverSelector).find(itemSelector).within(($el) => {
           if ($el.find('button.selected').length > 0) {
+            cy.get('button').scrollIntoView()
             cy.get('button').click() // Value can't be selected when force: true is set, not sure why
           }
         })
       }
 
       if (values.includes(optionValue)) {
+        cy.get(popoverSelector).find(itemSelector).scrollIntoView()
         cy.get(popoverSelector).find(itemSelector).click() // Value can't be selected when force: true is set, not sure why
       }
     }


### PR DESCRIPTION
# Summary

In this PR:
- enum filler: run scrollIntoView before select option;
- Skips `shamefullyTransform` on FreeForm;
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
