### PR TITLE
fix(redis): remove new redis option [khcp-20947]

### DIFF
--- a/packages/core/forms/src/components/RedisConfigSelect.vue
+++ b/packages/core/forms/src/components/RedisConfigSelect.vue
@@ -58,7 +58,10 @@
           {{ t('redis.shared_configuration.empty_state') }}
         </div>
       </template>
-      <template #dropdown-footer-text>
+      <template
+        v-if="!shouldHideNewRedisConfiguration(formConfig)"
+        #dropdown-footer-text
+      >
         <div
           class="new-redis-config-area"
           data-testid="new-redis-config-area"
@@ -109,6 +112,7 @@ import {
   type RedisConfigurationSource,
   redisManagedSourceFromTags,
 } from '../utils/redisPartialManagedSource'
+import { shouldHideNewRedisConfiguration } from '../utils/hideNewRedisConfiguration'
 import RedisConfigCard from './RedisConfigCard.vue'
 
 defineEmits<{

--- a/packages/core/forms/src/utils/hideNewRedisConfiguration.spec.ts
+++ b/packages/core/forms/src/utils/hideNewRedisConfiguration.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldHideNewRedisConfiguration } from './hideNewRedisConfiguration'
+
+describe('shouldHideNewRedisConfiguration', () => {
+  it('is true for Konnect when managed-redis FF is enabled', () => {
+    expect(shouldHideNewRedisConfiguration({
+      app: 'konnect',
+      apiBaseUrl: '/us/kong-api',
+      controlPlaneId: 'cp-1',
+      isKonnectManagedRedisEnabled: true,
+    })).toBe(true)
+  })
+
+  it('is false for Konnect when managed-redis FF is disabled', () => {
+    expect(shouldHideNewRedisConfiguration({
+      app: 'konnect',
+      apiBaseUrl: '/us/kong-api',
+      controlPlaneId: 'cp-1',
+      isKonnectManagedRedisEnabled: false,
+    })).toBe(false)
+  })
+
+  it('is false for Kong Manager', () => {
+    expect(shouldHideNewRedisConfiguration({
+      app: 'kongManager',
+      apiBaseUrl: '/kong-manager',
+      workspace: 'default',
+      isKonnectManagedRedisEnabled: true,
+    })).toBe(false)
+  })
+})

--- a/packages/core/forms/src/utils/hideNewRedisConfiguration.ts
+++ b/packages/core/forms/src/utils/hideNewRedisConfiguration.ts
@@ -1,0 +1,10 @@
+import type { KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
+
+type PluginFormsConfig = (KonnectBaseFormConfig | KongManagerBaseFormConfig) & {
+  isKonnectManagedRedisEnabled?: boolean
+}
+
+// Konnect + managed-redis FF: hide inline "+ New Redis" in plugin forms
+export function shouldHideNewRedisConfiguration(config: PluginFormsConfig): boolean {
+  return config.app === 'konnect' && !!config.isKonnectManagedRedisEnabled
+}

--- a/packages/entities/entities-plugins/src/components/free-form/shared/RedisSelector.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/RedisSelector.vue
@@ -56,6 +56,7 @@
           :model-value="selectedRedisConfigItem"
           :placeholder="redisSelectorPlaceholderText"
           :redis-type="redisType"
+          :show-create-button="!shouldHideNewRedisConfiguration(formConfig)"
           @error-change="onRedisSelectorFetchError"
           @toast="toaster"
           @update:model-value="redisConfigSelected"
@@ -186,6 +187,10 @@ const { value: partialValue } = useFormData<PartialArray | null | undefined>('$.
 const { value: redisFieldsValue, hide } = useField<Redis | undefined>(formRedisPath)
 
 const formConfig: KonnectBaseFormConfig | KongManagerBaseFormConfig = inject(FORMS_CONFIG)!
+
+const shouldHideNewRedisConfiguration = (
+  config: (KonnectBaseFormConfig | KongManagerBaseFormConfig) & { isKonnectManagedRedisEnabled?: boolean },
+) => config.app === 'konnect' && !!config.isKonnectManagedRedisEnabled
 
 const redisCardTitle = computed(() =>
   props.isKonnectManagedRedisEnabled ? t('redis.managed_ui.title') : t('redis.title'),


### PR DESCRIPTION
# Summary
Addresses: [https://konghq.atlassian.net/browse/KHCP-20947](https://konghq.atlassian.net/browse/KHCP-20947)

This PR removes the **+ New Redis** option from the plugins form. Based on discussions with Design and Product, creating a new Redis instance during plugin setup is considered an edge case that's primarily relevant for dedicated CGW customers. To keep the experience simpler for this release, we're removing this option. If customer demand emerges in the future, we can revisit and reintroduce it as needed.

**_NOTE:_** Only for `Konnect`, with `khcp-19709-konnect-managed-redis` enabled. Legacy Konnect and Kong Manager not altered. 

**Before:**

_Cloud gateway_

<img width="1909" height="1018" alt="screen capture 2026-07-08 at 11 40 07 AM" src="https://github.com/user-attachments/assets/128b738a-485a-415c-a641-552a4f8c53ed" />


_Self-managed gateway_

<img width="1909" height="1018" alt="screen capture 2026-07-08 at 11 41 29 AM" src="https://github.com/user-attachments/assets/085fd83f-98fb-489a-a000-4f6b0bd8e421" />


_Serverless gateway_

<img width="1909" height="1018" alt="screen capture 2026-07-08 at 11 41 53 AM" src="https://github.com/user-attachments/assets/215427da-2df2-46d5-89c3-b608c8f0ca83" />


**After:**

_Cloud gateway_

<img width="1907" height="980" alt="screen capture 2026-07-08 at 11 43 06 AM" src="https://github.com/user-attachments/assets/e7169389-e6a2-4e46-aee8-5c608204e0e3" />


_Self-managed gateway_

<img width="1907" height="980" alt="screen capture 2026-07-08 at 11 43 28 AM" src="https://github.com/user-attachments/assets/aeb13ffe-e21c-4d6f-a9f7-446aa11418a2" />


_Serverless gateway_

<img width="1907" height="980" alt="screen capture 2026-07-08 at 11 43 46 AM" src="https://github.com/user-attachments/assets/bcb57f90-6dc8-47e2-b630-d9c83a4b188e" />


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
