### PR TITLE
fix(entities-plugins): remove workspace from Konnect custom plugin endpoints

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginCatalog.vue
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.vue
@@ -292,7 +292,7 @@ const streamingPluginsUrl = computed<string | null>(() => {
     let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].streamingCustomPlugins}`
 
     if (props.config.app === 'konnect') {
-      url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+      return url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
     }
 
     return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
@@ -306,7 +306,7 @@ const clonedPluginsUrl = computed<string | null>(() => {
     let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].clonedPlugins}`
 
     if (props.config.app === 'konnect') {
-      url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+      return url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
     }
 
     return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')

--- a/packages/entities/entities-plugins/src/components/PluginSelect.vue
+++ b/packages/entities/entities-plugins/src/components/PluginSelect.vue
@@ -545,7 +545,7 @@ const streamingPluginsUrl = computed<string | null>(() => {
     let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].streamingCustomPlugins}`
 
     if (props.config.app === 'konnect') {
-      url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+      return url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
     }
 
     return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
@@ -559,7 +559,7 @@ const clonedPluginsUrl = computed<string | null>(() => {
     let url = `${props.config.apiBaseUrl}${endpoints.select[props.config.app].clonedPlugins}`
 
     if (props.config.app === 'konnect') {
-      url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
+      return url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
     }
 
     return url.replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')

--- a/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
+++ b/packages/entities/entities-plugins/src/components/custom-plugins/DeleteCustomPluginSchemaModal.vue
@@ -105,7 +105,6 @@ const requestUrl = computed(() => {
 
     return `${props.config.apiBaseUrl}${partialPluginURL}`
       .replace(/{controlPlaneId}/gi, props.config.controlPlaneId || '')
-      .replace(/\/{workspace}/gi, props.config.workspace ? `/${props.config.workspace}` : '')
       .replace(/{pluginId}/gi, props.plugin.id)
   }
 

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -1,5 +1,6 @@
 const konnectV1BaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/v1'
 const konnectBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities/{workspace}'
+const konnectNoWorkspaceBaseApiUrl = '/v2/control-planes/{controlPlaneId}/core-entities'
 const KMBaseApiUrl = '/{workspace}'
 
 export default {
@@ -16,10 +17,10 @@ export default {
   select: {
     konnect: {
       availablePlugins: `${konnectV1BaseApiUrl}/available-plugins`,
-      streamingCustomPlugins: `${konnectBaseApiUrl}/custom-plugins`,
-      clonedPlugins: `${konnectBaseApiUrl}/cloned-plugins`,
-      schemaCustomPluginItem: `${konnectBaseApiUrl}/plugin-schemas/{pluginId}`,
-      streamingCustomPluginItem: `${konnectBaseApiUrl}/custom-plugins/{pluginId}`,
+      streamingCustomPlugins: `${konnectNoWorkspaceBaseApiUrl}/custom-plugins`,
+      clonedPlugins: `${konnectNoWorkspaceBaseApiUrl}/cloned-plugins`,
+      schemaCustomPluginItem: `${konnectNoWorkspaceBaseApiUrl}/plugin-schemas/{pluginId}`,
+      streamingCustomPluginItem: `${konnectNoWorkspaceBaseApiUrl}/custom-plugins/{pluginId}`,
     },
     kongManager: {
       availablePlugins: `${KMBaseApiUrl}/kong`,
@@ -72,16 +73,16 @@ export default {
   customPlugin: {
     konnect: {
       installed: {
-        create: `${konnectBaseApiUrl}/plugin-schemas`,
-        edit: `${konnectBaseApiUrl}/plugin-schemas/{pluginId}`,
+        create: `${konnectNoWorkspaceBaseApiUrl}/plugin-schemas`,
+        edit: `${konnectNoWorkspaceBaseApiUrl}/plugin-schemas/{pluginId}`,
       },
       streamed: {
-        create: `${konnectBaseApiUrl}/custom-plugins`,
-        edit: `${konnectBaseApiUrl}/custom-plugins/{pluginId}`,
+        create: `${konnectNoWorkspaceBaseApiUrl}/custom-plugins`,
+        edit: `${konnectNoWorkspaceBaseApiUrl}/custom-plugins/{pluginId}`,
       },
       cloned: {
-        create: `${konnectBaseApiUrl}/cloned-plugins`,
-        edit: `${konnectBaseApiUrl}/cloned-plugins/{pluginId}`,
+        create: `${konnectNoWorkspaceBaseApiUrl}/cloned-plugins`,
+        edit: `${konnectNoWorkspaceBaseApiUrl}/cloned-plugins/{pluginId}`,
       },
     },
     kongManager: {


### PR DESCRIPTION
## Summary

- Konnect does not support workspace for custom plugin APIs (installed, streamed, cloned)
- Added `konnectNoWorkspaceBaseApiUrl` constant in `plugins-endpoints.ts` and switched all Konnect custom plugin endpoint templates to use it
- Updated `streamingPluginsUrl` and `clonedPluginsUrl` computed in `PluginSelect` and `PluginCatalog` to return early for Konnect (skipping workspace substitution)
- Removed workspace substitution from the Konnect branch of `DeleteCustomPluginSchemaModal`

## Test plan

- [x] Verify installed/streamed/cloned plugin CRUD in Konnect hits `/v2/control-planes/{cpId}/core-entities/{resource}` (no workspace segment)
- [x] Verify Kong Manager custom plugin flows are unaffected (still uses `/{workspace}/...`)
- [x] Existing Cypress tests in `CustomPluginForm.cy.ts`, `PluginForm.cy.ts`, and `PluginCatalog.cy.ts` already assert workspace-free URLs for Konnect — confirm they pass