### PR TITLE
test(entities-plugins): fix flaky enum-field cypress test

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/test/enum-field.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/test/enum-field.cy.ts
@@ -58,9 +58,14 @@ function assertLastChange(expected: Record<string, unknown>) {
 }
 
 function removeSelectedValue(value: string) {
+  // Avoid `.findTestId()` here: it wraps the matched badge with `cy.wrap()`,
+  // which pins a specific DOM node and breaks Cypress's ability to requery
+  // the chain if KMultiselect re-renders its badges mid-retry (flaky
+  // "subject is no longer attached to the DOM" failures). Using `.find()`
+  // directly keeps this a single retryable chain rooted at `cy.getTestId()`.
   cy.getTestId(`ff-${FIELD_NAME}`)
     .contains('.multiselect-selection-badge', new RegExp(value, 'i'))
-    .findTestId('badge-dismiss-button')
+    .find('[data-testid="badge-dismiss-button"]')
     .click()
 }
 


### PR DESCRIPTION
## Summary
- `removeSelectedValue` in `enum-field.cy.ts` used the `.findTestId()` custom command, which internally does `cy.wrap(subject).find(...)`. `cy.wrap()` pins a specific DOM node reference and breaks Cypress's automatic requery/retry for the rest of the chain.
- `KMultiselect` recalculates badge overflow asynchronously (`setTimeout(..., 0)`) after each selection change and bumps a `v-for` key that recreates **all** selection badges, not just the one that changed.
- When that async rebuild lands between `.contains()` locating a badge and `.find()`/`.click()` running on it, the pinned node is already detached, producing an intermittent `subject is no longer attached to the DOM` failure (~30-40% failure rate locally over repeated runs).
- Fix: replace `.findTestId('badge-dismiss-button')` with an inline `.find('[data-testid="badge-dismiss-button"]')`, keeping the whole query as a single retryable chain rooted at `cy.getTestId()` so Cypress can requery it if the DOM changes mid-command.

## Test plan
- [x] Ran `packages/entities/entities-plugins/src/components/free-form/test/enum-field.cy.ts` 10x locally in a loop with `retries=0` — all green (previously failed ~2/5 runs before the fix).