### PR TITLE
 fix(analytics): ensure old data is shown when query is aborted [MA-5146]

### DIFF
--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -46,6 +46,9 @@
       "message": "Data request timed out",
       "details": "We're sorry, the request timed out. Please consider using a shorter time period or try again later."
     },
+    "canceled": {
+      "message": "Request canceled"
+    },
     "other": {
       "message": "Bad request"
     }

--- a/packages/analytics/analytics-chart/src/types/query-error.ts
+++ b/packages/analytics/analytics-chart/src/types/query-error.ts
@@ -1,6 +1,6 @@
 export interface QueryError {
-  status: number
-  type: 'forbidden' | 'timeout' | 'range_exceeded' | 'other'
+  status?: number
+  type: 'forbidden' | 'timeout' | 'range_exceeded' | 'canceled' | 'other'
   message: string
   details?: string
 }

--- a/packages/analytics/analytics-chart/src/utils/queryError.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/queryError.spec.ts
@@ -1,8 +1,41 @@
 import { describe, it, expect } from 'vitest'
 
-import { handleQueryError } from './queryError'
+import { handleQueryError, isCancellationError } from './queryError'
+
+describe('isCancellationError', () => {
+  it('detects axios cancellations', () => {
+    expect(isCancellationError({ code: 'ERR_CANCELED', name: 'CanceledError' })).toBe(true)
+    expect(isCancellationError({ code: 'ERR_CANCELED' })).toBe(true)
+  })
+
+  it('detects fetch aborts', () => {
+    expect(isCancellationError(new DOMException('The user aborted a request.', 'AbortError'))).toBe(true)
+  })
+
+  it('rejects other errors', () => {
+    expect(isCancellationError(new Error('boom'))).toBe(false)
+    expect(isCancellationError({ status: 403 })).toBe(false)
+    expect(isCancellationError(undefined)).toBe(false)
+  })
+})
 
 describe('handleQueryError', () => {
+  it('axios cancellation to canceled', () => {
+    const res = handleQueryError({ code: 'ERR_CANCELED', name: 'CanceledError', message: 'canceled' })
+
+    expect(res.type).toBe('canceled')
+    expect(res.message).toBe('Request canceled')
+    expect(res.status).toBeUndefined()
+    expect(res.details).toBeUndefined()
+  })
+
+  it('abort to canceled', () => {
+    const res = handleQueryError(new DOMException('The user aborted a request.', 'AbortError'))
+
+    expect(res.type).toBe('canceled')
+    expect(res.message).toBe('Request canceled')
+  })
+
   it('403 to forbidden', () => {
     const res = handleQueryError({ status: 403 })
 

--- a/packages/analytics/analytics-chart/src/utils/queryError.ts
+++ b/packages/analytics/analytics-chart/src/utils/queryError.ts
@@ -2,8 +2,19 @@ import type { QueryError } from '../types'
 
 import composables from '../composables'
 
+export const isCancellationError = (error: any): boolean => {
+  return error?.code === 'ERR_CANCELED' || error?.name === 'CanceledError' || error?.name === 'AbortError'
+}
+
 export const handleQueryError = (error: any): QueryError => {
   const { i18n } = composables.useI18n()
+
+  if (isCancellationError(error)) {
+    return {
+      type: 'canceled',
+      message: i18n.t('query_errors.canceled.message'),
+    }
+  }
 
   if (error?.status === 403) {
     return {
@@ -12,7 +23,7 @@ export const handleQueryError = (error: any): QueryError => {
       message: i18n.t('query_errors.forbidden.message'),
       details: i18n.t('query_errors.forbidden.details'),
     }
-  } else if (error?.status === 408) {
+  } else if (error?.status === 408 || error?.message?.includes('timeout')) {
     return {
       status: error.status,
       type: 'timeout',

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -161,6 +161,7 @@
         v-bind="componentData.rendererProps"
         v-on="componentEventHandlers"
         @chart-data="onChartData"
+        @query-complete="onQueryComplete"
       />
     </div>
   </div>
@@ -489,6 +490,10 @@ const onChartData = (data: ExploreResultV4) => {
   chartData.value = data
   loadingChartData.value = false
   emit('chart-data', data)
+}
+
+const onQueryComplete = () => {
+  loadingChartData.value = false
 }
 
 const onLoadingChange = (isLoading: boolean) => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTilePreview.cy.ts
@@ -59,6 +59,7 @@ describe('<DashboardTilePreview />', () => {
         provide: {
           [INJECT_QUERY_PROVIDER]: {
             configFn: () => Promise.resolve(),
+            datasourceConfigFn: () => Promise.resolve([]),
           },
         },
         stubs: {
@@ -286,6 +287,7 @@ describe('<DashboardTilePreview />', () => {
         provide: {
           [INJECT_QUERY_PROVIDER]: {
             configFn: () => Promise.resolve(),
+            datasourceConfigFn: () => Promise.resolve([]),
           },
         },
         stubs: {
@@ -358,6 +360,7 @@ describe('<DashboardTilePreview />', () => {
         provide: {
           [INJECT_QUERY_PROVIDER]: {
             configFn: () => Promise.resolve(),
+            datasourceConfigFn: () => Promise.resolve([]),
           },
         },
         stubs: {

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.spec.ts
@@ -181,6 +181,23 @@ describe('QueryDataProvider', () => {
     expect(wrapper.findTestId('chart-skeleton').exists()).toBe(false)
   })
 
+  it('shows the skeleton instead of previous data when the query is not ready', async () => {
+    const result = { data: [{ timestamp: 'now' }], meta: {} }
+    const wrapper = mountProvider()
+
+    setSwrvState({ data: result })
+    await flushPromises()
+
+    expect(wrapper.findTestId('slot-content').exists()).toBe(true)
+
+    setSwrvState({ data: undefined, isValidating: true })
+    await wrapper.setProps({ queryReady: false })
+    await flushPromises()
+
+    expect(wrapper.findTestId('slot-content').exists()).toBe(false)
+    expect(wrapper.findTestId('chart-skeleton').exists()).toBe(true)
+  })
+
   it('shows a settled error for the current query even when previous data exists', async () => {
     const result = { data: [{ timestamp: 'now' }], meta: {} }
     const wrapper = mountProvider({ queryFn: vi.fn().mockRejectedValue({ status: 403 }) })

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.spec.ts
@@ -10,6 +10,8 @@ const swrvData = ref<any>(undefined)
 const swrvError = ref<any>(null)
 const swrvIsValidating = ref(false)
 
+let mockedFetcher: (() => Promise<any>) | undefined
+
 function setSwrvState(opts: { data?: any, error?: any, isValidating?: boolean } = {}) {
   swrvData.value = opts.data
   swrvError.value = opts.error
@@ -21,22 +23,86 @@ function resetSwrvState() {
 }
 
 vi.mock('swrv', () => ({
-  default: () => ({
-    data: swrvData,
-    error: swrvError,
-    isValidating: swrvIsValidating,
-  }),
+  default: (_key: any, fetcher: any) => {
+    mockedFetcher = fetcher
+
+    return {
+      data: swrvData,
+      error: swrvError,
+      isValidating: swrvIsValidating,
+    }
+  },
 }))
 
 vi.mock('@kong-ui-public/analytics-config-store', () => ({
   useDatasourceConfigStore: vi.fn(),
 }))
 
+const defaultProps = {
+  context: {
+    filters: [],
+    timeSpec: { type: 'relative', time_range: '15m' },
+    editable: false,
+    tz: '',
+    refreshInterval: 0,
+    zoomable: false,
+  },
+  query: {
+    datasource: 'api_usage',
+    metrics: [],
+    filters: [],
+  },
+  queryReady: true,
+  refreshCounter: 0,
+} as any
+
+const mountProvider = (opts: { queryFn?: any } = {}) => mount(QueryDataProvider, {
+  props: defaultProps,
+  global: {
+    provide: {
+      [INJECT_QUERY_PROVIDER]: {
+        queryFn: opts.queryFn ?? vi.fn(),
+      },
+    },
+    stubs: {
+      KSkeleton: {
+        template: '<div data-testid="chart-skeleton" />',
+      },
+      KEmptyState: {
+        template: '<div data-testid="chart-empty-state"><slot name="title" /></div>',
+      },
+    },
+  },
+  slots: {
+    default: `
+      <template #default="{ data }">
+        <div data-testid="slot-content">{{ data.data[0].timestamp }}</div>
+      </template>
+    `,
+  },
+})
+
+const deferred = () => {
+  let resolveFn!: (v: any) => void
+  let rejectFn!: (e: any) => void
+
+  const promise = new Promise((resolve, reject) => {
+    resolveFn = resolve
+    rejectFn = reject
+  })
+
+  return { promise, resolve: resolveFn, reject: rejectFn }
+}
+
+const canceledError = { code: 'ERR_CANCELED', name: 'CanceledError', message: 'canceled' }
+
 describe('QueryDataProvider', () => {
   beforeEach(() => {
     resetSwrvState()
+    mockedFetcher = undefined
     vi.mocked(useDatasourceConfigStore).mockReturnValue({
-      stripUnknownFilters: ({ filters }: { filters: any[] }) => filters,
+      isReady: vi.fn().mockResolvedValue(undefined),
+      stripUnknownFilters: ref(({ filters }: { filters: any[] }) => filters),
     } as any)
   })
 
@@ -44,42 +110,92 @@ describe('QueryDataProvider', () => {
     // Simulates swrv entering ERROR without the fetcher throwing
     setSwrvState({ error: new Error('swrv internal error') })
 
-    const wrapper = mount(QueryDataProvider, {
-      props: {
-        context: {
-          filters: [],
-          timeSpec: { type: 'relative', time_range: '15m' },
-          editable: false,
-          tz: '',
-          refreshInterval: 0,
-          zoomable: false,
-        },
-        query: {
-          datasource: 'api_usage',
-          metrics: [],
-          filters: [],
-        },
-        queryReady: true,
-        refreshCounter: 0,
-      },
-      global: {
-        provide: {
-          [INJECT_QUERY_PROVIDER]: {
-            queryFn: vi.fn(),
-          },
-        },
-        stubs: {
-          KSkeleton: true,
-          KEmptyState: {
-            template: '<div data-testid="chart-empty-state"><slot name="title" /></div>',
-          },
-        },
-      },
-    })
+    const wrapper = mountProvider()
 
     await flushPromises()
 
     expect(wrapper.findTestId('chart-empty-state').exists()).toBe(true)
     expect(wrapper.text()).toContain('An unexpected error has occurred.')
+  })
+
+  it('drops rejections from superseded queries', async () => {
+    const request = deferred()
+    const wrapper = mountProvider({ queryFn: vi.fn().mockReturnValue(request.promise) })
+
+    const fetchPromise = mockedFetcher!()
+
+    // Change the query so the fetch's key no longer matches the current one.
+    await wrapper.setProps({ query: { ...defaultProps.query, dimensions: ['route'] } })
+
+    request.reject(canceledError)
+
+    // The stale rejection resolves to undefined instead of propagating.
+    await expect(fetchPromise).resolves.toBeUndefined()
+    await flushPromises()
+
+    expect(wrapper.findTestId('chart-empty-state').exists()).toBe(false)
+    expect(wrapper.findTestId('chart-skeleton').exists()).toBe(true)
+  })
+
+  it('discards results from superseded queries', async () => {
+    const request = deferred()
+    const wrapper = mountProvider({ queryFn: vi.fn().mockReturnValue(request.promise) })
+
+    const fetchPromise = mockedFetcher!()
+
+    await wrapper.setProps({ query: { ...defaultProps.query, dimensions: ['route'] } })
+
+    request.resolve({ data: [{ timestamp: 'stale' }], meta: {} })
+
+    await expect(fetchPromise).resolves.toBeUndefined()
+  })
+
+  it('shows "Request canceled" when the current query is canceled', async () => {
+    const wrapper = mountProvider({ queryFn: vi.fn().mockRejectedValue(canceledError) })
+
+    await expect(mockedFetcher!()).rejects.toEqual(canceledError)
+
+    setSwrvState({ error: canceledError })
+    await flushPromises()
+
+    expect(wrapper.findTestId('chart-empty-state').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Request canceled')
+  })
+
+  it('keeps showing previous data while a new query loads', async () => {
+    const result = { data: [{ timestamp: 'now' }], meta: {} }
+    const wrapper = mountProvider()
+
+    setSwrvState({ data: result })
+    await flushPromises()
+
+    expect(wrapper.findTestId('slot-content').exists()).toBe(true)
+    expect(wrapper.emitted('chart-data')).toBeTruthy()
+
+    // Simluate a new query but the previous data should be shown while loading
+    setSwrvState({ data: undefined, isValidating: true })
+    await flushPromises()
+
+    expect(wrapper.findTestId('slot-content').exists()).toBe(true)
+    expect(wrapper.findTestId('slot-content').text()).toContain('now')
+    expect(wrapper.findTestId('chart-skeleton').exists()).toBe(false)
+  })
+
+  it('shows a settled error for the current query even when previous data exists', async () => {
+    const result = { data: [{ timestamp: 'now' }], meta: {} }
+    const wrapper = mountProvider({ queryFn: vi.fn().mockRejectedValue({ status: 403 }) })
+
+    setSwrvState({ data: result })
+    await flushPromises()
+
+    expect(wrapper.findTestId('slot-content').exists()).toBe(true)
+
+    await expect(mockedFetcher!()).rejects.toEqual({ status: 403 })
+    setSwrvState({ data: undefined, error: { status: 403 } })
+    await flushPromises()
+
+    expect(wrapper.findTestId('chart-empty-state').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Data request forbidden')
+    expect(wrapper.findTestId('slot-content').exists()).toBe(false)
   })
 })

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
@@ -125,7 +125,9 @@ const hasError = computed(() => state.value === STATE.ERROR || !!queryError.valu
 const isLoading = computed(() => !props.queryReady || state.value === STATE.PENDING)
 
 const oldData = ref<ExploreResultV4 | undefined>()
-const displayData = computed(() => v4Data.value ?? oldData.value)
+const displayData = computed(() => {
+  return v4Data.value ?? (props.queryReady && state.value === STATE.PENDING ? oldData.value : undefined)
+})
 
 watch([() => v4Data.value, () => state.value], ([data, state]) => {
   if (data && (state === 'SUCCESS_HAS_DATA' || state === 'SUCCESS') && data !== oldData.value) {

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.vue
@@ -1,11 +1,11 @@
 <template>
   <KSkeleton
-    v-if="isLoading || (!v4Data && !hasError)"
+    v-if="(isLoading || (!v4Data && !hasError)) && !displayData"
     class="chart-skeleton"
     type="table"
   />
   <KEmptyState
-    v-else-if="hasError"
+    v-else-if="hasError && !isLoading"
     :action-button-visible="false"
     data-testid="chart-empty-state"
   >
@@ -25,8 +25,8 @@
   </KEmptyState>
 
   <slot
-    v-else-if="v4Data"
-    :data="v4Data"
+    v-else-if="displayData"
+    :data="displayData"
   />
 </template>
 <script setup lang="ts">
@@ -65,7 +65,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'chart-data', chartData: ExploreResultV4): void
-  (e: 'queryComplete'): void
+  (e: 'query-complete'): void
 }>()
 
 const { i18n } = composables.useI18n()
@@ -83,19 +83,34 @@ const queryKey = () => {
 }
 
 const { data: v4Data, error, isValidating } = useSWRV(queryKey, async () => {
+  const startKey = queryKey()
+
   try {
     const result = await issueQuery(props.query, props.context, props.limitOverride)
+
+    if (queryKey() !== startKey) {
+      // The original fetch has been superseded by a newer query
+      return undefined
+    }
+
     queryError.value = null
 
     return result
   } catch (e: any) {
+    if (queryKey() !== startKey) {
+      // This will avoid an empty error state when a query has been aborted
+      return undefined
+    }
+
     // Note: The error object will contain a response status property at the root when the analytics bridge
     // detects a 403 or 408 status code. This allows us to provide proper error messages for impacted tiles.
     queryError.value = handleQueryError(e)
 
     throw e
   } finally {
-    emit('queryComplete')
+    if (queryKey() === startKey) {
+      emit('query-complete')
+    }
   }
 }, {
   refreshInterval: props.context.refreshInterval,
@@ -109,8 +124,12 @@ const queryError = ref<QueryError | null>(null)
 const hasError = computed(() => state.value === STATE.ERROR || !!queryError.value)
 const isLoading = computed(() => !props.queryReady || state.value === STATE.PENDING)
 
+const oldData = ref<ExploreResultV4 | undefined>()
+const displayData = computed(() => v4Data.value ?? oldData.value)
+
 watch([() => v4Data.value, () => state.value], ([data, state]) => {
-  if (data && (state === 'SUCCESS_HAS_DATA' || state === 'SUCCESS')) {
+  if (data && (state === 'SUCCESS_HAS_DATA' || state === 'SUCCESS') && data !== oldData.value) {
+    oldData.value = data
     emit('chart-data', data)
   }
 })

--- a/packages/analytics/dashboard-renderer/src/composables/useDashboardInternalContext.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useDashboardInternalContext.spec.ts
@@ -32,13 +32,15 @@ import { getCurrentInstance, nextTick, ref, type App, type Ref } from 'vue'
 describe('useContextLinks', () => {
   let app: App | undefined
   let configFn: Mock
+  let datasourceConfigFn: Mock
 
   beforeEach(() => {
     vi.clearAllMocks()
     configFn = vi.fn(() => Promise.resolve({}))
+    datasourceConfigFn = vi.fn(() => Promise.resolve([]))
     app = setupPiniaTestStore({ createVueApp: true })
     if (app) {
-      app.provide(INJECT_QUERY_PROVIDER, { configFn })
+      app.provide(INJECT_QUERY_PROVIDER, { configFn, datasourceConfigFn })
     }
   })
 
@@ -93,6 +95,9 @@ describe('useContextLinks', () => {
 
       return Promise.resolve({})
     })
+    datasourceConfigFn.mockImplementation(() =>
+      isLoading ? new Promise(() => {}) : Promise.resolve([]),
+    )
 
     let internalContext: Ref<DashboardRendererContextInternal>
     let queryReady: Ref<boolean>

--- a/packages/analytics/dashboard-renderer/src/composables/useDashboardInternalContext.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useDashboardInternalContext.ts
@@ -4,12 +4,13 @@ import type {
   AllFilters,
   TimeRangeV4,
 } from '@kong-ui-public/analytics-utilities'
+import { storeToRefs } from 'pinia'
 import {
   DEFAULT_TILE_REFRESH_INTERVAL_MS,
   FULLSCREEN_LONG_REFRESH_INTERVAL_MS,
   FULLSCREEN_SHORT_REFRESH_INTERVAL_MS,
 } from '../constants'
-import { useAnalyticsConfigStore } from '@kong-ui-public/analytics-config-store'
+import { useAnalyticsConfigStore, useDatasourceConfigStore } from '@kong-ui-public/analytics-config-store'
 
 export default function useDashboardInternalContext({
   context,
@@ -26,6 +27,9 @@ export default function useDashboardInternalContext({
   queryReady: Readonly<Ref<boolean>>
 } {
   const configStore = useAnalyticsConfigStore()
+  const datasourceStore = useDatasourceConfigStore()
+  const { loading: configloading } = storeToRefs(configStore)
+  const { loading: datasourceLoading } = storeToRefs(datasourceStore)
 
   const timeSpec = computed<TimeRangeV4>(() => {
     if (context.value.timeSpec) {
@@ -111,7 +115,7 @@ export default function useDashboardInternalContext({
   })
 
   const queryReady = computed<boolean>(() => {
-    return !!context.value.timeSpec || !configStore.loading
+    return !!context.value.timeSpec || (!configloading.value && !datasourceLoading.value)
   })
 
   return {

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import useIssueQuery from './useIssueQuery'
 import { INJECT_QUERY_PROVIDER } from '../constants'
 import type { AllFilters, AnalyticsBridge } from '@kong-ui-public/analytics-utilities'
@@ -143,5 +143,36 @@ describe('useIssueQuery', () => {
         filters: [validContextFilter],
       },
     })
+  })
+
+  it('aborts the previous occurring query when a new one is issued', async () => {
+    const queryFn = vi.fn().mockReturnValue(new Promise(() => {}))
+    const wrapper = mountComposable({
+      queryFn,
+    } as any)
+
+    const query: any = { metrics: [], dimensions: [], filters: [] }
+    wrapper.vm.issueQuery(query, context)
+    wrapper.vm.issueQuery(query, context)
+    await flushPromises()
+
+    expect(queryFn).toHaveBeenCalledTimes(2)
+    expect((queryFn.mock.calls[0][1] as AbortController).signal.aborted).toBe(true)
+    expect((queryFn.mock.calls[1][1] as AbortController).signal.aborted).toBe(false)
+  })
+
+  it('aborts the query on unmount', async () => {
+    const queryFn = vi.fn().mockReturnValue(new Promise(() => {}))
+    const wrapper = mountComposable({
+      queryFn,
+    } as any)
+
+    wrapper.vm.issueQuery({ metrics: [], dimensions: [], filters: [] } as any, context)
+    await flushPromises()
+    const controller = queryFn.mock.calls[0][1] as AbortController
+    expect(controller.signal.aborted).toBe(false)
+
+    wrapper.unmount()
+    expect(controller.signal.aborted).toBe(true)
   })
 })

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
@@ -14,17 +14,22 @@ export default function useIssueQuery() {
   const datasourceConfigStore = useDatasourceConfigStore()
   const { stripUnknownFilters } = storeToRefs(datasourceConfigStore)
 
-  // Ensure that any pending requests are canceled on unmount.
-  const abortController = new AbortController()
+  // Ensure that any pending requests are canceled when superseded or on unmount.
+  let abortController: AbortController | null = null
 
   onUnmounted(() => {
-    abortController.abort()
+    abortController?.abort()
   })
 
   const issueQuery = async (query: ValidDashboardChartQuery, context: DashboardRendererContextInternal, limitOverride?: number) => {
     if (!queryBridge) {
       throw new Error('Query bridge is not defined')
     }
+
+    // This will abort any previous query and pass a new controller to the bridge.
+    abortController?.abort()
+    const controller = new AbortController()
+    abortController = controller
 
     await datasourceConfigStore.isReady()
 
@@ -74,7 +79,7 @@ export default function useIssueQuery() {
       },
     } as DatasourceAwareQuery
 
-    return queryBridge.queryFn(mergedQuery, abortController)
+    return queryBridge.queryFn(mergedQuery, controller)
   }
 
   return { issueQuery }


### PR DESCRIPTION
# Summary

Fix [MA-5146](https://konghq.atlassian.net/browse/MA-5146)
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

A few issues have been fixed here:
- In the `QueryDataProvider`, queries were not being properly aborted when a new query has been issued which causes undue stress to the backend and can also create some odd behavior on the frontend when an older query eventually finishes and overwrites a new one that fails.
- Requests that timeout were showing a generic error message rather than the proper "Timed out" message already in place.




[MA-5146]: https://konghq.atlassian.net/browse/MA-5146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ