### PR TITLE
fix(forms): pre-fill principal_claim with sub as real model value

### DIFF
--- a/packages/core/forms/src/components/forms/PrincipalLookupSettings.vue
+++ b/packages/core/forms/src/components/forms/PrincipalLookupSettings.vue
@@ -260,6 +260,14 @@ export default {
       return `Defaults to the subject (sub) claim, but you can specify a different token claim if needed. ${dotNotation}`
     },
   },
+  created() {
+    // One-time prefill: if principal_claim has never been set, write the gateway
+    // default `sub` into the model so users see it explicitly rather than an
+    // implicit default. Only fires once, on creation — later clears stay cleared.
+    if (!hasValue(this.formModel['config-principals-principal_claim'])) {
+      this.updateField('config-principals-principal_claim', ['sub'])
+    }
+  },
   methods: {
     handleEnableToggle(enabled) {
       if (this.onEnabledChange) {
@@ -275,9 +283,7 @@ export default {
       if (typeof claim === 'string' && claim) {
         return claim
       }
-      // Pre-fill the gateway default so users recognize `sub` is used when left unset.
-      // The model stays empty until edited; an empty principal_claim already resolves to `sub`.
-      return 'sub'
+      return ''
     },
     handleTokenClaimChange(rawValue) {
       const value = typeof rawValue === 'string' ? rawValue.trim() : ''

--- a/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/OIDCPrincipals.spec.ts
@@ -252,6 +252,8 @@ describe('OIDCPrincipals', () => {
         'config-client_id': ['client-a'],
       }, { onModelUpdated })
       const formModel = wrapper.props('formModel')
+      // Clear the call from PrincipalLookupSettings' one-time principal_claim prefill on mount.
+      onModelUpdated.mockClear()
 
       ;(wrapper.vm as any).removeClientRow(0)
 

--- a/packages/core/forms/src/components/forms/__tests__/PrincipalLookupSettings.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/PrincipalLookupSettings.spec.ts
@@ -82,7 +82,9 @@ describe('PrincipalLookupSettings', () => {
 
       expect((wrapper.vm as any).selectedLookupMethod).toBe('custom-identity')
       expect(formModel['config-principals-principal_by']).toBeNull()
-      expect(formModel['config-principals-principal_claim']).toBeNull()
+      // principal_claim was already pre-filled with `sub` on mount; switching to
+      // custom-identity doesn't touch it.
+      expect(formModel['config-principals-principal_claim']).toEqual(['sub'])
     })
   })
 
@@ -144,9 +146,23 @@ describe('PrincipalLookupSettings', () => {
       expect(wrapper.props('formModel')['config-principals-principal_claim']).toEqual([])
     })
 
-    it('pre-fills the default `sub` claim when none is set', () => {
-      expect((mountComponent({ 'config-principals-principal_claim': null }).vm as any).getTokenClaimInputValue()).toBe('sub')
-      expect((mountComponent({ 'config-principals-principal_claim': [] }).vm as any).getTokenClaimInputValue()).toBe('sub')
+    it('pre-fills the default `sub` claim into the model when none is set', () => {
+      const nullWrapper = mountComponent({ 'config-principals-principal_claim': null })
+      expect(nullWrapper.props('formModel')['config-principals-principal_claim']).toEqual(['sub'])
+      expect((nullWrapper.vm as any).getTokenClaimInputValue()).toBe('sub')
+
+      const emptyWrapper = mountComponent({ 'config-principals-principal_claim': [] })
+      expect(emptyWrapper.props('formModel')['config-principals-principal_claim']).toEqual(['sub'])
+      expect((emptyWrapper.vm as any).getTokenClaimInputValue()).toBe('sub')
+    })
+
+    it('does not re-prefill after the user explicitly clears the field', () => {
+      const wrapper = mountComponent({ 'config-principals-principal_claim': null })
+
+      ;(wrapper.vm as any).handleTokenClaimChange('')
+
+      expect(wrapper.props('formModel')['config-principals-principal_claim']).toEqual([])
+      expect((wrapper.vm as any).getTokenClaimInputValue()).toBe('')
     })
 
     it('displays array with literal dots using escape notation', () => {


### PR DESCRIPTION
# Summary

Previously the Token claim input displayed `sub` only visually (via a fallback in getTokenClaimInputValue), without writing it into formModel. Since the fallback fired for any empty value, it also re-displayed `sub` immediately after a user cleared the field. Now the default is written into formModel once on creation, and the input strictly reflects the model with no fallback.