### PR TITLE
feat(entities-vaults): use sensitive input for secret value

### DIFF
--- a/packages/entities/entities-vaults/sandbox/App.vue
+++ b/packages/entities/entities-vaults/sandbox/App.vue
@@ -8,9 +8,9 @@
 
 <style lang="scss" scoped>
 body, html {
+  height: 100%;
   margin: 0;
   padding: 0;
-  height: 100%;
 }
 </style>
 

--- a/packages/entities/entities-vaults/src/components/SecretForm.cy.ts
+++ b/packages/entities/entities-vaults/src/components/SecretForm.cy.ts
@@ -82,8 +82,8 @@ describe('<SecretForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       cy.getTestId('other-create-form-submit').should('be.disabled')
       // enables save when required fields have values
       cy.getTestId('secret-form-key').type('bicycle-kick')
-      cy.getTestId('secret-form-value').clear()
-      cy.getTestId('secret-form-value').type('101')
+      cy.getTestId('secret-form-value').find('textarea').clear()
+      cy.getTestId('secret-form-value').find('textarea').type('101')
       cy.getTestId('other-create-form-submit').should('be.enabled')
       // disables save when required field is cleared
       cy.getTestId('secret-form-key').clear()
@@ -111,7 +111,9 @@ describe('<SecretForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       // form fields
       cy.getTestId('secret-form-key').should('be.disabled')
       cy.getTestId('secret-form-key').should('have.value', secret.key)
-      cy.getTestId('secret-form-value').should('have.value', '')
+      // the value is masked and read-only until the user rotates it
+      cy.getTestId('sensitive-input-rotate').should('be.visible')
+      cy.getTestId('secret-form-value').find('textarea').should('have.attr', 'readonly')
     })
 
     it('should correctly handle button state - edit', () => {
@@ -132,11 +134,14 @@ describe('<SecretForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
       cy.getTestId('other-edit-form-submit').should('be.visible')
       cy.getTestId('other-edit-form-cancel').should('be.enabled')
       cy.getTestId('other-edit-form-submit').should('be.disabled')
+      // the value starts masked; rotate to make it editable
+      cy.getTestId('sensitive-input-rotate').click()
+      cy.getTestId('secret-form-value').find('textarea').should('not.have.attr', 'readonly')
       // enables save when form has changes
-      cy.getTestId('secret-form-value').type('ubiquitous')
+      cy.getTestId('secret-form-value').find('textarea').type('ubiquitous')
       cy.getTestId('other-edit-form-submit').should('be.enabled')
       // disables save when form changes are undone
-      cy.getTestId('secret-form-value').clear()
+      cy.getTestId('secret-form-value').find('textarea').clear()
       cy.getTestId('other-edit-form-submit').should('be.disabled')
     })
 
@@ -310,7 +315,7 @@ describe('<SecretForm />', { viewportHeight: 700, viewportWidth: 700 }, () => {
 
       cy.wait('@getAiVault')
       cy.getTestId('secret-form-key').type('password')
-      cy.getTestId('secret-form-value').type('hunter2')
+      cy.getTestId('secret-form-value').find('textarea').type('hunter2')
       cy.getTestId('other-create-form-submit').click()
 
       cy.wait('@createAiSecret').then(({ request }) => {

--- a/packages/entities/entities-vaults/src/components/SecretFormInner.vue
+++ b/packages/entities/entities-vaults/src/components/SecretFormInner.vue
@@ -32,17 +32,16 @@
           required
           type="text"
         />
-        <KTextArea
+        <SensitiveInput
           v-model.trim="state.fields.value"
-          autocomplete="off"
-          :character-limit="false"
           data-testid="secret-form-value"
           :label="t('secrets.form.fields.value.label')"
+          :labels="{ rotateLabel: t('secrets.form.fields.value.rotateLabel') }"
+          :mode="sensitiveInputMode"
+          multiline
           :placeholder="t('secrets.form.fields.value.placeholder')"
           :readonly="state.readonly"
           required
-          resizable
-          type="text"
         />
         <KAlert
           appearance="warning"
@@ -61,6 +60,7 @@ import {
   EntityBaseForm,
   EntityBaseFormType,
   SupportedEntityType,
+  SensitiveInput,
 } from '@kong-ui-public/entities-shared'
 import composables from '../composables'
 import '@kong-ui-public/entities-shared/dist/style.css'
@@ -162,6 +162,8 @@ const updateFormValues = (data: Record<string, any>): void => {
 const formType = computed((): EntityBaseFormType => props.secretId
   ? EntityBaseFormType.Edit
   : EntityBaseFormType.Create)
+
+const sensitiveInputMode = computed((): 'edit' | 'create' => formType.value === EntityBaseFormType.Edit ? 'edit' : 'create')
 
 const submitUrl = computed<string>(() => {
   return `${props.config.apiBaseUrl}${formEndpoints.value[formType.value]}`

--- a/packages/entities/entities-vaults/src/locales/en.json
+++ b/packages/entities/entities-vaults/src/locales/en.json
@@ -80,7 +80,8 @@
         },
         "value": {
           "label": "Value",
-          "placeholder": "Enter value here, can be simple values or multi-line"
+          "placeholder": "Enter value here, can be simple values or multi-line",
+          "rotateLabel": "Rotate value"
         }
       },
       "hint": "Once saved, the secret value will not be visible"


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Use SensitiveInput for the secret value input.

<img width="2410" height="1094" alt="Kapture 2026-07-17 at 17 16 15" src="https://github.com/user-attachments/assets/ca28a5d0-b39a-4edd-b16f-25fa3c5cc96f" />

KM-2918
