### PR TITLE
fix(entities-plugins): derive free-form field visibility purely

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/ObjectField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ObjectField.vue
@@ -174,7 +174,6 @@ const currentRenderRules = useCurrentRenderRules({
   fieldPath: field.path!,
   rules: toRef(props, 'renderRules'),
   omittedFields: toRef(() => omit),
-  parentValue: fieldValue!,
 })
 
 const added = defineModel<boolean>('added', { default: undefined })

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
@@ -44,14 +44,13 @@ export const [provideFormShared, useOptionalFormShared] = createInjectionState(
     const {
       useCurrentRules: useCurrentRenderRules,
       createComputedRules: createComputedRenderRules,
-      hiddenPaths,
+      hasDependencies,
       isFieldHidden,
-    } = createRenderRuleRegistry(() => onChange?.(getValue()), schemaHelpers.getSchemaMap)
+    } = createRenderRuleRegistry(schemaHelpers.getSchemaMap, () => innerData)
 
     const rootRenderRules = useCurrentRenderRules({
       fieldPath: utils.rootSymbol,
       rules: propsRenderRules,
-      parentValue: innerData,
     })
 
     function setValue(newData: T) {
@@ -97,7 +96,7 @@ export const [provideFormShared, useOptionalFormShared] = createInjectionState(
       // Reset hidden fields to their empty-or-default value by walking the tree
       // top-down, so a hidden subtree is dropped wholesale and no missing parent
       // is ever auto-created (replaces the KM-2182 `parentExists` workaround).
-      if (hiddenPaths.value.size > 0) {
+      if (hasDependencies.value) {
         utils.pruneHiddenPaths(
           nextValue,
           isFieldHidden,

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
@@ -91,7 +91,7 @@ export const [provideFormShared, useOptionalFormShared] = createInjectionState(
      * Get transformed form data
      */
     function getValue(): T {
-      const nextValue = cloneDeep(toValue(innerData))
+      const nextValue = keyIdMap.deserialize(innerData)
 
       // Reset hidden fields to their empty-or-default value by walking the tree
       // top-down, so a hidden subtree is dropped wholesale and no missing parent
@@ -100,11 +100,15 @@ export const [provideFormShared, useOptionalFormShared] = createInjectionState(
         utils.pruneHiddenPaths(
           nextValue,
           isFieldHidden,
-          getEmptyOrDefaultFromSchema,
+          // `getEmptyOrDefault` may hand back a `schema.default` reference
+          // verbatim (see `createFieldDefault`). Clone it so the emitted tree
+          // never aliases the schema — previously the post-prune `deserialize`
+          // pass provided this isolation for free.
+          (path) => cloneDeep(getEmptyOrDefaultFromSchema(path)),
         )
       }
 
-      return keyIdMap.deserialize(nextValue)
+      return nextValue
     }
 
     // Emit changes when the inner data changes

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
@@ -91,24 +91,26 @@ export const [provideFormShared, useOptionalFormShared] = createInjectionState(
      * Get transformed form data
      */
     function getValue(): T {
-      const nextValue = keyIdMap.deserialize(innerData)
+      const nextValue = cloneDeep(toValue(innerData))
 
       // Reset hidden fields to their empty-or-default value by walking the tree
       // top-down, so a hidden subtree is dropped wholesale and no missing parent
       // is ever auto-created (replaces the KM-2182 `parentExists` workaround).
+      //
+      // NOTE: pruning MUST run here, on the still-serialized (kid-keyed) tree,
+      // before `deserialize` renames map keys. `isFieldHidden` reads each
+      // dependency's actual value from `innerData` (kid-keyed) with a concrete
+      // path; pruning a name-keyed tree would feed it name-keyed paths that miss
+      // inside maps, silently mis-evaluating visibility for map-nested fields.
       if (hasDependencies.value) {
         utils.pruneHiddenPaths(
           nextValue,
           isFieldHidden,
-          // `getEmptyOrDefault` may hand back a `schema.default` reference
-          // verbatim (see `createFieldDefault`). Clone it so the emitted tree
-          // never aliases the schema — previously the post-prune `deserialize`
-          // pass provided this isolation for free.
-          (path) => cloneDeep(getEmptyOrDefaultFromSchema(path)),
+          getEmptyOrDefaultFromSchema,
         )
       }
 
-      return nextValue
+      return keyIdMap.deserialize(nextValue)
     }
 
     // Emit changes when the inner data changes

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { meetsDependency, renderRuleExactMatch } from './render-rules'
+
+describe('meetsDependency', () => {
+  describe('primitive / deep equality', () => {
+    it('matches equal primitives', () => {
+      expect(meetsDependency('a', 'a')).toBe(true)
+      expect(meetsDependency(1, 1)).toBe(true)
+      expect(meetsDependency(true, true)).toBe(true)
+    })
+
+    it('rejects unequal primitives', () => {
+      expect(meetsDependency('a', 'b')).toBe(false)
+      expect(meetsDependency(1, 2)).toBe(false)
+    })
+
+    it('treats null/undefined via deep equality', () => {
+      expect(meetsDependency(null, null)).toBe(true)
+      expect(meetsDependency(undefined, null)).toBe(false)
+      expect(meetsDependency(null, 'x')).toBe(false)
+    })
+
+    it('deeply compares plain objects', () => {
+      expect(meetsDependency({ type: 'redis' }, { type: 'redis' })).toBe(true)
+      expect(meetsDependency({ type: 'redis' }, { type: 'local' })).toBe(false)
+    })
+  })
+
+  describe('array = any-of', () => {
+    it('matches when the value equals any element', () => {
+      expect(meetsDependency('a', ['a', 'b'])).toBe(true)
+      expect(meetsDependency('b', ['a', 'b'])).toBe(true)
+    })
+
+    it('rejects when the value matches no element', () => {
+      expect(meetsDependency('c', ['a', 'b'])).toBe(false)
+    })
+  })
+
+  describe('renderRuleExactMatch = exact deep equality', () => {
+    it('matches when the array equals exactly', () => {
+      expect(meetsDependency(['x', 'y'], renderRuleExactMatch(['x', 'y']))).toBe(true)
+    })
+
+    it('rejects a partial array match', () => {
+      expect(meetsDependency(['x'], renderRuleExactMatch(['x', 'y']))).toBe(false)
+    })
+
+    it('does not treat a plain element as an any-of match', () => {
+      // 'x' is an element of ['x','y'] but must NOT satisfy an exact-match wrapper
+      expect(meetsDependency('x', renderRuleExactMatch(['x', 'y']))).toBe(false)
+    })
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/render-rules.ts
@@ -1,4 +1,4 @@
-import { computed, onBeforeUnmount, readonly, ref, toValue, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, toValue, watch } from 'vue'
 import { generalizePath } from './schema'
 import { get, isEqual } from 'lodash-es'
 import * as utils from '../utils'
@@ -33,10 +33,35 @@ export function renderRuleExactMatch<T>(value: T): { [RENDER_RULE_EXACT_MATCH]: 
   return { [RENDER_RULE_EXACT_MATCH]: value }
 }
 
-export function createRenderRuleRegistry(onChange: () => void, getSchemaMap: () => Record<string, UnionFieldSchema>) {
+/**
+ * Evaluates whether a dependency condition is satisfied.
+ * - `renderRuleExactMatch(value)` → exact deep equality (dependency field holds an array).
+ * - array → any-of: satisfied when the actual value matches any element.
+ * - anything else → exact deep equality.
+ */
+export function meetsDependency(actual: unknown, expected: unknown): boolean {
+  const isExactWrapper = typeof expected === 'object'
+    && expected !== null
+    && RENDER_RULE_EXACT_MATCH in (expected as object)
+
+  if (isExactWrapper) {
+    return isEqual(actual, (expected as Record<typeof RENDER_RULE_EXACT_MATCH, unknown>)[RENDER_RULE_EXACT_MATCH])
+  }
+  if (Array.isArray(expected)) {
+    return expected.some((v: unknown) => isEqual(actual, v))
+  }
+  return isEqual(actual, expected)
+}
+
+export function createRenderRuleRegistry(
+  getSchemaMap: () => Record<string, UnionFieldSchema>,
+  getFormData: () => Record<string, any>,
+) {
   type RenderRulesMap = Record<string, RenderRules>
   const registry = ref<RenderRulesMap>({})
-  const hiddenPaths = ref<Set<string>>(new Set())
+  // Fields the host form manages itself (ObjectField `omit`), keyed by the
+  // registering field's concrete path. Such fields are never hidden by rules.
+  const omittedRegistry = ref<Record<string, string[]>>({})
 
   /**
    * Validates that all fields in a bundle/dependency are at the same level
@@ -250,7 +275,7 @@ export function createRenderRuleRegistry(onChange: () => void, getSchemaMap: () 
    * @throws {Error} If fields in bundle/dependency are at different levels
    * @throws {Error} If dependencies have cycles
    */
-  const flattenedRules = computed<RenderRulesMap>(() => {
+  function buildFlattenedRules(): RenderRulesMap {
     const result: RenderRulesMap = {}
 
     // Iterate through each rule in the registry
@@ -326,6 +351,21 @@ export function createRenderRuleRegistry(onChange: () => void, getSchemaMap: () 
     validateNoCycleInDeps(result)
 
     return result
+  }
+
+  /**
+   * Flattened rules for the whole form. Rule validation (bundle size, same
+   * level, cycles) throws inside `buildFlattenedRules`; we catch it here so
+   * that invalid rules degrade to "no rules" (fields render normally) with a
+   * console error, instead of crashing every consumer that reads this value.
+   */
+  const flattenedRules = computed<RenderRulesMap>(() => {
+    try {
+      return buildFlattenedRules()
+    } catch (error) {
+      console.error('Invalid render rules:', error instanceof Error ? error.message : String(error))
+      return {}
+    }
   })
 
   function getRules(fieldPath?: string): RenderRules | undefined {
@@ -354,97 +394,101 @@ export function createRenderRuleRegistry(onChange: () => void, getSchemaMap: () 
     })
   }
 
+  /**
+   * Whether any dependency rule exists at all — lets consumers skip visibility
+   * work entirely for the common case of forms without conditional fields.
+   */
+  const hasDependencies = computed(() =>
+    Object.values(flattenedRules.value).some(
+      rule => rule.dependencies && Object.keys(rule.dependencies).length > 0,
+    ),
+  )
+
   function useCurrentRules(options: {
     fieldPath: MaybeRefOrGetter<string>
     rules?: MaybeRefOrGetter<RenderRules | undefined>
-    parentValue?: MaybeRefOrGetter<unknown>
     omittedFields?: MaybeRefOrGetter<string[] | undefined>
   }) {
     const {
       fieldPath,
       rules,
-      parentValue,
       omittedFields,
     } = options
-    // Watch for changes in rules or fieldPath
+
+    // Register/unregister this field's rules and omitted children by path.
+    // Visibility itself is derived lazily by `isFieldHidden`, so there is no
+    // imperative hidden-state to keep in sync here.
     watch([
       () => toValue(rules),
       () => toValue(fieldPath),
-    ], ([newRules, path], [, oldPath]) => {
-      // Set new rules
+      () => toValue(omittedFields),
+    ], ([newRules, path, omitted], [, oldPath]) => {
       if (newRules) {
         registry.value[path] = newRules
       } else {
         delete registry.value[path]
       }
 
+      if (omitted && omitted.length) {
+        omittedRegistry.value[path] = [...omitted]
+      } else {
+        delete omittedRegistry.value[path]
+      }
+
       // Clean up old path
       if (oldPath && oldPath !== path) {
         delete registry.value[oldPath]
+        delete omittedRegistry.value[oldPath]
       }
     }, { immediate: true, deep: true })
 
     const computedRules = createComputedRules(fieldPath)
 
-    watch(
-      [
-        () => toValue(parentValue),
-        () => toValue(computedRules)?.dependencies,
-        () => toValue(fieldPath),
-        () => toValue(omittedFields),
-      ],
-      ([parent, deps, path, omitted]) => {
-        if (!deps || !parent) return
-
-        Object.entries(deps).forEach(([fieldName, [depField, expectedDepFieldValue]]) => {
-          // Skip omitted fields
-          if (omitted?.includes(fieldName)) return
-
-          const actualDepFieldValue = get(parent, depField)
-          const sourceFieldPath = path
-            ? utils.removeRootSymbol(utils.resolve(path, fieldName))
-            : fieldName
-
-          // Skip if dependency condition is met:
-          // - array → any-of (common case: string field, show when value matches any element)
-          // - renderRuleExactMatch(value) → exact deep equality (rare case: field itself holds an array)
-          // - anything else → exact deep equality
-          const isExactWrapper = typeof expectedDepFieldValue === 'object' && expectedDepFieldValue !== null && RENDER_RULE_EXACT_MATCH in expectedDepFieldValue
-          const meetsCondition = isExactWrapper
-            ? isEqual(actualDepFieldValue, (expectedDepFieldValue as Record<typeof RENDER_RULE_EXACT_MATCH, unknown>)[RENDER_RULE_EXACT_MATCH])
-            : Array.isArray(expectedDepFieldValue)
-              ? expectedDepFieldValue.some((v: unknown) => isEqual(actualDepFieldValue, v))
-              : isEqual(actualDepFieldValue, expectedDepFieldValue)
-          if (meetsCondition) {
-            hiddenPaths.value.delete(sourceFieldPath) // Unhide the field
-            onChange()
-            return
-          }
-
-          hiddenPaths.value.add(sourceFieldPath) // Mark field as hidden
-          onChange()
-        })
-      },
-      { deep: true, immediate: true },
-    )
-
     // Clean up on unmount
     onBeforeUnmount(() => {
       const path = toValue(fieldPath)
       delete registry.value[path]
+      delete omittedRegistry.value[path]
     })
 
     return computedRules
   }
 
+  /**
+   * Pure visibility check: a field is hidden when a dependency rule targets it
+   * and the dependency's current value does not satisfy the condition.
+   *
+   * Derived on demand from the flattened rules and the live form data, so any
+   * reactive consumer (e.g. a field's `hide` computed, or `getValue`) tracks the
+   * exact dependency value it reads and re-evaluates when that value changes.
+   */
   function isFieldHidden(fieldPath: string): boolean {
-    return hiddenPaths.value.has(fieldPath)
+    const parts = utils.toArray(fieldPath)
+    if (!parts.length) return false
+
+    const fieldName = parts[parts.length - 1]
+    const parentPath = utils.resolve(...parts.slice(0, -1)) // '' for root-level fields
+
+    // Fields the host form manages itself are never hidden by render rules.
+    if (omittedRegistry.value[parentPath]?.includes(fieldName)) return false
+
+    const rulesKey = parentPath === ''
+      ? utils.rootSymbol
+      : generalizePath(parentPath, getSchemaMap())
+    const dependency = flattenedRules.value[rulesKey]?.dependencies?.[fieldName]
+    if (!dependency) return false
+
+    const [depName, expectedValue] = dependency
+    const depPath = parentPath ? utils.resolve(parentPath, depName) : depName
+    const actualValue = get(getFormData(), utils.toArray(depPath))
+
+    return !meetsDependency(actualValue, expectedValue)
   }
 
   return {
     useCurrentRules,
     createComputedRules,
-    hiddenPaths: readonly(hiddenPaths),
+    hasDependencies,
     isFieldHidden,
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/test/free-form-render-rules.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/test/free-form-render-rules.cy.ts
@@ -770,6 +770,7 @@ describe('Render Rules', () => {
                 {
                   entries: {
                     type: 'map',
+                    keys: { type: 'string' },
                     values: {
                       type: 'record',
                       fields: [
@@ -809,6 +810,61 @@ describe('Render Rules', () => {
       cy.get('@onChangeSpy').should('have.been.calledWith', Cypress.sinon.match((value: any) => {
         const entry = value?.config?.entries?.primary
         return !!entry && entry.strategy === 'local' && entry.secret === null
+      }))
+    })
+
+    // Companion to the test above with the dependency SATISFIED: the map-nested
+    // field must stay visible and keep its value. This is the case that only
+    // works when the dependency's actual value is read with a kid-keyed path
+    // that matches `innerData` — i.e. pruning happens before `deserialize`.
+    it('keeps a shown field inside a map value, keyed by its real name', () => {
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            config: {
+              type: 'record',
+              fields: [
+                {
+                  entries: {
+                    type: 'map',
+                    keys: { type: 'string' },
+                    values: {
+                      type: 'record',
+                      fields: [
+                        { strategy: { type: 'string' } },
+                        { secret: { type: 'string' } },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }
+
+      const renderRules: RenderRules = {
+        dependencies: {
+          'config.entries.#.secret': ['config.entries.#.strategy', 'redis'],
+        },
+      }
+
+      const onChangeSpy = cy.spy().as('onChangeSpy')
+
+      cy.mount(Form, {
+        props: {
+          schema,
+          renderRules,
+          // strategy === 'redis' → secret is shown and must be preserved
+          data: { config: { entries: { primary: { strategy: 'redis', secret: 'keep' } } } },
+          onChange: onChangeSpy,
+        },
+      })
+
+      cy.get('@onChangeSpy').should('have.been.calledWith', Cypress.sinon.match((value: any) => {
+        const entry = value?.config?.entries?.primary
+        return !!entry && entry.strategy === 'redis' && entry.secret === 'keep'
       }))
     })
   })

--- a/packages/entities/entities-plugins/src/components/free-form/test/free-form-render-rules.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/test/free-form-render-rules.cy.ts
@@ -1,4 +1,6 @@
+import { h } from 'vue'
 import Form from '../shared/Form.vue'
+import ObjectField from '../shared/ObjectField.vue'
 import type { FormSchema } from '../../../types/plugins/form-schema'
 import { renderRuleExactMatch } from '../shared/composables/render-rules'
 import type { RenderRules } from '../shared/types'
@@ -807,6 +809,63 @@ describe('Render Rules', () => {
       cy.get('@onChangeSpy').should('have.been.calledWith', Cypress.sinon.match((value: any) => {
         const entry = value?.config?.entries?.primary
         return !!entry && entry.strategy === 'local' && entry.secret === null
+      }))
+    })
+  })
+
+  describe('Omitted fields', () => {
+    // Fields excluded from an ObjectField via `omit` are managed by the host
+    // form, so render-rule dependencies must never hide or reset them — even
+    // when a non-omitted sibling under the same condition IS hidden. Locks the
+    // omittedRegistry branch introduced when visibility became purely derived.
+    it('never hides/resets an omitted field, while a non-omitted sibling still resets', () => {
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            config: {
+              type: 'record',
+              fields: [
+                { strategy: { type: 'string' } },
+                { redis: { type: 'string' } },
+                { other: { type: 'string' } },
+              ],
+            },
+          },
+        ],
+      }
+
+      const renderRules: RenderRules = {
+        dependencies: {
+          // both are shown only when strategy === 'redis'
+          'config.redis': ['config.strategy', 'redis'],
+          'config.other': ['config.strategy', 'redis'],
+        },
+      }
+
+      const onChangeSpy = cy.spy().as('onChangeSpy')
+
+      cy.mount(Form, {
+        props: {
+          schema,
+          renderRules,
+          data: { config: { strategy: 'local', redis: 'keep-me', other: 'drop-me' } },
+          onChange: onChangeSpy,
+        },
+        slots: {
+          // `redis` is omitted here → host-managed, must survive the dependency
+          default: () => h(ObjectField, { name: 'config', omit: ['redis'] }),
+        },
+      })
+
+      // Interact so an emit happens with the omit registration already in place
+      // (avoids depending on initial-emit vs. child-mount ordering).
+      cy.getTestId('ff-config.strategy').type('x')
+
+      cy.get('@onChangeSpy').should('have.been.calledWith', Cypress.sinon.match((value: any) => {
+        const config = value?.config
+        // redis omitted → preserved; other not omitted, dependency unmet → reset to null
+        return !!config && config.redis === 'keep-me' && config.other === null
       }))
     })
   })


### PR DESCRIPTION
## Summary

Replaces the mutable `hiddenPaths` Set and its side-effecting watcher in the free-form render-rules engine with a **pure derivation** of field visibility.


KM-2182