### PR TITLE
feat(dashboard-renderer): add markdown as first-class tile type

### DIFF
--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -8,6 +8,8 @@ import {
   llmUsageSchema,
   agenticUsageSchema,
   validDashboardChartQuery,
+  markdownTileDefinitionSchema,
+  markdownTileConfigSchema,
   validDashboardQuery,
   validDashboardTableQuery,
   platformQuerySchema,
@@ -458,5 +460,53 @@ describe('dashboardSchema.v2', () => {
       ...invalidStrictQuery,
       datasource: 'agentic_usage',
     })).toBe(false)
+  })
+
+  describe('markdownTileDefinitionSchema', () => {
+    const validateMarkdownTileDefinitionSchema = ajv.compile(markdownTileDefinitionSchema)
+    const validateMarkdownTileConfigSchema = ajv.compile(markdownTileConfigSchema)
+
+    it('accepts a valid markdown tile definition', () => {
+      expect(validateMarkdownTileDefinitionSchema({
+        content: '## Hello\n\nThis is a **markdown** tile.',
+      })).toBe(true)
+    })
+
+    it('rejects a markdown tile definition missing content', () => {
+      expect(validateMarkdownTileDefinitionSchema({})).toBe(false)
+    })
+
+    it('rejects a markdown tile definition with extra properties', () => {
+      expect(validateMarkdownTileDefinitionSchema({
+        content: 'Some notes.',
+        unknown_field: true,
+      })).toBe(false)
+    })
+
+    it('accepts a valid markdown tile config', () => {
+      expect(validateMarkdownTileConfigSchema({
+        type: 'markdown',
+        definition: { content: '## Notes' },
+        layout: {
+          position: { col: 0, row: 0 },
+          size: { cols: 3, rows: 2 },
+        },
+      })).toBe(true)
+    })
+
+    it('accepts a markdown tile within a full dashboard config', () => {
+      expect(validateDashboardConfigSchema({
+        tiles: [
+          {
+            type: 'markdown',
+            definition: { content: '## Notes' },
+            layout: {
+              position: { col: 0, row: 0 },
+              size: { cols: 3, rows: 2 },
+            },
+          },
+        ],
+      })).toBe(true)
+    })
   })
 })

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -462,7 +462,7 @@ describe('dashboardSchema.v2', () => {
     })).toBe(false)
   })
 
-  describe('markdownTileDefinitionSchema', () => {
+  describe('markdown tile schemas', () => {
     const validateMarkdownTileDefinitionSchema = ajv.compile(markdownTileDefinitionSchema)
     const validateMarkdownTileConfigSchema = ajv.compile(markdownTileConfigSchema)
 

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -799,7 +799,42 @@ export const chartTileConfigSchema = {
   additionalProperties: false,
 } as const satisfies JSONSchema
 
-export const tileConfigSchema = chartTileConfigSchema
+export type ChartTileConfig = FromSchemaWithOptions<typeof chartTileConfigSchema>
+
+export const markdownTileDefinitionSchema = {
+  type: 'object',
+  properties: {
+    content: { type: 'string' },
+  },
+  required: ['content'],
+  additionalProperties: false,
+} as const satisfies JSONSchema
+
+export type MarkdownTileDefinition = FromSchemaWithOptions<typeof markdownTileDefinitionSchema>
+
+export const markdownTileConfigSchema = {
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string',
+      enum: ['markdown'],
+    },
+    definition: markdownTileDefinitionSchema,
+    layout: tileLayoutSchema,
+    id: {
+      type: 'string',
+      description: 'Unique identifier for the tile.  If not provided, one will be generated.',
+    },
+  },
+  required: ['type', 'definition', 'layout'],
+  additionalProperties: false,
+} as const satisfies JSONSchema
+
+export type MarkdownTileConfig = FromSchemaWithOptions<typeof markdownTileConfigSchema>
+
+export const tileConfigSchema = {
+  oneOf: [chartTileConfigSchema, markdownTileConfigSchema],
+} as const satisfies JSONSchema
 
 export type TileConfig = FromSchemaWithOptions<typeof tileConfigSchema>
 

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -84,12 +84,12 @@
     "@kong-ui-public/table-data-grid": "workspace:^",
     "@kong/icons": "^1.58.0",
     "@kong/kongponents": "^9.59.0",
+    "@kong/markdown": "^1.9.8",
     "swrv": "^1.2.0",
     "vue": ">= 3.3.13 < 4"
   },
   "dependencies": {
     "@kong-ui-public/core": "workspace:^",
-    "@kong/markdown": "^1.9.8",
     "gridstack": "^11.5.1",
     "p-queue": "^8.1.1"
   }

--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -89,6 +89,7 @@
   },
   "dependencies": {
     "@kong-ui-public/core": "workspace:^",
+    "@kong/markdown": "^1.9.8",
     "gridstack": "^11.5.1",
     "p-queue": "^8.1.1"
   }

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -33,7 +33,13 @@
         <template #tile="{ tile }">
           <!-- eslint-disable @kong/eslint-plugin-design-tokens/token-constant-requires-css-var -->
           <div
-            v-if="isSlottableTile(tile)"
+            v-if="tile.type === 'markdown'"
+            class="tile-container"
+          >
+            <MarkdownTileRenderer :content="(tile.meta as any).content" />
+          </div>
+          <div
+            v-else-if="isSlottableTile(tile)"
             class="tile-container slottable-tile"
           >
             <slot :name="getSlottableSlotName(tile)" />
@@ -76,6 +82,7 @@ import type {
   TileDefinition,
 } from '@kong-ui-public/analytics-utilities'
 import DashboardTile from './DashboardTile.vue'
+import MarkdownTileRenderer from './MarkdownTileRenderer.vue'
 import type { ComponentPublicInstance } from 'vue'
 import { computed, inject, nextTick, ref } from 'vue'
 import composables from '../composables'
@@ -136,7 +143,23 @@ const tileSortFn = (a: TileConfig, b: TileConfig) => {
 }
 
 const gridTiles = computed<Array<GridTile<TileDefinition>>>(() => {
-  return model.value.tiles.map((tile: TileConfig) => {
+  return model.value.tiles.map((tile: TileConfig): GridTile<TileDefinition> => {
+    if (tile.type === 'markdown') {
+      if (internalContext.value.editable && !tile.id) {
+        console.warn(
+          'No id provided for tile. One will be generated automatically,',
+          'however tracking changes to this tile may not work as expected.',
+          tile,
+        )
+      }
+      return {
+        layout: tile.layout,
+        meta: tile.definition as unknown as TileDefinition,
+        type: tile.type,
+        id: tile.id ?? crypto.randomUUID(),
+      }
+    }
+
     let tileMeta = tile.definition
     const tileType = tile.type ?? 'chart'
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -32,12 +32,18 @@
       >
         <template #tile="{ tile }">
           <!-- eslint-disable @kong/eslint-plugin-design-tokens/token-constant-requires-css-var -->
-          <div
+          <MarkdownTile
             v-if="tile.type === 'markdown'"
             class="tile-container"
-          >
-            <MarkdownTileRenderer :content="(tile.meta as any).content" />
-          </div>
+            :content="(tile.meta as any).content"
+            :context="internalContext"
+            :hide-actions="!internalContext.showTileActions"
+            :is-fullscreen="isFullscreen"
+            :tile-id="tile.id"
+            @duplicate-tile="onDuplicateTile(tile)"
+            @edit-tile="onEditTile(tile)"
+            @remove-tile="onRemoveTile(tile)"
+          />
           <div
             v-else-if="isSlottableTile(tile)"
             class="tile-container slottable-tile"
@@ -82,7 +88,7 @@ import type {
   TileDefinition,
 } from '@kong-ui-public/analytics-utilities'
 import DashboardTile from './DashboardTile.vue'
-import MarkdownTileRenderer from './MarkdownTileRenderer.vue'
+import MarkdownTile from './MarkdownTile.vue'
 import type { ComponentPublicInstance } from 'vue'
 import { computed, inject, nextTick, ref } from 'vue'
 import composables from '../composables'

--- a/packages/analytics/dashboard-renderer/src/components/MarkdownTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/MarkdownTile.vue
@@ -11,9 +11,9 @@
       <div class="tile-actions">
         <EditIcon
           class="edit-icon"
-          :color="KUI_COLOR_TEXT_NEUTRAL"
+          :color="`var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL})`"
           :data-testid="`edit-tile-${tileId}`"
-          :size="KUI_ICON_SIZE_40"
+          :size="`var(--kui-icon-size-40, ${KUI_ICON_SIZE_40})`"
           @click="emit('edit-tile')"
         />
         <KDropdown
@@ -23,9 +23,9 @@
         >
           <MoreIcon
             class="kebab-action-menu"
-            :color="KUI_COLOR_TEXT_NEUTRAL"
+            :color="`var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL})`"
             :data-testid="`kebab-action-menu-${tileId}`"
-            :size="KUI_ICON_SIZE_40"
+            :size="`var(--kui-icon-size-40, ${KUI_ICON_SIZE_40})`"
           />
           <template #items>
             <KDropdownItem

--- a/packages/analytics/dashboard-renderer/src/components/MarkdownTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/MarkdownTile.vue
@@ -1,0 +1,130 @@
+<template>
+  <div
+    class="tile-boundary"
+    :class="{ editable: context.editable }"
+    :data-testid="`tile-${tileId}`"
+  >
+    <div
+      v-if="hasTileHeader"
+      class="tile-header"
+    >
+      <div class="tile-actions">
+        <EditIcon
+          class="edit-icon"
+          :color="KUI_COLOR_TEXT_NEUTRAL"
+          :data-testid="`edit-tile-${tileId}`"
+          :size="KUI_ICON_SIZE_40"
+          @click="emit('edit-tile')"
+        />
+        <KDropdown
+          class="dropdown"
+          :data-testid="`chart-action-menu-${tileId}`"
+          :kpop-attributes="{ placement: 'bottom-end' }"
+        >
+          <MoreIcon
+            class="kebab-action-menu"
+            :color="KUI_COLOR_TEXT_NEUTRAL"
+            :data-testid="`kebab-action-menu-${tileId}`"
+            :size="KUI_ICON_SIZE_40"
+          />
+          <template #items>
+            <KDropdownItem
+              :data-testid="`duplicate-tile-${tileId}`"
+              @click="emit('duplicate-tile')"
+            >
+              {{ i18n.t('renderer.duplicateTile') }}
+            </KDropdownItem>
+            <KDropdownItem
+              :data-testid="`remove-tile-${tileId}`"
+              @click="emit('remove-tile')"
+            >
+              <span class="delete-option">{{ i18n.t('renderer.delete') }}</span>
+            </KDropdownItem>
+          </template>
+        </KDropdown>
+      </div>
+    </div>
+    <div class="tile-content">
+      <MarkdownTileRenderer :content="content" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DashboardRendererContextInternal } from '../types'
+import { EditIcon, MoreIcon } from '@kong/icons'
+import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+import MarkdownTileRenderer from './MarkdownTileRenderer.vue'
+import composables from '../composables'
+
+const props = withDefaults(defineProps<{
+  content: string
+  context: DashboardRendererContextInternal
+  hideActions?: boolean
+  isFullscreen?: boolean
+  tileId: string | number
+}>(), {
+  hideActions: false,
+  isFullscreen: false,
+})
+
+const emit = defineEmits<{
+  (e: 'edit-tile'): void
+  (e: 'duplicate-tile'): void
+  (e: 'remove-tile'): void
+}>()
+
+const { i18n } = composables.useI18n()
+
+const hasTileHeader = computed(() => props.context.editable && !props.isFullscreen && !props.hideActions)
+</script>
+
+<style scoped lang="scss">
+.tile-boundary {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+
+  &.editable:hover {
+    .tile-header {
+      background: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
+    }
+  }
+
+  .tile-header {
+    align-items: center;
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--kui-space-40, $kui-space-40) var(--kui-space-50, $kui-space-50);
+    width: 100%;
+
+    .tile-actions {
+      display: flex;
+      gap: var(--kui-space-30, $kui-space-30);
+
+      .edit-icon {
+        cursor: pointer;
+      }
+    }
+
+    .dropdown {
+      display: flex;
+
+      .kebab-action-menu {
+        cursor: pointer;
+      }
+
+      .delete-option {
+        color: var(--kui-color-text-danger, $kui-color-text-danger);
+      }
+    }
+  }
+
+  .tile-content {
+    flex-grow: 1;
+    overflow: hidden;
+  }
+}
+</style>

--- a/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.cy.ts
@@ -31,7 +31,9 @@ describe('<MarkdownTileRenderer />', () => {
     })
 
     cy.get('.markdown-tile-renderer script').should('not.exist')
-    cy.window().then(win => { expect((win as any).__xss).to.be.undefined })
+    cy.window().then(win => {
+      expect((win as any).__xss).to.equal(undefined)
+    })
   })
 
   it('does not render inline event handlers', () => {
@@ -42,6 +44,8 @@ describe('<MarkdownTileRenderer />', () => {
     })
 
     cy.get('.markdown-tile-renderer [onerror]').should('not.exist')
-    cy.window().then(win => { expect((win as any).__xss2).to.be.undefined })
+    cy.window().then(win => {
+      expect((win as any).__xss2).to.equal(undefined)
+    })
   })
 })

--- a/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.cy.ts
@@ -26,7 +26,7 @@ describe('<MarkdownTileRenderer />', () => {
   it('does not execute injected script tags', () => {
     cy.mount(MarkdownTileRenderer, {
       props: {
-        content: '<script>window.__xss = true<\/script>\n\nSafe content.',
+        content: '<script>window.__xss = true</s' + 'cript>\n\nSafe content.',
       },
     })
 

--- a/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.cy.ts
@@ -1,0 +1,47 @@
+import MarkdownTileRenderer from './MarkdownTileRenderer.vue'
+
+describe('<MarkdownTileRenderer />', () => {
+  it('renders markdown content as HTML', () => {
+    cy.mount(MarkdownTileRenderer, {
+      props: {
+        content: '## Hello World\n\nThis is **bold** text.',
+      },
+    })
+
+    cy.get('.markdown-tile-renderer').should('exist')
+    cy.get('.markdown-tile-renderer h2').should('contain.text', 'Hello World')
+    cy.get('.markdown-tile-renderer strong').should('contain.text', 'bold')
+  })
+
+  it('renders paragraph text', () => {
+    cy.mount(MarkdownTileRenderer, {
+      props: {
+        content: 'Plain paragraph text.',
+      },
+    })
+
+    cy.get('.markdown-tile-renderer').should('contain.text', 'Plain paragraph text.')
+  })
+
+  it('does not execute injected script tags', () => {
+    cy.mount(MarkdownTileRenderer, {
+      props: {
+        content: '<script>window.__xss = true<\/script>\n\nSafe content.',
+      },
+    })
+
+    cy.get('.markdown-tile-renderer script').should('not.exist')
+    cy.window().its('__xss').should('equal', undefined)
+  })
+
+  it('does not render inline event handlers', () => {
+    cy.mount(MarkdownTileRenderer, {
+      props: {
+        content: '<img src="x" onerror="window.__xss2 = true">',
+      },
+    })
+
+    cy.get('.markdown-tile-renderer [onerror]').should('not.exist')
+    cy.window().its('__xss2').should('equal', undefined)
+  })
+})

--- a/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.cy.ts
@@ -31,7 +31,7 @@ describe('<MarkdownTileRenderer />', () => {
     })
 
     cy.get('.markdown-tile-renderer script').should('not.exist')
-    cy.window().its('__xss').should('equal', undefined)
+    cy.window().then(win => { expect((win as any).__xss).to.be.undefined })
   })
 
   it('does not render inline event handlers', () => {
@@ -42,6 +42,6 @@ describe('<MarkdownTileRenderer />', () => {
     })
 
     cy.get('.markdown-tile-renderer [onerror]').should('not.exist')
-    cy.window().its('__xss2').should('equal', undefined)
+    cy.window().then(win => { expect((win as any).__xss2).to.be.undefined })
   })
 })

--- a/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/MarkdownTileRenderer.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="markdown-tile-renderer">
+    <MarkdownUi
+      :editable="false"
+      mode="read"
+      :model-value="content"
+      theme="light"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { MarkdownUi } from '@kong/markdown'
+import '@kong/markdown/dist/style.css'
+
+defineProps<{ content: string }>()
+</script>
+
+<style scoped lang="scss">
+.markdown-tile-renderer {
+  height: 100%;
+  overflow-y: auto;
+  padding: var(--kui-space-60, $kui-space-60);
+}
+</style>

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
@@ -552,4 +552,58 @@ describe('configureAllowedDefinition', () => {
       expect(result.tiles[0].layout?.position).toEqual({ col: 0, row: 0 })
     })
   })
+
+  describe('Markdown tiles', () => {
+    const mockMarkdownTile: TileConfig = {
+      id: 'markdown_tile_1',
+      type: 'markdown',
+      layout: {
+        size: { cols: 3, rows: 2 },
+        position: { col: 0, row: 0 },
+      },
+      definition: {
+        content: '## Notes\n\nSome context here.',
+      },
+    }
+
+    it('passes through unchanged for the advanced tier', () => {
+      const config: DashboardConfig = {
+        tiles: [mockMarkdownTile],
+        tile_height: 167,
+      }
+
+      const result = configureAllowedDefinition(config, true)
+
+      expect(result.tiles).toHaveLength(1)
+      expect(result.tiles[0]).toEqual(mockMarkdownTile)
+    })
+
+    it('passes through unchanged for the basic tier', () => {
+      const config: DashboardConfig = {
+        tiles: [mockMarkdownTile],
+        tile_height: 167,
+      }
+
+      const result = configureAllowedDefinition(config, false)
+
+      expect(result.tiles).toHaveLength(1)
+      expect(result.tiles[0]).toEqual(mockMarkdownTile)
+    })
+
+    it('survives alongside chart tiles when basic tier filters api_usage charts', () => {
+      const config: DashboardConfig = {
+        tiles: [
+          mockMarkdownTile,
+          mockApiUsageTile,
+        ],
+        tile_height: 167,
+      }
+
+      const result = configureAllowedDefinition(config, false)
+
+      // api_usage chart is filtered; markdown tile survives
+      expect(result.tiles).toHaveLength(1)
+      expect(result.tiles[0].type).toBe('markdown')
+    })
+  })
 })

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
@@ -13,7 +13,11 @@ import { isTableChartDefinition } from './tile-definition'
  * @returns The updated tile configuration object.
  */
 const processTileForBasicTier = (tile: TileConfig): TileConfig | undefined => {
-  const query = tile.definition?.query
+  if (tile.type === 'markdown') {
+    return tile
+  }
+
+  const query = tile.definition.query
 
   if (!query) {
     return tile
@@ -35,8 +39,8 @@ const processTileForBasicTier = (tile: TileConfig): TileConfig | undefined => {
  * @returns The updated tile configuration object.
  */
 const processTileForAdvancedTier = (tile: TileConfig): TileConfig => {
-  if (isTableChartDefinition(tile.definition)) {
-    // Table chart queries use the platform tabular API, so leave their datasource unchanged.
+  if (tile.type === 'markdown' || isTableChartDefinition(tile.definition)) {
+    // Markdown tiles have no query; table chart queries use the platform tabular API — skip datasource migration for both.
     return tile
   }
 

--- a/packages/analytics/dashboard-renderer/vite.config.ts
+++ b/packages/analytics/dashboard-renderer/vite.config.ts
@@ -25,6 +25,7 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
         '@kong-ui-public/analytics-utilities',
         '@kong-ui-public/analytics-geo-map',
         '@kong-ui-public/table-data-grid',
+        '@kong/markdown',
         'swrv',
       ],
       output: {
@@ -36,6 +37,7 @@ const config = mergeConfig(sharedViteConfig, defineConfig({
           '@kong-ui-public/analytics-utilities': 'kong-ui-public-analytics-utilities',
           '@kong-ui-public/analytics-geo-map': 'kong-ui-public-analytics-geo-map',
           '@kong-ui-public/table-data-grid': 'kong-ui-public-table-data-grid',
+          '@kong/markdown': 'kong-markdown',
           swrv: 'swrv',
         },
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,9 @@ importers:
       '@kong-ui-public/core':
         specifier: workspace:^
         version: link:../../core/core
+      '@kong/markdown':
+        specifier: ^1.9.8
+        version: 1.9.8(@types/markdown-it@14.1.2)(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3))
       gridstack:
         specifier: ^11.5.1
         version: 11.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,7 +403,7 @@ importers:
         version: link:../../core/core
       '@kong/markdown':
         specifier: ^1.9.8
-        version: 1.9.8(@types/markdown-it@14.1.2)(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3))
+        version: 1.9.9(@types/markdown-it@14.1.2)(vue@3.5.35(typescript@5.9.3))
       gridstack:
         specifier: ^11.5.1
         version: 11.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,7 +403,7 @@ importers:
         version: link:../../core/core
       '@kong/markdown':
         specifier: ^1.9.8
-        version: 1.9.9(@types/markdown-it@14.1.2)(vue@3.5.35(typescript@5.9.3))
+        version: 1.9.10(@types/markdown-it@14.1.2)(vue@3.5.35(typescript@5.9.3))
       gridstack:
         specifier: ^11.5.1
         version: 11.5.1


### PR DESCRIPTION
# Summary

Adds markdown as a first-class tile type in the analytics dashboard schema and renderer.

- Schema (analytics-utilities): adds markdownTileDefinitionSchema, MarkdownTileDefinition, markdownTileConfigSchema, and MarkdownTileConfig types. The top-level tileConfigSchema is now a oneOf: [chartTileConfigSchema, markdownTileConfigSchema] discriminated union. All types are derived via FromSchemaWithOptions so the schema and types stay in sync.
- Renderer (dashboard-renderer): DashboardRenderer.vue routes tile.type === 'markdown' to a new MarkdownTile component. MarkdownTile.vue renders the header chrome (edit / kebab with duplicate+delete), delegating content to MarkdownTileRenderer.vue which uses @kong/markdown for safe rendering. Tier-aware configure-definition.ts now short-circuits markdown tiles (no datasource to migrate or filter).
- Tests: unit tests for the updated tileConfigSchema (AJV validation), component tests for MarkdownTileRenderer including XSS injection guards (script tags, inline event handlers).

<img width="1924" height="957" alt="image" src="https://github.com/user-attachments/assets/ec950788-b17e-415a-be45-31d20b3a1bf9" />
