### PR TITLE
fix(entities-plugins): make freeform filler robust to scroll, animation, and layout timing issues

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/filler/README.md
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/README.md
@@ -78,7 +78,7 @@ Creates a filler instance.
 **`filler.fill(data)`**
 Fills entire form. Skips `undefined` values.
 
-**`filler.fillField(fieldKey, value, options?)`**
+**`filler.fillField(fieldKey, value)`**
 Fills a single field. Use dot notation for nested fields: `'config.timeout'`, `'servers.0.host'`.
 
 ## Development

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/create-filler.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/create-filler.ts
@@ -1,4 +1,4 @@
-import { handlers, type Handlers, type ActionOptions } from './handlers'
+import { handlers, type Handlers } from './handlers'
 import type {
   FormSchema,
   UnionFieldSchema,
@@ -25,7 +25,7 @@ import {
 
 export interface FillerInstance {
   fill: (data: Record<string, any>) => void
-  fillField: (fieldKey: string, value: any, actionOptions?: ActionOptions) => void
+  fillField: (fieldKey: string, value: any) => void
   schemaMap: Record<string, UnionFieldSchema>
   handlers: Handlers
 }
@@ -43,22 +43,22 @@ export function createFiller(
     }
   }
 
-  function fillFieldByInfo({ handlerType, fieldKey, fieldSchema, value }: FieldToFill, actionOptions?: ActionOptions): void {
+  function fillFieldByInfo({ handlerType, fieldKey, fieldSchema, value }: FieldToFill): void {
     switch (handlerType) {
       case 'string':
-        mergedHandlers.fillString({ fieldKey, fieldSchema: fieldSchema as StringFieldSchema, value, actionOptions })
+        mergedHandlers.fillString({ fieldKey, fieldSchema: fieldSchema as StringFieldSchema, value })
         break
       case 'number':
-        mergedHandlers.fillNumber({ fieldKey, fieldSchema: fieldSchema as NumberLikeFieldSchema, value, actionOptions })
+        mergedHandlers.fillNumber({ fieldKey, fieldSchema: fieldSchema as NumberLikeFieldSchema, value })
         break
       case 'boolean':
-        mergedHandlers.fillBoolean({ fieldKey, fieldSchema: fieldSchema as BooleanFieldSchema, value, actionOptions })
+        mergedHandlers.fillBoolean({ fieldKey, fieldSchema: fieldSchema as BooleanFieldSchema, value })
         break
       case 'enum':
-        mergedHandlers.fillEnum({ fieldKey, fieldSchema: fieldSchema as StringFieldSchema | NumberLikeFieldSchema | SetFieldSchema, value, actionOptions })
+        mergedHandlers.fillEnum({ fieldKey, fieldSchema: fieldSchema as StringFieldSchema | NumberLikeFieldSchema | SetFieldSchema, value })
         break
       case 'tag':
-        mergedHandlers.fillTag({ fieldKey, fieldSchema: fieldSchema as SetFieldSchema, value, actionOptions })
+        mergedHandlers.fillTag({ fieldKey, fieldSchema: fieldSchema as SetFieldSchema, value })
         break
       case 'map':
         mergedHandlers.fillMap({
@@ -71,10 +71,10 @@ export function createFiller(
         })
         break
       case 'json':
-        mergedHandlers.fillJson({ fieldKey, fieldSchema: fieldSchema as JsonFieldSchema, value, actionOptions })
+        mergedHandlers.fillJson({ fieldKey, fieldSchema: fieldSchema as JsonFieldSchema, value })
         break
       case 'foreign':
-        mergedHandlers.fillForeign({ fieldKey, fieldSchema: fieldSchema as ForeignFieldSchema, value, actionOptions })
+        mergedHandlers.fillForeign({ fieldKey, fieldSchema: fieldSchema as ForeignFieldSchema, value })
         break
       case 'array':
         mergedHandlers.fillArray({
@@ -131,7 +131,7 @@ export function createFiller(
     }
   }
 
-  function fillField(fieldKey: string, value: any, actionOptions?: ActionOptions): void {
+  function fillField(fieldKey: string, value: any): void {
     const fieldSchema = ctx.schemaMap[fieldKey]
     if (!fieldSchema) {
       throw new Error(`Field schema for "${fieldKey}" not found in schema map`)
@@ -142,7 +142,7 @@ export function createFiller(
       fieldKey,
       fieldSchema,
       value,
-    }, actionOptions)
+    })
   }
 
   return {

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
@@ -383,8 +383,8 @@ describe('Filler - Cypress', () => {
     it('array: add-item button click succeeds even when sticky tabs cover the button', () => {
       // The hosts array has default items; fillField adds new ones via the
       // add-item button. Cypress's default scrollBehavior ('top') would land
-      // the button behind a sticky header; scrollBehavior: 'center' avoids
-      // that collision without needing force.
+      // the button behind a sticky header; scrollIntoViewNative +
+      // SCROLL_BEHAVIOR: 'center' avoids that collision without needing force.
       const schema: FormSchema = {
         type: 'record',
         fields: [
@@ -459,7 +459,7 @@ describe('Filler - Cypress', () => {
       // `position: sticky; top: 0`. Cypress's default scrollBehavior ('top')
       // scrolls the target flush against the viewport top, landing it right
       // behind that sticky header - "not visible ... covered by <ul role=tablist>".
-      // scrollBehavior: 'center' avoids the collision entirely.
+      // scrollIntoViewNative + SCROLL_BEHAVIOR: 'center' avoids the collision entirely.
       const schema: FormSchema = {
         type: 'record',
         fields: [
@@ -497,6 +497,59 @@ describe('Filler - Cypress', () => {
       ])
 
       cy.getTestId('ff-servers.1.host').should('have.value', 'server-1.example.com')
+    })
+
+    it('array: fills a boolean field immediately after its optional parent object expands, further down a long page', () => {
+      // Covers the exact shape of a real failure: a tab-appearance array item
+      // containing an optional (switch-driven) nested object, whose boolean
+      // child field is filled right after the switch expands it. Note: this
+      // does NOT reliably reproduce the SlideTransition race itself (the
+      // animation is too fast locally, and `uncheck()`'s own actionability
+      // retry tends to absorb it) - it only asserts the correct end state.
+      // The race was confirmed and fixed against a real failing GM run; this
+      // test is here for basic structural coverage of the field shape, not
+      // as a regression guard for the timing issue.
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            targets: {
+              type: 'array',
+              elements: {
+                type: 'record',
+                fields: [
+                  {
+                    auth: {
+                      type: 'record',
+                      fields: [
+                        { allow_override: { type: 'boolean', default: true } },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      }
+
+      cy.mount(() =>
+        h('div', { style: 'padding-top: 1200px; padding-bottom: 20px' },
+          h(Form, { schema }, {
+            [FIELD_RENDERERS]: () => h(FieldRenderer,
+              { match: ({ path }: { path: string }) => path === 'targets' },
+              { default: (slotProps: any) => h(ArrayField as any, { ...slotProps, appearance: 'tabs', stickyTabs: true }) },
+            ),
+          }),
+        ),
+      )
+
+      const filler = createFiller(schema)
+      filler.fillField('targets', [
+        { auth: { allow_override: false } },
+      ])
+
+      cy.getTestId('ff-targets.0.auth.allow_override').should('not.be.checked')
     })
 
     it('should fill json field', () => {

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
@@ -3,6 +3,7 @@ import type { FormSchema } from '../../../../types/plugins/form-schema'
 import Form from '../../shared/Form.vue'
 import FieldRenderer from '../../shared/FieldRenderer.vue'
 import MapField from '../../shared/MapField.vue'
+import ArrayField from '../../shared/ArrayField.vue'
 import { h } from 'vue'
 
 const FIELD_RENDERERS = 'free-form-field-renderers-slot' as const
@@ -381,8 +382,9 @@ describe('Filler - Cypress', () => {
 
     it('array: add-item button click succeeds even when sticky tabs cover the button', () => {
       // The hosts array has default items; fillField adds new ones via the
-      // add-item button. With scrollIntoView + force:true this works even when
-      // a sticky header overlaps the button center.
+      // add-item button. Cypress's default scrollBehavior ('top') would land
+      // the button behind a sticky header; scrollBehavior: 'center' avoids
+      // that collision without needing force.
       const schema: FormSchema = {
         type: 'record',
         fields: [
@@ -404,6 +406,97 @@ describe('Filler - Cypress', () => {
 
       cy.getTestId('ff-hosts.0').should('have.value', 'alpha.example.com')
       cy.getTestId('ff-hosts.1').should('have.value', 'beta.example.com')
+    })
+
+    it('array: fills every item of a tab-appearance record array, not just the last-active tab', () => {
+      // With appearance="tabs", only the active tab's fields are rendered
+      // (see KTabs' per-tab v-if). Item 0's fields must still be reachable
+      // and filled correctly even after later items switch the active tab away.
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            servers: {
+              type: 'array',
+              elements: {
+                type: 'record',
+                fields: [
+                  { host: { type: 'string' } },
+                ],
+              },
+            },
+          },
+        ],
+      }
+
+      cy.mount(() =>
+        h('div', { style: 'padding: 20px' },
+          h(Form, { schema }, {
+            [FIELD_RENDERERS]: () => h(FieldRenderer,
+              { match: ({ path }: { path: string }) => path === 'servers' },
+              { default: (slotProps: any) => h(ArrayField as any, { ...slotProps, appearance: 'tabs' }) },
+            ),
+          }),
+        ),
+      )
+
+      const filler = createFiller(schema)
+      filler.fillField('servers', [
+        { host: 'server-0.example.com' },
+        { host: 'server-1.example.com' },
+      ])
+
+      cy.get('[data-testid="ff-array-tabs-servers"] .tab-item')
+        .eq(0).click()
+      cy.getTestId('ff-servers.0.host').should('have.value', 'server-0.example.com')
+      cy.get('[data-testid="ff-array-tabs-servers"] .tab-item')
+        .eq(1).click()
+      cy.getTestId('ff-servers.1.host').should('have.value', 'server-1.example.com')
+    })
+
+    it('array: fills fields sitting right under a sticky tab header further down a long page', () => {
+      // Reproduces a real failure: with stickyTabs, the tab header is
+      // `position: sticky; top: 0`. Cypress's default scrollBehavior ('top')
+      // scrolls the target flush against the viewport top, landing it right
+      // behind that sticky header - "not visible ... covered by <ul role=tablist>".
+      // scrollBehavior: 'center' avoids the collision entirely.
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            servers: {
+              type: 'array',
+              elements: {
+                type: 'record',
+                fields: [
+                  { host: { type: 'string' } },
+                ],
+              },
+            },
+          },
+        ],
+      }
+
+      cy.mount(() =>
+        // Enough space above the array to force real scrolling once the
+        // form is filled and the field is queried.
+        h('div', { style: 'padding-top: 1200px; padding-bottom: 20px' },
+          h(Form, { schema }, {
+            [FIELD_RENDERERS]: () => h(FieldRenderer,
+              { match: ({ path }: { path: string }) => path === 'servers' },
+              { default: (slotProps: any) => h(ArrayField as any, { ...slotProps, appearance: 'tabs', stickyTabs: true }) },
+            ),
+          }),
+        ),
+      )
+
+      const filler = createFiller(schema)
+      filler.fillField('servers', [
+        { host: 'server-0.example.com' },
+        { host: 'server-1.example.com' },
+      ])
+
+      cy.getTestId('ff-servers.1.host').should('have.value', 'server-1.example.com')
     })
 
     it('should fill json field', () => {

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
@@ -73,20 +73,6 @@ describe('Filler - Cypress', () => {
     cy.getTestId('ff-port').should('have.value', '3000')
   })
 
-  it('should handle custom action options', () => {
-    cy.mount(() => h('div', { style: 'padding: 20px' }, h(Form, { schema: basicSchema })))
-
-    const filler = createFiller(basicSchema)
-
-    // First fill with a value
-    filler.fillField('name', 'old-value')
-
-    // Fill without clearing
-    filler.fillField('name', 'new', { clear: false })
-
-    cy.getTestId('ff-name').should('have.value', 'old-valuenew')
-  })
-
   describe('Complex fields', () => {
     it('should fill enum field (single select)', () => {
       const schema: FormSchema = {

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/array.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/array.ts
@@ -1,4 +1,4 @@
-import { type ArrayHandlerOption, SCROLL_BEHAVIOR } from './types'
+import { type ArrayHandlerOption, SCROLL_BEHAVIOR, scrollIntoViewNative } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillArray(option: ArrayHandlerOption): void {
@@ -35,13 +35,17 @@ export function fillArray(option: ArrayHandlerOption): void {
       for (let i = 0; i < value.length; i++) {
         // Click add button to add more items.
         const addBtnSelector = selectors.arrayAddBtn(fieldKey)
+        scrollIntoViewNative(addBtnSelector)
         cy.get(addBtnSelector).click(SCROLL_BEHAVIOR)
 
-        // For tab-appearance arrays, the newly added item's fields only exist
-        // while its tab is active (see KTabs' v-if per-tab rendering). Wait for
-        // it to actually become visible before filling it, instead of blindly
-        // typing into whatever tab happens to be active at the time.
-        cy.get(selectors.arrayItem(fieldKey, i)).should('be.visible')
+        // For tab-appearance arrays, a tab's fields only exist in the DOM
+        // while that tab is active (KTabs uses v-if, not v-show, per tab -
+        // see KTabs.vue). So existing IS the signal that this item's tab is
+        // now active; `be.visible` is wrong here since it also demands the
+        // item be scrolled into view and unobstructed by a fixed ancestor,
+        // which is an unrelated concern already handled per-field via
+        // scrollIntoViewNative/SCROLL_BEHAVIOR when each field is actually filled.
+        cy.get(selectors.arrayItem(fieldKey, i)).should('exist')
 
         // Fill the item
         onFillItem(i, value[i])

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/array.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/array.ts
@@ -1,4 +1,4 @@
-import type { ArrayHandlerOption } from './types'
+import { type ArrayHandlerOption, SCROLL_BEHAVIOR } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillArray(option: ArrayHandlerOption): void {
@@ -20,7 +20,7 @@ export function fillArray(option: ArrayHandlerOption): void {
         cy.get('body').then(($body) => {
           const $btn = $body.find(itemRemoveBtnsSelector).first()
           if ($btn.length > 0) {
-            cy.wrap($btn).click()
+            cy.wrap($btn).click(SCROLL_BEHAVIOR)
             removeNext()
           }
         })
@@ -33,11 +33,15 @@ export function fillArray(option: ArrayHandlerOption): void {
 
       // Add items and fill each one
       for (let i = 0; i < value.length; i++) {
-        // Click add button to add more items; scrollIntoView + force:true prevents
-        // sticky-tabs headers from blocking the click.
+        // Click add button to add more items.
         const addBtnSelector = selectors.arrayAddBtn(fieldKey)
-        cy.get(addBtnSelector).scrollIntoView()
-        cy.get(addBtnSelector).click({ force: true })
+        cy.get(addBtnSelector).click(SCROLL_BEHAVIOR)
+
+        // For tab-appearance arrays, the newly added item's fields only exist
+        // while its tab is active (see KTabs' v-if per-tab rendering). Wait for
+        // it to actually become visible before filling it, instead of blindly
+        // typing into whatever tab happens to be active at the time.
+        cy.get(selectors.arrayItem(fieldKey, i)).should('be.visible')
 
         // Fill the item
         onFillItem(i, value[i])

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/boolean.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/boolean.ts
@@ -1,5 +1,5 @@
 import type { BooleanFieldSchema } from '../../../../../types/plugins/form-schema'
-import type { HandlerOption } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillBoolean(option: HandlerOption<BooleanFieldSchema>): void {
@@ -8,8 +8,8 @@ export function fillBoolean(option: HandlerOption<BooleanFieldSchema>): void {
   const selector = selectors.field(fieldKey)
 
   if (value === true) {
-    cy.get(selector).check()
+    cy.get(selector).check(SCROLL_BEHAVIOR)
   } else if (value === false) {
-    cy.get(selector).uncheck()
+    cy.get(selector).uncheck(SCROLL_BEHAVIOR)
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/boolean.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/boolean.ts
@@ -1,16 +1,15 @@
 import type { BooleanFieldSchema } from '../../../../../types/plugins/form-schema'
 import type { HandlerOption } from './types'
 import { selectors } from '../../shared/selectors'
-import { defaultActionOptions } from './types'
 
 export function fillBoolean(option: HandlerOption<BooleanFieldSchema>): void {
-  const { fieldKey, value, actionOptions = defaultActionOptions } = option
+  const { fieldKey, value } = option
 
   const selector = selectors.field(fieldKey)
 
   if (value === true) {
-    cy.get(selector).check(actionOptions.check)
+    cy.get(selector).check()
   } else if (value === false) {
-    cy.get(selector).uncheck(actionOptions.check)
+    cy.get(selector).uncheck()
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/boolean.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/boolean.ts
@@ -1,11 +1,13 @@
 import type { BooleanFieldSchema } from '../../../../../types/plugins/form-schema'
-import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR, scrollIntoViewNative } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillBoolean(option: HandlerOption<BooleanFieldSchema>): void {
   const { fieldKey, value } = option
 
   const selector = selectors.field(fieldKey)
+
+  scrollIntoViewNative(selector)
 
   if (value === true) {
     cy.get(selector).check(SCROLL_BEHAVIOR)

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
@@ -1,5 +1,5 @@
 import type { StringFieldSchema, NumberLikeFieldSchema, SetFieldSchema } from '../../../../../types/plugins/form-schema'
-import type { HandlerOption } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
 import { selectors } from '../../shared/selectors'
 import { isMultiEnumField } from '../../shared/schema-utils'
 
@@ -11,13 +11,11 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
 
   // Click to open dropdown
   const fieldSelector = selectors.field(fieldKey)
-  cy.get(fieldSelector).scrollIntoView()
-  cy.get(fieldSelector).click()
+  cy.get(fieldSelector).click(SCROLL_BEHAVIOR)
 
   // Scope all option interactions to this field's own popover to avoid matching
   // identically-named options from other enum fields on the same form.
   const popoverSelector = selectors.selectTrigger(fieldKey)
-  cy.get(popoverSelector).scrollIntoView()
 
   // Select each value within the dropdown
   for (const optionValue of fieldSchema.one_of ?? (fieldSchema as SetFieldSchema).elements?.one_of ?? []) {
@@ -30,15 +28,13 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
       if (isMulti) {
         cy.get(popoverSelector).find(itemSelector).within(($el) => {
           if ($el.find('button.selected').length > 0) {
-            cy.get('button').scrollIntoView()
-            cy.get('button').click({ force: true })
+            cy.get('button').click(SCROLL_BEHAVIOR)
           }
         })
       }
 
       if (values.includes(optionValue)) {
-        cy.get(popoverSelector).find(itemSelector).scrollIntoView()
-        cy.get(popoverSelector).find(itemSelector).click()
+        cy.get(popoverSelector).find(itemSelector).click(SCROLL_BEHAVIOR)
       }
     }
   }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
@@ -1,11 +1,10 @@
 import type { StringFieldSchema, NumberLikeFieldSchema, SetFieldSchema } from '../../../../../types/plugins/form-schema'
 import type { HandlerOption } from './types'
 import { selectors } from '../../shared/selectors'
-import { defaultActionOptions } from './types'
 import { isMultiEnumField } from '../../shared/schema-utils'
 
 export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFieldSchema | SetFieldSchema>): void {
-  const { fieldKey, fieldSchema, value, actionOptions = defaultActionOptions } = option
+  const { fieldKey, fieldSchema, value } = option
 
   const isMulti = isMultiEnumField(fieldSchema)
   const values = isMulti ? (Array.isArray(value) ? value : [value]) : [value]
@@ -13,7 +12,7 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
   // Click to open dropdown
   const fieldSelector = selectors.field(fieldKey)
   cy.get(fieldSelector).scrollIntoView()
-  cy.get(fieldSelector).click(actionOptions.click)
+  cy.get(fieldSelector).click()
 
   // Scope all option interactions to this field's own popover to avoid matching
   // identically-named options from other enum fields on the same form.
@@ -32,14 +31,14 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
         cy.get(popoverSelector).find(itemSelector).within(($el) => {
           if ($el.find('button.selected').length > 0) {
             cy.get('button').scrollIntoView()
-            cy.get('button').click(actionOptions.click)
+            cy.get('button').click({ force: true })
           }
         })
       }
 
       if (values.includes(optionValue)) {
         cy.get(popoverSelector).find(itemSelector).scrollIntoView()
-        cy.get(popoverSelector).find(itemSelector).click(actionOptions.click)
+        cy.get(popoverSelector).find(itemSelector).click()
       }
     }
   }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
@@ -1,5 +1,5 @@
 import type { StringFieldSchema, NumberLikeFieldSchema, SetFieldSchema } from '../../../../../types/plugins/form-schema'
-import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR, scrollIntoViewNative } from './types'
 import { selectors } from '../../shared/selectors'
 import { isMultiEnumField } from '../../shared/schema-utils'
 
@@ -11,6 +11,7 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
 
   // Click to open dropdown
   const fieldSelector = selectors.field(fieldKey)
+  scrollIntoViewNative(fieldSelector)
   cy.get(fieldSelector).click(SCROLL_BEHAVIOR)
 
   // Scope all option interactions to this field's own popover to avoid matching

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/enum.ts
@@ -32,14 +32,14 @@ export function fillEnum(option: HandlerOption<StringFieldSchema | NumberLikeFie
         cy.get(popoverSelector).find(itemSelector).within(($el) => {
           if ($el.find('button.selected').length > 0) {
             cy.get('button').scrollIntoView()
-            cy.get('button').click() // Value can't be selected when force: true is set, not sure why
+            cy.get('button').click(actionOptions.click)
           }
         })
       }
 
       if (values.includes(optionValue)) {
         cy.get(popoverSelector).find(itemSelector).scrollIntoView()
-        cy.get(popoverSelector).find(itemSelector).click() // Value can't be selected when force: true is set, not sure why
+        cy.get(popoverSelector).find(itemSelector).click(actionOptions.click)
       }
     }
   }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/foreign.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/foreign.ts
@@ -1,5 +1,5 @@
 import type { ForeignFieldSchema } from '../../../../../types/plugins/form-schema'
-import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR, scrollIntoViewNative } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillForeign(option: HandlerOption<ForeignFieldSchema>): void {
@@ -8,6 +8,7 @@ export function fillForeign(option: HandlerOption<ForeignFieldSchema>): void {
   const selector = selectors.field(fieldKey)
 
   // For foreign fields, typically need to click to open selector and select item
+  scrollIntoViewNative(selector)
   cy.get(selector).click(SCROLL_BEHAVIOR)
 
   // Handle different value formats

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/foreign.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/foreign.ts
@@ -1,21 +1,20 @@
 import type { ForeignFieldSchema } from '../../../../../types/plugins/form-schema'
 import type { HandlerOption } from './types'
 import { selectors } from '../../shared/selectors'
-import { defaultActionOptions } from './types'
 
 export function fillForeign(option: HandlerOption<ForeignFieldSchema>): void {
-  const { fieldKey, value, actionOptions = defaultActionOptions } = option
+  const { fieldKey, value } = option
 
   const selector = selectors.field(fieldKey)
 
   // For foreign fields, typically need to click to open selector and select item
-  cy.get(selector).click(actionOptions.click)
+  cy.get(selector).click()
 
   // Handle different value formats
   const itemValue = typeof value === 'object' && value?.id ? value.id : value
 
   if (itemValue) {
     // Look for select item with the id
-    cy.get(`[data-testid="select-item-${itemValue}"]`).click(actionOptions.click)
+    cy.get(`[data-testid="select-item-${itemValue}"]`).click()
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/foreign.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/foreign.ts
@@ -1,5 +1,5 @@
 import type { ForeignFieldSchema } from '../../../../../types/plugins/form-schema'
-import type { HandlerOption } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillForeign(option: HandlerOption<ForeignFieldSchema>): void {
@@ -8,13 +8,13 @@ export function fillForeign(option: HandlerOption<ForeignFieldSchema>): void {
   const selector = selectors.field(fieldKey)
 
   // For foreign fields, typically need to click to open selector and select item
-  cy.get(selector).click()
+  cy.get(selector).click(SCROLL_BEHAVIOR)
 
   // Handle different value formats
   const itemValue = typeof value === 'object' && value?.id ? value.id : value
 
   if (itemValue) {
     // Look for select item with the id
-    cy.get(`[data-testid="select-item-${itemValue}"]`).click()
+    cy.get(`[data-testid="select-item-${itemValue}"]`).click(SCROLL_BEHAVIOR)
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/json.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/json.ts
@@ -1,5 +1,5 @@
 import type { JsonFieldSchema } from '../../../../../types/plugins/form-schema'
-import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR, scrollIntoViewNative } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillJson(option: HandlerOption<JsonFieldSchema>): void {
@@ -7,6 +7,8 @@ export function fillJson(option: HandlerOption<JsonFieldSchema>): void {
 
   const selector = selectors.json(fieldKey)
   const jsonString = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
+
+  scrollIntoViewNative(selector)
 
   cy.get(selector).then(($el) => {
     cy.wrap($el.find('textarea')).clear(SCROLL_BEHAVIOR)

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/json.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/json.ts
@@ -1,5 +1,5 @@
 import type { JsonFieldSchema } from '../../../../../types/plugins/form-schema'
-import type { HandlerOption } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillJson(option: HandlerOption<JsonFieldSchema>): void {
@@ -9,7 +9,7 @@ export function fillJson(option: HandlerOption<JsonFieldSchema>): void {
   const jsonString = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
 
   cy.get(selector).then(($el) => {
-    cy.wrap($el.find('textarea')).clear()
-    cy.wrap($el.find('textarea')).type(jsonString)
+    cy.wrap($el.find('textarea')).clear(SCROLL_BEHAVIOR)
+    cy.wrap($el.find('textarea')).type(jsonString, SCROLL_BEHAVIOR)
   })
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/json.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/json.ts
@@ -1,18 +1,15 @@
 import type { JsonFieldSchema } from '../../../../../types/plugins/form-schema'
 import type { HandlerOption } from './types'
 import { selectors } from '../../shared/selectors'
-import { defaultActionOptions } from './types'
 
 export function fillJson(option: HandlerOption<JsonFieldSchema>): void {
-  const { fieldKey, value, actionOptions = defaultActionOptions } = option
+  const { fieldKey, value } = option
 
   const selector = selectors.json(fieldKey)
   const jsonString = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
 
   cy.get(selector).then(($el) => {
-    if (actionOptions.clear !== false) {
-      cy.wrap($el.find('textarea')).clear(actionOptions.clear)
-    }
-    cy.wrap($el.find('textarea')).type(jsonString, actionOptions.type)
+    cy.wrap($el.find('textarea')).clear()
+    cy.wrap($el.find('textarea')).type(jsonString)
   })
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/map.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/map.ts
@@ -1,4 +1,4 @@
-import type { MapHandlerOption } from './types'
+import { type MapHandlerOption, SCROLL_BEHAVIOR, scrollIntoViewNative } from './types'
 import { selectors } from '../../shared/selectors'
 
 function extractKidId(testId: string | undefined, fieldKey: string): string {
@@ -25,7 +25,7 @@ export function fillMap(option: MapHandlerOption): void {
     cy.get('body').then(($body) => {
       const $btn = $body.find(mapRemoveBtnsSelector).first()
       if ($btn.length > 0) {
-        cy.wrap($btn).click()
+        cy.wrap($btn).click(SCROLL_BEHAVIOR)
         removeNext()
       }
     })
@@ -44,10 +44,14 @@ export function fillMap(option: MapHandlerOption): void {
   for (let i = 0; i < entries.length; i++) {
     const [key, val] = entries[i]
 
-    cy.get(selectors.mapAddBtn(fieldKey)).click()
+    const addBtnSelector = selectors.mapAddBtn(fieldKey)
+    scrollIntoViewNative(addBtnSelector)
+    cy.get(addBtnSelector).click(SCROLL_BEHAVIOR)
 
-    cy.get(selectors.mapKey(fieldKey, i)).clear({ force: true })
-    cy.get(selectors.mapKey(fieldKey, i)).type(String(key), { force: true })
+    const mapKeySelector = selectors.mapKey(fieldKey, i)
+    scrollIntoViewNative(mapKeySelector)
+    cy.get(mapKeySelector).clear(SCROLL_BEHAVIOR)
+    cy.get(mapKeySelector).type(String(key), SCROLL_BEHAVIOR)
 
     cy.get(selectors.mapContainer(fieldKey, i))
       .find(`[data-testid*="${fieldKey}.kid:"]`)

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/number.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/number.ts
@@ -1,19 +1,16 @@
 import type { NumberLikeFieldSchema } from '../../../../../types/plugins/form-schema'
 import type { HandlerOption } from './types'
 import { selectors } from '../../shared/selectors'
-import { defaultActionOptions } from './types'
 
 export function fillNumber(option: HandlerOption<NumberLikeFieldSchema>): void {
-  const { fieldKey, value, actionOptions = defaultActionOptions } = option
+  const { fieldKey, value } = option
 
   const selector = selectors.field(fieldKey)
 
   cy.get(selector).then(($el) => {
-    if (actionOptions.clear !== false) {
-      cy.wrap($el).clear(actionOptions.clear)
-    }
+    cy.wrap($el).clear()
     if (value !== undefined && value !== null) {
-      cy.wrap($el).type(String(value), actionOptions.type)
+      cy.wrap($el).type(String(value))
     }
   })
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/number.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/number.ts
@@ -1,5 +1,5 @@
 import type { NumberLikeFieldSchema } from '../../../../../types/plugins/form-schema'
-import type { HandlerOption } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillNumber(option: HandlerOption<NumberLikeFieldSchema>): void {
@@ -8,9 +8,9 @@ export function fillNumber(option: HandlerOption<NumberLikeFieldSchema>): void {
   const selector = selectors.field(fieldKey)
 
   cy.get(selector).then(($el) => {
-    cy.wrap($el).clear()
+    cy.wrap($el).clear(SCROLL_BEHAVIOR)
     if (value !== undefined && value !== null) {
-      cy.wrap($el).type(String(value))
+      cy.wrap($el).type(String(value), SCROLL_BEHAVIOR)
     }
   })
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/number.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/number.ts
@@ -1,11 +1,13 @@
 import type { NumberLikeFieldSchema } from '../../../../../types/plugins/form-schema'
-import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR, scrollIntoViewNative } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillNumber(option: HandlerOption<NumberLikeFieldSchema>): void {
   const { fieldKey, value } = option
 
   const selector = selectors.field(fieldKey)
+
+  scrollIntoViewNative(selector)
 
   cy.get(selector).then(($el) => {
     cy.wrap($el).clear(SCROLL_BEHAVIOR)

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/record.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/record.ts
@@ -18,6 +18,13 @@ export function fillRecord(option: RecordHandlerOption): void {
     if (hasSwitch) {
       // Enable the object via switch
       cy.get(objectSwitchSelector).check({ force: true })
+
+      // Enabling the switch expands the object's content via SlideTransition
+      // (height animates from 0). Filling children immediately can hit them
+      // mid-transition, when the content container still has height 0 and
+      // `overflow: hidden`, making its fields fail Cypress's visibility
+      // check. Wait for the container to finish expanding first.
+      cy.get(selectors.objectContent(fieldKey)).should('be.visible')
     }
 
     // Fill children fields

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/record.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/record.ts
@@ -10,21 +10,28 @@ export function fillRecord(option: RecordHandlerOption): void {
     const hasSwitch = $body.find(objectSwitchSelector).length > 0
 
     if ((value === null || value === undefined) && hasSwitch) {
-      // Disable the object via switch
+      // Disable the object via switch. The switch's native checkbox input is
+      // deliberately `display: none` (a styled label drives it instead), so
+      // force is required here for a real reason - it's not a scroll/coverage
+      // issue like elsewhere in this file.
       cy.get(objectSwitchSelector).uncheck({ force: true })
       return
     }
 
     if (hasSwitch) {
-      // Enable the object via switch
+      // Enable the object via switch; see note above about force.
       cy.get(objectSwitchSelector).check({ force: true })
 
       // Enabling the switch expands the object's content via SlideTransition
       // (height animates from 0). Filling children immediately can hit them
-      // mid-transition, when the content container still has height 0 and
-      // `overflow: hidden`, making its fields fail Cypress's visibility
-      // check. Wait for the container to finish expanding first.
-      cy.get(selectors.objectContent(fieldKey)).should('be.visible')
+      // mid-transition, when the content container still has height 0.
+      // `should('be.visible')` isn't right here: it also requires the
+      // container to be on-screen right now, which conflates "animation
+      // done" with "scrolled into view" - the latter is unrelated and is
+      // already handled per-field by each field's own scrollIntoViewNative/SCROLL_BEHAVIOR when
+      // it's actually filled. Wait for the transition's own class instead,
+      // regardless of current scroll position.
+      cy.get(selectors.objectContent(fieldKey)).should('not.have.class', 'ff-slide-active')
     }
 
     // Fill children fields

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/string.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/string.ts
@@ -1,19 +1,16 @@
 import type { StringFieldSchema } from '../../../../../types/plugins/form-schema'
 import type { HandlerOption } from './types'
 import { selectors } from '../../shared/selectors'
-import { defaultActionOptions } from './types'
 
 export function fillString(option: HandlerOption<StringFieldSchema>): void {
-  const { fieldKey, value, actionOptions = defaultActionOptions } = option
+  const { fieldKey, value } = option
 
   const selector = selectors.field(fieldKey)
 
   cy.get(selector).then(($el) => {
-    if (actionOptions.clear !== false) {
-      cy.wrap($el).clear(actionOptions.clear)
-    }
+    cy.wrap($el).clear()
     if (value !== undefined && value !== null && value !== '') {
-      cy.wrap($el).type(String(value), actionOptions.type)
+      cy.wrap($el).type(String(value))
     }
   })
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/string.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/string.ts
@@ -1,5 +1,5 @@
 import type { StringFieldSchema } from '../../../../../types/plugins/form-schema'
-import type { HandlerOption } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillString(option: HandlerOption<StringFieldSchema>): void {
@@ -8,9 +8,9 @@ export function fillString(option: HandlerOption<StringFieldSchema>): void {
   const selector = selectors.field(fieldKey)
 
   cy.get(selector).then(($el) => {
-    cy.wrap($el).clear()
+    cy.wrap($el).clear(SCROLL_BEHAVIOR)
     if (value !== undefined && value !== null && value !== '') {
-      cy.wrap($el).type(String(value))
+      cy.wrap($el).type(String(value), SCROLL_BEHAVIOR)
     }
   })
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/string.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/string.ts
@@ -1,11 +1,13 @@
 import type { StringFieldSchema } from '../../../../../types/plugins/form-schema'
-import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR, scrollIntoViewNative } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillString(option: HandlerOption<StringFieldSchema>): void {
   const { fieldKey, value } = option
 
   const selector = selectors.field(fieldKey)
+
+  scrollIntoViewNative(selector)
 
   cy.get(selector).then(($el) => {
     cy.wrap($el).clear(SCROLL_BEHAVIOR)

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/tag.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/tag.ts
@@ -1,5 +1,5 @@
 import type { SetFieldSchema } from '../../../../../types/plugins/form-schema'
-import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR, scrollIntoViewNative } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillTag(option: HandlerOption<SetFieldSchema>): void {
@@ -8,5 +8,6 @@ export function fillTag(option: HandlerOption<SetFieldSchema>): void {
   const values = Array.isArray(value) ? value : [value]
   const selector = selectors.tagInput(fieldKey)
 
+  scrollIntoViewNative(selector)
   cy.get(selector).type(values.join(','), SCROLL_BEHAVIOR)
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/tag.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/tag.ts
@@ -1,13 +1,12 @@
 import type { SetFieldSchema } from '../../../../../types/plugins/form-schema'
 import type { HandlerOption } from './types'
 import { selectors } from '../../shared/selectors'
-import { defaultActionOptions } from './types'
 
 export function fillTag(option: HandlerOption<SetFieldSchema>): void {
-  const { fieldKey, value, actionOptions = defaultActionOptions } = option
+  const { fieldKey, value } = option
 
   const values = Array.isArray(value) ? value : [value]
   const selector = selectors.tagInput(fieldKey)
 
-  cy.get(selector).type(values.join(','), actionOptions.type)
+  cy.get(selector).type(values.join(','))
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/tag.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/tag.ts
@@ -1,5 +1,5 @@
 import type { SetFieldSchema } from '../../../../../types/plugins/form-schema'
-import type { HandlerOption } from './types'
+import { type HandlerOption, SCROLL_BEHAVIOR } from './types'
 import { selectors } from '../../shared/selectors'
 
 export function fillTag(option: HandlerOption<SetFieldSchema>): void {
@@ -8,5 +8,5 @@ export function fillTag(option: HandlerOption<SetFieldSchema>): void {
   const values = Array.isArray(value) ? value : [value]
   const selector = selectors.tagInput(fieldKey)
 
-  cy.get(selector).type(values.join(','))
+  cy.get(selector).type(values.join(','), SCROLL_BEHAVIOR)
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/types.ts
@@ -4,8 +4,27 @@ import type { UnionFieldSchema } from '../../../../../types/plugins/form-schema'
 // the viewport top, which lands it directly behind any sticky/fixed header
 // (e.g. ArrayField's sticky-tabs). Scrolling to center instead avoids that
 // collision without skipping any actionability check - unlike `force`, an
-// element that's genuinely hidden still correctly fails.
+// element that's genuinely hidden still correctly fails. Unlike the one-shot
+// `scrollIntoViewNative` below, this re-applies on every actionability retry
+// inside a single `.type()`/`.click()` call, so it still catches the target
+// if late layout settling (e.g. a tab's content still mounting) moves it
+// after the initial scroll.
 export const SCROLL_BEHAVIOR = { scrollBehavior: 'center' } as const
+
+// Host apps can embed the form inside their own fixed-position, internally
+// scrolling containers (e.g. a slideout panel). Cypress's built-in
+// scrollable-ancestor detection (which `scrollBehavior` relies on) can fail
+// to find the right container in that layout, leaving the target
+// permanently out of view no matter what `scrollBehavior` is set. The
+// native `Element.scrollIntoView()` walks the real scroll-container chain
+// per spec regardless of `position: fixed`, so use it as a first pass
+// before the Cypress action runs. This only runs once though - keep
+// SCROLL_BEHAVIOR too for the retry-loop coverage it provides.
+export function scrollIntoViewNative(selector: string): void {
+  cy.get(selector).then(($el) => {
+    $el[0]?.scrollIntoView({ block: 'center', inline: 'nearest' })
+  })
+}
 
 export type HandlerOption<T extends UnionFieldSchema = UnionFieldSchema> = {
   fieldKey: string

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/types.ts
@@ -1,34 +1,19 @@
 import type { UnionFieldSchema } from '../../../../../types/plugins/form-schema'
 
-export interface ActionOptions {
-  type?: Partial<Cypress.TypeOptions>
-  click?: Partial<Cypress.ClickOptions>
-  check?: Partial<Cypress.CheckOptions>
-  clear?: Partial<Cypress.ClearOptions> | false
-}
-
-export const defaultActionOptions: ActionOptions = {
-  type: { force: true },
-  click: { force: true },
-  check: { force: true },
-  clear: { force: true },
-}
-
 export type HandlerOption<T extends UnionFieldSchema = UnionFieldSchema> = {
   fieldKey: string
   fieldSchema: T
   value: any
-  actionOptions?: ActionOptions
 }
 
-export type RecordHandlerOption = Omit<HandlerOption, 'actionOptions'> & {
+export type RecordHandlerOption = HandlerOption & {
   onFillChildren: () => void
 }
 
-export type ArrayHandlerOption = Omit<HandlerOption, 'actionOptions'> & {
+export type ArrayHandlerOption = HandlerOption & {
   onFillItem: (index: number, itemValue: any) => void
 }
 
-export type MapHandlerOption = Omit<HandlerOption, 'actionOptions'> & {
+export type MapHandlerOption = HandlerOption & {
   onFillEntry: (kidId: string, entryValue: any) => void
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/types.ts
@@ -1,5 +1,12 @@
 import type { UnionFieldSchema } from '../../../../../types/plugins/form-schema'
 
+// Cypress's default scrollBehavior ('top') scrolls the target flush against
+// the viewport top, which lands it directly behind any sticky/fixed header
+// (e.g. ArrayField's sticky-tabs). Scrolling to center instead avoids that
+// collision without skipping any actionability check - unlike `force`, an
+// element that's genuinely hidden still correctly fails.
+export const SCROLL_BEHAVIOR = { scrollBehavior: 'center' } as const
+
 export type HandlerOption<T extends UnionFieldSchema = UnionFieldSchema> = {
   fieldKey: string
   fieldSchema: T

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/create-filler.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/create-filler.ts
@@ -24,13 +24,9 @@ import {
   type RecordFieldSchema,
 } from '../shared/field-walker'
 
-export interface TypeOptions {
-  delay?: number
-}
-
 export interface FillerInstance {
   fill: (data: Record<string, any>) => Promise<void>
-  fillField: (fieldKey: string, value: any, typeOptions?: TypeOptions) => Promise<void>
+  fillField: (fieldKey: string, value: any) => Promise<void>
   schemaMap: Record<string, UnionFieldSchema>
   handlers: Handlers
 }
@@ -49,22 +45,22 @@ export function createFiller(
     }
   }
 
-  async function fillFieldByInfo({ handlerType, fieldKey, fieldSchema, value }: FieldToFill, typeOptions?: TypeOptions): Promise<void> {
+  async function fillFieldByInfo({ handlerType, fieldKey, fieldSchema, value }: FieldToFill): Promise<void> {
     switch (handlerType) {
       case 'string':
-        await mergedHandlers.fillString({ page, fieldKey, fieldSchema: fieldSchema as StringFieldSchema, value, typeOptions })
+        await mergedHandlers.fillString({ page, fieldKey, fieldSchema: fieldSchema as StringFieldSchema, value })
         break
       case 'number':
-        await mergedHandlers.fillNumber({ page, fieldKey, fieldSchema: fieldSchema as NumberLikeFieldSchema, value, typeOptions })
+        await mergedHandlers.fillNumber({ page, fieldKey, fieldSchema: fieldSchema as NumberLikeFieldSchema, value })
         break
       case 'boolean':
-        await mergedHandlers.fillBoolean({ page, fieldKey, fieldSchema: fieldSchema as BooleanFieldSchema, value, typeOptions })
+        await mergedHandlers.fillBoolean({ page, fieldKey, fieldSchema: fieldSchema as BooleanFieldSchema, value })
         break
       case 'enum':
-        await mergedHandlers.fillEnum({ page, fieldKey, fieldSchema: fieldSchema as StringFieldSchema | NumberLikeFieldSchema | SetFieldSchema, value, typeOptions })
+        await mergedHandlers.fillEnum({ page, fieldKey, fieldSchema: fieldSchema as StringFieldSchema | NumberLikeFieldSchema | SetFieldSchema, value })
         break
       case 'tag':
-        await mergedHandlers.fillTag({ page, fieldKey, fieldSchema: fieldSchema as SetFieldSchema, value, typeOptions })
+        await mergedHandlers.fillTag({ page, fieldKey, fieldSchema: fieldSchema as SetFieldSchema, value })
         break
       case 'map':
         await mergedHandlers.fillMap({
@@ -78,10 +74,10 @@ export function createFiller(
         })
         break
       case 'json':
-        await mergedHandlers.fillJson({ page, fieldKey, fieldSchema: fieldSchema as JsonFieldSchema, value, typeOptions })
+        await mergedHandlers.fillJson({ page, fieldKey, fieldSchema: fieldSchema as JsonFieldSchema, value })
         break
       case 'foreign':
-        await mergedHandlers.fillForeign({ page, fieldKey, fieldSchema: fieldSchema as ForeignFieldSchema, value, typeOptions })
+        await mergedHandlers.fillForeign({ page, fieldKey, fieldSchema: fieldSchema as ForeignFieldSchema, value })
         break
       case 'array':
         await mergedHandlers.fillArray({
@@ -140,7 +136,7 @@ export function createFiller(
     }
   }
 
-  async function fillField(fieldKey: string, value: any, typeOptions?: TypeOptions): Promise<void> {
+  async function fillField(fieldKey: string, value: any): Promise<void> {
     const fieldSchema = ctx.schemaMap[fieldKey]
     if (!fieldSchema) {
       throw new Error(`Field schema for "${fieldKey}" not found in schema map`)
@@ -151,7 +147,7 @@ export function createFiller(
       fieldKey,
       fieldSchema,
       value,
-    }, typeOptions)
+    })
   }
 
   return {

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
@@ -366,8 +366,10 @@ test.describe('Filler - Playwright', () => {
     })
 
     test('array: add-item button click succeeds even when sticky tabs cover the button', async ({ mount, page }) => {
-      // scrollIntoViewIfNeeded + force:true lets the click through even when
-      // a sticky header overlaps the button center.
+      // Playwright's own actionability scroll (unlike Cypress's default
+      // scroll-to-top) scrolls the minimum distance needed and re-checks
+      // that the click point isn't obstructed, so no explicit scroll/force
+      // is needed here.
       const schema: FormSchema = {
         type: 'record',
         fields: [

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/array.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/array.ts
@@ -30,11 +30,9 @@ export async function fillArray(option: ArrayHandlerOption): Promise<void> {
 
     // Add items and fill each one
     for (let i = 0; i < value.length; i++) {
-      // Click add button to add more items; scrollIntoView + force:true prevents
-      // sticky-tabs headers from blocking the click.
+      // Click add button to add more items.
       const addBtnSelector = selectors.arrayAddBtn(fieldKey)
-      await page.locator(addBtnSelector).scrollIntoViewIfNeeded()
-      await page.locator(addBtnSelector).click({ force: true })
+      await page.locator(addBtnSelector).click()
 
       await onFillItem(i, value[i])
     }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/boolean.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/boolean.ts
@@ -9,8 +9,8 @@ export async function fillBoolean(option: HandlerOption<BooleanFieldSchema>): Pr
   const element = page.locator(selector)
 
   if (value === true) {
-    await element.check({ force: true })
+    await element.check()
   } else if (value === false) {
-    await element.uncheck({ force: true })
+    await element.uncheck()
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
@@ -15,7 +15,7 @@ export async function fillRecord(option: RecordHandlerOption): Promise<void> {
       .locator(objectSwitchSelector)
       .locator('..')
       .locator('[data-testid="switch-control"]')
-      .click({ force: true })
+      .click()
     return
   }
 
@@ -25,7 +25,7 @@ export async function fillRecord(option: RecordHandlerOption): Promise<void> {
       .locator(objectSwitchSelector)
       .locator('..')
       .locator('[data-testid="switch-control"]')
-      .click({ force: true })
+      .click()
 
     // Enabling the switch expands the object's content via SlideTransition
     // (height animates from 0). Filling children immediately can hit them

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
@@ -26,10 +26,14 @@ export async function fillRecord(option: RecordHandlerOption): Promise<void> {
       .locator('..')
       .locator('[data-testid="switch-control"]')
       .click({ force: true })
-  }
 
-  // eslint-disable-next-line promise/param-names
-  await new Promise(r => setTimeout(r, 300)) // wait for animation
+    // Enabling the switch expands the object's content via SlideTransition
+    // (height animates from 0). Filling children immediately can hit them
+    // mid-transition, when the content container still has height 0.
+    // Wait for it to actually become visible instead of a blind fixed
+    // delay, which can still race under CI load.
+    await page.locator(selectors.objectContent(fieldKey)).waitFor({ state: 'visible' })
+  }
 
   // Fill children fields
   await onFillChildren()

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/types.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/types.ts
@@ -6,17 +6,16 @@ export type HandlerOption<T extends UnionFieldSchema = UnionFieldSchema> = {
   fieldKey: string
   fieldSchema: T
   value: any
-  typeOptions?: { delay?: number }
 }
 
-export type RecordHandlerOption = Omit<HandlerOption, 'typeOptions'> & {
+export type RecordHandlerOption = HandlerOption & {
   onFillChildren: () => Promise<void>
 }
 
-export type ArrayHandlerOption = Omit<HandlerOption, 'typeOptions'> & {
+export type ArrayHandlerOption = HandlerOption & {
   onFillItem: (index: number, itemValue: any) => Promise<void>
 }
 
-export type MapHandlerOption = Omit<HandlerOption, 'typeOptions'> & {
+export type MapHandlerOption = HandlerOption & {
   onFillEntry: (kidId: string, entryValue: any) => Promise<void>
 }


### PR DESCRIPTION
## Summary

The Cypress/Playwright freeform filler used to work around actionability failures by defaulting every field action to `force: true`. That masked real bugs instead of fixing them and made the filler unreliable in real host apps (e.g. gateway-manager), where several distinct issues surfaced once force was removed:

- Cypress's default `scrollBehavior: 'top'` scrolls a target flush against the viewport top, landing it behind sticky/fixed headers (e.g. an array rendered with `appearance="tabs"` + `sticky-tabs`, or a host app's own fixed chrome). Fixed by scrolling to viewport center instead (`SCROLL_BEHAVIOR`), plus a native `Element.scrollIntoView()` pass (`scrollIntoViewNative`) for layouts where Cypress's own scrollable-ancestor detection doesn't find the right container. Both are needed together: the native scroll is one-shot and can be overtaken by late layout settling, while `scrollBehavior` keeps re-applying on every actionability retry.
- A collapsible optional object's `SlideTransition` enter animation could still be in progress when a child field was filled immediately after toggling the parent switch. Fixed by waiting for the animation's own CSS class to clear, instead of a generic `be.visible` check (which also - incorrectly - demands the element be currently scrolled into view).
- A tab-appearance array (`KTabs`) only renders the active tab's content via `v-if`; filling a newly-added item's fields could race the tab switch. Fixed by asserting the item exists in the DOM before filling it.
- Removed remaining `force: true` usages (Cypress `map.ts`, Playwright `boolean.ts`/`record.ts`/`array.ts`) that turned out to be masking the same scroll/timing issues rather than addressing anything actually hidden. Kept the one `force: true` that's genuinely required (Cypress `record.ts`'s object-enable switch, whose native checkbox is `display: none` by design).

## Test plan

- [x] `vue-tsc --noEmit` passes
- [x] Full Cypress component suite for the filler (`fill-form.cy.ts`, 37 tests) passes
- [x] Full Playwright component suite for the filler (`fill-form.pw.ts`, 34 tests) passes
- [x] Verified against real failing gateway-manager e2e runs (not just synthetic repros) for the scroll/animation issues
- [x] Reviewed via an independent pass focused on: revert cleanliness, cross-handler consistency, dead code, and whether new tests actually exercise the bugs they claim to