### PR TITLE
feat(entities-plugins): expose freeform field composables from the freeform subpath

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/README.md
+++ b/packages/entities/entities-plugins/src/components/free-form/README.md
@@ -122,6 +122,8 @@ FormSchema + data props
 
 ### Composables (`shared/composables/`)
 
+All exports below are re-exported from `@kong-ui-public/entities-plugins/freeform` (`render-rules.ts` only exports `renderRuleExactMatch` publicly; `createRenderRuleRegistry` stays internal) — see the "Standalone Usage" section below.
+
 | File | Exports | Purpose |
 |---|---|---|
 | `form-context.ts` | `provideFormShared()`, `useFormShared()` | Central form state: reactive data, schema, config, render rules, getValue/setValue |
@@ -130,8 +132,8 @@ FormSchema + data props
 | `schema.ts` | `useSchemaHelpers()` | Schema introspection: getSchema, getDefault, getSelectItems, getLabelAttributes |
 | `useMapField.ts` | `useMapField()` | KeyId-backed map field state: keys, add/remove/rename, display labels |
 | `labels.ts` | `useLabelPath()`, `useFieldAttrs()` | Label generation with dictionary lookup (IP, SSL, TTL, JWT, etc.) |
-| `render-rules.ts` | `createRenderRuleRegistry()` | Bundles (field grouping/ordering) and dependencies (conditional visibility) |
-| `ancestors.ts` | `useAncestors()` | Access parent field context for nested components |
+| `render-rules.ts` | `createRenderRuleRegistry()`, `renderRuleExactMatch()` | Bundles (field grouping/ordering) and dependencies (conditional visibility) |
+| `ancestors.ts` | `useFieldAncestors()` | Access parent field context for nested components |
 | `constants.ts` | `FIELD_RENDERERS`, `FIELD_RENDERER_SLOTS` | Injection key symbols |
 
 ### Path System
@@ -416,6 +418,30 @@ function handleSubmit() {
 }
 </script>
 ```
+
+### Writing a Custom Field Component
+
+The `shared/composables/` primitives listed above are re-exported from the `freeform` subpath, so a host app can author its own field component that reads and writes a named field's value the same way `SwitchField`/`RadioField` do internally — no `getValue`/`setValue` round-trip needed:
+
+```vue
+<script setup lang="ts">
+import { toRef } from 'vue'
+import { useField } from '@kong-ui-public/entities-plugins/freeform'
+
+const props = defineProps<{ name: string }>()
+const { value } = useField<boolean>(toRef(() => props.name))
+</script>
+
+<template>
+  <input
+    type="checkbox"
+    :checked="value"
+    @change="value = ($event.target as HTMLInputElement).checked"
+  >
+</template>
+```
+
+Register it against a field path with `FieldRenderer`, or place it directly inside a `Form`/layout slot with `name` set to the field's path — both wire into the same reactive form state as the built-in field components.
 
 ## Reference
 

--- a/packages/entities/entities-plugins/src/freeform.ts
+++ b/packages/entities/entities-plugins/src/freeform.ts
@@ -12,7 +12,7 @@ export { default as StringArrayField } from './components/free-form/shared/Strin
 export { default as JsonField } from './components/free-form/shared/JsonField.vue'
 export { default as ForeignField } from './components/free-form/shared/ForeignField.vue'
 export { default as MapField } from './components/free-form/shared/MapField.vue'
-export { FIELD_RENDERERS } from './components/free-form/shared/composables'
+export * from './components/free-form/shared/composables'
 export { renderRuleExactMatch } from './components/free-form/shared/composables/render-rules'
 export type { FormSchema, UnionFieldSchema, NamedFieldSchema } from './types/plugins/form-schema'
 export type { RenderRules, FormConfig } from './components/free-form/shared/types'


### PR DESCRIPTION
# Summary

Re-export `shared/composables/*` (`useField`, `useFormData`, `useFieldAttrs`, `useFieldPath`, `useMapField`, `useSchemaHelpers`, `useFormShared`, `provideFormShared`, `useFieldAncestors`, etc.) from `@kong-ui-public/entities-plugins/freeform` via `export * from './components/free-form/shared/composables'` in `src/freeform.ts`.

Today, `SwitchField`/`RadioField`/`ScopeEntityField`/etc. read and write their bound field's value via `useField(name)`, but that composable is internal-only — it isn't reachable from any published entry point (`.`, `./freeform`, or any `./dist/*` path), so a host app authoring its own custom field UI has no way to hook into a single field's reactive value. The only public workaround is a full-form `getValue()`/`setValue()` round-trip on `Form`/`PluginConfigurationForm`, which replaces the entire tracked form data rather than a single field.

This change makes the same composables the built-in field components already use internally available to consumers of the `freeform` subpath, so they can build a custom field component the same way `SwitchField`/`RadioField` do.

Also fixes two stale entries in the composables reference table in `free-form/README.md` (`useAncestors` → `useFieldAncestors`; `render-rules.ts` was missing its public `renderRuleExactMatch` export) and adds a short "Writing a Custom Field Component" example.
