### PR TITLE
fix(table-data-grid): use theme-aware text colors

### DIFF
--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -20,6 +20,7 @@ type TestTableDataGridSlots = {
 }
 
 type MountTableOptions = {
+  containerStyle?: Record<string, string>
   fetcher: TableDataGridFetcher<TestRow>
   headers?: Array<TableDataGridHeader<TestRow>>
   error?: boolean
@@ -61,6 +62,7 @@ const createResetFetcher = () => cy.stub().callsFake(({ pageSize }) => Promise.r
 const TestTableDataGrid = TableDataGrid as unknown as DefineComponent
 
 const mountTestTableDataGrid = ({
+  containerStyle,
   headers: tableHeaders = headers,
   onGridReady,
   slots,
@@ -81,6 +83,7 @@ const mountTestTableDataGrid = ({
         style: {
           height: '520px',
           width: '640px',
+          ...containerStyle,
         },
       }, [
         h(TestTableDataGrid, componentProps, slots),
@@ -237,6 +240,25 @@ describe('<TableDataGrid />', () => {
       pageSize: 15,
       cursor: undefined,
     })
+  })
+
+  it('uses Kong theme text colors for AG Grid headers and cells', () => {
+    const fetcher = cy.stub().resolves({
+      data: rows,
+      total: rows.length,
+    })
+
+    mountTestTableDataGrid({
+      containerStyle: {
+        '--kui-color-text-neutral': '#123456',
+        '--kui-color-text': '#abcdef',
+      },
+      fetcher,
+    })
+
+    cy.contains('.ag-cell', 'Gateway service').should('be.visible')
+    cy.contains('.ag-header-cell-text', 'Name').should('have.css', 'color', 'rgb(18, 52, 86)')
+    cy.contains('.ag-cell', 'Gateway service').should('have.css', 'color', 'rgb(171, 205, 239)')
   })
 
   it('fills a taller parent height by default', () => {

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -166,11 +166,13 @@ const onGridReady = (event: GridReadyEvent<Row>) => {
   /* stylelint-disable custom-property-pattern -- AG Grid theme variables must use AG Grid's --ag-* namespace. */
   --ag-background-color: var(--kui-color-background, #{$kui-color-background});
   --ag-border-color: var(--kui-color-border, #{$kui-color-border});
+  --ag-foreground-color: var(--kui-color-text, #{$kui-color-text});
   --ag-header-background-color: var(--kui-color-background, #{$kui-color-background});
   --ag-header-column-border: 1px solid var(--kui-color-border, #{$kui-color-border});
   --ag-header-column-border-height: 30%;
   --ag-header-column-resize-handle-color: transparent;
   --ag-header-font-weight: var(--kui-font-weight-semibold, #{$kui-font-weight-semibold});
+  --ag-header-text-color: var(--kui-color-text-neutral, #{$kui-color-text-neutral});
   --ag-wrapper-border: none;
   --ag-wrapper-border-radius: 0;
   /* stylelint-enable custom-property-pattern */


### PR DESCRIPTION
## Summary

closes [MA-5231](https://konghq.atlassian.net/browse/MA-5231)

- Map AG Grid cell text to Kong's theme-aware text token.
- Map Quartz header text to Kong's neutral text token.
- Add component coverage for both computed colors.

TableDataGrid already followed Kong theme tokens for backgrounds and borders, but Quartz kept its default text colors. AG Grid 35 Quartz uses `--ag-header-text-color`; the similarly named `--ag-header-foreground-color` applies to legacy themes.

Use the preview package in Konnect Explorer to verify the Table visual in light and night modes.

Konnect validation PR: [kong-konnect/konnect-ui-apps#12711](https://github.com/kong-konnect/konnect-ui-apps/pull/12711)

## Before
<img width="1487" height="964" alt="image" src="https://github.com/user-attachments/assets/8738054c-ba48-4388-ab8f-04428312a6d4" />


## After
<img width="1478" height="962" alt="image" src="https://github.com/user-attachments/assets/e874ccc4-2ea6-4303-9981-5918ff5b546c" />



[MA-5231]: https://konghq.atlassian.net/browse/MA-5231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ