### PR TITLE
fix(analytics): adjust for the actual scale of pdf canvas [MA-5230]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
@@ -134,6 +134,18 @@ describe('calculatePageSlices', () => {
       { startY: 0, height: 300 },
     ])
   })
+
+  it('gives an oversized row its own page instead of cramming later rows in with it', () => {
+    const rows = [
+      { top: 0, bottom: 900 }, // taller than a 400px page
+      { top: 900, bottom: 1000 },
+    ]
+
+    expect(calculatePageSlices(rows, 1000, 400, 1)).toEqual([
+      { startY: 0, height: 900 },
+      { startY: 900, height: 100 },
+    ])
+  })
 })
 
 describe('getRowBoundaries', () => {

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
@@ -102,6 +102,7 @@ function drawPageMeta(pdf: jsPDF, ctx: PageMetaContext): void {
   pdf.text(ctx.pageLabel, pageWidth - margin, footerBaseline, { align: 'right' })
 }
 
+// Measures the top and bottom of every tile row relative to the container.
 export function getRowBoundaries(container: HTMLElement): RowBoundary[] {
   const gridLayout = container.querySelector<HTMLElement>('.kong-ui-public-grid-layout, .grid-stack')
 
@@ -115,7 +116,6 @@ export function getRowBoundaries(container: HTMLElement): RowBoundary[] {
     return []
   }
 
-  // This will measure relative to the grid-stack container
   const containerTop = container.getBoundingClientRect().top
 
   const rowMap = new Map<number, number>()
@@ -142,6 +142,7 @@ export function calculatePageSlices(
   scale: number,
 ): PageSlice[] {
   if (!rows.length) {
+    // Fall back to fixed page height slices
     const pages: PageSlice[] = []
     let y = 0
 
@@ -155,22 +156,28 @@ export function calculatePageSlices(
   }
 
   const pages: PageSlice[] = []
-  let pageStartY = 0
+  let startY = 0
 
-  for (let i = 0; i < rows.length; i++) {
-    const rowTopPx = rows[i].top * scale
-    const rowBottomPx = rows[i].bottom * scale
+  for (const row of rows) {
+    const top = row.top * scale
+    const bottom = row.bottom * scale
 
-    // Would this row exceed the current page?
-    if (rowBottomPx - pageStartY > pageHeightPx && pageStartY < rowTopPx) {
-      // Close the current page at the top of this row
-      pages.push({ startY: pageStartY, height: rowTopPx - pageStartY })
-      pageStartY = rowTopPx
+    // Does this row fit on the page that started at startY?
+    if (bottom - startY > pageHeightPx) {
+      if (top > startY) {
+        // Close the page at the top of this row so the row moves to the next page.
+        pages.push({ startY, height: top - startY })
+        startY = top
+      } else {
+        // The row alone is taller than a page
+        pages.push({ startY, height: bottom - startY })
+        startY = bottom
+      }
     }
   }
 
-  if (pageStartY < canvasHeight) {
-    pages.push({ startY: pageStartY, height: canvasHeight - pageStartY })
+  if (startY < canvasHeight) {
+    pages.push({ startY, height: canvasHeight - startY })
   }
 
   return pages
@@ -208,8 +215,6 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
       exportState.value = { status: 'preparing' }
       await onBeforeCapture?.()
 
-      const rowBoundaries = getRowBoundaries(element)
-
       const [{ snapdom }, { jsPDF }] = await Promise.all([
         import('@zumer/snapdom'),
         import('jspdf'),
@@ -228,6 +233,14 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
 
       const canvas = await snapdom.toCanvas(element, { scale, exclude, plugins: [webglSnapshotPlugin] })
 
+      // Measure the rendered rows and the real scale after the snapdom captures
+      // the canvas. If the capture is oversized, snapdom will scale it down to fit
+      // within the requested size, so derive the actual scale from the produced canvas
+      // rather than trusting the `scale` option.
+      const rowBoundaries = getRowBoundaries(element)
+      const elementWidth = element.getBoundingClientRect().width
+      const realScale = elementWidth ? canvas.width / elementWidth : scale
+
       exportState.value = { status: 'generating' }
 
       const now = new Date()
@@ -241,7 +254,7 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
       const pxPerMm = canvas.width / contentWidth
       const pageHeightPx = contentHeight * pxPerMm
 
-      const pages = calculatePageSlices(rowBoundaries, canvas.height, pageHeightPx, scale)
+      const pages = calculatePageSlices(rowBoundaries, canvas.height, pageHeightPx, realScale)
 
       const pageMeta: Omit<PageMetaContext, 'pageLabel'> = {
         title,


### PR DESCRIPTION
# Summary

Fix [MA-5230](https://konghq.atlassian.net/browse/MA-5230)

After switching the page layout from `A4` to `Letter`, the page slices were not being properly calculated due to the way snapdom will scale back the canvas if a row is considered "oversized". This will calculate the _actual_ scale by dividing the canvas width by the element width.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-5230]: https://konghq.atlassian.net/browse/MA-5230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ