### PR TITLE
fix(entities-plugins): stop fillRecord from re-toggling an already-set switch

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/cypress/fill-form.cy.ts
@@ -206,6 +206,44 @@ describe('Filler - Cypress', () => {
       cy.get('[data-testid="ff-config.port"]').should('have.value', '6379')
     })
 
+    it('record: re-filling an already-enabled optional object does not collapse it', () => {
+      // Companion to the playwright regression test: cypress's fillRecord already
+      // uses .check()/.uncheck() (idempotent - no-op if already in that state),
+      // so it doesn't have the playwright handler's bug (a plain .click() that
+      // re-toggles, and thus collapses, an already-enabled object). Kept here as
+      // regression coverage so it stays that way.
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            auth: {
+              type: 'record',
+              fields: [
+                { username: { type: 'string' } },
+                { password: { type: 'string' } },
+              ],
+            },
+          },
+        ],
+      }
+
+      cy.mount(() => h('div', { style: 'padding: 20px' }, h(Form, { schema })))
+
+      const filler = createFiller(schema)
+
+      // First fill enables the switch from scratch (simulates create).
+      filler.fillField('auth', { username: 'alice', password: 'secret1' })
+      cy.get('[data-testid="ff-object-switch-auth"]').should('be.checked')
+      cy.getTestId('ff-auth.username').should('have.value', 'alice')
+
+      // Second fill (simulates editing an existing record): the object is
+      // already enabled and must stay that way, with children still reachable.
+      filler.fillField('auth', { username: 'bob', password: 'secret2' })
+      cy.get('[data-testid="ff-object-switch-auth"]').should('be.checked')
+      cy.getTestId('ff-auth.username').should('have.value', 'bob')
+      cy.getTestId('ff-auth.password').should('have.value', 'secret2')
+    })
+
     it('should fill map field (key-value pairs)', () => {
       const schema: FormSchema = {
         type: 'record',

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/fill-form.pw.ts
@@ -202,6 +202,46 @@ test.describe('Filler - Playwright', () => {
       await expect(page.locator('[data-testid="ff-config.port"]')).toHaveValue('6379')
     })
 
+    test('record: re-filling an already-enabled optional object does not collapse it', async ({ mount, page }) => {
+      // Regression test: fillRecord used to unconditionally .click() the
+      // switch-control, which toggles it off when the object was already
+      // enabled (e.g. from a prior fill simulating create, then updating the
+      // same form). That collapses the object's SlideTransition content via
+      // v-if="expanded", detaching any child element the filler is about to
+      // interact with - this is what broke KM's kafka-upstream edit-form test
+      // (updating a nested `authentication` record that already had a value).
+      const schema: FormSchema = {
+        type: 'record',
+        fields: [
+          {
+            auth: {
+              type: 'record',
+              fields: [
+                { username: { type: 'string' } },
+                { password: { type: 'string' } },
+              ],
+            },
+          },
+        ],
+      }
+
+      await mount(FormWrapper, { props: { schema } })
+
+      const filler = createFiller(page, schema)
+
+      // First fill enables the switch from scratch (simulates create).
+      await filler.fillField('auth', { username: 'alice', password: 'secret1' })
+      await expect(page.locator('[data-testid="ff-object-switch-auth"]').locator('..').locator('[data-testid="switch-control"]')).toBeChecked()
+      await expect(page.getByTestId('ff-auth.username')).toHaveValue('alice')
+
+      // Second fill (simulates editing an existing record): the object is
+      // already enabled and must stay that way, with children still reachable.
+      await filler.fillField('auth', { username: 'bob', password: 'secret2' })
+      await expect(page.locator('[data-testid="ff-object-switch-auth"]').locator('..').locator('[data-testid="switch-control"]')).toBeChecked()
+      await expect(page.getByTestId('ff-auth.username')).toHaveValue('bob')
+      await expect(page.getByTestId('ff-auth.password')).toHaveValue('secret2')
+    })
+
     test('should fill map field (key-value pairs)', async ({ mount, page }) => {
       const schema: FormSchema = {
         type: 'record',

--- a/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/filler/playwright/handlers/record.ts
@@ -10,22 +10,28 @@ export async function fillRecord(option: RecordHandlerOption): Promise<void> {
   const hasSwitch = await page.locator(objectSwitchSelector).count() > 0
 
   if ((option.value === null || option.value === undefined) && hasSwitch) {
-    // Disable the object via switch
+    // Disable the object via switch. `uncheck` is a no-op if it's already
+    // unchecked - a plain `.click()` would incorrectly re-toggle (and thus
+    // re-enable) an already-disabled object when re-filling it with null,
+    // e.g. on a second pass over the same form.
     await page
       .locator(objectSwitchSelector)
       .locator('..')
       .locator('[data-testid="switch-control"]')
-      .click()
+      .uncheck({ force: true })
     return
   }
 
   if (hasSwitch) {
-    // Enable the object via switch
+    // Enable the object via switch. `check` is a no-op if it's already
+    // checked - a plain `.click()` would incorrectly re-toggle (and thus
+    // collapse) an object that already has a value, e.g. when filling an
+    // edit form whose existing data already enabled it.
     await page
       .locator(objectSwitchSelector)
       .locator('..')
       .locator('[data-testid="switch-control"]')
-      .click()
+      .check({ force: true })
 
     // Enabling the switch expands the object's content via SlideTransition
     // (height animates from 0). Filling children immediately can hit them


### PR DESCRIPTION
## Summary
- `fillRecord` (playwright filler) unconditionally `.click()`'d an optional record field's enable/disable switch, with no check of its current state.
- Re-filling a record that's already enabled (e.g. updating a plugin whose existing config already populated that field) incorrectly **toggles the switch off**, collapsing the object's `SlideTransition` content (`v-if="expanded"`) and detaching any child element the filler is mid-interaction with.
- Fixed by using `.check()`/`.uncheck()` instead of `.click()` - both are no-ops if the element is already in the target state, matching what the cypress `fillRecord` handler already does correctly.
- Added a regression test to both fillers: fill an optional record twice (simulating create then update) and assert the switch stays checked and children remain fillable.

## Root cause
Traced from a Kong Manager test failure: `TimeoutError ... element was detached from the DOM, retrying` while updating a nested `authentication` record (`mode`/`basic`/`oauth2`, discriminated by `mode`) that already had data from a prior create step. The record's switch was already checked; the second `fill()` call's `fillRecord` step for `authentication` unconditionally clicked the switch, unchecking it and collapsing everything inside - including the `mode` field the filler was about to click next.

## Test plan
- [x] New playwright test **fails** against the pre-fix handler (`git stash` the fix) with `Received: unchecked` on the second fill - confirms it reproduces the exact bug
- [x] New playwright test **passes** with the fix - `npx playwright test fill-form.pw.ts`: 35/35 passed
- [x] New cypress test **passes** as-is (cypress's handler already uses `.check()`/`.uncheck()`) - `cypress run --component --spec fill-form.cy.ts`: 38/38 passed
- [x] `eslint` clean on all changed files