### PR TITLE
fix(analytics): use dimensionId for dataset keys [MA-4992]

### DIFF
--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToDatasets.spec.ts
@@ -124,6 +124,56 @@ describe('useVitalsExploreDatasets', () => {
     )
   })
 
+  it('keeps entities with the same name but different ids as separate datasets', () => {
+    const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
+      data: [
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            request_count: 100,
+            principal: '019e1df4-fb64-7566-8552-de6ea6bb9425',
+          },
+        },
+        {
+          timestamp: '2022-01-01T01:01:02Z',
+          event: {
+            request_count: 50,
+            principal: '019f4222-3849-7d7c-92f5-f42e47fdbe25',
+          },
+        },
+      ],
+      meta: {
+        start: '2022-01-01T01:01:02.000Z',
+        end: '2022-01-01T01:01:10.000Z',
+        granularity_ms: 8000,
+        display: {
+          principal: {
+            '019e1df4-fb64-7566-8552-de6ea6bb9425': { name: 'dp-mock-principal' },
+            '019f4222-3849-7d7c-92f5-f42e47fdbe25': { name: 'dp-mock-principal' },
+          },
+        },
+        metric_names: ['request_count'],
+        query_id: '',
+        metric_units: { request_count: 'units' },
+        truncated: false,
+        limit: 15,
+      },
+    }))
+    const result = useExploreResultToDatasets({ fill: true }, exploreResult)
+
+    expect(result.value).toEqual(
+      {
+        labels: ['dp-mock-principal', 'dp-mock-principal'],
+        datasets: [
+          { label: 'dp-mock-principal', backgroundColor: '#a86cd5', data: [100, null], isSegmentEmpty: false },
+          { label: 'dp-mock-principal', backgroundColor: '#6a86d2', data: [null, 50], isSegmentEmpty: false },
+        ],
+        isMultiDimension: false,
+        isLabelEmpty: [false, false],
+      },
+    )
+  })
+
   it('handles multi dimension query', () => {
     const exploreResult: ComputedRef<ExploreResultV4> = computed(() => ({
       data: [

--- a/packages/analytics/analytics-chart/src/composables/useExploreResultToTimeDatasets.ts
+++ b/packages/analytics/analytics-chart/src/composables/useExploreResultToTimeDatasets.ts
@@ -139,12 +139,12 @@ export default function useExploreResultToTimeDataset(
                   if (!acc[timestamp][metric]) {
                     acc[timestamp][metric] = {}
                   }
-                  acc[timestamp][metric][label.name] = Math.round(Number(event[metric]) * 1e3) / 1e3
+                  acc[timestamp][metric][label.id] = Math.round(Number(event[metric]) * 1e3) / 1e3
                 } else if (!dimensionFieldNames.length) { // using metrics as dimensions
                   if (!acc[timestamp][metric]) {
                     acc[timestamp][metric] = {}
                   }
-                  acc[timestamp][metric][label.name] = Math.round(Number(event[label.id]) * 1e3) / 1e3
+                  acc[timestamp][metric][label.id] = Math.round(Number(event[label.id]) * 1e3) / 1e3
                 }
               })
             }
@@ -152,16 +152,16 @@ export default function useExploreResultToTimeDataset(
             return acc
           }, {})
 
-        const dimensionsCrossMetrics: Array<[string, string, boolean]> = metricNames.length === 1
-          ? metricNames.flatMap<[string, string, boolean]>(metric => {
-            return datasetLabels.map<[string, string, boolean]>(label => [metric, label.name, label.id === 'empty'])
+        const dimensionsCrossMetrics: Array<[string, string, string, boolean]> = metricNames.length === 1
+          ? metricNames.flatMap<[string, string, string, boolean]>(metric => {
+            return datasetLabels.map<[string, string, string, boolean]>(label => [metric, label.id, label.name, label.id === 'empty'])
           })
-          : datasetLabels.map(label => [label.name, label.name, label.id === 'empty'])
+          : datasetLabels.map(label => [label.name, label.id, label.name, label.id === 'empty'])
 
-        const datasets: Dataset[] = [...dimensionsCrossMetrics].map(([metric, dimension, isSegmentEmpty], i) => {
+        const datasets: Dataset[] = [...dimensionsCrossMetrics].map(([metric, dimensionId, dimensionName, isSegmentEmpty], i) => {
           const filled = zeroFilledTimeSeries.map(ts => {
             if (ts in timedEvents && metric in timedEvents[ts]) {
-              return { x: ts, y: timedEvents[ts][metric][dimension] || 0 }
+              return { x: ts, y: timedEvents[ts][metric][dimensionId] || 0 }
             }
 
             return { x: ts, y: 0 }
@@ -174,13 +174,13 @@ export default function useExploreResultToTimeDataset(
             colorPalette = datavisPalette
           }
 
-          const baseColor = determineBaseColor(i, dimension, isSegmentEmpty, colorPalette)
+          const baseColor = determineBaseColor(i, dimensionName, isSegmentEmpty, colorPalette)
 
           return {
-            rawDimension: dimension,
+            rawDimension: dimensionName,
             rawMetric: metric,
             // @ts-ignore - dynamic i18n key
-            label: (i18n && i18n.te(`chartLabels.${dimension}`) && i18n.t(`chartLabels.${dimension}`)) || dimension,
+            label: (i18n && i18n.te(`chartLabels.${dimensionName}`) && i18n.t(`chartLabels.${dimensionName}`)) || dimensionName,
             borderColor: baseColor,
             backgroundColor: baseColor,
             data: filled,


### PR DESCRIPTION
# Summary

Fix [MA-4992](https://konghq.atlassian.net/browse/MA-4992)

Entities sharing a display name were being consolidated into one causing requests in a timeline chart to appear identical. This was caused by mapping the entities by their `name` rather than the `id`.

<details open>
<summary>Before</summary>

<img width="1076" height="657" alt="before" src="https://github.com/user-attachments/assets/2223d5a2-e2fc-4ba8-9ce1-c060c3640252" />

</details>


<details open>
<summary>After</summary>

<img width="1076" height="657" alt="after" src="https://github.com/user-attachments/assets/defe41ea-b8b7-4d92-aa61-67a54ab987ea" />

</details>


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-4992]: https://konghq.atlassian.net/browse/MA-4992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ