### PR TITLE
fix(entities): kcodeblock theming [KHCP-21053]

### DIFF
--- a/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
@@ -10,6 +10,7 @@
       </KBadge>
       <KCodeBlock
         id="json-endpoint-codeblock"
+        :key="konnectColorMode"
         :code="fetcherUrl"
         language="plaintext"
         single-line
@@ -19,6 +20,7 @@
     <KCodeBlock
       v-if="entityRecord"
       id="json-codeblock"
+      :key="konnectColorMode"
       :class="{ 'json-content': fetcherUrl }"
       :code="JSON.stringify(jsonContent, null, 2)"
       :copy-code="JSON.stringify(unredactedRecord || jsonContent, null, 2)"

--- a/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
@@ -12,7 +12,7 @@
         :code="fetcherUrl"
         language="plaintext"
         single-line
-        theme="dark"
+        :theme="konnectColorMode"
       />
     </div>
     <KCodeBlock
@@ -23,14 +23,14 @@
       :copy-code="JSON.stringify(unredactedRecord || jsonContent, null, 2)"
       data-dd-privacy="mask"
       language="json"
-      theme="dark"
+      :theme="konnectColorMode"
       @code-block-render="highlightCodeBlock"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType } from 'vue'
+import { computed, inject, type ComputedRef, type PropType } from 'vue'
 import type { BadgeAppearance } from '@kong/kongponents'
 import type { KonnectBaseEntityConfig, KongManagerBaseEntityConfig, KonnectBaseFormConfig, KongManagerBaseFormConfig } from '../../types'
 import { highlightCodeBlock } from '../../utils/code-block'
@@ -65,6 +65,8 @@ const props = defineProps({
     default: null,
   },
 })
+
+const konnectColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 const jsonContent = computed((): Record<string, any> => props.entityRecord)
 

--- a/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
@@ -92,7 +92,7 @@ const displayedCharLength = computed((): number => {
 
 .json-endpoint {
   align-items: baseline;
-  background-color: var(--kui-color-background-inverse, $kui-color-background-inverse);
+  background-color: var(--kui-color-background, $kui-color-background);
   border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border-inverse, $kui-color-border-inverse);
   border-top-left-radius: var(--kui-border-radius-40, $kui-border-radius-40);
   border-top-right-radius: var(--kui-border-radius-40, $kui-border-radius-40);

--- a/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
@@ -3,6 +3,7 @@
     <div
       v-if="fetcherUrl"
       class="json-endpoint"
+      :class="{ 'konnect-color-mode': config.app === 'konnect' }"
     >
       <KBadge :appearance="requestMethod">
         {{ requestMethod }}
@@ -92,12 +93,16 @@ const displayedCharLength = computed((): number => {
 
 .json-endpoint {
   align-items: baseline;
-  background-color: var(--kui-color-background, $kui-color-background);
+  background-color: var(--kui-color-background-inverse, $kui-color-background-inverse);
   border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border-inverse, $kui-color-border-inverse);
   border-top-left-radius: var(--kui-border-radius-40, $kui-border-radius-40);
   border-top-right-radius: var(--kui-border-radius-40, $kui-border-radius-40);
   display: flex;
   padding: var(--kui-space-40, $kui-space-40) var(--kui-space-0, $kui-space-0) var(--kui-space-40, $kui-space-40) var(--kui-space-50, $kui-space-50);
+
+  &.konnect-color-mode {
+    background-color: var(--kui-color-background, $kui-color-background);
+  }
 
   .k-code-block {
     flex: auto;

--- a/packages/entities/entities-shared/src/components/common/TerraformCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/TerraformCodeBlock.vue
@@ -3,6 +3,7 @@
     <KCodeBlock
       v-if="props.entityRecord"
       id="terraform-codeblock"
+      :key="konnectColorMode"
       :code="terraformContent"
       :copy-code="unredactedTerraformContent"
       data-dd-privacy="mask"

--- a/packages/entities/entities-shared/src/components/common/TerraformCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/TerraformCodeBlock.vue
@@ -7,14 +7,15 @@
       :copy-code="unredactedTerraformContent"
       data-dd-privacy="mask"
       language="terraform"
-      theme="dark"
+      :theme="konnectColorMode"
       @code-block-render="highlightCodeBlock"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { type PropType, computed } from 'vue'
+import { computed, inject } from 'vue'
+import type { ComputedRef, PropType } from 'vue'
 import { EventGatewayTypesArray, SupportedEntityType, SupportedEntityTypesArray, IdentityTypesArray } from '../../types'
 import { highlightCodeBlock } from '../../utils/code-block'
 
@@ -49,6 +50,8 @@ const props = defineProps({
     default: '',
   },
 })
+
+const konnectColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 const isAddonPayload = computed((): boolean => {
   const record = props.entityRecord

--- a/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
@@ -12,6 +12,7 @@
     <KCodeBlock
       v-if="props.entityRecord"
       id="yaml-codeblock"
+      :key="konnectColorMode"
       :code="yamlContent"
       :copy-code="unredactedYamlContent"
       data-dd-privacy="mask"

--- a/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
@@ -16,7 +16,7 @@
       :copy-code="unredactedYamlContent"
       data-dd-privacy="mask"
       language="yaml"
-      theme="dark"
+      :theme="konnectColorMode"
       @code-block-render="highlightCodeBlock"
     />
   </div>
@@ -24,12 +24,12 @@
 
 <script setup lang="ts">
 import yaml from 'js-yaml'
-import { computed, ref, watch } from 'vue'
+import { computed, inject, ref, watch } from 'vue'
 
 import { highlightCodeBlock } from '../../utils/code-block'
 import DeckCallout from './DeckCallout.vue'
 
-import type { PropType } from 'vue'
+import type { ComputedRef, PropType } from 'vue'
 
 import type { DeckCalloutPreference } from '../../types'
 
@@ -61,6 +61,8 @@ const emit = defineEmits<{
   'deck-callout:click-cta': []
   'deck-callout:dismiss': []
 }>()
+
+const konnectColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 const deckCalloutPreference = ref<DeckCalloutPreference>('visible')
 


### PR DESCRIPTION
# Summary

Display KCodeBlock in `dark` or `light` mode depending on user-selected Konnect theme using `app:konnectColorMode` injectable 

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
