### PR TITLE
fix: allow platform and platform_usage for datasource [MA-5024]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
@@ -185,6 +185,20 @@ describe('<AnalyticsChart />', () => {
     })
   })
 
+  it('renders the platform_usage datasource timestamp axis title', () => {
+    mount({
+      chartData: {
+        ...exploreResult,
+        meta: {
+          ...exploreResult.meta,
+          datasource: 'platform_usage',
+        },
+      },
+    }).then(({ wrapper }) => {
+      expect(wrapper.findComponent(TimeSeriesChart).props('dimensionAxesTitle')).to.eq('@timestamp created at')
+    })
+  })
+
   it('shows the empty state with no data', () => {
     mount({
       chartData: emptyExploreResult,

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -309,7 +309,7 @@ const dimensionAxesTitle = computed<string | undefined>(() => {
 })
 
 const timestampAxisTitle = computed(() => {
-  if (props.chartData.meta.datasource === 'platform') {
+  if (props.chartData.meta.datasource === 'platform' || props.chartData.meta.datasource === 'platform_usage') {
     return i18n.t('timestampAxisTitles.platform')
   }
 

--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -108,7 +108,7 @@ import { ChartLegendPosition } from '../enums'
 import StackedBarChart from './chart-types/StackedBarChart.vue'
 import DonutChart from './chart-types/DonutChart.vue'
 import { computed, provide, toRef } from 'vue'
-import { msToGranularity } from '@kong-ui-public/analytics-utilities'
+import { isPlatformDatasource, msToGranularity } from '@kong-ui-public/analytics-utilities'
 import type { AbsoluteTimeRangeV4, ExploreAggregations, ExploreResultV4, GranularityValues } from '@kong-ui-public/analytics-utilities'
 import { hasMillisecondTimestamps, defaultStatusCodeColors, isNoSuffixMetric } from '../utils'
 import TimeSeriesChart from './chart-types/TimeSeriesChart.vue'
@@ -309,7 +309,7 @@ const dimensionAxesTitle = computed<string | undefined>(() => {
 })
 
 const timestampAxisTitle = computed(() => {
-  if (props.chartData.meta.datasource === 'platform' || props.chartData.meta.datasource === 'platform_usage') {
+  if (isPlatformDatasource(props.chartData.meta.datasource)) {
     return i18n.t('timestampAxisTitles.platform')
   }
 

--- a/packages/analytics/analytics-utilities/package.json
+++ b/packages/analytics/analytics-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong-ui-public/analytics-utilities",
-  "version": "12.19.5",
+  "version": "12.20.0",
   "type": "module",
   "main": "./dist/vitals-utilities.umd.js",
   "module": "./dist/vitals-utilities.es.js",

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -201,6 +201,31 @@ describe('dashboardSchema.v2', () => {
     expect(validateDashboardConfigSchema(mixedDashboardConfig)).toBe(true)
   })
 
+  it('accepts platform_usage as a datasource for chart queries', () => {
+    const platformUsageChartQuery = { ...platformChartQuery, datasource: 'platform_usage' }
+    expect(validatePlatformQuerySchema(platformUsageChartQuery)).toBe(true)
+    expect(validateValidDashboardQuery(platformUsageChartQuery)).toBe(true)
+    expect(validateDashboardConfigSchema({
+      ...dashboardConfig,
+      tiles: [{ ...dashboardConfig.tiles[0], definition: { ...dashboardConfig.tiles[0].definition, query: platformUsageChartQuery } }],
+    })).toBe(true)
+  })
+
+  it('accepts platform_usage as a datasource for tabular queries', () => {
+    expect(validateValidDashboardTableQuery({ ...tableChartTile.definition.query, datasource: 'platform_usage' })).toBe(true)
+    expect(validateDashboardConfigSchema({
+      tiles: [
+        {
+          ...tableChartTile,
+          definition: {
+            query: { datasource: 'platform_usage' },
+            chart: { type: 'table' },
+          },
+        },
+      ],
+    })).toBe(true)
+  })
+
   it('accepts table chart tiles with tabular explore query shape', () => {
     expect(validateValidDashboardQuery(tableChartTile.definition.query)).toBe(true)
     expect(validateValidDashboardTableQuery(tableChartTile.definition.query)).toBe(true)
@@ -411,7 +436,7 @@ describe('dashboardSchema.v2', () => {
   })
 
   it('loosens only the platform branch', () => {
-    expect(platformQuerySchema.properties.datasource.enum).toEqual(['platform'])
+    expect(platformQuerySchema.properties.datasource.enum).toEqual(['platform', 'platform_usage'])
     expect(platformQuerySchema.properties.metrics.items.enum).toBeUndefined()
     expect(platformQuerySchema.properties.dimensions.items.enum).toBeUndefined()
     expect(platformQuerySchema.properties.filters.items.oneOf[0].properties.field.enum).toBeUndefined()

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -436,7 +436,9 @@ describe('dashboardSchema.v2', () => {
   })
 
   it('loosens only the platform branch', () => {
-    expect(platformQuerySchema.properties.datasource.enum).toEqual(['platform', 'platform_usage'])
+    expect(platformQuerySchema.properties.datasource.oneOf).toHaveLength(2)
+    expect(platformQuerySchema.properties.datasource.oneOf?.[0]).toMatchObject({ const: 'platform', deprecated: true })
+    expect(platformQuerySchema.properties.datasource.oneOf?.[1]).toMatchObject({ const: 'platform_usage' })
     expect(platformQuerySchema.properties.metrics.items.enum).toBeUndefined()
     expect(platformQuerySchema.properties.dimensions.items.enum).toBeUndefined()
     expect(platformQuerySchema.properties.filters.items.oneOf[0].properties.field.enum).toBeUndefined()

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -610,13 +610,18 @@ export const agenticUsageSchema = {
 
 export const platformQuerySchema = {
   type: 'object',
-  description: 'A query to launch at the platform dashboard API',
+  description: "A query to launch at the platform dashboard API. Use datasource 'platform_usage'; 'platform' is accepted for backward compatibility but deprecated.",
   properties: {
     datasource: {
-      type: 'string',
-      enum: [
-        'platform',
-        'platform_usage',
+      oneOf: [
+        {
+          const: 'platform',
+          deprecated: true,
+          description: "Deprecated: use 'platform_usage'.",
+        } as unknown as JSONSchema,
+        {
+          const: 'platform_usage',
+        },
       ],
     },
     metrics: metricsFn(),
@@ -630,13 +635,18 @@ export const platformQuerySchema = {
 
 export const platformTabularQuerySchema = {
   type: 'object',
-  description: 'A query to launch at the platform tabular explore API',
+  description: "A query to launch at the platform tabular explore API. Use datasource 'platform_usage'; 'platform' is accepted for backward compatibility but deprecated.",
   properties: {
     datasource: {
-      type: 'string',
-      enum: [
-        'platform',
-        'platform_usage',
+      oneOf: [
+        {
+          const: 'platform',
+          deprecated: true,
+          description: "Deprecated: use 'platform_usage'.",
+        } as unknown as JSONSchema,
+        {
+          const: 'platform_usage',
+        },
       ],
     },
     entity: {

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -616,6 +616,7 @@ export const platformQuerySchema = {
       type: 'string',
       enum: [
         'platform',
+        'platform_usage',
       ],
     },
     metrics: metricsFn(),
@@ -635,6 +636,7 @@ export const platformTabularQuerySchema = {
       type: 'string',
       enum: [
         'platform',
+        'platform_usage',
       ],
     },
     entity: {

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -608,22 +608,24 @@ export const agenticUsageSchema = {
   additionalProperties: false,
 } as const satisfies JSONSchema
 
+const platformDatasourceSchema = {
+  oneOf: [
+    {
+      const: 'platform',
+      deprecated: true,
+      description: "Deprecated: use 'platform_usage'.",
+    },
+    {
+      const: 'platform_usage',
+    },
+  ],
+} as const
+
 export const platformQuerySchema = {
   type: 'object',
   description: "A query to launch at the platform dashboard API. Use datasource 'platform_usage'; 'platform' is accepted for backward compatibility but deprecated.",
   properties: {
-    datasource: {
-      oneOf: [
-        {
-          const: 'platform',
-          deprecated: true,
-          description: "Deprecated: use 'platform_usage'.",
-        } as unknown as JSONSchema,
-        {
-          const: 'platform_usage',
-        },
-      ],
-    },
+    datasource: platformDatasourceSchema,
     metrics: metricsFn(),
     dimensions: dimensionsFn(),
     filters: platformFiltersFn(),
@@ -637,18 +639,7 @@ export const platformTabularQuerySchema = {
   type: 'object',
   description: "A query to launch at the platform tabular explore API. Use datasource 'platform_usage'; 'platform' is accepted for backward compatibility but deprecated.",
   properties: {
-    datasource: {
-      oneOf: [
-        {
-          const: 'platform',
-          deprecated: true,
-          description: "Deprecated: use 'platform_usage'.",
-        } as unknown as JSONSchema,
-        {
-          const: 'platform_usage',
-        },
-      ],
-    },
+    datasource: platformDatasourceSchema,
     entity: {
       type: 'string',
     },

--- a/packages/analytics/analytics-utilities/src/types/explore/all.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/all.ts
@@ -15,7 +15,8 @@ export type AllFilterableDimensionsAndMetrics = FilterableExploreDimensions
   | FilterableRequestMetrics
   | FilterableRequestWildcardDimensions
 
-export const queryDatasources = ['basic', 'api_usage', 'llm_usage', 'agentic_usage', 'platform'] as const
+// 'platform' is deprecated; use 'platform_usage'.
+export const queryDatasources = ['basic', 'api_usage', 'llm_usage', 'agentic_usage', 'platform', 'platform_usage'] as const
 
 export type QueryDatasource = typeof queryDatasources[number]
 
@@ -26,7 +27,9 @@ export interface FilterTypeMap extends Record<QueryDatasource, AllFilters> {
   api_usage: ExploreFilterAll
   llm_usage: AiExploreFilterAll
   agentic_usage: AgenticExploreFilterAll
+  /** @deprecated Use `platform_usage`. */
   platform: PlatformExploreFilterAll
+  platform_usage: PlatformExploreFilterAll
 }
 
 /**
@@ -55,6 +58,7 @@ export const datasourceToFilterableDimensions: Record<QueryDatasource, Set<strin
   llm_usage: new Set(filterableAiExploreDimensions),
   agentic_usage: new Set(filterableAgenticExploreDimensions),
   platform: new Set(),
+  platform_usage: new Set(),
 } as const
 
 /**
@@ -67,7 +71,7 @@ export const stripUnknownFilters = <K extends keyof typeof datasourceToFilterabl
     return filters as any
   }
 
-  if (datasource === 'platform') {
+  if (datasource === 'platform' || datasource === 'platform_usage') {
     return filters as Array<FilterTypeMap[K]>
   }
 

--- a/packages/analytics/analytics-utilities/src/types/explore/all.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/all.ts
@@ -57,6 +57,7 @@ export const datasourceToFilterableDimensions: Record<QueryDatasource, Set<strin
   api_usage: new Set(filterableExploreDimensions),
   llm_usage: new Set(filterableAiExploreDimensions),
   agentic_usage: new Set(filterableAgenticExploreDimensions),
+  /** @deprecated Use `platform_usage`. */
   platform: new Set(),
   platform_usage: new Set(),
 } as const

--- a/packages/analytics/analytics-utilities/src/types/explore/platform.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/platform.ts
@@ -28,6 +28,12 @@ export interface PlatformTabularQuery {
   page_size?: number
 }
 
+export const PLATFORM_DATASOURCES = ['platform', 'platform_usage'] as const
+export type PlatformDatasource = typeof PLATFORM_DATASOURCES[number]
+
+export const isPlatformDatasource = (datasource: unknown): datasource is PlatformDatasource =>
+  (PLATFORM_DATASOURCES as readonly unknown[]).includes(datasource)
+
 export type PlatformTabularRecord = Record<string, string | number | boolean | null>
 
 export interface PlatformTabularResponseMeta {

--- a/packages/analytics/analytics-utilities/src/types/explore/platform.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/platform.ts
@@ -43,7 +43,6 @@ export interface PlatformTabularResponseMeta {
   page_size: number
   display: DisplayBlob
   cursor?: string
-  /** @deprecated Will be `platform_usage` in future responses. */
   datasource?: 'platform' | 'platform_usage'
 }
 

--- a/packages/analytics/analytics-utilities/src/types/explore/platform.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/platform.ts
@@ -37,7 +37,8 @@ export interface PlatformTabularResponseMeta {
   page_size: number
   display: DisplayBlob
   cursor?: string
-  datasource?: 'platform'
+  /** @deprecated Will be `platform_usage` in future responses. */
+  datasource?: 'platform' | 'platform_usage'
 }
 
 export interface PlatformTabularResponse {

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -40,7 +40,7 @@ export interface PlatformDatasourceQuery {
 export type DatasourceAwareQuery = BasicDatasourceQuery | AdvancedDatasourceQuery | AiDatasourceQuery | AgenticDatasourceQuery | PlatformDatasourceQuery
 
 export interface PlatformDatasourceTabularQuery {
-  datasource: 'platform'
+  datasource: 'platform' | 'platform_usage'
   query: PlatformTabularQuery
 }
 

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -33,7 +33,6 @@ export interface AgenticDatasourceQuery {
 }
 
 export interface PlatformDatasourceQuery {
-  /** @deprecated Use `platform_usage`. `platform` will be removed in a future version. */
   datasource: 'platform' | 'platform_usage'
   query: PlatformExploreQuery
 }

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -33,7 +33,8 @@ export interface AgenticDatasourceQuery {
 }
 
 export interface PlatformDatasourceQuery {
-  datasource: 'platform'
+  /** @deprecated Use `platform_usage`. `platform` will be removed in a future version. */
+  datasource: 'platform' | 'platform_usage'
   query: PlatformExploreQuery
 }
 

--- a/packages/analytics/analytics-utilities/src/types/query-bridge.ts
+++ b/packages/analytics/analytics-utilities/src/types/query-bridge.ts
@@ -32,19 +32,31 @@ export interface AgenticDatasourceQuery {
   query: AgenticExploreQuery
 }
 
+/** @deprecated Use `PlatformUsageDatasourceQuery`. */
 export interface PlatformDatasourceQuery {
-  datasource: 'platform' | 'platform_usage'
+  datasource: 'platform'
   query: PlatformExploreQuery
 }
 
-export type DatasourceAwareQuery = BasicDatasourceQuery | AdvancedDatasourceQuery | AiDatasourceQuery | AgenticDatasourceQuery | PlatformDatasourceQuery
+export interface PlatformUsageDatasourceQuery {
+  datasource: 'platform_usage'
+  query: PlatformExploreQuery
+}
 
+export type DatasourceAwareQuery = BasicDatasourceQuery | AdvancedDatasourceQuery | AiDatasourceQuery | AgenticDatasourceQuery | PlatformDatasourceQuery | PlatformUsageDatasourceQuery
+
+/** @deprecated Use `PlatformUsageDatasourceTabularQuery`. */
 export interface PlatformDatasourceTabularQuery {
-  datasource: 'platform' | 'platform_usage'
+  datasource: 'platform'
   query: PlatformTabularQuery
 }
 
-export type DatasourceAwareTabularQuery = PlatformDatasourceTabularQuery
+export interface PlatformUsageDatasourceTabularQuery {
+  datasource: 'platform_usage'
+  query: PlatformTabularQuery
+}
+
+export type DatasourceAwareTabularQuery = PlatformDatasourceTabularQuery | PlatformUsageDatasourceTabularQuery
 
 // All flags in this interface should be optional; defaults are as documented.
 export interface StaticConfig {

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -457,7 +457,7 @@ interface ChartTileDefinition {
 
 interface TableChartTileDefinition {
   chart: TableChartOptions    // Configuration for the table chart
-  query: PlatformTabularQuery & { datasource: 'platform' } // Configuration for the platform tabular query
+  query: PlatformTabularQuery & { datasource: 'platform_usage' } // Configuration for the platform tabular query ('platform' also accepted)
 }
 ```
 
@@ -510,7 +510,7 @@ interface PlatformTabularQuery {
 
 `definition.query.columns` controls the visible table columns. If columns are omitted, the renderer can fall back to response `meta.columns` after the first tabular response. `definition.chart.chart_title` controls the tile title.
 
-The dashboard config query includes `datasource: 'platform'`. The host application's `AnalyticsBridge.tabularQueryFn` receives a datasource-aware tabular query, currently `{ datasource: 'platform', query: { entity, columns, filters, page_size, cursor } }`.
+The dashboard config query uses `datasource: 'platform_usage'` (the canonical value; `'platform'` is also accepted for backward compatibility with persisted dashboards). The host application's `AnalyticsBridge.tabularQueryFn` receives a datasource-aware tabular query, e.g. `{ datasource: 'platform_usage', query: { entity, columns, filters, page_size, cursor } }`.
 
 The renderer replaces raw record values with display labels when the tabular response includes a matching `meta.display[column][value].name`. Missing display entries and `null` values are rendered unchanged.
 
@@ -525,7 +525,7 @@ const tableTile: TileConfig = {
       chart_title: 'Platform routes',
     },
     query: {
-      datasource: 'platform',
+      datasource: 'platform_usage',
       entity: 'route',
       columns: ['name', 'control_plane', 'gateway_service', 'env', 'team', 'region'],
       filters: [
@@ -569,7 +569,7 @@ Chart queries can be configured for these data sources:
 2. `basic`: Uses the basic explore API
 3. `llm_usage`: Uses the AI explore API
 4. `agentic_usage`: Uses the agentic usage explore API
-5. `platform`: Uses the platform dashboard API
+5. `platform_usage`: Uses the platform dashboard API (`platform` is also accepted for backward compatibility)
 
 Chart query fields include:
 - `metrics`: Array of aggregations to collect
@@ -580,7 +580,7 @@ Chart query fields include:
 - `limit`: Number of results to return
 
 Table chart queries use the platform tabular query shape:
-- `datasource`: Must be `platform`
+- `datasource`: Must be `platform_usage` (`platform` is also accepted for backward compatibility)
 - `entity`: Entity collection to query, such as `route`
 - `columns`: Ordered table columns to request and render
 - `filters`: Platform filters to apply before fetching rows

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
@@ -270,6 +270,14 @@ describe('<DashboardTile /> zoom requests drilldown', () => {
     expect(badge.text()).toContain('As of today')
   })
 
+  it('shows the as-of-today badge for non-timeseries platform_usage tiles', async () => {
+    const wrapper = mountTile('platform_usage', ['status_code'])
+    await flushPromises()
+
+    const badge = wrapper.getTestId('time-range-badge')
+    expect(badge.text()).toContain('As of today')
+  })
+
   it('does not show the as-of-today badge when the time dimension is present', async () => {
     const wrapper = mountTile('platform', ['time'])
     await flushPromises()

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -183,7 +183,7 @@ import type {
 } from '@kong-ui-public/analytics-utilities'
 
 import { type Component, computed, defineAsyncComponent, inject, nextTick, readonly, ref, toRef, watch } from 'vue'
-import { formatTime, TimePeriods, msToGranularity, TIMEFRAME_LOOKUP, EXPORT_RECORD_LIMIT } from '@kong-ui-public/analytics-utilities'
+import { formatTime, isPlatformDatasource, TimePeriods, msToGranularity, TIMEFRAME_LOOKUP, EXPORT_RECORD_LIMIT } from '@kong-ui-public/analytics-utilities'
 import { CsvExportModal } from '@kong-ui-public/analytics-chart'
 import '@kong-ui-public/analytics-chart/dist/style.css'
 import '@kong-ui-public/analytics-metric-provider/dist/style.css'
@@ -383,7 +383,7 @@ const badgeData = computed<string | null>(() => {
   const timeRange = query?.time_range
 
   // TODO: Temporary until we have more robust solution for non-timeseries "platform analytics" charts
-  if ((query?.datasource === 'platform' || query?.datasource === 'platform_usage') && !query.dimensions?.includes('time')) {
+  if (isPlatformDatasource(query?.datasource) && !query.dimensions?.includes('time')) {
     return i18n.t('renderer.as_of_today')
   }
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -383,7 +383,7 @@ const badgeData = computed<string | null>(() => {
   const timeRange = query?.time_range
 
   // TODO: Temporary until we have more robust solution for non-timeseries "platform analytics" charts
-  if (query?.datasource === 'platform' && !query.dimensions?.includes('time')) {
+  if ((query?.datasource === 'platform' || query?.datasource === 'platform_usage') && !query.dimensions?.includes('time')) {
     return i18n.t('renderer.as_of_today')
   }
 

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
@@ -14,6 +14,7 @@ vi.mock('@kong-ui-public/analytics-utilities', () => ({
     if (ms === ONE_DAY_MS) return 'daily'
     return 'auto'
   }),
+  isPlatformDatasource: (datasource: unknown) => datasource === 'platform' || datasource === 'platform_usage',
 }))
 
 const analyticsConfig = { analytics: true, percentiles: true }

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.spec.ts
@@ -280,6 +280,19 @@ describe('useContextLinks', () => {
     expect(params.get('d')).toBe('platform')
   })
 
+  it('preserves platform_usage for explore link', async () => {
+    const { wrapper } = mountComposable({
+      datasource: 'platform_usage',
+      queryFilters: [makeFilter('gateway_service')],
+    })
+    await flushPromises()
+
+    expect(wrapper.vm.canGenerateExploreLink).toBe(true)
+
+    const params = new URLSearchParams((wrapper.vm.exploreLinkKebabMenu as string).split('?')[1])
+    expect(params.get('d')).toBe('platform_usage')
+  })
+
   it('builds explore link for table charts with the tabular query shape', async () => {
     const tableQuery = {
       datasource: 'platform',
@@ -319,6 +332,19 @@ describe('useContextLinks', () => {
     expect(wrapper.vm.exploreLinkKebabMenu).toContain('#explore?')
   })
 
+  it('does not generate requests drilldown for platform_usage tiles', async () => {
+    const { wrapper } = mountComposable({
+      datasource: 'platform_usage',
+      queryFilters: [makeFilter('shared_field')],
+    })
+    await flushPromises()
+
+    expect(wrapper.vm.canGenerateRequestsLink).toBe(false)
+    expect(wrapper.vm.requestsLinkKebabMenu).toBe('')
+    expect(wrapper.vm.requestsLinkZoomActions).toBeUndefined()
+    expect(wrapper.vm.exploreLinkKebabMenu).toContain('#explore?')
+  })
+
   it('falls back to api_usage when query datasource is not provided', async () => {
     const { wrapper } = mountComposable({ datasource: undefined })
     await flushPromises()
@@ -337,7 +363,7 @@ describe('useContextLinks', () => {
   })
 
   it('builds explore link for expected datasources', async () => {
-    const datasources = ['api_usage', 'basic', 'llm_usage', 'agentic_usage', 'platform', undefined]
+    const datasources = ['api_usage', 'basic', 'llm_usage', 'agentic_usage', 'platform', 'platform_usage', undefined]
 
     for (const ds of datasources) {
       const { wrapper } = mountComposable({

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -1,5 +1,5 @@
 import { computed, onMounted, ref, watch } from 'vue'
-import { msToGranularity } from '@kong-ui-public/analytics-utilities'
+import { isPlatformDatasource, msToGranularity } from '@kong-ui-public/analytics-utilities'
 import { useAnalyticsConfigStore, useDatasourceConfigStore } from '@kong-ui-public/analytics-config-store'
 import { storeToRefs } from 'pinia'
 import type { DeepReadonly, Ref } from 'vue'
@@ -14,6 +14,7 @@ const EXPLORE_DATASOURCES = [
   'llm_usage',
   'agentic_usage',
   'platform',
+  'platform_usage',
   undefined,
 ] as const
 
@@ -68,7 +69,7 @@ export default function useContextLinks(
     return true
   })
 
-  const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && !isTableChart.value && definition.value.query.datasource !== 'llm_usage' && definition.value.query.datasource !== 'platform' && definition.value.query.datasource !== 'platform_usage' && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
+  const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && !isTableChart.value && definition.value.query.datasource !== 'llm_usage' && !isPlatformDatasource(definition.value.query.datasource) && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
   const canGenerateExploreLink = computed(() => exploreBaseUrl.value && definition.value.query && isExploreDatasource(definition.value.query.datasource) && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
 
   const chartDataGranularity = computed(() => {

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -68,7 +68,7 @@ export default function useContextLinks(
     return true
   })
 
-  const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && !isTableChart.value && definition.value.query.datasource !== 'llm_usage' && definition.value.query.datasource !== 'platform' && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
+  const canGenerateRequestsLink = computed(() => requestsBaseUrl.value && definition.value.query && !isTableChart.value && definition.value.query.datasource !== 'llm_usage' && definition.value.query.datasource !== 'platform' && definition.value.query.datasource !== 'platform_usage' && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
   const canGenerateExploreLink = computed(() => exploreBaseUrl.value && definition.value.query && isExploreDatasource(definition.value.query.datasource) && isAdvancedAnalytics.value && !datasourceConfigLoading.value)
 
   const chartDataGranularity = computed(() => {

--- a/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { DashboardRendererContextInternal } from '../types'
-import type { PlatformDatasourceTabularQuery, PlatformTabularResponse } from '@kong-ui-public/analytics-utilities'
+import type { PlatformDatasourceTabularQuery, PlatformUsageDatasourceTabularQuery, PlatformTabularResponse } from '@kong-ui-public/analytics-utilities'
 import {
   tableDataGridFetcherByDatasource,
   tableDataGridHeadersByDatasource,
@@ -211,7 +211,7 @@ describe('table data grid renderer utilities', () => {
 
   it('platform_usage fetcher resolves using the same implementation as platform', async () => {
     const tabularQueryFn = vi.fn().mockResolvedValue(response)
-    const query: PlatformDatasourceTabularQuery = {
+    const query: PlatformUsageDatasourceTabularQuery = {
       datasource: 'platform_usage',
       query: { entity: 'route', columns: ['control_plane'], page_size: 10 },
     }

--- a/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.spec.ts
@@ -62,15 +62,15 @@ describe('table data grid renderer utilities', () => {
 
     const canTranslate = (key: string): boolean => key !== 'chartLabels.unknown_column'
 
-    expect(tableDataGridHeadersByDatasource.platform({
-      columns: ['control_plane', 'gateway_service', 'unknown_column'],
-      translate,
-      canTranslate,
-    })).toEqual([
+    const expected = [
       { key: 'control_plane', label: 'Control plane' },
       { key: 'gateway_service', label: 'Gateway service' },
       { key: 'unknown_column', label: 'unknown_column' },
-    ])
+    ]
+    const args = { columns: ['control_plane', 'gateway_service', 'unknown_column'], translate, canTranslate }
+
+    expect(tableDataGridHeadersByDatasource.platform(args)).toEqual(expected)
+    expect(tableDataGridHeadersByDatasource.platform_usage(args)).toEqual(expected)
   })
 
   it('selects the platform fetcher and fetches tabular data with a datasource-aware query', async () => {
@@ -207,5 +207,27 @@ describe('table data grid renderer utilities', () => {
       stripUnknownFilters: ({ filters }) => filters,
       tabularQueryFn: undefined,
     })).rejects.toThrow('AnalyticsBridge.tabularQueryFn is not defined')
+  })
+
+  it('platform_usage fetcher resolves using the same implementation as platform', async () => {
+    const tabularQueryFn = vi.fn().mockResolvedValue(response)
+    const query: PlatformDatasourceTabularQuery = {
+      datasource: 'platform_usage',
+      query: { entity: 'route', columns: ['control_plane'], page_size: 10 },
+    }
+
+    await expect(tableDataGridFetcherByDatasource.platform_usage({
+      abortController: new AbortController(),
+      context,
+      pageSize: 10,
+      query,
+      stripUnknownFilters: ({ filters }) => filters,
+      tabularQueryFn,
+    })).resolves.toMatchObject({ hasMore: true, cursor: 'next-page' })
+
+    expect(tabularQueryFn).toHaveBeenCalledWith(
+      expect.objectContaining({ datasource: 'platform_usage' }),
+      expect.any(AbortController),
+    )
   })
 })

--- a/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.ts
@@ -70,6 +70,7 @@ const platformTableDataGridHeaders = ({
 
 /** Maps a table tile datasource to the header builder used by TableDataGridRenderer. */
 export const tableDataGridHeadersByDatasource = {
+  /** @deprecated Use `platform_usage`. */
   platform: platformTableDataGridHeaders,
   platform_usage: platformTableDataGridHeaders,
 }
@@ -148,6 +149,7 @@ const platformTableDataGridFetcher = async ({
  * Maps a table tile datasource to the fetcher used by TableDataGridRenderer.
  */
 export const tableDataGridFetcherByDatasource = {
+  /** @deprecated Use `platform_usage`. */
   platform: platformTableDataGridFetcher,
   platform_usage: platformTableDataGridFetcher,
 }

--- a/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.ts
@@ -42,108 +42,112 @@ const platformTabularResponseToTableDataGridRows = (
 })
 
 /**
- * Maps a table tile datasource to the header builder used by TableDataGridRenderer.
+ * Builds platform table headers from configured or response-provided column names.
+ * Known chart label translations are reused for user-facing labels, with the raw column as fallback.
+ *
+ * @param options - Header builder options.
+ * @param options.canTranslate - Checks whether a chart label translation exists for a column key.
+ * @param options.columns - Column keys to expose as TableDataGrid headers.
+ * @param options.translate - Resolves a translation key into a display label.
+ * @returns TableDataGrid header definitions for the provided columns.
  */
-export const tableDataGridHeadersByDatasource = {
-  /**
-   * Builds platform table headers from configured or response-provided column names.
-   * Known chart label translations are reused for user-facing labels, with the raw column as fallback.
-   *
-   * @param options - Header builder options.
-   * @param options.canTranslate - Checks whether a chart label translation exists for a column key.
-   * @param options.columns - Column keys to expose as TableDataGrid headers.
-   * @param options.translate - Resolves a translation key into a display label.
-   * @returns TableDataGrid header definitions for the provided columns.
-   */
-  platform: ({
-    canTranslate,
-    columns,
-    translate,
-  }: {
-    canTranslate: (key: string) => boolean
-    columns: string[]
-    translate: (key: string) => string
-  }): Array<TableDataGridHeader<TableDataGridRow>> => columns.map(column => {
-    const labelKey = `chartLabels.${column}`
+const platformTableDataGridHeaders = ({
+  canTranslate,
+  columns,
+  translate,
+}: {
+  canTranslate: (key: string) => boolean
+  columns: string[]
+  translate: (key: string) => string
+}): Array<TableDataGridHeader<TableDataGridRow>> => columns.map(column => {
+  const labelKey = `chartLabels.${column}`
 
-    return {
-      key: column,
-      label: canTranslate(labelKey) ? translate(labelKey) : column,
-    }
-  }),
+  return {
+    key: column,
+    label: canTranslate(labelKey) ? translate(labelKey) : column,
+  }
+})
+
+/** Maps a table tile datasource to the header builder used by TableDataGridRenderer. */
+export const tableDataGridHeadersByDatasource = {
+  platform: platformTableDataGridHeaders,
+  platform_usage: platformTableDataGridHeaders,
+}
+
+/**
+ * Fetches one page of platform tabular rows, applying dashboard context filters and
+ * forwarding the datasource-aware query to AnalyticsBridge.tabularQueryFn.
+ *
+ * @param options - Fetcher options supplied by TableDataGridRenderer.
+ * @param options.abortController - Abort controller passed through to the tabular bridge request.
+ * @param options.context - Dashboard renderer context used to merge tile filters with dashboard filters.
+ * @param options.cursor - Optional pagination cursor supplied by TableDataGrid.
+ * @param options.onResponseColumns - Optional callback for response metadata columns.
+ * @param options.pageSize - Number of records to request for the current page.
+ * @param options.query - Datasource-aware platform tabular query from the table tile definition.
+ * @param options.stripUnknownFilters - Filter sanitizer for the target datasource.
+ * @param options.tabularQueryFn - Analytics bridge function that executes the tabular query.
+ * @returns A TableDataGrid page result with rows, the next cursor, and whether more pages are available.
+ */
+const platformTableDataGridFetcher = async ({
+  abortController,
+  context,
+  cursor,
+  pageSize,
+  query,
+  onResponseColumns,
+  stripUnknownFilters,
+  tabularQueryFn,
+}: {
+  abortController: AbortController
+  context: DashboardRendererContextInternal
+  cursor?: unknown
+  onResponseColumns?: (columns: string[]) => void
+  pageSize: number
+  query: PlatformDatasourceTabularQuery
+  stripUnknownFilters: StripUnknownFilters
+  tabularQueryFn: AnalyticsBridge['tabularQueryFn']
+}): Promise<TableDataGridFetcherResult<TableDataGridRow>> => {
+  if (!tabularQueryFn) {
+    throw new Error('AnalyticsBridge.tabularQueryFn is not defined')
+  }
+
+  const platformQuery = query.query
+  const filters = stripUnknownFilters({
+    datasource: 'platform',
+    filters: [
+      ...((platformQuery.filters ?? []) as AllFilters[]),
+      ...context.filters,
+    ],
+    queryFields: platformQuery.entity === undefined ? undefined : [platformQuery.entity],
+  }) as PlatformTabularQuery['filters']
+
+  const response = await tabularQueryFn({
+    datasource: query.datasource,
+    query: {
+      columns: platformQuery.columns,
+      cursor: cursor === undefined ? platformQuery.cursor : String(cursor),
+      entity: platformQuery.entity,
+      filters,
+      page_size: pageSize,
+    },
+  }, abortController)
+
+  if (response.meta.columns?.length) {
+    onResponseColumns?.(response.meta.columns)
+  }
+
+  return {
+    data: platformTabularResponseToTableDataGridRows(response),
+    cursor: response.meta.cursor,
+    hasMore: Boolean(response.meta.cursor),
+  }
 }
 
 /**
  * Maps a table tile datasource to the fetcher used by TableDataGridRenderer.
  */
 export const tableDataGridFetcherByDatasource = {
-  /**
-   * Fetches one page of platform tabular rows, applying dashboard context filters and
-   * forwarding the datasource-aware query to AnalyticsBridge.tabularQueryFn.
-   *
-   * @param options - Fetcher options supplied by TableDataGridRenderer.
-   * @param options.abortController - Abort controller passed through to the tabular bridge request.
-   * @param options.context - Dashboard renderer context used to merge tile filters with dashboard filters.
-   * @param options.cursor - Optional pagination cursor supplied by TableDataGrid.
-   * @param options.onResponseColumns - Optional callback for response metadata columns.
-   * @param options.pageSize - Number of records to request for the current page.
-   * @param options.query - Datasource-aware platform tabular query from the table tile definition.
-   * @param options.stripUnknownFilters - Filter sanitizer for the target datasource.
-   * @param options.tabularQueryFn - Analytics bridge function that executes the tabular query.
-   * @returns A TableDataGrid page result with rows, the next cursor, and whether more pages are available.
-   */
-  platform: async ({
-    abortController,
-    context,
-    cursor,
-    pageSize,
-    query,
-    onResponseColumns,
-    stripUnknownFilters,
-    tabularQueryFn,
-  }: {
-    abortController: AbortController
-    context: DashboardRendererContextInternal
-    cursor?: unknown
-    onResponseColumns?: (columns: string[]) => void
-    pageSize: number
-    query: PlatformDatasourceTabularQuery
-    stripUnknownFilters: StripUnknownFilters
-    tabularQueryFn: AnalyticsBridge['tabularQueryFn']
-  }): Promise<TableDataGridFetcherResult<TableDataGridRow>> => {
-    if (!tabularQueryFn) {
-      throw new Error('AnalyticsBridge.tabularQueryFn is not defined')
-    }
-
-    const platformQuery = query.query
-    const filters = stripUnknownFilters({
-      datasource: 'platform',
-      filters: [
-        ...((platformQuery.filters ?? []) as AllFilters[]),
-        ...context.filters,
-      ],
-      queryFields: platformQuery.entity === undefined ? undefined : [platformQuery.entity],
-    }) as PlatformTabularQuery['filters']
-
-    const response = await tabularQueryFn({
-      datasource: query.datasource,
-      query: {
-        columns: platformQuery.columns,
-        cursor: cursor === undefined ? platformQuery.cursor : String(cursor),
-        entity: platformQuery.entity,
-        filters,
-        page_size: pageSize,
-      },
-    }, abortController)
-
-    if (response.meta.columns?.length) {
-      onResponseColumns?.(response.meta.columns)
-    }
-
-    return {
-      data: platformTabularResponseToTableDataGridRows(response),
-      cursor: response.meta.cursor,
-      hasMore: Boolean(response.meta.cursor),
-    }
-  },
+  platform: platformTableDataGridFetcher,
+  platform_usage: platformTableDataGridFetcher,
 }

--- a/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/table-data-grid-renderer.ts
@@ -2,7 +2,7 @@ import type { DashboardRendererContextInternal } from '../types'
 import type {
   AllFilters,
   AnalyticsBridge,
-  PlatformDatasourceTabularQuery,
+  DatasourceAwareTabularQuery,
   PlatformTabularQuery,
   PlatformTabularResponse,
 } from '@kong-ui-public/analytics-utilities'
@@ -105,7 +105,7 @@ const platformTableDataGridFetcher = async ({
   cursor?: unknown
   onResponseColumns?: (columns: string[]) => void
   pageSize: number
-  query: PlatformDatasourceTabularQuery
+  query: DatasourceAwareTabularQuery
   stripUnknownFilters: StripUnknownFilters
   tabularQueryFn: AnalyticsBridge['tabularQueryFn']
 }): Promise<TableDataGridFetcherResult<TableDataGridRow>> => {


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

MA-5024-dashboard-add-data-source
Add an additional allowed data source to platform analytics dashboard query.  `platform_usage` will act the same as `platform`
