### PR TITLE
feat(entities-shared): sensitive input supports multiline

### DIFF
--- a/packages/entities/entities-shared/docs/sensitive-input.md
+++ b/packages/entities/entities-shared/docs/sensitive-input.md
@@ -1,6 +1,6 @@
 # SensitiveInput.vue
 
-An input component (built on top of `KInput`) for entering sensitive fields such as API keys or tokens.
+An input component for entering sensitive fields such as API keys or tokens. Renders a single-line `KInput` by default, or a multi-line `KTextArea` when `multiline` is set.
 
 - [Features](#features)
 - [Requirements](#requirements)
@@ -19,6 +19,7 @@ An input component (built on top of `KInput`) for entering sensitive fields such
 - When editing an existing resource, starts in a read-only masked state with a "Rotate key" action that switches the field to the editable state.
 - Optional "Generate key" action — only shown when a `generator` callback is provided, so the value can be generated locally or fetched from a backend, depending on the host application.
 - Optional one-time hint banner ("The key is shown only once…") with a Copy action, displayed under the host application's control.
+- Optional multi-line mode (`multiline` prop) that switches the inner input to a `KTextArea` — useful for PEM keys, JWKs, and other multi-line credentials. Because `<textarea>` has no `type="password"`, the visibility toggle is omitted; masking is all-or-nothing (masked dots in edit mode, plain text in create/editing mode).
 
 ## Requirements
 
@@ -71,9 +72,17 @@ When `true`, a one-time hint banner ("The key is shown only once. Copy it now an
 
 Overrides for the built-in UI texts, so the component can be reused for other credential types (passwords, tokens, …). Any omitted label falls back to its default. Available keys: `rotateLabel`, `generateLabel`, `hintLabel`. The input placeholder is configured separately via the `placeholder` prop.
 
+#### `multiline`
+
+- type: `Boolean`
+- required: `false`
+- default: `false`
+
+When `true`, the inner input switches from `KInput` to `KTextArea`. The "Rotate key" and "Generate key" actions are moved to a row below the textarea; the visibility toggle is not shown (because `<textarea>` has no `type="password"`).
+
 #### Other props
 
-The following props are forwarded to the underlying `KInput`: `label`, `labelAttributes`, `placeholder`, `help`, `required`, `disabled`, `readonly`, `error`, and `errorMessage`. When `placeholder` is omitted, a default placeholder ("Enter or generate a key") is used in the editable state.
+The following props are supported in both single-line and multiline modes: `label`, `labelAttributes`, `placeholder`, `help`, `required`, `disabled`, `readonly`, `error`, and `errorMessage`. When `placeholder` is omitted, a default placeholder ("Enter or generate a key") is used in the editable state.
 
 ### Events
 

--- a/packages/entities/entities-shared/sandbox/pages/SensitiveInputPage.vue
+++ b/packages/entities/entities-shared/sandbox/pages/SensitiveInputPage.vue
@@ -53,6 +53,28 @@
     </section>
 
     <section>
+      <h3>Multiline — Create mode</h3>
+      <SensitiveInput
+        v-model="multilineCreateValue"
+        :generator="generateKey"
+        label="Private key"
+        multiline
+      />
+      <pre>modelValue: {{ multilineCreateValue }}</pre>
+    </section>
+
+    <section>
+      <h3>Multiline — Edit mode (starts masked → Rotate key)</h3>
+      <SensitiveInput
+        v-model="multilineEditValue"
+        label="Private key"
+        mode="edit"
+        multiline
+      />
+      <pre>modelValue: {{ multilineEditValue }}</pre>
+    </section>
+
+    <section>
       <h3>Alert slot (shown after the "rotate" event fires)</h3>
       <SensitiveInput
         v-model="rotateAlertValue"
@@ -69,6 +91,25 @@
       </SensitiveInput>
       <pre>modelValue: {{ rotateAlertValue }}</pre>
     </section>
+
+    <section>
+      <h3>Multiline — Alert slot (shown after the "rotate" event fires)</h3>
+      <SensitiveInput
+        v-model="multilineRotateAlertValue"
+        label="Private key"
+        mode="edit"
+        multiline
+        @rotate="showMultilineRotateAlert = true"
+      >
+        <template #alert>
+          <KAlert
+            v-if="showMultilineRotateAlert"
+            message="Once saved, the key value will not be visible."
+          />
+        </template>
+      </SensitiveInput>
+      <pre>modelValue: {{ multilineRotateAlertValue }}</pre>
+    </section>
   </div>
 </template>
 
@@ -84,6 +125,10 @@ const hintValue = ref('')
 const showHint = ref(false)
 const rotateAlertValue = ref('')
 const showRotateAlert = ref(false)
+const multilineCreateValue = ref('')
+const multilineEditValue = ref('')
+const multilineRotateAlertValue = ref('')
+const showMultilineRotateAlert = ref(false)
 
 const generateKey = (): string => {
   const bytes = new Uint8Array(24)

--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
@@ -122,6 +122,101 @@ describe('<SensitiveInput />', () => {
     })
   })
 
+  describe('multiline mode', () => {
+    const textarea = () => cy.get('textarea')
+
+    describe('create mode', () => {
+      it('renders an editable textarea with no eye icon or rotate button', () => {
+        cy.mount(SensitiveInput, {
+          props: { modelValue: '', multiline: true },
+        })
+
+        textarea().should('not.have.attr', 'readonly')
+        cy.getTestId('sensitive-input-toggle').should('not.exist')
+        cy.getTestId('sensitive-input-rotate').should('not.exist')
+      })
+
+      it('emits update:modelValue while typing', () => {
+        cy.mount(SensitiveInput, {
+          props: { modelValue: '', multiline: true },
+        })
+
+        textarea().type('my-secret')
+        cy.then(() => Cypress.vueWrapper.emitted('update:modelValue'))
+          .should('not.be.undefined')
+      })
+
+      it('hides the Generate button when no generator prop is provided', () => {
+        cy.mount(SensitiveInput, {
+          props: { modelValue: '', multiline: true },
+        })
+
+        cy.getTestId('sensitive-input-generate').should('not.exist')
+      })
+
+      it('calls the generator, writes the value back and emits "generated"', () => {
+        const generate = cy.stub().as('generate').resolves('generated-key-123')
+
+        cy.mount(SensitiveInput, {
+          props: {
+            modelValue: '',
+            multiline: true,
+            generator: generate,
+            'onUpdate:modelValue': (value: string) => {
+              Cypress.vueWrapper.setProps({ modelValue: value })
+            },
+          },
+        })
+
+        cy.getTestId('sensitive-input-generate').click()
+        cy.get('@generate').should('have.been.calledOnce')
+        textarea().should('have.value', 'generated-key-123')
+        cy.then(() => Cypress.vueWrapper.emitted('generated'))
+          .should('deep.equal', [['generated-key-123']])
+      })
+    })
+
+    describe('edit mode', () => {
+      it('starts masked and read-only with a Rotate key button', () => {
+        cy.mount(SensitiveInput, {
+          props: { modelValue: '', multiline: true, mode: 'edit' },
+        })
+
+        textarea().should('have.attr', 'readonly')
+        cy.getTestId('sensitive-input-rotate').should('contain.text', rotateLabel)
+        cy.getTestId('sensitive-input-toggle').should('not.exist')
+      })
+
+      it('switches to editable state and emits "rotate" when Rotate is clicked', () => {
+        cy.mount(SensitiveInput, {
+          props: { modelValue: '', multiline: true, mode: 'edit' },
+        })
+
+        cy.getTestId('sensitive-input-rotate').click()
+        cy.then(() => Cypress.vueWrapper.emitted('rotate')).should('have.length', 1)
+        cy.getTestId('sensitive-input-rotate').should('not.exist')
+        textarea().should('not.have.attr', 'readonly')
+      })
+    })
+
+    it('renders the one-time hint banner with a Copy action', () => {
+      cy.mount(SensitiveInput, {
+        props: { modelValue: 'a-key', multiline: true, showOneTimeHint: true },
+      })
+
+      cy.getTestId('sensitive-input-hint').should('contain.text', oneTimeHint)
+      cy.getTestId('sensitive-input-copy').should('be.visible')
+    })
+
+    it('renders the error message when error and errorMessage are both set', () => {
+      cy.mount(SensitiveInput, {
+        props: { modelValue: '', multiline: true, error: true, errorMessage: 'This field is required' },
+      })
+
+      cy.getTestId('sensitive-input-error-message').should('contain.text', 'This field is required')
+    })
+  })
+
   describe('custom labels', () => {
     it('overrides the rotate, generate and hint texts via the labels prop', () => {
       const labels = {

--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
@@ -4,6 +4,7 @@
     class="kong-ui-public-sensitive-input"
   >
     <KInput
+      v-if="!multiline"
       autocomplete="off"
       data-testid="sensitive-input"
       :disabled="disabled"
@@ -60,6 +61,56 @@
         </template>
       </template>
     </KInput>
+
+    <!-- Multiline mode: KTextArea + action row below (no visibility toggle; textarea has no type="password") -->
+    <template v-else>
+      <KTextArea
+        autocomplete="off"
+        :character-limit="false"
+        data-testid="sensitive-input"
+        :disabled="disabled || undefined"
+        :error="error"
+        :help="help"
+        :label="label"
+        :label-attributes="labelAttributes"
+        :model-value="isMasked ? maskedValue : modelValue"
+        :placeholder="isMasked ? undefined : resolvedPlaceholder"
+        :readonly="isMasked || readonly || undefined"
+        :required="required || undefined"
+        resizable
+        @update:model-value="handleInput"
+      />
+      <p
+        v-if="error && errorMessage"
+        class="sensitive-input-error-message"
+        data-testid="sensitive-input-error-message"
+      >
+        {{ errorMessage }}
+      </p>
+      <div class="sensitive-input-textarea-actions">
+        <KButton
+          v-if="isMasked"
+          appearance="tertiary"
+          class="sensitive-input-action"
+          data-testid="sensitive-input-rotate"
+          size="small"
+          @click="enterEditing(true)"
+        >
+          {{ rotateLabel }}
+        </KButton>
+        <KButton
+          v-else-if="generator"
+          appearance="tertiary"
+          class="sensitive-input-action"
+          data-testid="sensitive-input-generate"
+          :disabled="disabled || isGenerating"
+          size="small"
+          @click="handleGenerate"
+        >
+          {{ generateLabel }}
+        </KButton>
+      </div>
+    </template>
 
     <div
       v-if="showOneTimeHint"
@@ -125,6 +176,7 @@ const {
   readonly = false,
   error = false,
   errorMessage,
+  multiline = false,
 } = defineProps<{
   /** The sensitive value, bound via v-model. */
   modelValue?: string
@@ -159,6 +211,8 @@ const {
   readonly?: boolean
   error?: boolean
   errorMessage?: string
+  /** When true, renders a KTextArea instead of a KInput. */
+  multiline?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -302,6 +356,17 @@ onBeforeUnmount(() => {
   .sensitive-input-toggle {
     color: var(--kui-color-text-neutral, $kui-color-text-neutral);
     cursor: pointer;
+  }
+
+  .sensitive-input-error-message {
+    color: var(--kui-color-text-danger, $kui-color-text-danger);
+    font-size: var(--kui-font-size-20, $kui-font-size-20);
+    margin-top: calc(-1 * var(--kui-space-20, $kui-space-20));
+  }
+
+  .sensitive-input-textarea-actions {
+    display: flex;
+    justify-content: flex-end;
   }
 
   .sensitive-input-hint {

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -631,7 +631,7 @@
               />
               <SensitiveInput
                 v-else
-                v-model.trim="configFields[VaultProviders.HCV].cert_auth_cert_key"
+                v-model="configFields[VaultProviders.HCV].cert_auth_cert_key"
                 data-testid="vault-form-config-hcv-cert_auth_cert_key"
                 :label="t('form.config.hcv.fields.cert_auth_cert_key.label')"
                 :labels="{ rotateLabel: t('form.config.hcv.fields.cert_auth_cert_key.rotateLabel') }"
@@ -644,7 +644,7 @@
                 <template #alert>
                   <KAlert
                     v-if="showCertKeyRotateAlert"
-                    message="Once saved, the cert key value will not be visible."
+                    :message="t('form.config.hcv.fields.cert_auth_cert_key.rotateAlert')"
                   />
                 </template>
               </SensitiveInput>

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -637,6 +637,7 @@
                 :labels="{ rotateLabel: t('form.config.hcv.fields.cert_auth_cert_key.rotateLabel') }"
                 :mode="sensitiveInputMode"
                 multiline
+                placeholder=""
                 :readonly="form.isReadonly"
                 :required="sensitiveInputMode === 'create'"
                 @rotate="showCertKeyRotateAlert = true"

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -621,6 +621,7 @@
                 required
               />
               <KTextArea
+                v-if="!isAiGateway"
                 v-model.trim="configFields[VaultProviders.HCV].cert_auth_cert_key"
                 autocomplete="off"
                 data-testid="vault-form-config-hcv-cert_auth_cert_key"
@@ -628,6 +629,25 @@
                 :readonly="form.isReadonly"
                 required
               />
+              <SensitiveInput
+                v-else
+                v-model.trim="configFields[VaultProviders.HCV].cert_auth_cert_key"
+                data-testid="vault-form-config-hcv-cert_auth_cert_key"
+                :label="t('form.config.hcv.fields.cert_auth_cert_key.label')"
+                :labels="{ rotateLabel: t('form.config.hcv.fields.cert_auth_cert_key.rotateLabel') }"
+                :mode="sensitiveInputMode"
+                multiline
+                :readonly="form.isReadonly"
+                :required="sensitiveInputMode === 'create'"
+                @rotate="showCertKeyRotateAlert = true"
+              >
+                <template #alert>
+                  <KAlert
+                    v-if="showCertKeyRotateAlert"
+                    message="Once saved, the cert key value will not be visible."
+                  />
+                </template>
+              </SensitiveInput>
             </div>
             <div
               v-else-if="configFields[VaultProviders.HCV].auth_method === VaultAuthMethods.JWT"
@@ -1496,6 +1516,8 @@ const formType = computed((): EntityBaseFormType => props.vaultId
   : EntityBaseFormType.Create)
 
 const sensitiveInputMode = computed((): 'edit' | 'create' => formType.value === EntityBaseFormType.Edit ? 'edit' : 'create')
+
+const showCertKeyRotateAlert = ref(false)
 
 const fetchUrl = computed<string>(() => withAiGatewayId(endpoints.form[endpointKey.value]?.edit))
 

--- a/packages/entities/entities-vaults/src/locales/en.json
+++ b/packages/entities/entities-vaults/src/locales/en.json
@@ -365,7 +365,8 @@
           },
           "cert_auth_cert_key": {
             "label": "Cert key",
-            "rotateLabel": "Rotate cert key"
+            "rotateLabel": "Rotate cert key",
+            "rotateAlert": "Once saved, the cert key value will not be visible."
           },
           "cert_auth_role_name": {
             "label": "Role name"

--- a/packages/entities/entities-vaults/src/locales/en.json
+++ b/packages/entities/entities-vaults/src/locales/en.json
@@ -364,7 +364,8 @@
             "label": "Cert"
           },
           "cert_auth_cert_key": {
-            "label": "Cert key"
+            "label": "Cert key",
+            "rotateLabel": "Rotate cert key"
           },
           "cert_auth_role_name": {
             "label": "Role name"


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
This PR extends the shared `SensitiveInput` component to support a multiline mode (rendering a `KTextArea` instead of `KInput`) and wires it into the Vault HCV cert key field for AI Gateway vaults.

<img width="1624" height="456" alt="image" src="https://github.com/user-attachments/assets/cf6332b0-5c51-4710-8a6a-0c1043b62515" />
