### PR TITLE
fix: prune tile filters by query fields

### DIFF
--- a/packages/analytics/analytics-config-store/src/stores/datasource-config.ts
+++ b/packages/analytics/analytics-config-store/src/stores/datasource-config.ts
@@ -112,29 +112,34 @@ export const useDatasourceConfigStore = defineStore('datasource-config', () => {
     return ({
       datasource,
       filters,
+      queryFields = undefined,
       metrics = undefined,
     }: {
       datasource: string
       filters: AllFilters[]
+      queryFields?: readonly string[]
+      /** @deprecated Use queryFields instead. */
       metrics?: readonly string[]
     }): AllFilters[] => {
       const filtered = filters.filter(filter => isFilterValidForDatasource.value({ datasource, filter }))
+      const fields = queryFields ?? metrics
 
-      if (!metrics?.length) {
+      if (!fields?.length) {
         return filtered
       }
 
-      // If metrics are provided, further filter the dimensions based on which dimensions are supported by the metric
+      // If query fields are provided, further filter dimensions based on which dimensions they support.
+      // `metrics` is the deprecated name for the same query field restriction.
       const datasourceConfigEntry = datasourceConfigMap.value[datasource]
       if (!datasourceConfigEntry) {
         return filtered
       }
 
-      const metricFields = metrics
-        .map(metric => datasourceConfigEntry.fieldsMap[metric])
+      const configuredFields = fields
+        .map(field => datasourceConfigEntry.fieldsMap[field])
         .filter((field) => field !== undefined)
 
-      const fieldsWithSupportedDimensions = metricFields.filter((field) => {
+      const fieldsWithSupportedDimensions = configuredFields.filter((field) => {
         return field.supportedDimensions !== undefined
       })
 

--- a/packages/analytics/analytics-config-store/src/stores/tests/datasource-config.spec.ts
+++ b/packages/analytics/analytics-config-store/src/stores/tests/datasource-config.spec.ts
@@ -430,5 +430,18 @@ describe('useDatasourceConfigStore', () => {
         metrics: ['request_size', 'consumer_count'],
       })).toEqual([])
     })
+
+    it('strips unsupported filters for query fields', async () => {
+      const store = useStore()
+      await store.isReady()
+
+      const filters = ['status_code', 'gateway_service', 'route'].map(makeFilter)
+
+      expect(store.stripUnknownFilters({
+        datasource: 'api_usage',
+        filters,
+        queryFields: ['error_rate'],
+      })).toEqual([makeFilter('status_code'), makeFilter('route')])
+    })
   })
 })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -469,7 +469,7 @@ const datasourceScopedFilters = computed(() => {
   return stripUnknownFilters.value({
     datasource,
     filters,
-    metrics,
+    queryFields: metrics,
   })
 })
 

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
@@ -214,7 +214,7 @@ describe('useContextLinks', () => {
     expect(params.get('c')).toBe('line')
   })
 
-  it('forwards metrics to filter stripping when generating dashboard links', async () => {
+  it('forwards query fields to filter stripping when generating dashboard links', async () => {
     const stripUnknownFiltersSpy = vi.fn(mockStripUnknownFilters)
     vi.mocked(useDatasourceConfigStore).mockReturnValueOnce({
       stripUnknownFilters: ref(stripUnknownFiltersSpy),
@@ -231,7 +231,7 @@ describe('useContextLinks', () => {
 
     expect(stripUnknownFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({
       datasource: 'api_usage',
-      metrics: ['request_count', 'request_size'],
+      queryFields: ['request_count', 'request_size'],
     }))
   })
 

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -84,7 +84,7 @@ export default function useContextLinks(
     return stripUnknownFilters.value({
       datasource,
       filters,
-      metrics,
+      queryFields: metrics,
     })
   })
 

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
@@ -135,6 +135,7 @@ describe('useIssueQuery', () => {
     expect(mockStripUnknownFilters).toHaveBeenCalledWith(expect.objectContaining({
       datasource: 'basic',
       filters: [invalidQueryFilter, validContextFilter],
+      queryFields: [],
     }))
     expect(queryFn).toHaveBeenCalledOnce()
     expect(queryFn.mock.calls[0][0]).toMatchObject({

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
@@ -42,7 +42,7 @@ export default function useIssueQuery() {
         ...(query.filters ?? []) as AllFilters[],
         ...context.filters,
       ],
-      metrics: query.metrics,
+      queryFields: query.metrics,
     })
 
     // TODO: the cast is necessary because TimeRangeV4 specifies date objects for absolute time ranges.

--- a/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.spec.ts
@@ -132,6 +132,7 @@ describe('table data grid renderer utilities', () => {
           value: ['service-1'],
         },
       ],
+      queryFields: ['route'],
     })
     expect(tabularQueryFn).toHaveBeenCalledWith({
       datasource: 'platform',

--- a/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.ts
@@ -122,6 +122,7 @@ export const tableDataGridFetcherByDatasource = {
         ...((platformQuery.filters ?? []) as AllFilters[]),
         ...context.filters,
       ],
+      queryFields: platformQuery.entity === undefined ? undefined : [platformQuery.entity],
     }) as PlatformTabularQuery['filters']
 
     const response = await tabularQueryFn({


### PR DESCRIPTION
## Summary

Closes [MA-5180](https://konghq.atlassian.net/browse/MA-5180)

- Add `queryFields` as the preferred `stripUnknownFilters` option while keeping `metrics` as a deprecated alias.
- Pass platform table tile `entity` as the query field when pruning table request filters.
- Update dashboard-renderer call sites to pass selected metric fields through `queryFields` instead of the deprecated `metrics` option.

## Why

`metrics` was too narrow as an option name. Filter availability is not affected only by selected metric fields; any datasource field with `supportedDimensions` can constrain which filters are valid. Table tiles expose that through `entity`, so a platform table query for `control_plane` should prune dashboard/context filters against the `control_plane` field's supported dimensions and drop unsupported filters such as `consumer`.

Keeping `metrics` as a deprecated alias preserves existing callers while making the new contract clearer for both metric-backed charts and entity-backed table queries.


[MA-5180]: https://konghq.atlassian.net/browse/MA-5180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ