### PR TITLE
fix(entities-plugins): refactor free-form hidden-path projection (KM-2182)

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, get, isEqual, isFunction, omit, set } from 'lodash-es'
+import { cloneDeep, isEqual, isFunction, omit } from 'lodash-es'
 import { createInjectionState } from '@vueuse/core'
 import { createRenderRuleRegistry } from './render-rules'
 import { FIELD_RENDERER_SLOTS, FIELD_RENDERERS } from './constants'
@@ -92,24 +92,17 @@ export const [provideFormShared, useOptionalFormShared] = createInjectionState(
      * Get transformed form data
      */
     function getValue(): T {
-      const value = toValue(innerData)
-      const nextValue = cloneDeep(value)
+      const nextValue = cloneDeep(toValue(innerData))
 
-      // Set hidden paths to default or null
+      // Reset hidden fields to their empty-or-default value by walking the tree
+      // top-down, so a hidden subtree is dropped wholesale and no missing parent
+      // is ever auto-created (replaces the KM-2182 `parentExists` workaround).
       if (hiddenPaths.value.size > 0) {
-        for (const path of hiddenPaths.value) {
-          const pathArray = utils.toArray(path)
-
-          // Check if the parent path exists before setting
-          // This is a temporary fix to prevent lodash set() from auto-creating intermediate objects
-          // todo(KM-2182): Refactor data layer to listen to data source changes and clean up hiddenPaths accordingly
-          const parentPath = pathArray.slice(0, -1)
-          const parentExists = parentPath.length === 0 || get(nextValue, parentPath) != null
-
-          if (parentExists) {
-            set(nextValue, pathArray, getEmptyOrDefaultFromSchema(path))
-          }
-        }
+        utils.pruneHiddenPaths(
+          nextValue,
+          isFieldHidden,
+          getEmptyOrDefaultFromSchema,
+        )
       }
 
       return keyIdMap.deserialize(nextValue)

--- a/packages/entities/entities-plugins/src/components/free-form/shared/utils.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { sortFieldsByBundles, normalizeMatch } from './utils'
+import { sortFieldsByBundles, normalizeMatch, pruneHiddenPaths } from './utils'
 import type { NamedFieldSchema } from '../../../types/plugins/form-schema'
 
 describe('sortFieldsByBundles', () => {
@@ -350,6 +350,78 @@ describe('sortFieldsByBundles', () => {
         'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
       ])
     })
+  })
+})
+
+describe('pruneHiddenPaths', () => {
+  // Reset value resolver: default map falls back to null (optional field).
+  const resolver = (defaults: Record<string, unknown> = {}) =>
+    (path: string) => (path in defaults ? defaults[path] : null)
+
+  const hiddenBy = (...paths: string[]) => {
+    const set = new Set(paths)
+    return (path: string) => set.has(path)
+  }
+
+  it('resets a hidden top-level field to its empty-or-default value', () => {
+    const data = { a: 'keep', b: 'secret' }
+    pruneHiddenPaths(data, hiddenBy('b'), resolver())
+
+    expect(data).toEqual({ a: 'keep', b: null })
+  })
+
+  it('leaves visible fields untouched', () => {
+    const data = { a: 'x', b: 'y' }
+    pruneHiddenPaths(data, hiddenBy(), resolver())
+
+    expect(data).toEqual({ a: 'x', b: 'y' })
+  })
+
+  it('resets only the hidden nested field without adding extra keys', () => {
+    const data = { config: { strategy: 'local', host: 'h' } }
+    pruneHiddenPaths(data, hiddenBy('config.host'), resolver())
+
+    expect(data).toEqual({ config: { strategy: 'local', host: null } })
+  })
+
+  it('replaces a hidden record subtree wholesale and never leaks its children', () => {
+    const data = { config: { redis: { host: 'h', port: 6379 } } }
+    pruneHiddenPaths(data, hiddenBy('config.redis'), resolver())
+
+    // redis reset to null; its children (host/port) must not appear anywhere
+    expect(data).toEqual({ config: { redis: null } })
+  })
+
+  it('does not descend into a hidden subtree even if its children are also hidden', () => {
+    const data = { config: { redis: { host: 'h' } } }
+    // Both parent and child hidden; parent wins, child is never processed.
+    pruneHiddenPaths(data, hiddenBy('config.redis', 'config.redis.host'), resolver())
+
+    expect(data).toEqual({ config: { redis: null } })
+  })
+
+  it('does not auto-create a missing parent for a stale deep hidden path (KM-2182)', () => {
+    // config.redis is null, but a stale hidden path points below it.
+    const data = { config: { redis: null } }
+    pruneHiddenPaths(data, hiddenBy('config.redis.host'), resolver())
+
+    // Must stay null — no spurious { redis: { host: ... } } created.
+    expect(data).toEqual({ config: { redis: null } })
+  })
+
+  it('resets a hidden field inside an array item', () => {
+    const data = { callouts: [{ name: 'a', secret: 's' }, { name: 'b', secret: 't' }] }
+    pruneHiddenPaths(data, hiddenBy('callouts.1.secret'), resolver())
+
+    expect(data).toEqual({ callouts: [{ name: 'a', secret: 's' }, { name: 'b', secret: null }] })
+  })
+
+  it('uses the provided default (e.g. required field) as the reset value and does not recurse into it', () => {
+    const data = { config: { opts: { a: 1, b: 2 } } }
+    const defaults = { 'config.opts': { a: 0 } }
+    pruneHiddenPaths(data, hiddenBy('config.opts'), resolver(defaults))
+
+    expect(data).toEqual({ config: { opts: { a: 0 } } })
   })
 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/utils.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/utils.ts
@@ -47,6 +47,46 @@ export function removeRootSymbol(path: string) {
   return path
 }
 
+/**
+ * Replaces hidden fields in a data tree with their empty-or-default value.
+ *
+ * Walks the tree **top-down**, which gives two structural guarantees the old
+ * flat `hiddenPaths` + lodash `set()` approach could not:
+ * - A hidden node is replaced wholesale and never descended into, so its
+ *   children can never leak into the output.
+ * - Values are only written onto containers that already exist, so a stale or
+ *   deep hidden path can never auto-create intermediate objects (the bug that
+ *   `todo(KM-2182)` used to guard against with a `parentExists` check).
+ *
+ * Mutates `node` in place — callers must pass a clone.
+ *
+ * @param node The (cloned) data tree to prune.
+ * @param isHidden Predicate: is the field at this absolute path hidden?
+ * @param getEmptyOrDefault Resolves the reset value for a hidden path.
+ * @param path Current absolute path; omit at the root.
+ */
+export function pruneHiddenPaths(
+  node: any,
+  isHidden: (path: string) => boolean,
+  getEmptyOrDefault: (path: string) => unknown,
+  path: string = '',
+): void {
+  if (node == null || typeof node !== 'object') return
+
+  const keys = Array.isArray(node)
+    ? node.map((_, index) => String(index))
+    : Object.keys(node)
+
+  for (const key of keys) {
+    const childPath = path ? resolve(path, key) : key
+    if (isHidden(childPath)) {
+      node[key] = getEmptyOrDefault(childPath)
+    } else {
+      pruneHiddenPaths(node[key], isHidden, getEmptyOrDefault, childPath)
+    }
+  }
+}
+
 export function useRedisNonstandardFields(
   partialFields: FlattendRedisConfigurationFields,
   redisFields: Field[],

--- a/packages/entities/entities-plugins/src/components/free-form/test/free-form-render-rules.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/test/free-form-render-rules.cy.ts
@@ -750,6 +750,67 @@ describe('Render Rules', () => {
     })
   })
 
+  describe('Output projection', () => {
+    // Locks the ordering invariant in `getValue()`: hidden fields are pruned in
+    // the internal kid-space *before* `keyIdMap.deserialize()` renames map keys.
+    // If pruning ran after deserialize, the concrete kid path stored in
+    // `hiddenPaths` (`config.entries.kid:N.secret`) would no longer match the
+    // deserialized tree (`config.entries.primary.secret`) and the hidden field
+    // would leak into the emitted payload.
+    it('resets a hidden field inside a map value, keyed by its real name', () => {
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            config: {
+              type: 'record',
+              fields: [
+                {
+                  entries: {
+                    type: 'map',
+                    values: {
+                      type: 'record',
+                      fields: [
+                        { strategy: { type: 'string' } },
+                        { secret: { type: 'string' } },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }
+
+      const renderRules: RenderRules = {
+        dependencies: {
+          // `#` addresses the map value; secret is shown only when strategy === 'redis'
+          'config.entries.#.secret': ['config.entries.#.strategy', 'redis'],
+        },
+      }
+
+      const onChangeSpy = cy.spy().as('onChangeSpy')
+
+      cy.mount(Form, {
+        props: {
+          schema,
+          renderRules,
+          data: { config: { entries: { primary: { strategy: 'local', secret: 'leak' } } } },
+          onChange: onChangeSpy,
+        },
+      })
+
+      // secret is hidden (strategy !== 'redis') → must be null in the output,
+      // and the entry must be keyed by 'primary' (proving deserialize ran and
+      // kid-space matching worked).
+      cy.get('@onChangeSpy').should('have.been.calledWith', Cypress.sinon.match((value: any) => {
+        const entry = value?.config?.entries?.primary
+        return !!entry && entry.strategy === 'local' && entry.secret === null
+      }))
+    })
+  })
+
   describe('Reactivity', () => {
     describe('Props change reactivity', () => {
       it('should react to renderRules prop changes at runtime', () => {


### PR DESCRIPTION
## Summary

Refactors the free-form output projection in `getValue()` so hidden fields are reset by a **top-down tree walk** instead of replaying a flat `hiddenPaths` list onto a clone with lodash `set()`.