### PR TITLE
fix(analytics): remove filename build method and unused date-fns

### DIFF
--- a/packages/analytics/dashboard-renderer/package.json
+++ b/packages/analytics/dashboard-renderer/package.json
@@ -90,7 +90,6 @@
   "dependencies": {
     "@kong-ui-public/core": "workspace:^",
     "@zumer/snapdom": "^2.6.0",
-    "date-fns": "^4.4.0",
     "gridstack": "^11.5.1",
     "jspdf": "^4.2.1",
     "p-queue": "^8.1.1"

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
 import { ref } from 'vue'
 import { CAPTURE_PREPARE_EVENT, CAPTURE_RESTORE_EVENT } from '@kong-ui-public/analytics-utilities'
-import useExportPdf, { buildFilename, calculatePageSlices, getRowBoundaries, slugify } from './useExportPdf'
+import useExportPdf, { calculatePageSlices, getRowBoundaries } from './useExportPdf'
 import { snapdom } from '@zumer/snapdom'
 
 vi.mock('@zumer/snapdom', () => ({
@@ -39,37 +39,6 @@ const stubRect = (el: HTMLElement, top: number, height: number) => {
     toJSON: () => ({}),
   } as DOMRect)
 }
-
-describe('slugify', () => {
-  it('lowercases and replaces non-alphanumerics with hyphens', () => {
-    expect(slugify('API Usage Dashboard')).toBe('api-usage-dashboard')
-    expect(slugify('  My  (test) dashboard!  ')).toBe('my-test-dashboard')
-  })
-
-  it('collapses consecutive separators and trims leading/trailing hyphens', () => {
-    expect(slugify('--a__b--')).toBe('a-b')
-  })
-})
-
-describe('buildFilename', () => {
-  const now = new Date(2026, 6, 8)
-
-  it('appends the date to an explicit filename', () => {
-    expect(buildFilename('my-report', 'Ignored Title', now)).toBe('my-report-2026-07-08.pdf')
-  })
-
-  it('slugifies the title when no filename is given', () => {
-    expect(buildFilename(undefined, 'API Usage Dashboard', now)).toBe('api-usage-dashboard-2026-07-08.pdf')
-  })
-
-  it('falls back to dashboard-export when neither is given', () => {
-    expect(buildFilename(undefined, undefined, now)).toBe('dashboard-export-2026-07-08.pdf')
-  })
-
-  it('prepends zeros to single-digit months and days', () => {
-    expect(buildFilename('x', undefined, new Date(2026, 0, 5))).toBe('x-2026-01-05.pdf')
-  })
-})
 
 describe('calculatePageSlices', () => {
   it('slices at fixed page height intervals when there are no row boundaries', () => {

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
@@ -4,7 +4,6 @@ import type { SnapdomPlugin } from '@zumer/snapdom'
 import type { PdfExportOptions, PdfExportState } from '../types/renderer-types'
 
 import { readonly, ref } from 'vue'
-import { format } from 'date-fns'
 import { prepareForCapture, restoreAfterCapture } from '@kong-ui-public/analytics-utilities'
 import useI18n from './useI18n'
 
@@ -34,21 +33,6 @@ interface PageMetaContext {
   pageHeight: number
   headerHeight: number
   margin: number
-}
-
-export function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-}
-
-export function buildFilename(filename: string | undefined, title: string | undefined, now: Date): string {
-  const base = filename || (title && slugify(title)) || 'dashboard-export'
-  const dateString = format(now, 'yyyy-MM-dd')
-
-  return `${base}-${dateString}.pdf`
 }
 
 function drawPageMeta(pdf: jsPDF, ctx: PageMetaContext): void {
@@ -189,7 +173,7 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
 
   async function exportPdf(options: PdfExportOptions = {}): Promise<Blob | undefined> {
     const {
-      filename,
+      filename = 'dashboard-export',
       title,
       subtitle,
       dashboardUrl,
@@ -316,7 +300,7 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
         return blob
       }
 
-      pdf.save(buildFilename(filename, title, now))
+      pdf.save(filename)
       exportState.value = { status: 'complete', pageCount: pages.length }
     } catch (error) {
       exportState.value = { status: 'error', error }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,9 +404,6 @@ importers:
       '@zumer/snapdom':
         specifier: ^2.6.0
         version: 2.15.0
-      date-fns:
-        specifier: ^4.4.0
-        version: 4.4.0
       gridstack:
         specifier: ^11.5.1
         version: 11.5.1


### PR DESCRIPTION
# Summary


The functions to build the filename do not need to be within the `dashboard-renderer` package, this should be supplied by the host application.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
