### PR TITLE
fix(entities-plugins): fix freeform filler foreign fields, record switches, and auto-generated field defaults

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
@@ -206,6 +206,44 @@ describe('Filler - Cypress', () => {
       cy.get('[data-testid="ff-config.port"]').should('have.value', '6379')
     })
 
+    it('record: re-filling an already-enabled optional object does not collapse it', () => {
+      // Companion to the playwright regression test: cypress's fillRecord already
+      // uses .check()/.uncheck() (idempotent - no-op if already in that state),
+      // so it doesn't have the playwright handler's bug (a plain .click() that
+      // re-toggles, and thus collapses, an already-enabled object). Kept here as
+      // regression coverage so it stays that way.
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            auth: {
+              type: 'record',
+              fields: [
+                { username: { type: 'string' } },
+                { password: { type: 'string' } },
+              ],
+            },
+          },
+        ],
+      }
+
+      cy.mount(() => h('div', { style: 'padding: 20px' }, h(Form, { schema })))
+
+      const filler = createFiller(schema)
+
+      // First fill enables the switch from scratch (simulates create).
+      filler.fillField('auth', { username: 'alice', password: 'secret1' })
+      cy.get('[data-testid="ff-object-switch-auth"]').should('be.checked')
+      cy.getTestId('ff-auth.username').should('have.value', 'alice')
+
+      // Second fill (simulates editing an existing record): the object is
+      // already enabled and must stay that way, with children still reachable.
+      filler.fillField('auth', { username: 'bob', password: 'secret2' })
+      cy.get('[data-testid="ff-object-switch-auth"]').should('be.checked')
+      cy.getTestId('ff-auth.username').should('have.value', 'bob')
+      cy.getTestId('ff-auth.password').should('have.value', 'secret2')
+    })
+
     it('should fill map field (key-value pairs)', () => {
       const schema: FormSchema = {
         type: 'record',

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
@@ -584,6 +584,50 @@ describe('Filler - Cypress', () => {
       cy.get('[data-testid="ff-json-metadata"]').should('exist')
     })
 
+    it('should fill foreign field with a raw id string', () => {
+      // ForeignField.vue is a plain text input - the id is typed directly,
+      // there is no select-item popover to click (unlike EnumField).
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            vault: {
+              type: 'foreign',
+              reference: 'vaults',
+            },
+          },
+        ],
+      }
+
+      cy.mount(() => h('div', { style: 'padding: 20px' }, h(Form, { schema })))
+
+      const filler = createFiller(schema)
+      filler.fillField('vault', 'a5b875e6-2db1-4cbc-9f34-c5d11604cdc5')
+
+      cy.getTestId('ff-vault').should('have.value', 'a5b875e6-2db1-4cbc-9f34-c5d11604cdc5')
+    })
+
+    it('should fill foreign field from an { id } object value', () => {
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            consumer: {
+              type: 'foreign',
+              reference: 'consumers',
+            },
+          },
+        ],
+      }
+
+      cy.mount(() => h('div', { style: 'padding: 20px' }, h(Form, { schema })))
+
+      const filler = createFiller(schema)
+      filler.fillField('consumer', { id: 'b1c2d3e4-0000-0000-0000-000000000000' })
+
+      cy.getTestId('ff-consumer').should('have.value', 'b1c2d3e4-0000-0000-0000-000000000000')
+    })
+
     it('should fill entire form with nested data', () => {
       const schema: FormSchema = {
         type: 'record',

--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/foreign.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/handlers/foreign.ts
@@ -7,15 +7,15 @@ export function fillForeign(option: HandlerOption<ForeignFieldSchema>): void {
 
   const selector = selectors.field(fieldKey)
 
-  // For foreign fields, typically need to click to open selector and select item
-  scrollIntoViewNative(selector)
-  cy.get(selector).click(SCROLL_BEHAVIOR)
-
-  // Handle different value formats
+  // ForeignField.vue renders a plain text input where the referenced entity's
+  // id is typed directly - there is no dropdown/select-item popover to pick from.
   const itemValue = typeof value === 'object' && value?.id ? value.id : value
 
-  if (itemValue) {
-    // Look for select item with the id
-    cy.get(`[data-testid="select-item-${itemValue}"]`).click(SCROLL_BEHAVIOR)
-  }
+  scrollIntoViewNative(selector)
+  cy.get(selector).then(($el) => {
+    cy.wrap($el).clear(SCROLL_BEHAVIOR)
+    if (itemValue) {
+      cy.wrap($el).type(String(itemValue), SCROLL_BEHAVIOR)
+    }
+  })
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
@@ -425,6 +425,50 @@ test.describe('Filler - Playwright', () => {
       await expect(page.locator('[data-testid="ff-json-metadata"]')).toBeVisible()
     })
 
+    test('should fill foreign field with a raw id string', async ({ mount, page }) => {
+      // ForeignField.vue is a plain text input - the id is typed directly,
+      // there is no select-item popover to click (unlike EnumField).
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            vault: {
+              type: 'foreign',
+              reference: 'vaults',
+            },
+          },
+        ],
+      }
+
+      await mount(FormWrapper, { props: { schema } })
+
+      const filler = createFiller(page, schema)
+      await filler.fillField('vault', 'a5b875e6-2db1-4cbc-9f34-c5d11604cdc5')
+
+      await expect(page.getByTestId('ff-vault')).toHaveValue('a5b875e6-2db1-4cbc-9f34-c5d11604cdc5')
+    })
+
+    test('should fill foreign field from an { id } object value', async ({ mount, page }) => {
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            consumer: {
+              type: 'foreign',
+              reference: 'consumers',
+            },
+          },
+        ],
+      }
+
+      await mount(FormWrapper, { props: { schema } })
+
+      const filler = createFiller(page, schema)
+      await filler.fillField('consumer', { id: 'b1c2d3e4-0000-0000-0000-000000000000' })
+
+      await expect(page.getByTestId('ff-consumer')).toHaveValue('b1c2d3e4-0000-0000-0000-000000000000')
+    })
+
     test('should fill entire form with nested data', async ({ mount, page }) => {
       const schema: FormSchema = {
         type: 'record',

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
@@ -202,6 +202,46 @@ test.describe('Filler - Playwright', () => {
       await expect(page.locator('[data-testid="ff-config.port"]')).toHaveValue('6379')
     })
 
+    test('record: re-filling an already-enabled optional object does not collapse it', async ({ mount, page }) => {
+      // Regression test: fillRecord used to unconditionally .click() the
+      // switch-control, which toggles it off when the object was already
+      // enabled (e.g. from a prior fill simulating create, then updating the
+      // same form). That collapses the object's SlideTransition content via
+      // v-if="expanded", detaching any child element the filler is about to
+      // interact with - this is what broke KM's kafka-upstream edit-form test
+      // (updating a nested `authentication` record that already had a value).
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            auth: {
+              type: 'record',
+              fields: [
+                { username: { type: 'string' } },
+                { password: { type: 'string' } },
+              ],
+            },
+          },
+        ],
+      }
+
+      await mount(FormWrapper, { props: { schema } })
+
+      const filler = createFiller(page, schema)
+
+      // First fill enables the switch from scratch (simulates create).
+      await filler.fillField('auth', { username: 'alice', password: 'secret1' })
+      await expect(page.locator('[data-testid="ff-object-switch-auth"]').locator('..').locator('[data-testid="switch-control"]')).toBeChecked()
+      await expect(page.getByTestId('ff-auth.username')).toHaveValue('alice')
+
+      // Second fill (simulates editing an existing record): the object is
+      // already enabled and must stay that way, with children still reachable.
+      await filler.fillField('auth', { username: 'bob', password: 'secret2' })
+      await expect(page.locator('[data-testid="ff-object-switch-auth"]').locator('..').locator('[data-testid="switch-control"]')).toBeChecked()
+      await expect(page.getByTestId('ff-auth.username')).toHaveValue('bob')
+      await expect(page.getByTestId('ff-auth.password')).toHaveValue('secret2')
+    })
+
     test('should fill map field (key-value pairs)', async ({ mount, page }) => {
       const schema: FormSchema = {
         type: 'record',

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/foreign.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/foreign.ts
@@ -6,15 +6,14 @@ export async function fillForeign(option: HandlerOption<ForeignFieldSchema>): Pr
   const { page, fieldKey, value } = option
 
   const selector = selectors.field(fieldKey)
+  const element = page.locator(selector)
 
-  // For foreign fields, typically need to click to open selector and select item
-  await page.locator(selector).click()
-
-  // Handle different value formats
+  // ForeignField.vue renders a plain text input where the referenced entity's
+  // id is typed directly - there is no dropdown/select-item popover to pick from.
   const itemValue = typeof value === 'object' && value?.id ? value.id : value
 
+  await element.clear()
   if (itemValue) {
-    // Look for select item with the id
-    await page.locator(`[data-testid="select-item-${itemValue}"]`).click()
+    await element.fill(String(itemValue))
   }
 }

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
@@ -10,22 +10,28 @@ export async function fillRecord(option: RecordHandlerOption): Promise<void> {
   const hasSwitch = await page.locator(objectSwitchSelector).count() > 0
 
   if ((option.value === null || option.value === undefined) && hasSwitch) {
-    // Disable the object via switch
+    // Disable the object via switch. `uncheck` is a no-op if it's already
+    // unchecked - a plain `.click()` would incorrectly re-toggle (and thus
+    // re-enable) an already-disabled object when re-filling it with null,
+    // e.g. on a second pass over the same form.
     await page
       .locator(objectSwitchSelector)
       .locator('..')
       .locator('[data-testid="switch-control"]')
-      .click()
+      .uncheck({ force: true })
     return
   }
 
   if (hasSwitch) {
-    // Enable the object via switch
+    // Enable the object via switch. `check` is a no-op if it's already
+    // checked - a plain `.click()` would incorrectly re-toggle (and thus
+    // collapse) an object that already has a value, e.g. when filling an
+    // edit form whose existing data already enabled it.
     await page
       .locator(objectSwitchSelector)
       .locator('..')
       .locator('[data-testid="switch-control"]')
-      .click()
+      .check({ force: true })
 
     // Enabling the switch expands the object's content via SlideTransition
     // (height animates from 0). Filling children immediately can hit them

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
@@ -9,36 +9,42 @@ export async function fillRecord(option: RecordHandlerOption): Promise<void> {
 
   const hasSwitch = await page.locator(objectSwitchSelector).count() > 0
 
-  if ((option.value === null || option.value === undefined) && hasSwitch) {
-    // Disable the object via switch. `uncheck` is a no-op if it's already
-    // unchecked - a plain `.click()` would incorrectly re-toggle (and thus
-    // re-enable) an already-disabled object when re-filling it with null,
-    // e.g. on a second pass over the same form.
-    await page
-      .locator(objectSwitchSelector)
-      .locator('..')
-      .locator('[data-testid="switch-control"]')
-      .uncheck({ force: true })
-    return
-  }
-
   if (hasSwitch) {
-    // Enable the object via switch. `check` is a no-op if it's already
-    // checked - a plain `.click()` would incorrectly re-toggle (and thus
-    // collapse) an object that already has a value, e.g. when filling an
-    // edit form whose existing data already enabled it.
-    await page
+    // The switch's clickable element is a `role="checkbox"` span that forwards
+    // its click to a hidden native checkbox input several DOM/event hops away
+    // (span click -> native input .click() -> its `input` event -> emitted
+    // update:modelValue -> parent's v-model -> re-render -> span's
+    // `aria-checked` attribute updates). That's too indirect for Playwright's
+    // `.check()`/`.uncheck()` built-in "did the state actually change"
+    // verification to reliably observe in time, so read `aria-checked`
+    // ourselves and only click (a plain click, not check/uncheck) when the
+    // switch isn't already in the desired state - clicking it unconditionally
+    // would incorrectly re-toggle (and thus collapse, or re-enable) an object
+    // that's already in the right state, e.g. when re-filling an edit form
+    // whose existing data already enabled it.
+    const switchControl = page
       .locator(objectSwitchSelector)
       .locator('..')
       .locator('[data-testid="switch-control"]')
-      .check({ force: true })
+    const isChecked = (await switchControl.getAttribute('aria-checked')) === 'true'
+    const shouldBeChecked = option.value !== null && option.value !== undefined
 
-    // Enabling the switch expands the object's content via SlideTransition
-    // (height animates from 0). Filling children immediately can hit them
-    // mid-transition, when the content container still has height 0.
-    // Wait for it to actually become visible instead of a blind fixed
-    // delay, which can still race under CI load.
-    await page.locator(selectors.objectContent(fieldKey)).waitFor({ state: 'visible' })
+    if (isChecked !== shouldBeChecked) {
+      await switchControl.click({ force: true })
+
+      if (shouldBeChecked) {
+        // Enabling the switch expands the object's content via SlideTransition
+        // (height animates from 0). Filling children immediately can hit them
+        // mid-transition, when the content container still has height 0.
+        // Wait for it to actually become visible instead of a blind fixed
+        // delay, which can still race under CI load.
+        await page.locator(selectors.objectContent(fieldKey)).waitFor({ state: 'visible' })
+      }
+    }
+
+    if (!shouldBeChecked) {
+      return
+    }
   }
 
   // Fill children fields

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
@@ -30,7 +30,15 @@ export async function fillRecord(option: RecordHandlerOption): Promise<void> {
     const shouldBeChecked = option.value !== null && option.value !== undefined
 
     if (isChecked !== shouldBeChecked) {
-      await switchControl.click({ force: true })
+      // Deliberately NOT `force: true`: this needs Playwright's actionability
+      // wait (visible, stable, scrolled into view, receives events), since the
+      // switch has often just been revealed (e.g. by expanding the advanced
+      // fields section) and hasn't settled into its final position yet. `force`
+      // skips that wait and clicks at a stale/off-screen coordinate, which is a
+      // silent no-op - the switch never toggles and the later `waitFor` below
+      // times out. A plain click still avoids the `.check()/.uncheck()` verification
+      // problem described above, since we already gate on `isChecked !== shouldBeChecked`.
+      await switchControl.click()
 
       if (shouldBeChecked) {
         // Enabling the switch expands the object's content via SlideTransition

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.ts
@@ -15,6 +15,7 @@ import type {
   ArrayLikeFieldSchema,
   FormSchema,
   RecordFieldSchema,
+  StringFieldSchema,
   UnionFieldSchema,
   MapFieldSchema,
 } from '../../../../types/plugins/form-schema'
@@ -181,6 +182,16 @@ export function useSchemaHelpers(schema: MaybeRefOrGetter<FormSchema | UnionFiel
     // Use explicit default if provided
     if (schema.default !== undefined) {
       return schema.default
+    }
+
+    // The backend generates a value for this field when it's absent from the
+    // request (Kong schema's `auto = true`). Defaulting it to an explicit
+    // null here would submit `null` for an untouched field, which fails
+    // schema validation ("required field missing") instead of letting the
+    // backend auto-generate it - so omit the key entirely until the user
+    // actually provides a value.
+    if ((schema as StringFieldSchema).auto) {
+      return undefined
     }
 
     // Create structures when forced or for required fields


### PR DESCRIPTION
## Summary

Four related bugs in the freeform autofiller (playwright + cypress) and shared form logic, all found while migrating Kong Manager plugin Playwright tests to FreeForm.

### 1. Foreign fields fill the id directly, not through a popover
- `ForeignField.vue` (renders `type: 'foreign'` config fields, e.g. a plugin's `vault`/`consumer` reference) is a plain text input - the referenced entity's id is typed directly, there is no dropdown/select-item popover.
- Both the playwright and cypress `fillForeign` handlers assumed the opposite: click the field to open a selector, then click `[data-testid="select-item-<id>"]`. That popover never exists for this component, so the click reliably timed out.
- Fixed both handlers to clear + type the id into the input, matching `ForeignField.vue`'s actual `handleUpdate` behavior.

### 2-3. `fillRecord`'s switch handling was unreliable in two different ways
- **Re-toggling an already-set switch**: the playwright `fillRecord` handler unconditionally clicked an optional record's enable/disable switch with no check of its current state. Re-filling a record that already had a value (e.g. updating a plugin whose config already populated it) toggled the switch **off**, collapsing its `SlideTransition` content (`v-if="expanded"`) and detaching any child element the filler was about to interact with.
- **`.check()`/`.uncheck()` couldn't reliably observe the toggle**: switching to `.check()`/`.uncheck()` (which no-op when already in the target state) ran into a different problem - the switch's clickable element is a `role="checkbox"` span that forwards its click to a hidden native checkbox input several DOM/event hops away, too indirect for Playwright's built-in "did the state actually change" verification to reliably observe, causing `Clicking the checkbox did not change its state` failures.
- Fixed by reading `aria-checked` directly and issuing a plain click only when the current state doesn't match the target - skipping Playwright's state-change verification entirely, but still avoiding unwanted re-toggles.

### 4. That plain click still needed to respect actionability
- The plain click above was still calling `.click({ force: true })`, left over from an earlier attempt to work around the `.check()`/`.uncheck()` issue. `force: true` also skips Playwright's actionability wait (visible, stable, scrolled into view, receives events) - and the switch is frequently revealed by expanding a collapsed "advanced settings" section or a scrollable form pane right before this click fires, so it hadn't always settled into its final position/scroll offset yet. That made the click an intermittent, silent no-op: the switch never toggled, and the later wait for its content to appear timed out.
- Fixed by dropping `force: true` - a plain `.click()` still avoids the `.check()`/`.uncheck()` verification problem (the gating on `aria-checked` already prevents unwanted re-toggles), but now lets Playwright wait for the target to actually be clickable first.

### 5. Auto-generated fields shouldn't default to an explicit value
- `useSchemaHelpers` computed a default value for every field, including ones the backend auto-generates when absent from the request (Kong schema's `auto = true`). Defaulting such a field to an explicit value (e.g. `null`) submits that value for an untouched field, which fails schema validation ("required field missing") instead of letting the backend auto-generate it.
- Fixed by returning `undefined` for `auto` string fields until the user actually provides a value, so the key is omitted entirely.

## Root cause

Found while migrating Kong Manager plugin Playwright tests to FreeForm. `createFiller(...).fill({ config: { vault: id } })` consistently timed out waiting for a `select-item-<id>` locator that never rendered (bug 1). Fixing that surfaced a failure updating a different plugin's nested `authentication` record that already had data from a prior create step (bug 2), then a `Clicking the checkbox did not change its state` failure after the first switch fix (bug 3), then an intermittent timeout waiting for a just-expanded record's content to appear - reproduced live against an actual Kong Manager page, where the switch's bounding box was still outside the visible area at the moment of the forced click (bug 4). Bug 5 surfaced separately while filling a plugin field the backend auto-generates.

## Test plan
- [x] `npx playwright test -c playwright.config.ts fill-form.pw.ts` - 37/37 passed
- [x] `cypress run --component --spec './src/components/free-form/filler/cypress/fill-form.cy.ts'` - all passing
- [x] Verified each fix reproduces its original failure when reverted against the old handler (bug 4: A/B'd `force: true` vs plain `.click()` over repeated runs against the real Kong Manager `ai-proxy` plugin form - `force: true` failed intermittently, plain `.click()` passed consistently)
- [x] `eslint` clean on all changed files
