### PR TITLE
fix(redis-config): add segmented cache/partial UI [khcp-21001]

### DIFF
--- a/packages/entities/entities-redis-configurations/docs/redis-configuration-config-card.md
+++ b/packages/entities/entities-redis-configurations/docs/redis-configuration-config-card.md
@@ -107,7 +107,7 @@ A `@fetch:not-found` event is emitted when the underlying GET returns **404** (f
 
 #### fetch:success
 
-A `@fetch:success` event is emitted when the Koko redis partial is loaded. That's the legacy Konnect/Kong Manager config card. Konnect-managed detail loads the add-on and partial configs instead; use `fetch:managed-add-on-success` for that payload.
+A `@fetch:success` event is emitted when the Koko redis partial loads (`RedisConfigurationResponse`). Legacy Konnect/Kong Manager cards always emit this. Konnect-managed detail emits it from the partial segment when the add-on is `ready`; the cache segment uses `fetch:managed-add-on-success` for the add-on payload.
 
 #### fetch:managed-add-on-success
 

--- a/packages/entities/entities-redis-configurations/docs/redis-configuration-config-card.md
+++ b/packages/entities/entities-redis-configurations/docs/redis-configuration-config-card.md
@@ -99,11 +99,7 @@ A `@loading` event is emitted when loading state changes. The event payload is a
 
 #### fetch:error
 
-An `@fetch:error` event is emitted when the component fails to fetch the redis configuration. The event payload is the response error.
-
-#### fetch:not-found
-
-A `@fetch:not-found` event is emitted when the underlying GET returns **404** (for example after a Konnect-managed add-on or linked partial is deleted). It is **not** emitted as `@fetch:error`, so hosts can redirect to the list instead of showing a global not-found page. The payload is the Axios error.
+An `@fetch:error` event is emitted when the component fails to fetch the redis configuration (including **404** after a Konnect-managed add-on or linked partial is deleted). Hosts typically check `error.response?.status === 404` to redirect to the list.
 
 #### fetch:success
 

--- a/packages/entities/entities-redis-configurations/docs/redis-configuration-config-card.md
+++ b/packages/entities/entities-redis-configurations/docs/redis-configuration-config-card.md
@@ -107,7 +107,7 @@ A `@fetch:not-found` event is emitted when the underlying GET returns **404** (f
 
 #### fetch:success
 
-A `@fetch:success` event is emitted when the redis **partial** configuration is successfully fetched (legacy Konnect/Kong Manager partial card, or the nested partial section inside Konnect-managed Redis config tab). The event payload is the redis configuration object (`RedisConfigurationResponse`).
+A `@fetch:success` event is emitted when the Koko redis partial is loaded. That's the legacy Konnect/Kong Manager config card. Konnect-managed detail loads the add-on and partial configs instead; use `fetch:managed-add-on-success` for that payload.
 
 #### fetch:managed-add-on-success
 

--- a/packages/entities/entities-redis-configurations/sandbox/pages/RedisConfigurationDetail.vue
+++ b/packages/entities/entities-redis-configurations/sandbox/pages/RedisConfigurationDetail.vue
@@ -24,10 +24,9 @@ const route = useRoute()
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
 
 /**
- * Konnect-managed redis UI (Cache configuration + optional partial collapse) only appears when ALL of the following are true:
- * `isKonnectManagedRedisEnabled: true` and `isCloudGateway: true`
- * `cloudGatewaysApiBaseUrl`/`apiBaseUrl` must reach Konnect’s Cloud Gateways add-ons API (`/v2/cloud-gateways/add-ons/...`)
- * After mount, the resolver finds a managed-cache add-on for `entityId` (or a partial and linked add-on). Otherwise UI stays on the legacy partial-only card
+ * Konnect-managed redis on the config tab when konnect + isCloudGateway + isKonnectManagedRedisEnabled.
+ * cloudGatewaysApiBaseUrl must reach /v2/cloud-gateways/add-ons. On mount resolve entityId to a
+ * managed-cache add-on; otherwise the legacy partial card
  */
 const konnectConfig: KonnectRedisConfigurationEntityConfig = {
   app: 'konnect',

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationConfigCard.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationConfigCard.vue
@@ -46,7 +46,7 @@
           :hide-title="false"
           :preserve-code-block-timestamps="true"
           :record-resolver="addOnRecordResolver"
-          @fetch:error="onEntityBaseConfigCardFetchError"
+          @fetch:error="onFetchError"
           @fetch:success="onCacheAddOnLoaded"
           @loading="onLoadingChange"
         >
@@ -103,7 +103,6 @@
           disable-konnect-managed-detail
           :hide-title="false"
           @fetch:error="onFetchError"
-          @fetch:not-found="onFetchNotFound"
           @fetch:success="onPartialLoaded"
           @loading="onLoadingChange"
         >
@@ -126,7 +125,7 @@
       :formats-to-hide="disableKonnectManagedDetail ? ['yaml'] : []"
       :hide-title="hideTitle"
       :record-resolver="recordResolver"
-      @fetch:error="onEntityBaseConfigCardFetchError"
+      @fetch:error="onFetchError"
       @fetch:success="handleData"
       @loading="onLoadingChange"
     >
@@ -146,7 +145,7 @@
 <script setup lang="ts">
 import type { PropType } from 'vue'
 import { computed, onBeforeMount, onMounted, ref, useId, watch } from 'vue'
-import { isAxiosError, type AxiosError } from 'axios'
+import type { AxiosError } from 'axios'
 import type {
   ConfigurationSchema,
   ConfigurationSchemaItem,
@@ -242,14 +241,9 @@ const props = defineProps({
 const emit = defineEmits<{
   (e: 'loading', isLoading: boolean): void
   (e: 'fetch:error', error: AxiosError): void
-  (e: 'fetch:not-found', error: AxiosError): void
   (e: 'fetch:success', data: RedisConfigurationResponse): void
   (e: 'fetch:managed-add-on-success', data: ManagedCacheAddOn): void
 }>()
-
-const onFetchNotFound = (error: AxiosError): void => {
-  emit('fetch:not-found', error)
-}
 
 const onFetchError = (error: AxiosError): void => {
   emit('fetch:error', error)
@@ -257,16 +251,6 @@ const onFetchError = (error: AxiosError): void => {
 
 const onLoadingChange = (isLoading: boolean): void => {
   emit('loading', isLoading)
-}
-
-// Host app treat `fetch:error` as fatal navigation. After Konnect-managed Redis is deleted,
-// `GET …/add-ons/{id}` returns 404, surface `fetch:not-found` instead
-const onEntityBaseConfigCardFetchError = (error: AxiosError): void => {
-  if (isAxiosError(error) && error.response?.status === 404) {
-    onFetchNotFound(error)
-    return
-  }
-  onFetchError(error)
 }
 
 const { i18n: { t } } = composables.useI18n()

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationConfigCard.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationConfigCard.vue
@@ -25,7 +25,7 @@
             <KTooltip
               :disabled="isTooltipDisabled(option)"
               max-width="320"
-              placement="top"
+              placement="right"
               :text="partialSegmentTooltip"
             >
               <span>{{ option.label }}</span>

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationConfigCard.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationConfigCard.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="kong-ui-consumer-group-entity-config-card"
-    :class="{ 'redis-nested-detail': disableKonnectManagedDetail }"
-  >
+  <div class="kong-ui-consumer-group-entity-config-card">
     <!-- Konnect managed Redis only (FF). Self-managed Redis never uses this; it always uses the legacy card below -->
     <template v-if="isManagedKonnectDetailEnabled">
       <KSkeleton
@@ -17,26 +14,27 @@
         class="managed-konnect-redis-detail"
         data-testid="managed-konnect-redis-detail"
       >
-        <KAlert
-          v-if="isManagedKonnectDetailEnabled && managedAddOnState === 'initializing'"
-          appearance="info"
-          class="redis-managed-state-alert"
-          data-testid="redis-managed-state-alert-initializing"
-          show-icon
+        <KSegmentedControl
+          v-model="activeSegment"
+          class="redis-config-segment"
+          data-testid="managed-redis-config-segment"
+          :options="configSegmentOptions"
+          size="large"
         >
-          {{ t('config_card.managed_state.initializing_alert') }}
-        </KAlert>
-        <KAlert
-          v-else-if="isManagedKonnectDetailEnabled && managedAddOnState === 'terminating'"
-          appearance="danger"
-          class="redis-managed-state-alert"
-          data-testid="redis-managed-state-alert-terminating"
-          show-icon
-        >
-          {{ t('config_card.managed_state.terminating_alert') }}
-        </KAlert>
+          <template #option-label="{ option }">
+            <KTooltip
+              :disabled="isTooltipDisabled(option)"
+              max-width="320"
+              placement="top"
+              :text="partialSegmentTooltip"
+            >
+              <span>{{ option.label }}</span>
+            </KTooltip>
+          </template>
+        </KSegmentedControl>
         <EntityBaseConfigCard
-          :key="addOnIdForCacheFetch"
+          v-if="activeSegment === 'cache'"
+          :key="cacheConfigCardKey"
           :code-block-record-formatter="addOnCodeFmt"
           :code-block-record-resolver="addOnCodeRslv"
           :config="addOnCardRuntimeConfig"
@@ -50,7 +48,7 @@
           :record-resolver="addOnRecordResolver"
           @fetch:error="onEntityBaseConfigCardFetchError"
           @fetch:success="onCacheAddOnLoaded"
-          @loading="(v) => emit('loading', v)"
+          @loading="onLoadingChange"
         >
           <template #title>
             {{ t('config_card.sections.cache_configuration') }}
@@ -98,6 +96,21 @@
             </div>
           </template>
         </EntityBaseConfigCard>
+        <RedisConfigurationConfigCard
+          v-else-if="activeSegment === 'partial'"
+          :config="innerPartialCardConfig"
+          :config-card-doc="configCardDoc"
+          disable-konnect-managed-detail
+          :hide-title="false"
+          @fetch:error="onFetchError"
+          @fetch:not-found="onFetchNotFound"
+          @fetch:success="onPartialLoaded"
+          @loading="onLoadingChange"
+        >
+          <template #title>
+            {{ t('config_card.sections.partial_configuration') }}
+          </template>
+        </RedisConfigurationConfigCard>
       </div>
     </template>
 
@@ -115,7 +128,7 @@
       :record-resolver="recordResolver"
       @fetch:error="onEntityBaseConfigCardFetchError"
       @fetch:success="handleData"
-      @loading="(v) => emit('loading', v)"
+      @loading="onLoadingChange"
     >
       <template #type>
         <div>{{ redisTypeText }}</div>
@@ -132,7 +145,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed, onBeforeMount, onMounted, ref, useId } from 'vue'
+import { computed, onBeforeMount, onMounted, ref, useId, watch } from 'vue'
 import { isAxiosError, type AxiosError } from 'axios'
 import type {
   ConfigurationSchema,
@@ -147,7 +160,8 @@ import {
   highlightCodeBlock,
   useAxios,
 } from '@kong-ui-public/entities-shared'
-import { KAlert, KCodeBlock, KSkeleton } from '@kong/kongponents'
+import { KCodeBlock, KSegmentedControl, KSkeleton, KTooltip } from '@kong/kongponents'
+import type { SegmentedControlOption } from '@kong/kongponents'
 import type {
   DetailLayout,
   KonnectRedisConfigurationEntityConfig,
@@ -221,7 +235,7 @@ const props = defineProps({
 })
 
 /**
- * fetch:success` - Koko redis partial (`RedisConfigurationResponse`)
+ * `fetch:success` - Koko redis partial (`RedisConfigurationResponse`)
  * Konnect-managed redis loads Cloud Gateways add-ons as the primary entity; that payload is emitted
  * separately via `fetch:managed-add-on-success` to avoid confusion with legacy partial payload
  */
@@ -233,18 +247,26 @@ const emit = defineEmits<{
   (e: 'fetch:managed-add-on-success', data: ManagedCacheAddOn): void
 }>()
 
-const emitFetchNotFound = (error: AxiosError): void => {
+const onFetchNotFound = (error: AxiosError): void => {
   emit('fetch:not-found', error)
+}
+
+const onFetchError = (error: AxiosError): void => {
+  emit('fetch:error', error)
+}
+
+const onLoadingChange = (isLoading: boolean): void => {
+  emit('loading', isLoading)
 }
 
 // Host app treat `fetch:error` as fatal navigation. After Konnect-managed Redis is deleted,
 // `GET …/add-ons/{id}` returns 404, surface `fetch:not-found` instead
 const onEntityBaseConfigCardFetchError = (error: AxiosError): void => {
   if (isAxiosError(error) && error.response?.status === 404) {
-    emitFetchNotFound(error)
+    onFetchNotFound(error)
     return
   }
-  emit('fetch:error', error)
+  onFetchError(error)
 }
 
 const { i18n: { t } } = composables.useI18n()
@@ -309,9 +331,66 @@ const cloudGatewaysBase = computed((): string => {
 
 const detailLayout = ref<DetailLayout>('legacy')
 const addOnIdForCacheFetch = ref('')
+const linkedPartialId = ref<string | null>(null)
 
 // Add-on state from GET add-on
 const managedAddOnState = ref<CloudGatewaysAddOnState | null>(null)
+
+// EntityBaseConfigCard fetches once on mount; include state so poll transitions refetch cache fields
+const cacheConfigCardKey = computed(
+  () => `${addOnIdForCacheFetch.value}:${managedAddOnState.value ?? 'unknown'}`,
+)
+
+type ConfigSegment = 'cache' | 'partial'
+const activeSegment = ref<ConfigSegment>('cache')
+
+const isPartialReady = computed(() => managedAddOnState.value === 'ready')
+
+const partialSegmentTooltip = computed((): string => {
+  switch (managedAddOnState.value) {
+    case 'initializing':
+      return t('config_card.managed_state.initializing_tooltip')
+    case 'terminating':
+      return t('config_card.managed_state.terminating_tooltip')
+    default:
+      return ''
+  }
+})
+
+const isPartialSegmentTooltipDisabled = computed(
+  () => isPartialReady.value || !partialSegmentTooltip.value,
+)
+
+const isTooltipDisabled = (option: SegmentedControlOption<ConfigSegment>): boolean =>
+  option.value !== 'partial' || isPartialSegmentTooltipDisabled.value
+
+const configSegmentOptions = computed((): Array<SegmentedControlOption<ConfigSegment>> => [
+  { label: t('config_card.sections.cache_configuration'), value: 'cache' },
+  {
+    label: t('config_card.sections.partial_configuration'),
+    value: 'partial',
+    disabled: !isPartialReady.value,
+  },
+])
+
+// Host polls add-on state on the detail page, keep segment in sync, skip while host is still loading
+const hostManagedAddOnState = computed((): CloudGatewaysAddOnState | undefined => {
+  if (!isManagedKonnectDetailEnabled.value || props.config.app !== 'konnect') return undefined
+  return (props.config as KonnectRedisConfigurationEntityConfig).managedAddOnState
+})
+
+watch(hostManagedAddOnState, (state) => {
+  if (state !== undefined) {
+    managedAddOnState.value = state
+  }
+})
+
+// Partial stays disabled until ready
+watch(managedAddOnState, (state) => {
+  if (state !== 'ready') {
+    activeSegment.value = 'cache'
+  }
+})
 
 // The same Cloud Gateway add-on response powers 3 outputs:
 // Structured tab: `addOnRecordResolver` maps and filters API fields for card display
@@ -345,7 +424,7 @@ onMounted(() => {
   }
 
   void (async () => {
-    emit('loading', true)
+    onLoadingChange(true)
 
     const k = props.config as KonnectRedisConfigurationEntityConfig
     const routeEntityId = k.entityId
@@ -361,6 +440,7 @@ onMounted(() => {
 
       if (addOnFromRouteId) {
         addOnIdForCacheFetch.value = addOnFromRouteId.id
+        linkedPartialId.value = getCacheConfigId(addOnFromRouteId) ?? null
         managedAddOnState.value = addOnFromRouteId.state ?? null
         detailLayout.value = 'managed'
         return
@@ -386,6 +466,7 @@ onMounted(() => {
 
         if (addOnForPartial && isManagedCacheAddOn(addOnForPartial)) {
           addOnIdForCacheFetch.value = addOnForPartial.id
+          linkedPartialId.value = routeEntityId
           managedAddOnState.value = addOnForPartial.state ?? null
           detailLayout.value = 'managed'
           return
@@ -394,7 +475,7 @@ onMounted(() => {
     } catch {
       // fall back to legacy partial-only card
     } finally {
-      emit('loading', false)
+      onLoadingChange(false)
     }
 
     detailLayout.value = 'legacy'
@@ -417,6 +498,15 @@ const addOnCardRuntimeConfig = computed((): KonnectRedisConfigurationEntityConfi
   }
 })
 
+const innerPartialCardConfig = computed((): KonnectRedisConfigurationEntityConfig => {
+  const k = props.config as KonnectRedisConfigurationEntityConfig
+  return {
+    ...k,
+    entityId: linkedPartialId.value ?? k.entityId,
+    formatPreferenceKey: k.formatPreferenceKey ? `${k.formatPreferenceKey}_managed_partial` : undefined,
+  }
+})
+
 // Wire add-on JSON- pass through for JSON tab; TR uses `konnect_cloud_gateway_addon` map
 const addOnCodeFmt = (
   record: Record<string, any>,
@@ -435,10 +525,17 @@ const onCacheAddOnLoaded = (data: Record<string, any>): void => {
   setManagedAddOnSchemaFromDisplayRecord(display)
 
   if (isManagedCacheAddOn(row)) {
-    // Keep partial UI in sync when add-on transitions
     managedAddOnState.value = row.state ?? null
+    const partialId = getCacheConfigId(row)
+    if (partialId) {
+      linkedPartialId.value = partialId
+    }
     emit('fetch:managed-add-on-success', row)
   }
+}
+
+const onPartialLoaded = (data: RedisConfigurationResponse): void => {
+  emit('fetch:success', data)
 }
 
 const redisType = ref<RedisType>(DEFAULT_REDIS_TYPE)
@@ -806,8 +903,14 @@ const configSchema = computed<ConfigurationSchema>(() => {
 
 <style lang="scss" scoped>
 .managed-konnect-redis-detail {
-  .redis-managed-state-alert {
+  .redis-config-segment {
     margin-bottom: var(--kui-space-60, $kui-space-60);
+    width: fit-content;
+
+    :deep(.k-segmented-control) {
+      // Override for compact pill layout
+      width: fit-content !important;
+    }
   }
 
   // Fills the config card value column
@@ -839,14 +942,6 @@ const configSchema = computed<ConfigurationSchema>(() => {
     flex: 1;
     min-width: 0;
     width: 75%;
-  }
-
-  :deep(.redis-nested-detail .kong-ui-entity-base-config-card.k-card) {
-    background-color: transparent;
-    border: none;
-    box-shadow: none;
-    padding-left: var(--kui-space-0, $kui-space-0);
-    padding-right: var(--kui-space-0, $kui-space-0);
   }
 
   /* JsonArray fieldset legends (e.g. data plane groups): medium weight; keep global JsonCardItem unchanged */

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationConfigCard.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationConfigCard.vue
@@ -97,116 +97,6 @@
               </template>
             </div>
           </template>
-          <!-- Spinner while add-on is initializing/terminating; full partial card when state is ready -->
-          <template #after-fields>
-            <KCollapse
-              v-model="partialSectionCollapsed"
-              class="redis-kcollapse"
-              data-testid="managed-redis-partial-collapse"
-              trigger-alignment="leading"
-            >
-              <template #trigger="{ isCollapsed, toggle }">
-                <KButton
-                  appearance="tertiary"
-                  class="redis-collapse-trigger"
-                  data-testid="redis-collapse-trigger"
-                  type="button"
-                  @click="toggle()"
-                >
-                  <ChevronUpIcon
-                    v-if="!isCollapsed"
-                    decorative
-                    :size="`var(--kui-icon-size-40, ${KUI_ICON_SIZE_40})`"
-                  />
-                  <ChevronRightIcon
-                    v-else
-                    decorative
-                    :size="`var(--kui-icon-size-40, ${KUI_ICON_SIZE_40})`"
-                  />
-                  {{ partialCollapseTriggerLabel }}
-                </KButton>
-              </template>
-              <div class="redis-expand-body">
-                <!-- Initializing/terminating Add on: keep partial header + format control, but render placeholder content -->
-                <div
-                  v-if="!partialSectionCollapsed && showPartialTransitionalUi"
-                  class="redis-provisioning"
-                  :data-redis-kind="partialTransitionalKind"
-                  data-testid="redis-provisioning"
-                >
-                  <div class="redis-head">
-                    <span class="redis-title">
-                      {{ t('config_card.sections.partial_configuration') }}
-                    </span>
-                    <div class="redis-actions">
-                      <KLabel class="redis-format-label">
-                        {{ t('config_card.partial.format_label') }}
-                      </KLabel>
-                      <KSelect
-                        v-model="partialTransitionalFormat"
-                        data-testid="managed-redis-partial-format-select"
-                        :items="partialTransitionalFormatItems"
-                      />
-                    </div>
-                  </div>
-
-                  <div
-                    v-if="partialTransitionalFormat === 'structured'"
-                    class="redis-transitional"
-                  >
-                    <div
-                      v-for="field in partialTransitionalFields"
-                      :key="field.key"
-                      class="redis-row"
-                    >
-                      <div class="redis-lbl">
-                        {{ field.label }}
-                      </div>
-                      <div class="redis-val">
-                        <ProgressIcon
-                          decorative
-                        />
-                        <span>{{ partialTransitionalMessage }}</span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div
-                    v-else
-                    class="redis-code"
-                  >
-                    <!-- Reuse ready-state code block components so JSON/TR styling stays identical -->
-                    <JsonCodeBlock
-                      v-if="partialTransitionalFormat === 'json'"
-                      :config="innerPartialCardConfig"
-                      :entity-record="partialTransitionalCodeRecord"
-                    />
-                    <TerraformCodeBlock
-                      v-else
-                      :entity-record="partialTransitionalCodeRecord"
-                      :entity-type="SupportedEntityType.Partial"
-                    />
-                  </div>
-                </div>
-
-                <RedisConfigurationConfigCard
-                  v-else-if="!partialSectionCollapsed"
-                  :config="innerPartialCardConfig"
-                  :config-card-doc="configCardDoc"
-                  disable-konnect-managed-detail
-                  :hide-title="false"
-                  @fetch:error="(e) => emit('fetch:error', e)"
-                  @fetch:not-found="emitFetchNotFound"
-                  @fetch:success="onPartialNestedLoaded"
-                  @loading="(v) => emit('loading', v)"
-                >
-                  <template #title>
-                    {{ t('config_card.sections.partial_configuration') }}
-                  </template>
-                </RedisConfigurationConfigCard>
-              </div>
-            </KCollapse>
-          </template>
         </EntityBaseConfigCard>
       </div>
     </template>
@@ -242,7 +132,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed, onBeforeMount, onMounted, ref, useId, watch } from 'vue'
+import { computed, onBeforeMount, onMounted, ref, useId } from 'vue'
 import { isAxiosError, type AxiosError } from 'axios'
 import type {
   ConfigurationSchema,
@@ -253,15 +143,11 @@ import {
   ConfigurationSchemaSection,
   ConfigurationSchemaType,
   EntityBaseConfigCard,
-  JsonCodeBlock,
   SupportedEntityType,
-  TerraformCodeBlock,
   highlightCodeBlock,
   useAxios,
 } from '@kong-ui-public/entities-shared'
-import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
-import { ChevronRightIcon, ChevronUpIcon, ProgressIcon } from '@kong/icons'
-import { KAlert, KButton, KCodeBlock, KCollapse, KLabel, KSelect, KSkeleton } from '@kong/kongponents'
+import { KAlert, KCodeBlock, KSkeleton } from '@kong/kongponents'
 import type {
   DetailLayout,
   KonnectRedisConfigurationEntityConfig,
@@ -327,7 +213,7 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
-  /** Nested partial card only: skips managed (add-on + collapse) layout */
+  /** Nested partial card only: skips managed (add-on + segment) layout */
   disableKonnectManagedDetail: {
     type: Boolean,
     default: false,
@@ -423,121 +309,9 @@ const cloudGatewaysBase = computed((): string => {
 
 const detailLayout = ref<DetailLayout>('legacy')
 const addOnIdForCacheFetch = ref('')
-const linkedPartialIdForCollapse = ref<string | null>(null)
-const partialSectionCollapsed = ref(true)
 
 // Add-on state from GET add-on
 const managedAddOnState = ref<CloudGatewaysAddOnState | null>(null)
-
-const showNestedPartialConfiguration = computed((): boolean => {
-  const state = managedAddOnState.value
-  if (state === 'ready') {
-    return true
-  }
-
-  if (state === null) {
-    return !!linkedPartialIdForCollapse.value
-  }
-
-  if (state === 'initializing' || state === 'terminating') {
-    return false
-  }
-
-  return !!linkedPartialIdForCollapse.value
-})
-
-// Spinner row instead of nested partial when add-on is not in Ready state
-const showPartialTransitionalUi = computed((): boolean => !showNestedPartialConfiguration.value)
-
-const partialTransitionalKind = computed((): 'provisioning' | 'terminating' => (
-  managedAddOnState.value === 'terminating' ? 'terminating' : 'provisioning'
-))
-
-const isPartialNonReadyState = computed((): boolean =>
-  managedAddOnState.value === 'initializing' || managedAddOnState.value === 'terminating',
-)
-
-const partialTransitionalMessage = computed((): string =>
-  partialTransitionalKind.value === 'terminating'
-    ? t('config_card.partial.terminating_value')
-    : t('config_card.partial.provisioning_value'),
-)
-
-// Placeholder field keys for managed-cache partial only (not self-managed Redis variants)
-const partialTransitionalFieldKeys = [
-  'id',
-  'name',
-  'type',
-  'cluster_max_redirections',
-  'connection_is_proxied',
-  'database',
-  'host',
-  'port',
-  'ssl',
-  'ssl_verify',
-  'keepalive_backlog',
-  'keepalive_pool_size',
-  'read_timeout',
-  'send_timeout',
-  'connect_timeout',
-  'cloud_authentication',
-] as const
-
-const partialTransitionalFields = computed((): Array<{ key: string, label: string }> => {
-  // Keep placeholder rows aligned with the legacy partial schema labels
-  return partialTransitionalFieldKeys
-    .filter((key) => key !== 'cloud_authentication' || konnectCloudAuthAvailable.value)
-    .map((key) => ({
-      key,
-      label: configSchema.value[key]?.label || key,
-    }))
-})
-
-// Konnect managed Redis partial collapse
-type PartialTransitionalFormat = 'structured' | 'json' | 'terraform'
-
-const partialTransitionalFormat = ref<PartialTransitionalFormat>('structured')
-
-const partialTransitionalFormatItems = computed((): Array<{ label: string, value: PartialTransitionalFormat }> => [
-  { label: t('config_card.partial.format_structured'), value: 'structured' },
-  { label: t('config_card.partial.format_json'), value: 'json' },
-  { label: t('config_card.partial.format_terraform'), value: 'terraform' },
-])
-
-const partialTransitionalCodeRecord = computed((): Record<string, string> => {
-  // Code-format placeholders are string-only because syntax highlighters can't render Vue spinners inline
-  const msg = partialTransitionalMessage.value
-  return Object.fromEntries(partialTransitionalFields.value.map(({ key }) => [key, msg]))
-})
-
-const partialFormatPreferenceKey = computed((): string | undefined =>
-  innerPartialCardConfig.value.formatPreferenceKey,
-)
-
-watch(partialTransitionalFormat, (format: PartialTransitionalFormat) => {
-  if (partialFormatPreferenceKey.value) {
-    localStorage.setItem(partialFormatPreferenceKey.value, format)
-  }
-})
-
-watch(partialTransitionalFormatItems, (items) => {
-  const allowed = items.map(item => item.value)
-  if (!allowed.includes(partialTransitionalFormat.value)) {
-    partialTransitionalFormat.value = items[0]?.value ?? 'structured'
-  }
-})
-
-watch(isPartialNonReadyState, (isNonReady) => {
-  if (isNonReady) {
-    partialSectionCollapsed.value = true
-  }
-})
-
-const partialCollapseTriggerLabel = computed((): string =>
-  partialSectionCollapsed.value
-    ? t('config_card.collapse.show_partial')
-    : t('config_card.collapse.hide_partial'),
-)
 
 // The same Cloud Gateway add-on response powers 3 outputs:
 // Structured tab: `addOnRecordResolver` maps and filters API fields for card display
@@ -570,25 +344,6 @@ onMounted(() => {
     return
   }
 
-  // Partial format (Structured /JSON /TR): use the same localStorage key as the nested
-  // EntityBaseConfigCard (`innerPartialCardConfig.formatPreferenceKey`) so the user's choice
-  // while provisioning matches the tab when the add-on becomes ready
-  const formatItems = partialTransitionalFormatItems.value
-  const fallbackFormat = formatItems[0]?.value ?? 'structured'
-  const preferenceKey = partialFormatPreferenceKey.value
-
-  if (!preferenceKey) {
-    partialTransitionalFormat.value = fallbackFormat
-  } else {
-    const storedFormat = localStorage.getItem(preferenceKey) as PartialTransitionalFormat | null
-    if (storedFormat && formatItems.some(item => item.value === storedFormat)) {
-      partialTransitionalFormat.value = storedFormat
-    } else {
-      partialTransitionalFormat.value = fallbackFormat
-    }
-    localStorage.setItem(preferenceKey, partialTransitionalFormat.value)
-  }
-
   void (async () => {
     emit('loading', true)
 
@@ -606,12 +361,7 @@ onMounted(() => {
 
       if (addOnFromRouteId) {
         addOnIdForCacheFetch.value = addOnFromRouteId.id
-        linkedPartialIdForCollapse.value = getCacheConfigId(addOnFromRouteId) ?? null
-        // Lifecycle state from prefetch
         managedAddOnState.value = addOnFromRouteId.state ?? null
-        partialSectionCollapsed.value = isPartialNonReadyState.value
-          ? true
-          : linkedPartialIdForCollapse.value !== null
         detailLayout.value = 'managed'
         return
       }
@@ -636,10 +386,7 @@ onMounted(() => {
 
         if (addOnForPartial && isManagedCacheAddOn(addOnForPartial)) {
           addOnIdForCacheFetch.value = addOnForPartial.id
-          linkedPartialIdForCollapse.value = routeEntityId
-          // Route opened with Koko partial id; same lifecycle rules as direct add-on
           managedAddOnState.value = addOnForPartial.state ?? null
-          partialSectionCollapsed.value = true
           detailLayout.value = 'managed'
           return
         }
@@ -670,17 +417,6 @@ const addOnCardRuntimeConfig = computed((): KonnectRedisConfigurationEntityConfi
   }
 })
 
-// Runtime config for nested partial card
-const innerPartialCardConfig = computed((): KonnectRedisConfigurationEntityConfig => {
-  const k = props.config as KonnectRedisConfigurationEntityConfig
-  const partialId = linkedPartialIdForCollapse.value ?? k.entityId
-  return {
-    ...k,
-    entityId: partialId,
-    formatPreferenceKey: k.formatPreferenceKey ? `${k.formatPreferenceKey}_managed_partial` : undefined,
-  }
-})
-
 // Wire add-on JSON- pass through for JSON tab; TR uses `konnect_cloud_gateway_addon` map
 const addOnCodeFmt = (
   record: Record<string, any>,
@@ -701,17 +437,8 @@ const onCacheAddOnLoaded = (data: Record<string, any>): void => {
   if (isManagedCacheAddOn(row)) {
     // Keep partial UI in sync when add-on transitions
     managedAddOnState.value = row.state ?? null
-    const nextLinkedPartialId = getCacheConfigId(row) ?? null
-    if (nextLinkedPartialId && linkedPartialIdForCollapse.value !== nextLinkedPartialId) {
-      linkedPartialIdForCollapse.value = nextLinkedPartialId
-    }
     emit('fetch:managed-add-on-success', row)
   }
-}
-
-// Nested legacy partial config card
-const onPartialNestedLoaded = (data: RedisConfigurationResponse) => {
-  emit('fetch:success', data)
 }
 
 const redisType = ref<RedisType>(DEFAULT_REDIS_TYPE)
@@ -1114,19 +841,6 @@ const configSchema = computed<ConfigurationSchema>(() => {
     width: 75%;
   }
 
-  :deep(.config-card-details-after) {
-    padding-left: var(--kui-space-0, $kui-space-0);
-    padding-top: var(--kui-space-60, $kui-space-60);
-  }
-
-  :deep(.redis-kcollapse .collapse-heading) {
-    margin-bottom: var(--kui-space-0, $kui-space-0);
-  }
-
-  :deep(.redis-kcollapse .collapse-hidden-content) {
-    margin-top: var(--kui-space-0, $kui-space-0);
-  }
-
   :deep(.redis-nested-detail .kong-ui-entity-base-config-card.k-card) {
     background-color: transparent;
     border: none;
@@ -1139,89 +853,5 @@ const configSchema = computed<ConfigurationSchema>(() => {
   :deep(.config-card-fieldset-title b) {
     font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
   }
-
-  /* Tertiary KButton: no hover/active highlight */
-  :deep(.redis-collapse-trigger) {
-    &:hover:not(:disabled),
-    &:active:not(:disabled) {
-      background-color: transparent !important;
-      box-shadow: none !important;
-      color: var(--kui-color-text-primary, $kui-color-text-primary) !important;
-    }
-  }
-}
-
-.redis-expand-body {
-  margin-top: var(--kui-space-0, $kui-space-0);
-}
-
-.redis-provisioning {
-  width: 100%;
-}
-
-.redis-head {
-  align-items: center;
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: var(--kui-space-60, $kui-space-60);
-}
-
-.redis-title {
-  color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger);
-  font-size: var(--kui-font-size-40, $kui-font-size-40);
-  font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
-}
-
-.redis-actions {
-  align-items: center;
-  display: flex;
-  gap: var(--kui-space-40, $kui-space-40);
-}
-
-.redis-format-label {
-  margin-bottom: var(--kui-space-0, $kui-space-0);
-}
-
-.redis-transitional {
-  border-top: solid var(--kui-border-width-10, $kui-border-width-10) var(--kui-color-border, $kui-color-border);
-  width: 100%;
-}
-
-.redis-row {
-  border-bottom: solid var(--kui-border-width-10, $kui-border-width-10) var(--kui-color-border, $kui-color-border);
-  display: flex;
-  width: 100%;
-}
-
-.redis-lbl {
-  box-sizing: border-box;
-  color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger);
-  font-size: var(--kui-font-size-30, $kui-font-size-30);
-  font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
-  padding: var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60) var(--kui-space-60, var(--kui-space-0, $kui-space-0));
-  width: 25%;
-}
-
-.redis-val {
-  align-items: center;
-  box-sizing: border-box;
-  color: var(--kui-color-text-neutral, $kui-color-text-neutral);
-  display: flex;
-  gap: var(--kui-space-30, $kui-space-30);
-  min-height: 48px;
-  padding: var(--kui-space-60, $kui-space-60) var(--kui-space-0, $kui-space-0);
-  width: 75%;
-}
-
-.redis-val > span:last-child {
-  min-width: 0;
-  overflow-wrap: anywhere;
-  width: 100%;
-}
-
-.redis-code {
-  border-top: solid var(--kui-border-width-10, $kui-border-width-10) var(--kui-color-border, $kui-color-border);
-  padding-top: var(--kui-space-40, $kui-space-40);
-  width: 100%;
 }
 </style>

--- a/packages/entities/entities-redis-configurations/src/helpers/managed-cache-add-on-api.spec.ts
+++ b/packages/entities/entities-redis-configurations/src/helpers/managed-cache-add-on-api.spec.ts
@@ -39,6 +39,14 @@ describe('fetchManagedCacheAddOnById', () => {
 
     expect(await fetchManagedCacheAddOnById(axiosInstance, 'https://cg.example', 'addon-1', 'cp-1')).toBeNull()
   })
+
+  it('returns null on 404', async () => {
+    const axiosInstance = {
+      get: vi.fn(async () => ({ status: 404, data: {} })),
+    }
+
+    expect(await fetchManagedCacheAddOnById(axiosInstance, 'https://cg.example', 'addon-1', 'cp-1')).toBeNull()
+  })
 })
 
 describe('fetchAllManagedCacheAddOns', () => {

--- a/packages/entities/entities-redis-configurations/src/locales/en.json
+++ b/packages/entities/entities-redis-configurations/src/locales/en.json
@@ -57,8 +57,8 @@
       "partial_configuration": "Partial configuration"
     },
     "managed_state": {
-      "initializing_alert": "We're provisioning your instance. The partial configuration will update when provisioning is complete. This can take up to 20 minutes.",
-      "terminating_alert": "This instance is being deleted and all data will be lost. This can take up to 20 minutes."
+      "initializing_tooltip": "We're provisioning your instance. The partial configuration will update when provisioning is complete. This can take up to 20 minutes.",
+      "terminating_tooltip": "This instance is being deleted and all data will be lost. This can take up to 20 minutes."
     },
     "managed_dpg": {
       "entry_heading": "Data plane group {n}"

--- a/packages/entities/entities-redis-configurations/src/locales/en.json
+++ b/packages/entities/entities-redis-configurations/src/locales/en.json
@@ -56,18 +56,6 @@
       "cache_configuration": "Cache configuration",
       "partial_configuration": "Partial configuration"
     },
-    "collapse": {
-      "show_partial": "Show partial configuration",
-      "hide_partial": "Hide partial configuration"
-    },
-    "partial": {
-      "format_label": "Format:",
-      "format_structured": "Structured",
-      "format_json": "JSON",
-      "format_terraform": "Terraform",
-      "provisioning_value": "Provisioning cache...",
-      "terminating_value": "Terminating cache..."
-    },
     "managed_state": {
       "initializing_alert": "We're provisioning your instance. The partial configuration will update when provisioning is complete. This can take up to 20 minutes.",
       "terminating_alert": "This instance is being deleted and all data will be lost. This can take up to 20 minutes."

--- a/packages/entities/entities-redis-configurations/src/types/redis-configuration-config.ts
+++ b/packages/entities/entities-redis-configurations/src/types/redis-configuration-config.ts
@@ -2,6 +2,7 @@ import type {
   KonnectBaseEntityConfig,
   KongManagerBaseEntityConfig,
 } from '@kong-ui-public/entities-shared'
+import type { CloudGatewaysAddOnState } from './cloud-gateways-add-on'
 
 /** Konnect-managed Redis config card: deternine detail branch that's active */
 export type DetailLayout = 'legacy' | 'resolving' | 'managed'
@@ -20,6 +21,11 @@ export interface KonnectRedisConfigurationEntityConfig extends KonnectBaseEntity
   isCloudGateway?: boolean
   cloudGatewaysApiBaseUrl?: string
   controlPlaneGeo?: string
+  /**
+   * Add-on state from the host page (GM polls every 30s while initializing/terminating).
+   * Config card uses this for the Partial segment; don't pass until add-on is resolved
+   */
+  managedAddOnState?: CloudGatewaysAddOnState
 }
 
 /** Kong Manager redis configuration entity config */

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.cy.ts
@@ -650,7 +650,7 @@ describe('<EntityBaseConfigCard />', () => {
         { statusCode: 200, body: gatewayServiceRecord },
       ).as('fetchWithWorkspace')
 
-      cy.mount(EntityBaseConfigCard, {
+      cy.mount(EntityBaseConfigCardMount, {
         props: {
           config: configWithWorkspace('default'),
           configSchema,
@@ -672,7 +672,7 @@ describe('<EntityBaseConfigCard />', () => {
         { statusCode: 200, body: gatewayServiceRecord },
       ).as('fetchWithTestWorkspace')
 
-      cy.mount(EntityBaseConfigCard, {
+      cy.mount(EntityBaseConfigCardMount, {
         props: {
           config: configWithWorkspace('test'),
           configSchema,
@@ -694,7 +694,7 @@ describe('<EntityBaseConfigCard />', () => {
         { statusCode: 200, body: gatewayServiceRecord },
       ).as('fetchNoWorkspace')
 
-      cy.mount(EntityBaseConfigCard, {
+      cy.mount(EntityBaseConfigCardMount, {
         props: {
           config: configNoWorkspace,
           configSchema,
@@ -716,7 +716,7 @@ describe('<EntityBaseConfigCard />', () => {
         { statusCode: 500, body: {} },
       ).as('fetchError')
 
-      cy.mount(EntityBaseConfigCard, {
+      cy.mount(EntityBaseConfigCardMount, {
         props: {
           config: configWithWorkspace('default'),
           configSchema,
@@ -738,7 +738,7 @@ describe('<EntityBaseConfigCard />', () => {
         { statusCode: 200, body: gatewayServiceRecord },
       ).as('fetchPlain')
 
-      cy.mount(EntityBaseConfigCard, {
+      cy.mount(EntityBaseConfigCardMount, {
         props: {
           config: configWithWorkspace('default'),
           configSchema,
@@ -839,44 +839,6 @@ describe('<EntityBaseConfigCard />', () => {
       cy.getTestId('select-item-json').should('not.exist')
       cy.getTestId('select-item-yaml').should('not.exist')
       cy.getTestId('select-item-terraform').should('exist')
-    })
-  })
-
-  describe('after-fields slot', () => {
-    it('renders slotted content below the property grid', () => {
-      const afterText = 'Extra block below config fields'
-
-      interceptFetch()
-
-      cy.mount(EntityBaseConfigCardMount, {
-        props: {
-          config,
-          configSchema,
-          entityType,
-          fetchUrl,
-        },
-        slots: {
-          'after-fields': h('p', { 'data-testid': 'config-card-after-fields-marker' }, afterText),
-        },
-      })
-
-      cy.get('.config-card-details-after').should('exist')
-      cy.getTestId('config-card-after-fields-marker').should('be.visible').and('contain.text', afterText)
-    })
-
-    it('does not render the after-fields container when the slot is unused', () => {
-      interceptFetch()
-
-      cy.mount(EntityBaseConfigCardMount, {
-        props: {
-          config,
-          configSchema,
-          entityType,
-          fetchUrl,
-        },
-      })
-
-      cy.get('.config-card-details-after').should('not.exist')
     })
   })
 })

--- a/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
+++ b/packages/entities/entities-shared/src/components/entity-base-config-card/EntityBaseConfigCard.vue
@@ -93,53 +93,46 @@
     </KEmptyState>
 
     <!-- Properties Content -->
-    <template v-else>
-      <div class="config-card-details-section">
-        <ConfigCardDisplay
-          :code-block-record="codeBlockRecordFromApi"
-          :code-block-record-formatter="codeBlockRecordFormatter"
-          :code-block-record-redacted="!showSensitiveFields ? redactedCodeBlockRecord : undefined"
-          :config="config"
-          :entity-type="entityType"
-          :fetcher-url="fetcherUrl"
-          :format="configFormat"
-          :is-deck-customization-visible="isDeckCustomizationVisible"
-          :preserve-code-block-timestamps="preserveCodeBlockTimestamps"
-          :prop-list-types="propListTypes"
-          :property-collections="propertyLists"
-          :record="record"
-          :sub-entity-type="subEntityType"
-          @deck-customization:close="isDeckCustomizationVisible = false"
-          @request-deck-format="configFormat = 'deck'"
-        >
-          <!-- Pass through slots except `after-fields` -->
-          <template
-            v-for="slotKey in configCardDisplaySlotKeys"
-            :key="slotKey"
-            #[slotKey]="slotProps"
-          >
-            <slot
-              :name="slotKey"
-              :record="record"
-              v-bind="slotProps"
-            />
-          </template>
-        </ConfigCardDisplay>
-      </div>
-      <!-- Pairs with `config-card-details-section`; optional block below the property grid (`#after-fields`) -->
-      <div
-        v-if="hasAfterFieldsSlot"
-        class="config-card-details-after"
+    <div
+      v-else
+      class="config-card-details-section"
+    >
+      <ConfigCardDisplay
+        :code-block-record="codeBlockRecordFromApi"
+        :code-block-record-formatter="codeBlockRecordFormatter"
+        :code-block-record-redacted="!showSensitiveFields ? redactedCodeBlockRecord : undefined"
+        :config="config"
+        :entity-type="entityType"
+        :fetcher-url="fetcherUrl"
+        :format="configFormat"
+        :is-deck-customization-visible="isDeckCustomizationVisible"
+        :preserve-code-block-timestamps="preserveCodeBlockTimestamps"
+        :prop-list-types="propListTypes"
+        :property-collections="propertyLists"
+        :record="record"
+        :sub-entity-type="subEntityType"
+        @deck-customization:close="isDeckCustomizationVisible = false"
+        @request-deck-format="configFormat = 'deck'"
       >
-        <slot name="after-fields" />
-      </div>
-    </template>
+        <template
+          v-for="slotKey in Object.keys($slots)"
+          :key="slotKey"
+          #[slotKey]="slotProps"
+        >
+          <slot
+            :name="slotKey"
+            :record="record"
+            v-bind="slotProps"
+          />
+        </template>
+      </ConfigCardDisplay>
+    </div>
   </KCard>
 </template>
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed, ref, onBeforeMount, watch, onMounted, useSlots } from 'vue'
+import { computed, ref, onBeforeMount, watch, onMounted } from 'vue'
 import type { AxiosError } from 'axios'
 import type {
   KonnectBaseEntityConfig,
@@ -316,9 +309,6 @@ const props = defineProps({
   },
 })
 
-// If a parent passes `#after-fields`, dont forward that name to ConfigCardDisplay (its not a field slot)
-const RESERVED_ENTITY_CONFIG_CARD_SLOTS = new Set(['after-fields'])
-
 const { i18n: { t } } = composables.useI18n()
 const { getMessageFromError } = composables.useErrors()
 const { convertKeyToTitle } = composables.useStringHelpers()
@@ -327,16 +317,7 @@ composables.useSubSchema(props.pluginConfigKey) // reduce the schema to only the
 
 const { axiosInstance } = composables.useAxios(props.config?.axiosRequestConfig)
 
-const slots = useSlots()
-
 const isDeckCustomizationVisible = ref(false)
-
-/** Every dynamic slot (title, type etc) oter than `after-fields` is passed through to ConfigCardDisplay */
-const configCardDisplaySlotKeys = computed(() =>
-  Object.keys(slots).filter((name) => !RESERVED_ENTITY_CONFIG_CARD_SLOTS.has(name)),
-)
-
-const hasAfterFieldsSlot = computed((): boolean => Boolean(slots['after-fields']))
 
 const {
   isDeckEnabled,
@@ -744,7 +725,6 @@ onBeforeMount(async () => {
 </script>
 
 <style lang="scss" scoped>
-/* If `#after-fields` exists, keep a bottom border on the last property row so extra block aligns with grid */
 .kong-ui-entity-base-config-card {
   .config-card-actions {
     align-items: center;
@@ -778,16 +758,8 @@ onBeforeMount(async () => {
     margin-top: var(--kui-space-110, $kui-space-110);
   }
 
-  /* No `#after-fields`- hide last row’s bottom border */
-  &:not(:has(.config-card-details-after)) {
-    :deep(.config-card-details-row:last-of-type) {
-      border-bottom: none;
-    }
-  }
-
-  /* When `config-card-details-after` exists, keep border so that grid meets the next block */
-  .config-card-details-after {
-    padding-top: var(--kui-space-60, $kui-space-60);
+  :deep(.config-card-details-row:last-of-type) {
+    border-bottom: none;
   }
 
   .book-icon {


### PR DESCRIPTION
Addresses: [https://konghq.atlassian.net/browse/KHCP-21001](https://konghq.atlassian.net/browse/KHCP-21001)
# Summary

This PR updates the **Config** tab by replacing the stacked _Cache configuration_ and _Partial configuration_ sections with a **segmented** control, allowing users to switch between the configuration options.

**Before**

1. Create a Konnect-managed Redis add-on for a Cloud Gateway.

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 32 23 AM" src="https://github.com/user-attachments/assets/7481fba8-6f4a-41aa-a3c1-df552dcdf888" />

2. Navigate to the Configuration tab.

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 32 27 AM" src="https://github.com/user-attachments/assets/ad4e4c0a-848c-4b38-b187-884db5eec8cd" />

3. The Partial Configuration section was displayed below the Cache Configuration section.

4. When the add-on was not in the Ready state, the fields in the Partial Configuration section displayed either "Provisioning cache..." or "Terminating cache...".

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 32 32 AM" src="https://github.com/user-attachments/assets/ea916c20-7d72-444a-adbc-c75321db3000" />

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 33 07 AM" src="https://github.com/user-attachments/assets/820ab64f-d036-4b8f-aaae-870c86d61769" />

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 33 33 AM" src="https://github.com/user-attachments/assets/6a63fe5e-c845-4107-a980-e1acaf9901f0" />

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 33 39 AM" src="https://github.com/user-attachments/assets/317966d4-a46c-4ae2-a594-afe9a178f0c5" />


**After**

1. Create a Konnect-managed Redis add-on for a Cloud Gateway.

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 47 10 AM" src="https://github.com/user-attachments/assets/b2b329ac-3299-4dd0-b2fa-558b1b43aa3a" />

2. Navigate to the Configuration tab.

3. The Cache Configuration and Partial Configuration are now presented as options in a segmented control.

4. While the add-on is in a non-ready state, the Partial Configuration segment is disabled. Hovering over the disabled segment displays a tooltip with a state-specific message.

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 47 19 AM" src="https://github.com/user-attachments/assets/8d894170-51b8-415f-bfde-528dcceb0514" />

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 48 02 AM" src="https://github.com/user-attachments/assets/a84a053c-b850-43d9-8be9-d12c0505f71e" />

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 48 08 AM" src="https://github.com/user-attachments/assets/03e3363b-40b4-444c-942c-709498553991" />

5. Once the add-on reaches the Ready state, the Partial Configuration segment becomes enabled.

<img width="1724" height="1025" alt="screen capture 2026-07-02 at 11 47 54 AM" src="https://github.com/user-attachments/assets/6b04c25f-7de6-4cdc-b9f7-de177db0bdb8" />

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
