### PR TITLE
feat(entities-plugins): redesign Konnect plugin list (search API, Name/Scope/Status columns)

### DIFF
--- a/packages/entities/entities-plugins/sandbox/index.html
+++ b/packages/entities/entities-plugins/sandbox/index.html
@@ -16,6 +16,9 @@
         padding: 0;
       }
 
+      *, *::before, *::after {
+        box-sizing: border-box;
+      }
     </style>
   </head>
 

--- a/packages/entities/entities-plugins/sandbox/pages/PluginListPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginListPage.vue
@@ -61,6 +61,8 @@ const konnectConfig = ref<KonnectPluginListConfig>({
   apiBaseUrl: '/us/kong-api',
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
+  // Sandbox override for local testing of the redesigned plugin list (search API, Name/Scope/Status/Ordering columns, KFilterGroup toolbar)
+  pluginTableImprovements: { filtering: true },
   createRoute: { name: 'select-plugin' },
   getViewRoute: (plugin: EntityRow) => ({ name: 'view-plugin', params: { id: plugin.id, plugin: plugin.name } }),
   getEditRoute: (plugin: EntityRow) => ({ name: 'edit-plugin', params: { id: plugin.id, plugin: plugin.name } }),

--- a/packages/entities/entities-plugins/src/components/PluginFilter.vue
+++ b/packages/entities/entities-plugins/src/components/PluginFilter.vue
@@ -1,0 +1,186 @@
+<template>
+  <div class="plugin-filter">
+    <KInput
+      v-model="searchText"
+      autocomplete="off"
+      class="plugin-search-input"
+      data-testid="search-input"
+      :placeholder="t('search.placeholder.search')"
+    >
+      <template #before>
+        <SearchIcon decorative />
+      </template>
+      <template #after>
+        <CloseIcon
+          v-show="searchText !== ''"
+          class="plugin-search-clear"
+          role="button"
+          tabindex="0"
+          @click="searchText = ''"
+        />
+      </template>
+    </KInput>
+    <KFilterGroup
+      v-model="filterGroupSelection"
+      :filters="pluginFilterGroupFilters"
+      @apply="overrideDelimiter"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { FilterGroupFilters, FilterGroupSelection } from '@kong/kongponents'
+import { CloseIcon, SearchIcon } from '@kong/icons'
+import composables from '../composables'
+import { PluginScope } from '../types'
+import type { EntityType } from '../types'
+
+const { i18n: { t } } = composables.useI18n()
+
+// Maps a nested entity page's `entityType` to the search API's singular scope filter key
+const ENTITY_TYPE_TO_SCOPE_FILTER_KEY: Partial<Record<EntityType, PluginScope>> = {
+  routes: PluginScope.ROUTE,
+  services: PluginScope.SERVICE,
+  consumers: PluginScope.CONSUMER,
+  consumer_groups: PluginScope.CONSUMER_GROUP,
+}
+
+const { entityType, entityId } = defineProps<{
+  /**
+   * Set when this list is nested under a Route/Service/Consumer/Consumer-Group detail page - the
+   * scope is then implied by the page, so the Scope pill is hidden and every request is forced
+   * server-side to that one entity instead of being user-selectable.
+   */
+  entityType?: EntityType
+  entityId?: string
+}>()
+
+const nestedScopeFilterKey = computed(() => (
+  entityType && entityId ? ENTITY_TYPE_TO_SCOPE_FILTER_KEY[entityType] : undefined
+))
+
+/**
+ * The `/plugins/search` request's raw, wire-ready query string (bracket-notation `filter[field][operator]`
+ * params + top-level `tags`) - same idea as EntityFilter's fuzzy-match mode, which serializes straight
+ * into the params Kong Manager's API accepts natively, with no decode step needed downstream.
+ */
+const modelValue = defineModel<string>({ required: true })
+
+const searchText = ref('')
+const filterGroupSelection = ref<FilterGroupSelection>({})
+
+const pluginFilterGroupFilters = computed<FilterGroupFilters>(() => {
+  const scopeFilter: FilterGroupFilters = nestedScopeFilterKey.value
+    ? {}
+    : {
+      scope: {
+        label: t('plugins.list.table_headers.scope'),
+        operators: ['eq'],
+        pinned: true,
+        // TODO: the search API's filter.scope.eq only accepts a single value (no OR/"one-of"
+        // operator for scope as of the current SDK) - single-select until the backend supports
+        // filtering by more than one scope at once.
+        multiple: false,
+        options: [
+          { label: t('plugins.list.table_headers.applied_to_badges.route'), value: PluginScope.ROUTE },
+          { label: t('plugins.list.table_headers.applied_to_badges.service'), value: PluginScope.SERVICE },
+          { label: t('plugins.list.table_headers.applied_to_badges.consumer'), value: PluginScope.CONSUMER },
+          { label: t('plugins.list.table_headers.applied_to_badges.consumer_group'), value: PluginScope.CONSUMER_GROUP },
+          { label: t('plugins.list.table_headers.applied_to_badges.global'), value: PluginScope.GLOBAL },
+        ],
+      },
+    }
+
+  const filters: FilterGroupFilters = {
+    ...scopeFilter,
+    status: {
+      label: t('plugins.list.table_headers.status'),
+      operators: ['eq'],
+      pinned: true,
+      options: [
+        { label: t('actions.enabled'), value: 'true' },
+        { label: t('actions.disabled'), value: 'false' },
+      ],
+    },
+    tags: {
+      label: t('plugins.list.table_headers.tags'),
+      operators: ['eq'],
+      pinned: true,
+      multiple: true,
+    },
+  }
+
+  return filters
+})
+
+// Build the actual wire-format query string directly - no intermediate encoding for a consumer
+// to decode later. PluginList.vue's fetcher (via useFetcher/useFetchUrlBuilder with
+// isExactMatch: false) appends this straight onto the /plugins/search request.
+const serializedQuery = computed<string>(() => {
+  const params = new URLSearchParams()
+
+  if (searchText.value) {
+    params.set('filter[name][contains]', searchText.value)
+  }
+
+  if (nestedScopeFilterKey.value && entityId) {
+    // Nested entity page: always scope to that one entity, and the scope pill is hidden
+    params.set(`filter[${nestedScopeFilterKey.value}][eq]`, entityId)
+  } else {
+    const scopeSelection = filterGroupSelection.value.scope
+    if (typeof scopeSelection?.value === 'string' && scopeSelection.value) {
+      params.set('filter[scope][eq]', scopeSelection.value)
+    }
+  }
+
+  const statusSelection = filterGroupSelection.value.status
+  if (statusSelection?.value) {
+    params.set('filter[enabled]', statusSelection.value === 'true' ? 'true' : 'false')
+  }
+
+  const tagsSelection = filterGroupSelection.value.tags
+  const tagsValues = Array.isArray(tagsSelection?.value) ? tagsSelection.value : []
+  if (tagsValues.length) {
+    params.set('tags', tagsValues.join(','))
+  }
+
+  return params.toString()
+})
+
+watch(serializedQuery, (value) => {
+  modelValue.value = value
+})
+
+// Empty internal state when the external modelValue is cleared
+watch(modelValue, (value) => {
+  if (!value) {
+    searchText.value = ''
+    filterGroupSelection.value = {}
+  }
+})
+
+const overrideDelimiter = (appliedFilterKey: string, selection: FilterGroupSelection) => {
+  const appliedFilter = selection[appliedFilterKey]
+  if (appliedFilter) {
+    // Override the default `=` delimiter
+    appliedFilter.operatorDelimiter = ': '
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.plugin-filter {
+  align-items: center;
+  display: flex;
+  gap: var(--kui-space-70, $kui-space-70);
+
+  .plugin-search-input {
+    width: 320px;
+  }
+
+  .plugin-search-clear {
+    cursor: pointer;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/PluginFilter.vue
+++ b/packages/entities/entities-plugins/src/components/PluginFilter.vue
@@ -79,6 +79,9 @@
         </div>
       </template>
       <template #filter-scope>
+        <!-- TODO: the search API's filter.scope.eq only accepts a single value (no OR/"one-of"
+          operator for scope as of the current SDK) - single-select until the backend supports
+          filtering by more than one scope at once. -->
         <KSelect
           v-model="pendingScope"
           data-testid="scope-filter-select"
@@ -146,11 +149,6 @@ const filterGroupSelection = ref<FilterGroupSelection>({})
 const searchInput = useTemplateRef('search-input')
 const tagsInput = useTemplateRef('tags-input')
 
-// Working state for the custom `scope`/`status` filter popovers (see `#filter-scope` and
-// `#filter-status` slots below) - KFilterGroup's default select/radio rendering can't be
-// restyled (e.g. dropping the "Value" label, custom placeholder, radios instead of a select),
-// so both filters are fully slot-overridden and their selection is synced manually on apply,
-// the same way the `tags` filter already works.
 const pendingScope = ref<string | null>(null)
 const pendingStatus = ref<string | null>(null)
 
@@ -222,11 +220,6 @@ const pluginFilterGroupFilters = computed<FilterGroupFilters>(() => {
         label: t('plugins.list.table_headers.scope'),
         operators: ['eq'],
         pinned: true,
-        // TODO: the search API's filter.scope.eq only accepts a single value (no OR/"one-of"
-        // operator for scope as of the current SDK) - single-select until the backend supports
-        // filtering by more than one scope at once.
-        multiple: false,
-        options: scopeOptions.value,
       },
     }
 
@@ -236,7 +229,7 @@ const pluginFilterGroupFilters = computed<FilterGroupFilters>(() => {
       label: t('plugins.list.table_headers.status'),
       operators: ['eq'],
       pinned: true,
-      options: statusOptions.value,
+      maxWidth: 350,
     },
     tags: {
       label: t('plugins.list.table_headers.tags'),
@@ -305,60 +298,69 @@ watch(modelValue, (value) => {
 })
 
 const onFilterOpen = (openedFilterKey: string) => {
-  if (openedFilterKey === 'tags') {
-    const currentValue = filterGroupSelection.value.tags?.value
-    pendingTags.value = Array.isArray(currentValue) ? [...currentValue] : []
-    tagInputText.value = ''
-  } else if (openedFilterKey === 'scope') {
-    const currentValue = filterGroupSelection.value.scope?.value
-    pendingScope.value = typeof currentValue === 'string' ? currentValue : null
-  } else if (openedFilterKey === 'status') {
-    const currentValue = filterGroupSelection.value.status?.value
-    pendingStatus.value = typeof currentValue === 'string' ? currentValue : null
+  switch (openedFilterKey) {
+    case 'tags': {
+      const currentValue = filterGroupSelection.value.tags?.value
+      pendingTags.value = Array.isArray(currentValue) ? [...currentValue] : []
+      tagInputText.value = ''
+      return
+    }
+
+    case 'scope': {
+      const currentValue = filterGroupSelection.value.scope?.value
+      pendingScope.value = typeof currentValue === 'string' ? currentValue : null
+      return
+    }
+
+    case 'status': {
+      const currentValue = filterGroupSelection.value.status?.value
+      pendingStatus.value = typeof currentValue === 'string' ? currentValue : null
+    }
   }
 }
 
 const onFilterApply = (appliedFilterKey: string, selection: FilterGroupSelection) => {
-  if (appliedFilterKey === 'tags') {
-    if (pendingTags.value.length) {
-      selection.tags = {
-        operator: 'eq',
-        operatorDelimiter: ': ',
-        value: [...pendingTags.value],
-        text: pendingTags.value.join(', '),
+  switch (appliedFilterKey) {
+    case 'tags':
+      if (pendingTags.value.length) {
+        selection.tags = {
+          operator: 'eq',
+          operatorDelimiter: ': ',
+          value: [...pendingTags.value],
+          text: pendingTags.value.join(', '),
+        }
+      } else {
+        delete selection.tags
       }
-    } else {
-      delete selection.tags
-    }
-    return
-  }
+      return
 
-  if (appliedFilterKey === 'scope') {
-    const selectedOption = scopeOptions.value.find((option) => option.value === pendingScope.value)
-    if (selectedOption) {
-      selection.scope = {
-        operator: 'eq',
-        operatorDelimiter: ': ',
-        value: selectedOption.value,
-        text: selectedOption.label,
+    case 'scope': {
+      const selectedOption = scopeOptions.value.find((option) => option.value === pendingScope.value)
+      if (selectedOption) {
+        selection.scope = {
+          operator: 'eq',
+          operatorDelimiter: ': ',
+          value: selectedOption.value,
+          text: selectedOption.label,
+        }
+      } else {
+        delete selection.scope
       }
-    } else {
-      delete selection.scope
+      return
     }
-    return
-  }
 
-  if (appliedFilterKey === 'status') {
-    const selectedOption = statusOptions.value.find((option) => option.value === pendingStatus.value)
-    if (selectedOption) {
-      selection.status = {
-        operator: 'eq',
-        operatorDelimiter: ': ',
-        value: selectedOption.value,
-        text: selectedOption.label,
+    case 'status': {
+      const selectedOption = statusOptions.value.find((option) => option.value === pendingStatus.value)
+      if (selectedOption) {
+        selection.status = {
+          operator: 'eq',
+          operatorDelimiter: ': ',
+          value: selectedOption.value,
+          text: selectedOption.label,
+        }
+      } else {
+        delete selection.status
       }
-    } else {
-      delete selection.status
     }
   }
 }

--- a/packages/entities/entities-plugins/src/components/PluginFilter.vue
+++ b/packages/entities/entities-plugins/src/components/PluginFilter.vue
@@ -78,13 +78,33 @@
           </div>
         </div>
       </template>
+      <template #filter-scope>
+        <KSelect
+          v-model="pendingScope"
+          data-testid="scope-filter-select"
+          :items="scopeOptions"
+          :placeholder="t('search.placeholder.scope_filter')"
+        />
+      </template>
+      <template #filter-status>
+        <div class="plugin-status-filter">
+          <KRadio
+            v-for="option in statusOptions"
+            :key="option.value"
+            v-model="pendingStatus"
+            data-testid="status-filter-radio"
+            :label="option.label"
+            :selected-value="option.value"
+          />
+        </div>
+      </template>
     </KFilterGroup>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, useTemplateRef, watch } from 'vue'
-import type { FilterGroupFilters, FilterGroupSelection } from '@kong/kongponents'
+import type { FilterGroupFilters, FilterGroupSelection, FilterOption } from '@kong/kongponents'
 import { ArrowTopLeftIcon, CloseIcon, SearchIcon } from '@kong/icons'
 import composables from '../composables'
 import { PluginScope } from '../types'
@@ -125,6 +145,27 @@ const searchText = ref('')
 const filterGroupSelection = ref<FilterGroupSelection>({})
 const searchInput = useTemplateRef('search-input')
 const tagsInput = useTemplateRef('tags-input')
+
+// Working state for the custom `scope`/`status` filter popovers (see `#filter-scope` and
+// `#filter-status` slots below) - KFilterGroup's default select/radio rendering can't be
+// restyled (e.g. dropping the "Value" label, custom placeholder, radios instead of a select),
+// so both filters are fully slot-overridden and their selection is synced manually on apply,
+// the same way the `tags` filter already works.
+const pendingScope = ref<string | null>(null)
+const pendingStatus = ref<string | null>(null)
+
+const scopeOptions = computed<FilterOption[]>(() => [
+  { label: t('plugins.list.table_headers.applied_to_badges.route'), value: PluginScope.ROUTE },
+  { label: t('plugins.list.table_headers.applied_to_badges.service'), value: PluginScope.SERVICE },
+  { label: t('plugins.list.table_headers.applied_to_badges.consumer'), value: PluginScope.CONSUMER },
+  { label: t('plugins.list.table_headers.applied_to_badges.consumer_group'), value: PluginScope.CONSUMER_GROUP },
+  { label: t('plugins.list.table_headers.applied_to_badges.global'), value: PluginScope.GLOBAL },
+])
+
+const statusOptions = computed<FilterOption[]>(() => [
+  { label: t('actions.enabled'), value: 'true' },
+  { label: t('actions.disabled'), value: 'false' },
+])
 
 // Working state for the custom `tags` filter popover (see `#filter-tags` slot below) - the tag
 // badges the user has built up before hitting Apply. KFilterGroup can't derive a selection for
@@ -185,13 +226,7 @@ const pluginFilterGroupFilters = computed<FilterGroupFilters>(() => {
         // operator for scope as of the current SDK) - single-select until the backend supports
         // filtering by more than one scope at once.
         multiple: false,
-        options: [
-          { label: t('plugins.list.table_headers.applied_to_badges.route'), value: PluginScope.ROUTE },
-          { label: t('plugins.list.table_headers.applied_to_badges.service'), value: PluginScope.SERVICE },
-          { label: t('plugins.list.table_headers.applied_to_badges.consumer'), value: PluginScope.CONSUMER },
-          { label: t('plugins.list.table_headers.applied_to_badges.consumer_group'), value: PluginScope.CONSUMER_GROUP },
-          { label: t('plugins.list.table_headers.applied_to_badges.global'), value: PluginScope.GLOBAL },
-        ],
+        options: scopeOptions.value,
       },
     }
 
@@ -201,10 +236,7 @@ const pluginFilterGroupFilters = computed<FilterGroupFilters>(() => {
       label: t('plugins.list.table_headers.status'),
       operators: ['eq'],
       pinned: true,
-      options: [
-        { label: t('actions.enabled'), value: 'true' },
-        { label: t('actions.disabled'), value: 'false' },
-      ],
+      options: statusOptions.value,
     },
     tags: {
       label: t('plugins.list.table_headers.tags'),
@@ -267,6 +299,8 @@ watch(modelValue, (value) => {
     filterGroupSelection.value = {}
     tagInputText.value = ''
     pendingTags.value = []
+    pendingScope.value = null
+    pendingStatus.value = null
   }
 })
 
@@ -275,6 +309,12 @@ const onFilterOpen = (openedFilterKey: string) => {
     const currentValue = filterGroupSelection.value.tags?.value
     pendingTags.value = Array.isArray(currentValue) ? [...currentValue] : []
     tagInputText.value = ''
+  } else if (openedFilterKey === 'scope') {
+    const currentValue = filterGroupSelection.value.scope?.value
+    pendingScope.value = typeof currentValue === 'string' ? currentValue : null
+  } else if (openedFilterKey === 'status') {
+    const currentValue = filterGroupSelection.value.status?.value
+    pendingStatus.value = typeof currentValue === 'string' ? currentValue : null
   }
 }
 
@@ -293,10 +333,33 @@ const onFilterApply = (appliedFilterKey: string, selection: FilterGroupSelection
     return
   }
 
-  const appliedFilter = selection[appliedFilterKey]
-  if (appliedFilter) {
-    // Override the default `=` delimiter
-    appliedFilter.operatorDelimiter = ': '
+  if (appliedFilterKey === 'scope') {
+    const selectedOption = scopeOptions.value.find((option) => option.value === pendingScope.value)
+    if (selectedOption) {
+      selection.scope = {
+        operator: 'eq',
+        operatorDelimiter: ': ',
+        value: selectedOption.value,
+        text: selectedOption.label,
+      }
+    } else {
+      delete selection.scope
+    }
+    return
+  }
+
+  if (appliedFilterKey === 'status') {
+    const selectedOption = statusOptions.value.find((option) => option.value === pendingStatus.value)
+    if (selectedOption) {
+      selection.status = {
+        operator: 'eq',
+        operatorDelimiter: ': ',
+        value: selectedOption.value,
+        text: selectedOption.label,
+      }
+    } else {
+      delete selection.status
+    }
   }
 }
 
@@ -304,6 +367,10 @@ const onFilterClear = (clearedFilterKey: string) => {
   if (clearedFilterKey === 'tags') {
     pendingTags.value = []
     tagInputText.value = ''
+  } else if (clearedFilterKey === 'scope') {
+    pendingScope.value = null
+  } else if (clearedFilterKey === 'status') {
+    pendingStatus.value = null
   }
 }
 </script>
@@ -338,5 +405,11 @@ const onFilterClear = (clearedFilterKey: string) => {
     flex-wrap: wrap;
     gap: var(--kui-space-40, $kui-space-40);
   }
+}
+
+.plugin-status-filter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-40, $kui-space-40);
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/PluginFilter.vue
+++ b/packages/entities/entities-plugins/src/components/PluginFilter.vue
@@ -204,10 +204,7 @@ const serializedQuery = computed<string>(() => {
     params.set('filter[name][contains]', searchText.value)
   }
 
-  if (nestedScopeFilterKey.value && entityId) {
-    // Nested entity page: always scope to that one entity, and the scope pill is hidden
-    params.set(`filter[${nestedScopeFilterKey.value}][eq]`, entityId)
-  } else {
+  if (!nestedScopeFilterKey.value) {
     const scopeSelection = filterGroupSelection.value.scope
     if (typeof scopeSelection?.value === 'string' && scopeSelection.value) {
       params.set('filter[scope][eq]', scopeSelection.value)
@@ -224,6 +221,13 @@ const serializedQuery = computed<string>(() => {
   if (tagsValues.length) {
     // Multiple tags can be concatenated using ',' to mean AND or using '/' to mean OR.
     params.set('tags', tagsValues.join('/'))
+  }
+
+  // On a nested entity page, only scope to that one entity once the user has actually triggered a
+  // search/filter - an otherwise-unfiltered load should keep hitting the plain, already
+  // entity-scoped (by URL path) list endpoint instead of switching to /plugins/search.
+  if (nestedScopeFilterKey.value && entityId && params.toString()) {
+    params.set(`filter[${nestedScopeFilterKey.value}][eq]`, entityId)
   }
 
   return params.toString()

--- a/packages/entities/entities-plugins/src/components/PluginFilter.vue
+++ b/packages/entities/entities-plugins/src/components/PluginFilter.vue
@@ -23,15 +23,63 @@
     <KFilterGroup
       v-model="filterGroupSelection"
       :filters="pluginFilterGroupFilters"
-      @apply="overrideDelimiter"
-    />
+      @apply="onFilterApply"
+      @clear="onFilterClear"
+      @open="onFilterOpen"
+    >
+      <template #filter-tags>
+        <div class="plugin-tags-filter">
+          <KInput
+            v-model="tagInputText"
+            autocomplete="off"
+            data-testid="tags-filter-input"
+            :error="!!tagInputError"
+            :error-message="tagInputError"
+            :placeholder="t('search.placeholder.tags_filter')"
+            @keydown.enter.prevent="addPendingTag"
+          >
+            <template #after>
+              <ArrowTopLeftIcon
+                class="plugin-tags-filter-add"
+                data-testid="tags-filter-add"
+                role="button"
+                tabindex="0"
+                @click="addPendingTag"
+                @keydown.enter.prevent="addPendingTag"
+              />
+            </template>
+          </KInput>
+          <div
+            v-if="pendingTags.length"
+            class="plugin-tags-filter-badges"
+          >
+            <KBadge
+              v-for="tag in pendingTags"
+              :key="tag"
+              :icon-before="false"
+            >
+              {{ tag }}
+              <template #icon>
+                <CloseIcon
+                  data-testid="tags-filter-remove-tag"
+                  role="button"
+                  tabindex="0"
+                  @click="removePendingTag(tag)"
+                  @keydown.enter.prevent="removePendingTag(tag)"
+                />
+              </template>
+            </KBadge>
+          </div>
+        </div>
+      </template>
+    </KFilterGroup>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import type { FilterGroupFilters, FilterGroupSelection } from '@kong/kongponents'
-import { CloseIcon, SearchIcon } from '@kong/icons'
+import { ArrowTopLeftIcon, CloseIcon, SearchIcon } from '@kong/icons'
 import composables from '../composables'
 import { PluginScope } from '../types'
 import type { EntityType } from '../types'
@@ -69,6 +117,38 @@ const modelValue = defineModel<string>({ required: true })
 
 const searchText = ref('')
 const filterGroupSelection = ref<FilterGroupSelection>({})
+
+// Working state for the custom `tags` filter popover (see `#filter-tags` slot below) - the tag
+// badges the user has built up before hitting Apply. KFilterGroup can't derive a selection for
+// a slot-overridden filter itself, so this is synced into `filterGroupSelection.tags` on apply.
+const tagInputText = ref('')
+const pendingTags = ref<string[]>([])
+
+// Tag validation: unicode letters/numbers and most ASCII symbols are allowed,
+// but no commas (used as the tag-list delimiter), slashes, control characters,
+// or leading/trailing spaces. Interior spaces between characters are fine.
+const TAG_PATTERN = /^(?:[\x21-\x2B\x2D\x2E\x30-\x7E\p{N}\p{L}]+(?: *[\x21-\x2B\x2D\x2E\x30-\x7E\p{N}\p{L}])*)?$/u
+
+const tagInputError = computed(() => (
+  tagInputText.value && !TAG_PATTERN.test(tagInputText.value)
+    ? t('search.filter.tags_invalid')
+    : ''
+))
+
+const addPendingTag = () => {
+  const tag = tagInputText.value
+  if (!tag || !TAG_PATTERN.test(tag)) {
+    return
+  }
+  if (!pendingTags.value.includes(tag)) {
+    pendingTags.value.push(tag)
+  }
+  tagInputText.value = ''
+}
+
+const removePendingTag = (tag: string) => {
+  pendingTags.value = pendingTags.value.filter((pendingTag) => pendingTag !== tag)
+}
 
 const pluginFilterGroupFilters = computed<FilterGroupFilters>(() => {
   const scopeFilter: FilterGroupFilters = nestedScopeFilterKey.value
@@ -142,7 +222,8 @@ const serializedQuery = computed<string>(() => {
   const tagsSelection = filterGroupSelection.value.tags
   const tagsValues = Array.isArray(tagsSelection?.value) ? tagsSelection.value : []
   if (tagsValues.length) {
-    params.set('tags', tagsValues.join(','))
+    // Multiple tags can be concatenated using ',' to mean AND or using '/' to mean OR.
+    params.set('tags', tagsValues.join('/'))
   }
 
   return params.toString()
@@ -157,14 +238,45 @@ watch(modelValue, (value) => {
   if (!value) {
     searchText.value = ''
     filterGroupSelection.value = {}
+    tagInputText.value = ''
+    pendingTags.value = []
   }
 })
 
-const overrideDelimiter = (appliedFilterKey: string, selection: FilterGroupSelection) => {
+const onFilterOpen = (openedFilterKey: string) => {
+  if (openedFilterKey === 'tags') {
+    const currentValue = filterGroupSelection.value.tags?.value
+    pendingTags.value = Array.isArray(currentValue) ? [...currentValue] : []
+    tagInputText.value = ''
+  }
+}
+
+const onFilterApply = (appliedFilterKey: string, selection: FilterGroupSelection) => {
+  if (appliedFilterKey === 'tags') {
+    if (pendingTags.value.length) {
+      selection.tags = {
+        operator: 'eq',
+        operatorDelimiter: ': ',
+        value: [...pendingTags.value],
+        text: pendingTags.value.join(', '),
+      }
+    } else {
+      delete selection.tags
+    }
+    return
+  }
+
   const appliedFilter = selection[appliedFilterKey]
   if (appliedFilter) {
     // Override the default `=` delimiter
     appliedFilter.operatorDelimiter = ': '
+  }
+}
+
+const onFilterClear = (clearedFilterKey: string) => {
+  if (clearedFilterKey === 'tags') {
+    pendingTags.value = []
+    tagInputText.value = ''
   }
 }
 </script>
@@ -181,6 +293,23 @@ const overrideDelimiter = (appliedFilterKey: string, selection: FilterGroupSelec
 
   .plugin-search-clear {
     cursor: pointer;
+  }
+}
+
+.plugin-tags-filter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-60, $kui-space-60);
+
+  .plugin-tags-filter-add {
+    cursor: pointer;
+    transform: scaleY(-1);
+  }
+
+  .plugin-tags-filter-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--kui-space-40, $kui-space-40);
   }
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/PluginFilter.vue
+++ b/packages/entities/entities-plugins/src/components/PluginFilter.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="plugin-filter">
     <KInput
+      ref="search-input"
       v-model="searchText"
       autocomplete="off"
       class="plugin-search-input"
@@ -16,7 +17,9 @@
           class="plugin-search-clear"
           role="button"
           tabindex="0"
-          @click="searchText = ''"
+          @click="clearSearchText"
+          @keydown.enter.prevent="clearSearchText"
+          @keydown.space.prevent="clearSearchText"
         />
       </template>
     </KInput>
@@ -30,6 +33,7 @@
       <template #filter-tags>
         <div class="plugin-tags-filter">
           <KInput
+            ref="tags-input"
             v-model="tagInputText"
             autocomplete="off"
             data-testid="tags-filter-input"
@@ -46,6 +50,7 @@
                 tabindex="0"
                 @click="addPendingTag"
                 @keydown.enter.prevent="addPendingTag"
+                @keydown.space.prevent="addPendingTag"
               />
             </template>
           </KInput>
@@ -66,6 +71,7 @@
                   tabindex="0"
                   @click="removePendingTag(tag)"
                   @keydown.enter.prevent="removePendingTag(tag)"
+                  @keydown.space.prevent="removePendingTag(tag)"
                 />
               </template>
             </KBadge>
@@ -77,7 +83,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, useTemplateRef, watch } from 'vue'
 import type { FilterGroupFilters, FilterGroupSelection } from '@kong/kongponents'
 import { ArrowTopLeftIcon, CloseIcon, SearchIcon } from '@kong/icons'
 import composables from '../composables'
@@ -117,6 +123,8 @@ const modelValue = defineModel<string>({ required: true })
 
 const searchText = ref('')
 const filterGroupSelection = ref<FilterGroupSelection>({})
+const searchInput = useTemplateRef('search-input')
+const tagsInput = useTemplateRef('tags-input')
 
 // Working state for the custom `tags` filter popover (see `#filter-tags` slot below) - the tag
 // badges the user has built up before hitting Apply. KFilterGroup can't derive a selection for
@@ -135,15 +143,30 @@ const tagInputError = computed(() => (
     : ''
 ))
 
+const focusSearchInput = () => {
+  searchInput.value?.input?.focus()
+}
+
+const focusTagsInput = () => {
+  tagsInput.value?.input?.focus()
+}
+
+const clearSearchText = () => {
+  searchText.value = ''
+  focusSearchInput()
+}
+
 const addPendingTag = () => {
   const tag = tagInputText.value
   if (!tag || !TAG_PATTERN.test(tag)) {
+    focusTagsInput()
     return
   }
   if (!pendingTags.value.includes(tag)) {
     pendingTags.value.push(tag)
   }
   tagInputText.value = ''
+  focusTagsInput()
 }
 
 const removePendingTag = (tag: string) => {

--- a/packages/entities/entities-plugins/src/components/PluginList.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginList.cy.ts
@@ -1121,4 +1121,177 @@ describe('<PluginList />', () => {
       cy.get('.kong-ui-entities-plugins-list').should('be.visible')
     })
   })
+
+  describe('plugin list redesign (isPluginTableEnhanced)', () => {
+    const redesignConfig: KonnectPluginListConfig = {
+      ...baseConfigKonnect,
+      pluginTableImprovements: { filtering: true },
+    }
+
+    it('omitting the flag keeps hitting the plain list endpoint, not /plugins/search', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/plugins*`,
+        },
+        { statusCode: 200, body: plugins },
+      ).as('plainList')
+
+      cy.mount(PluginList, {
+        props: {
+          cacheIdentifier: `plugin-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+          canToggle: () => false,
+        },
+      })
+
+      cy.wait('@plainList')
+      cy.get('table thead th').eq(0).should('contain.text', 'Name')
+      cy.get('table thead th').eq(1).should('contain.text', 'Applied to')
+      cy.get('.kong-ui-entity-filter-input').should('exist')
+    })
+
+    it('a plain unfiltered load keeps hitting the plain list endpoint, only switching to /plugins/search once the user actually searches/filters', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/plugins*`,
+        },
+        (req) => {
+          // The search endpoint's path is a sub-path of the plain list URL pattern above - only stub the plain one here
+          if (!req.url.includes('/plugins/search')) {
+            req.reply({ statusCode: 200, body: plugins })
+          }
+        },
+      ).as('plainListRedesign')
+
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/plugins/search*`,
+        },
+        { statusCode: 200, body: { data: plugins.data, offset: null } },
+      ).as('searchPlugins')
+
+      cy.mount(PluginList, {
+        props: {
+          cacheIdentifier: `plugin-list-${uuidv4()}`,
+          config: redesignConfig,
+          canCreate: () => false,
+          canEdit: () => true,
+          canDelete: () => false,
+          canRetrieve: () => false,
+          canToggle: () => true,
+        },
+      })
+
+      // Plain load, nothing searched/filtered yet - plain endpoint, not /plugins/search
+      cy.wait('@plainListRedesign')
+
+      // Column headers: Plugin, Name, Scope, Status, Ordering, Tags, Actions
+      cy.get('table thead th').eq(0).should('contain.text', 'Plugin')
+      cy.get('table thead th').eq(1).should('contain.text', 'Name')
+      cy.get('table thead th').eq(2).should('contain.text', 'Scope')
+      cy.get('table thead th').eq(3).should('contain.text', 'Status')
+      cy.get('table thead th').eq(4).should('contain.text', 'Ordering')
+
+      // Legacy EntityFilter accordion is gone, replaced by a plain search input + KFilterGroup
+      cy.get('.kong-ui-entity-filter-input').should('not.exist')
+      cy.getTestId('search-input').filter(':visible').should('have.length', 1).should('have.attr', 'placeholder', 'Search')
+
+      // Name column shows instance_name / "-" when absent
+      cy.getTestId('basic-auth').find('[data-testid="instanceName"]').should('contain.text', 'instance-1')
+      cy.getTestId('acl').find('[data-testid="instanceName"]').should('contain.text', '-')
+
+      // Scope column is plain text, no badge - but still supports multiple values (comma-separated) and
+      // clickable links to the scoped entity, same as the legacy Applied To badges
+      cy.getTestId('basic-auth').find('[data-testid="appliedTo"] .k-badge').should('not.exist')
+      cy.getTestId('basic-auth').find('[data-testid="appliedTo"]')
+        .should('contain.text', 'Route')
+        .should('contain.text', 'Consumer')
+        .should('contain.text', 'Consumer group')
+        .find('.scope-link').should('have.length', 3)
+      cy.getTestId('acl').find('[data-testid="appliedTo"]')
+        .should('contain.text', 'Global')
+        .find('.scope-link').should('not.exist')
+
+      // Status column is a read-only badge, no switch
+      cy.getTestId('basic-auth').find('[data-testid="enabled"] .k-input-switch').should('not.exist')
+      cy.getTestId('basic-auth').find('[data-testid="enabled"] .k-badge').should('contain.text', 'Disabled')
+      cy.getTestId('acl').find('[data-testid="enabled"] .k-badge').should('contain.text', 'Enabled')
+
+      // Ordering column is plain text, no badge
+      cy.getTestId('basic-auth').find('[data-testid="ordering"] .k-badge').should('not.exist')
+      cy.getTestId('basic-auth').find('[data-testid="ordering"]').should('contain.text', 'Dynamic')
+
+      // Typing a search query is what actually switches the fetcher over to /plugins/search
+      cy.getTestId('search-input').filter(':visible').type('basic')
+      cy.wait('@searchPlugins').its('request.url').should('include', 'filter%5Bname%5D%5Bcontains%5D=basic')
+      cy.getTestId('search-input').filter(':visible').clear()
+
+      // add padding on right to the container to make the overflow actions button visible
+      cy.get('.kong-ui-entities-plugins-list').invoke('css', 'padding-right', '300px')
+
+      cy.get('[data-testid="basic-auth"] [data-testid="dropdown-trigger"]').click()
+      cy.scrollTo('100%', 0)
+      // Dropdown content is teleported out of the row's DOM subtree - only the open row's is visible
+      cy.getTestId('action-entity-toggle-enabled').filter(':visible').should('contain.text', 'Enable')
+      // eslint-disable-next-line cypress/unsafe-to-chain-command
+      cy.getTestId('action-entity-toggle-enabled').filter(':visible').click().then(() => {
+        cy.get('.k-modal').should('exist').should('contain.text', 'Enable plugin')
+      })
+    })
+
+    it('scopes the request to the entity and hides the Scope column/pill on a nested entity page', () => {
+      const nestedConfig: KonnectPluginListConfig = {
+        ...redesignConfig,
+        entityType: 'routes',
+        entityId: 'route-1',
+      }
+
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/routes/route-1/plugins*`,
+        },
+        { statusCode: 200, body: plugins },
+      ).as('plainForEntity')
+
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/plugins/search*`,
+        },
+        { statusCode: 200, body: { data: plugins.data, offset: null } },
+      ).as('searchPluginsNested')
+
+      cy.mount(PluginList, {
+        props: {
+          cacheIdentifier: `plugin-list-${uuidv4()}`,
+          config: nestedConfig,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+          canToggle: () => false,
+        },
+      })
+
+      // Plain nested-page load, nothing searched yet - the plain forEntity endpoint already scopes
+      // to the entity via its URL path, so no need to hit /plugins/search until the user searches
+      cy.wait('@plainForEntity')
+      cy.get('table thead th').should('not.contain.text', 'Scope')
+
+      // Once the user searches, the request goes through /plugins/search and still carries the
+      // entity scope (now as a forced, hidden filter param) alongside the free-text search
+      cy.getTestId('search-input').filter(':visible').type('basic')
+      cy.wait('@searchPluginsNested').its('request.url')
+        .should('include', 'filter%5Broute%5D%5Beq%5D=route-1')
+        .and('include', 'filter%5Bname%5D%5Bcontains%5D=basic')
+    })
+  })
 })

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -21,7 +21,14 @@
     >
       <!-- Filter -->
       <template #toolbar-filter>
+        <PluginFilter
+          v-if="isPluginTableEnhanced"
+          v-model="filterQuery"
+          :entity-id="props.config?.entityId"
+          :entity-type="props.config?.entityType"
+        />
         <EntityFilter
+          v-else
           v-model="filterQuery"
           :config="filterConfig"
         />
@@ -111,7 +118,16 @@
             :name="row.name"
             :size="24"
           />
-          <div class="info-wrapper">
+          <div
+            v-if="isPluginTableEnhanced"
+            class="info-wrapper"
+          >
+            <span class="info-name">{{ pluginMetaData.getDisplayName(row.name) }}</span>
+          </div>
+          <div
+            v-else
+            class="info-wrapper"
+          >
             <span
               v-if="row.instance_name"
               class="info-name"
@@ -128,16 +144,34 @@
         </div>
       </template>
 
+      <template #instanceName="{ row }">
+        {{ row.instance_name || '-' }}
+      </template>
+
       <template #appliedTo="{ row }">
         <KTruncate v-if="aggregateAppliedTo(row).length > 0">
           <PermissionsWrapper
-            v-for="tag in aggregateAppliedTo(row)"
+            v-for="(tag, index) in aggregateAppliedTo(row)"
             :key="tag.badgeText"
             :auth-function="() => checkAppliedToPermission(tag.type, row)"
             force-show
           >
             <template #default="{ isAllowed }">
+              <div v-if="isPluginTableEnhanced">
+                <RouterLink
+                  v-if="isAllowed && tag.type && getScopedEntityViewRoute(tag.type, row)"
+                  class="scope-link"
+                  :to="getScopedEntityViewRoute(tag.type, row)!"
+                >
+                  {{ tag.badgeText }}
+                </RouterLink>
+                <span v-else>
+                  {{ tag.badgeText }}
+                </span>
+                <span v-if="index < aggregateAppliedTo(row).length - 1">, </span>
+              </div>
               <KBadge
+                v-else
                 :class="isAllowed || 'disabled'"
                 @click.stop="isAllowed && tag.type && handleAppliedToClick(tag.type, row)"
               >
@@ -150,7 +184,14 @@
       </template>
 
       <template #enabled="{ row }">
+        <KBadge
+          v-if="isPluginTableEnhanced"
+          :appearance="row.enabled ? 'success' : 'neutral'"
+        >
+          {{ row.enabled ? t('actions.enabled') : t('actions.disabled') }}
+        </KBadge>
         <PermissionsWrapper
+          v-else
           :auth-function="async () => !!(await canEdit(row) && await canToggle(row))"
           force-show
         >
@@ -168,7 +209,17 @@
       </template>
 
       <template #ordering="{ rowValue }">
-        <KBadge :appearance="isEmpty(rowValue) ? 'info' : 'warning'">
+        <span v-if="isPluginTableEnhanced">
+          {{
+            isEmpty(rowValue)
+              ? t('plugins.list.table_headers.ordering_badge.static')
+              : t('plugins.list.table_headers.ordering_badge.dynamic')
+          }}
+        </span>
+        <KBadge
+          v-else
+          :appearance="isEmpty(rowValue) ? 'info' : 'warning'"
+        >
           {{
             isEmpty(rowValue)
               ? t('plugins.list.table_headers.ordering_badge.static')
@@ -215,6 +266,21 @@
             data-testid="action-entity-edit"
             :item="getEditDropdownItem(row)"
           />
+        </PermissionsWrapper>
+        <PermissionsWrapper
+          v-if="isPluginTableEnhanced"
+          :auth-function="async () => !!(await canEdit(row) && await canToggle(row))"
+          force-show
+        >
+          <template #default="{ isAllowed }">
+            <KDropdownItem
+              data-testid="action-entity-toggle-enabled"
+              :disabled="!isAllowed"
+              @click="isAllowed && toggleEnableStatus(row)"
+            >
+              {{ row.enabled ? t('actions.disable') : t('actions.enable') }}
+            </KDropdownItem>
+          </template>
         </PermissionsWrapper>
         <!-- Dynamic Plugin Ordering not supported for consumer/consumer-group plugins -->
         <PermissionsWrapper
@@ -300,6 +366,7 @@ import { AddIcon, BookIcon, PlugIcon } from '@kong/icons'
 
 import composables from '../composables'
 import endpoints from '../plugins-endpoints'
+import PluginFilter from './PluginFilter.vue'
 
 import type {
   KongManagerPluginListConfig,
@@ -427,19 +494,43 @@ const isOrderingSupported = props.config.app === 'konnect' || useGatewayFeatureS
 })
 
 /**
+ * Plugin list improvment (Konnect-only): search API, Name/Scope/Status/Ordering columns, KFilterGroup toolbar.
+ * Gated by `config.pluginTableImprovements.filtering` - see PluginTableImprovementFlags for the other
+ * (not yet implemented) flags this list will grow: `sorting`, `bulkActions`.
+ */
+const isPluginTableEnhanced = computed<boolean>(() =>
+  props.config.app === 'konnect' && !!props.config.pluginTableImprovements?.filtering,
+)
+
+/**
  * Table Headers
  */
 const disableSorting = computed((): boolean => props.config.app !== 'kongManager' || !!props.config.disableSorting)
 const fields: BaseTableHeaders = {
   // the Name column is non-hidable
-  name: { label: t('plugins.list.table_headers.name'), searchable: true, sortable: true, hidable: false },
-}
-// conditional display of Applied To column - hide if on an entity's details page (ie. plugins card on route details view)
-if (!props.config?.entityId) {
-  fields.appliedTo = { label: t('plugins.list.table_headers.applied_to'), sortable: false }
+  name: {
+    label: isPluginTableEnhanced.value ? t('plugins.list.table_headers.plugin') : t('plugins.list.table_headers.name'),
+    searchable: true,
+    sortable: !isPluginTableEnhanced.value,
+    hidable: false,
+  },
 }
 
-fields.enabled = { label: t('plugins.list.table_headers.enabled'), searchable: true, sortable: true }
+if (isPluginTableEnhanced.value) {
+  // New column: the plugin instance's custom name, split out of the combined "Plugin" cell
+  fields.instanceName = { label: t('plugins.list.table_headers.name'), sortable: false }
+}
+
+// conditional display of Applied To/Scope column - hide if on an entity's details page (ie. plugins card on route details view)
+if (!props.config?.entityId) {
+  fields.appliedTo = isPluginTableEnhanced.value
+    ? { label: t('plugins.list.table_headers.scope'), sortable: false }
+    : { label: t('plugins.list.table_headers.applied_to'), sortable: false }
+}
+
+fields.enabled = isPluginTableEnhanced.value
+  ? { label: t('plugins.list.table_headers.status'), sortable: false }
+  : { label: t('plugins.list.table_headers.enabled'), searchable: true, sortable: true }
 
 if (isOrderingSupported) {
   fields.ordering = { label: t('plugins.list.table_headers.ordering'), sortable: true }
@@ -497,11 +588,28 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
+// Only hit the new search endpoint once the user is actually searching
+const isSearchActive = computed((): boolean => isPluginTableEnhanced.value && !!filterQuery.value)
+
+const activeFetcherUrl = computed<string>(() => {
+  if (isSearchActive.value) {
+    const konnectConfig = props.config as KonnectPluginListConfig
+    return `${konnectConfig.apiBaseUrl}${endpoints.search.konnect.all}`
+      .replace(/{controlPlaneId}/gi, konnectConfig.controlPlaneId || '')
+  }
+
+  return fetcherBaseUrl.value
+})
+
 const {
   fetcher,
   fetcherState,
   fetcherCacheKey,
-} = useFetcher(computed(() => ({ ...props.config, cacheIdentifier: props.cacheIdentifier })), fetcherBaseUrl)
+} = useFetcher(computed(() => ({
+  ...props.config,
+  cacheIdentifier: props.cacheIdentifier,
+  ...(isSearchActive.value ? { isExactMatch: false } : {}),
+})), activeFetcherUrl)
 
 const clearFilter = (): void => {
   filterQuery.value = ''
@@ -549,28 +657,25 @@ const checkAppliedToPermission = async (type: ViewRouteType | null, row: EntityR
   return await props.canRetrieveScopedEntity?.(type, row.id)
 }
 
-const handleAppliedToClick = (type: ViewRouteType, row: EntityRow) => {
-  let id = null
+const getScopedEntityId = (type: ViewRouteType, row: EntityRow) => {
+  return row[type]?.id
+}
 
-  switch (type) {
-    case 'route':
-      id = row.route?.id
-      break
-    case 'service':
-      id = row.service?.id
-      break
-    case 'consumer':
-      id = row.consumer?.id
-      break
-    case 'consumer_group':
-      id = row.consumer_group?.id
-      break
-    default:
-      break
-  }
+const getScopedEntityViewRoute = (type: ViewRouteType, row: EntityRow) => {
+  const id = getScopedEntityId(type, row)
 
   if (id && props.config?.getScopedEntityViewRoute) {
-    router.push(props.config.getScopedEntityViewRoute(type, id))
+    return props.config.getScopedEntityViewRoute(type, id)
+  }
+
+  return null
+}
+
+const handleAppliedToClick = (type: ViewRouteType, row: EntityRow) => {
+  const route = getScopedEntityViewRoute(type, row)
+
+  if (route) {
+    router.push(route)
   }
 }
 
@@ -634,7 +739,7 @@ const confirmSwitchEnablement = async () => {
     let filteredTargetEntity: EntityRow | undefined = undefined
     if (filterQuery.value && app === 'konnect') {
       // Fetch the full entity data before updating enablement status
-      // This is needed because in Konnect the data returned from the filtered list endpoint
+      // This is needed because in Konnect the data returned from the filtered/search list endpoint
       // 1. does not contain all the fields required for the PUT request to succeed
       // 2. contains fields that are not recognized in the PUT request payload
       filteredTargetEntity = await axiosInstance.get(url)
@@ -891,6 +996,16 @@ onBeforeMount(async () => {
 
   .k-badge.disabled {
     cursor: default;
+  }
+
+  .scope-link {
+    color: var(--kui-color-text-primary, $kui-color-text-primary);
+    font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -22,7 +22,7 @@
       <!-- Filter -->
       <template #toolbar-filter>
         <PluginFilter
-          v-if="isPluginTableEnhanced"
+          v-if="isPluginFilterEnhanced"
           v-model="filterQuery"
           :entity-id="props.config?.entityId"
           :entity-type="props.config?.entityType"
@@ -119,7 +119,7 @@
             :size="24"
           />
           <div
-            v-if="isPluginTableEnhanced"
+            v-if="isPluginFilterEnhanced"
             class="info-wrapper"
           >
             <span class="info-name">{{ pluginMetaData.getDisplayName(row.name) }}</span>
@@ -157,7 +157,7 @@
             force-show
           >
             <template #default="{ isAllowed }">
-              <div v-if="isPluginTableEnhanced">
+              <div v-if="isPluginFilterEnhanced">
                 <RouterLink
                   v-if="isAllowed && tag.type && getScopedEntityViewRoute(tag.type, row)"
                   class="scope-link"
@@ -185,7 +185,7 @@
 
       <template #enabled="{ row }">
         <KBadge
-          v-if="isPluginTableEnhanced"
+          v-if="isPluginFilterEnhanced"
           :appearance="row.enabled ? 'success' : 'neutral'"
         >
           {{ row.enabled ? t('actions.enabled') : t('actions.disabled') }}
@@ -209,7 +209,7 @@
       </template>
 
       <template #ordering="{ rowValue }">
-        <span v-if="isPluginTableEnhanced">
+        <span v-if="isPluginFilterEnhanced">
           {{
             isEmpty(rowValue)
               ? t('plugins.list.table_headers.ordering_badge.static')
@@ -268,7 +268,7 @@
           />
         </PermissionsWrapper>
         <PermissionsWrapper
-          v-if="isPluginTableEnhanced"
+          v-if="isPluginFilterEnhanced"
           :auth-function="async () => !!(await canEdit(row) && await canToggle(row))"
           force-show
         >
@@ -498,7 +498,7 @@ const isOrderingSupported = props.config.app === 'konnect' || useGatewayFeatureS
  * Gated by `config.pluginTableImprovements.filtering` - see PluginTableImprovementFlags for the other
  * (not yet implemented) flags this list will grow: `sorting`, `bulkActions`.
  */
-const isPluginTableEnhanced = computed<boolean>(() =>
+const isPluginFilterEnhanced = computed<boolean>(() =>
   props.config.app === 'konnect' && !!props.config.pluginTableImprovements?.filtering,
 )
 
@@ -509,26 +509,26 @@ const disableSorting = computed((): boolean => props.config.app !== 'kongManager
 const fields: BaseTableHeaders = {
   // the Name column is non-hidable
   name: {
-    label: isPluginTableEnhanced.value ? t('plugins.list.table_headers.plugin') : t('plugins.list.table_headers.name'),
+    label: isPluginFilterEnhanced.value ? t('plugins.list.table_headers.plugin') : t('plugins.list.table_headers.name'),
     searchable: true,
-    sortable: !isPluginTableEnhanced.value,
+    sortable: !isPluginFilterEnhanced.value,
     hidable: false,
   },
 }
 
-if (isPluginTableEnhanced.value) {
+if (isPluginFilterEnhanced.value) {
   // New column: the plugin instance's custom name, split out of the combined "Plugin" cell
   fields.instanceName = { label: t('plugins.list.table_headers.name'), sortable: false }
 }
 
 // conditional display of Applied To/Scope column - hide if on an entity's details page (ie. plugins card on route details view)
 if (!props.config?.entityId) {
-  fields.appliedTo = isPluginTableEnhanced.value
+  fields.appliedTo = isPluginFilterEnhanced.value
     ? { label: t('plugins.list.table_headers.scope'), sortable: false }
     : { label: t('plugins.list.table_headers.applied_to'), sortable: false }
 }
 
-fields.enabled = isPluginTableEnhanced.value
+fields.enabled = isPluginFilterEnhanced.value
   ? { label: t('plugins.list.table_headers.status'), sortable: false }
   : { label: t('plugins.list.table_headers.enabled'), searchable: true, sortable: true }
 
@@ -589,7 +589,7 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
 })
 
 // Only hit the new search endpoint once the user is actually searching
-const isSearchActive = computed((): boolean => isPluginTableEnhanced.value && !!filterQuery.value)
+const isSearchActive = computed((): boolean => isPluginFilterEnhanced.value && !!filterQuery.value)
 
 const activeFetcherUrl = computed<string>(() => {
   if (isSearchActive.value) {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -10,6 +10,7 @@
     "edit": "Edit",
     "enable": "Enable",
     "enabled": "Enabled",
+    "disable": "Disable",
     "delete": "Delete",
     "disabled": "Disabled",
     "confirm_delete": "Yes, delete",
@@ -61,7 +62,8 @@
       "exact": "Filter by exact instance name or ID",
       "kongManager": "Filter by exact instance name or ID",
       "select": "Filter plugins",
-      "search_plugins": "Search plugins"
+      "search_plugins": "Search plugins",
+      "search": "Search"
     },
     "filter": {
       "field": {
@@ -89,8 +91,11 @@
           "consumer_group": "Consumer group"
         },
         "id": "ID",
+        "plugin": "Plugin",
         "name": "Name",
         "instance_name": "Instance name",
+        "scope": "Scope",
+        "status": "Status",
         "ordering": "Ordering",
         "ordering_badge": {
           "dynamic": "Dynamic",

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -63,12 +63,14 @@
       "kongManager": "Filter by exact instance name or ID",
       "select": "Filter plugins",
       "search_plugins": "Search plugins",
-      "search": "Search"
+      "search": "Search",
+      "tags_filter": "Type a tag and press Enter"
     },
     "filter": {
       "field": {
         "enabled": "Enabled"
-      }
+      },
+      "tags_invalid": "Tags can't contain commas, slashes, or leading/trailing spaces"
     },
     "no_results": "No results found for \"{filter}\""
   },

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -64,7 +64,7 @@
       "select": "Filter plugins",
       "search_plugins": "Search plugins",
       "search": "Search",
-      "tags_filter": "Type a tag and press Enter"
+      "tags_filter": "Type part of a tag and press Enter"
     },
     "filter": {
       "field": {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -64,7 +64,8 @@
       "select": "Filter plugins",
       "search_plugins": "Search plugins",
       "search": "Search",
-      "tags_filter": "Type part of a tag and press Enter"
+      "tags_filter": "Type part of a tag and press Enter",
+      "scope_filter": "Select a scope"
     },
     "filter": {
       "field": {

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -14,6 +14,11 @@ export default {
       forEntity: `${KMBaseApiUrl}/{entityType}/{entityId}/plugins`,
     },
   },
+  search: {
+    konnect: {
+      all: `${konnectNoWorkspaceBaseApiUrl}/plugins/search`,
+    },
+  },
   select: {
     konnect: {
       availablePlugins: `${konnectV1BaseApiUrl}/available-plugins`,

--- a/packages/entities/entities-plugins/src/types/plugin-list.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-list.ts
@@ -44,8 +44,21 @@ export interface BasePluginListConfig {
   getToggleDisabledTooltip?: (plugin: EntityRow) => string | null
 }
 
+/** Konnect-only: independently toggleable pieces of the plugin list improvement epic. Each defaults to false/undefined = current behavior. `sorting` and `bulkActions` only take effect when `filtering` is also on, since they build on the redesigned table layout it introduces. */
+export interface PluginTableImprovementFlags {
+  /** Enables the redesigned table (search API, Name/Scope/Status/Ordering columns, KFilterGroup toolbar). */
+  filtering?: boolean
+  /** Enables column sorting on the redesigned table. Requires `filtering`. */
+  sorting?: boolean
+  /** Enables bulk row selection/actions on the redesigned table. Requires `filtering`. */
+  bulkActions?: boolean
+}
+
 /** Konnect plugin list config */
-export interface KonnectPluginListConfig extends KonnectBaseTableConfig, BasePluginListConfig {}
+export interface KonnectPluginListConfig extends KonnectBaseTableConfig, BasePluginListConfig {
+  /** Konnect-only: flags for the plugin list improvement, rolled out incrementally. */
+  pluginTableImprovements?: PluginTableImprovementFlags
+}
 
 /** Kong Manager plugin list config */
 export interface KongManagerPluginListConfig extends KongManagerBaseTableConfig, BasePluginListConfig {

--- a/packages/entities/entities-shared/src/composables/tests/useFetchUrlBuilder.spec.ts
+++ b/packages/entities/entities-shared/src/composables/tests/useFetchUrlBuilder.spec.ts
@@ -92,6 +92,26 @@ describe('useFetchUrlBuilder()', () => {
     expect(builder(query)).toBe('http://foo.bar/entity/testQuery')
   })
 
+  it('should apply fuzzy multi-field passthrough for konnect when isExactMatch is explicitly false', () => {
+    const config = {
+      apiBaseUrl: '/',
+      app: 'konnect',
+      controlPlaneId: 'default',
+      isExactMatch: false,
+    } as KonnectConfig
+
+    const builder = useFetchUrlBuilder(config, 'http://foo.bar/entity')
+
+    const query: TableDataFetcherParams = {
+      page: 1,
+      pageSize: 10,
+      offset: '0',
+      query: 'filter[name][contains]=foo&filter[enabled]=true',
+    }
+
+    expect(builder(query)).toBe('http://foo.bar/entity?filter%5Bname%5D%5Bcontains%5D=foo&filter%5Benabled%5D=true&size=10')
+  })
+
   it('should preserve base URL query params in the exact match URL for konnect', () => {
     const config = {
       apiBaseUrl: '/',

--- a/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
+++ b/packages/entities/entities-shared/src/composables/useFetchUrlBuilder.ts
@@ -12,7 +12,11 @@ export default function useFetchUrlBuilder(
 ) {
   const isExactMatch = computed((): boolean => {
     const configValue = toValue(config)
-    return configValue.app === 'konnect' || !!configValue.isExactMatch
+    if (typeof configValue.isExactMatch === 'boolean') {
+      return configValue.isExactMatch
+    }
+    // defaults to false for kongManager and true for konnect
+    return configValue.app === 'konnect'
   })
 
   // Construct a URL object, adding the current `window.location.origin` if the path begins with a slash


### PR DESCRIPTION
[KM-1989]

## Summary
- Adds a Konnect-only `isPluginTableEnhanced` config flag to `PluginList.vue`; Kong Manager and non-flagged Konnect stay byte-for-byte unchanged.
- New "Name" column (`instance_name`), split out of the combined "Plugin" cell.
- "Applied To" → "Scope" and "Enabled" → "Status": rendered as plain text / read-only badges instead of interactive badges and a switch.
- "Ordering" badge becomes plain text under the flag.
- Enable/disable moves from the inline switch into a row action (dropdown item), reusing the existing `EntityToggleModal` confirmation flow unchanged.
- Toolbar filter swaps `EntityFilter` for a `KFilterGroup` (Scope / Status / Tags pills) backed by a new `GET .../core-entities/plugins/search` fetcher (Konnect only);
- Supports entity-nested plugin lists (Route/Service/Consumer/Consumer-Group detail pages): the Scope filter is hidden and the request is scoped server-side to that entity.

Design: https://www.figma.com/design/DqYE9HIMZqFgmt7JkRqS7W/Plugins-improvement?node-id=4512-43253

[KM-1989]: https://konghq.atlassian.net/browse/KM-1989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ