### PR TITLE
feat(entities-plugins): scope multiselect and workspace-aware plugin search

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginFilter.vue
+++ b/packages/entities/entities-plugins/src/components/PluginFilter.vue
@@ -79,10 +79,7 @@
         </div>
       </template>
       <template #filter-scope>
-        <!-- TODO: the search API's filter.scope.eq only accepts a single value (no OR/"one-of"
-          operator for scope as of the current SDK) - single-select until the backend supports
-          filtering by more than one scope at once. -->
-        <KSelect
+        <KMultiselect
           v-model="pendingScope"
           data-testid="scope-filter-select"
           :items="scopeOptions"
@@ -149,7 +146,7 @@ const filterGroupSelection = ref<FilterGroupSelection>({})
 const searchInput = useTemplateRef('search-input')
 const tagsInput = useTemplateRef('tags-input')
 
-const pendingScope = ref<string | null>(null)
+const pendingScope = ref<string[]>([])
 const pendingStatus = ref<string | null>(null)
 
 const scopeOptions = computed<FilterOption[]>(() => [
@@ -220,6 +217,7 @@ const pluginFilterGroupFilters = computed<FilterGroupFilters>(() => {
         label: t('plugins.list.table_headers.scope'),
         operators: ['eq'],
         pinned: true,
+        multiple: true,
       },
     }
 
@@ -254,8 +252,13 @@ const serializedQuery = computed<string>(() => {
 
   if (!nestedScopeFilterKey.value) {
     const scopeSelection = filterGroupSelection.value.scope
-    if (typeof scopeSelection?.value === 'string' && scopeSelection.value) {
-      params.set('filter[scope][eq]', scopeSelection.value)
+    const scopeValues = Array.isArray(scopeSelection?.value)
+      ? scopeSelection.value
+      : typeof scopeSelection?.value === 'string' && scopeSelection.value
+        ? [scopeSelection.value]
+        : []
+    if (scopeValues.length) {
+      params.set('filter[scope][oeq]', scopeValues.join(','))
     }
   }
 
@@ -292,7 +295,7 @@ watch(modelValue, (value) => {
     filterGroupSelection.value = {}
     tagInputText.value = ''
     pendingTags.value = []
-    pendingScope.value = null
+    pendingScope.value = []
     pendingStatus.value = null
   }
 })
@@ -308,7 +311,11 @@ const onFilterOpen = (openedFilterKey: string) => {
 
     case 'scope': {
       const currentValue = filterGroupSelection.value.scope?.value
-      pendingScope.value = typeof currentValue === 'string' ? currentValue : null
+      pendingScope.value = Array.isArray(currentValue)
+        ? [...currentValue]
+        : typeof currentValue === 'string' && currentValue
+          ? [currentValue]
+          : []
       return
     }
 
@@ -335,13 +342,13 @@ const onFilterApply = (appliedFilterKey: string, selection: FilterGroupSelection
       return
 
     case 'scope': {
-      const selectedOption = scopeOptions.value.find((option) => option.value === pendingScope.value)
-      if (selectedOption) {
+      const selectedOptions = scopeOptions.value.filter((option) => pendingScope.value.includes(option.value))
+      if (selectedOptions.length) {
         selection.scope = {
           operator: 'eq',
           operatorDelimiter: ': ',
-          value: selectedOption.value,
-          text: selectedOption.label,
+          value: selectedOptions.map((option) => option.value),
+          text: selectedOptions.map((option) => option.label).join(', '),
         }
       } else {
         delete selection.scope
@@ -370,7 +377,7 @@ const onFilterClear = (clearedFilterKey: string) => {
     pendingTags.value = []
     tagInputText.value = ''
   } else if (clearedFilterKey === 'scope') {
-    pendingScope.value = null
+    pendingScope.value = []
   } else if (clearedFilterKey === 'status') {
     pendingStatus.value = null
   }

--- a/packages/entities/entities-plugins/src/components/PluginList.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginList.cy.ts
@@ -1135,7 +1135,7 @@ describe('<PluginList />', () => {
           url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/plugins*`,
         },
         { statusCode: 200, body: plugins },
-      ).as('plainList')
+      ).as('listPlugins')
 
       cy.mount(PluginList, {
         props: {
@@ -1149,7 +1149,7 @@ describe('<PluginList />', () => {
         },
       })
 
-      cy.wait('@plainList')
+      cy.wait('@listPlugins')
       cy.get('table thead th').eq(0).should('contain.text', 'Name')
       cy.get('table thead th').eq(1).should('contain.text', 'Applied to')
       cy.get('.kong-ui-entity-filter-input').should('exist')
@@ -1167,7 +1167,7 @@ describe('<PluginList />', () => {
             req.reply({ statusCode: 200, body: plugins })
           }
         },
-      ).as('plainListRedesign')
+      ).as('listPlugins')
 
       cy.intercept(
         {
@@ -1190,7 +1190,7 @@ describe('<PluginList />', () => {
       })
 
       // Plain load, nothing searched/filtered yet - plain endpoint, not /plugins/search
-      cy.wait('@plainListRedesign')
+      cy.wait('@listPlugins')
 
       // Column headers: Plugin, Name, Scope, Status, Ordering, Tags, Actions
       cy.get('table thead th').eq(0).should('contain.text', 'Plugin')
@@ -1246,6 +1246,55 @@ describe('<PluginList />', () => {
       })
     })
 
+    it('filters by multiple scopes using oeq', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/plugins*`,
+        },
+        (req) => {
+          if (!req.url.includes('/plugins/search')) {
+            req.reply({ statusCode: 200, body: plugins })
+          }
+        },
+      ).as('listPlugins')
+
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/plugins/search*`,
+        },
+        { statusCode: 200, body: { data: plugins.data, offset: null } },
+      ).as('searchPlugins')
+
+      cy.mount(PluginList, {
+        props: {
+          cacheIdentifier: `plugin-list-${uuidv4()}`,
+          config: redesignConfig,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+          canToggle: () => false,
+        },
+      })
+
+      cy.wait('@listPlugins')
+
+      cy.getTestId('filter-group-pill-scope').find('[data-testid="interactive-pill-trigger"]').click()
+      cy.getTestId('scope-filter-select').click()
+      cy.get('.multiselect-popover [data-testid="multiselect-item-route"]').click()
+      cy.get('.multiselect-popover [data-testid="multiselect-item-service"]').click()
+      cy.get('body').type('{esc}')
+      cy.getTestId('filter-pill-apply').filter(':visible').click()
+
+      cy.wait('@searchPlugins').its('request.url').then((url) => {
+        const params = new URL(url).searchParams
+
+        expect(params.get('filter[scope][oeq]')).to.equal('route,service')
+      })
+    })
+
     it('scopes the request to the entity and hides the Scope column/pill on a nested entity page', () => {
       const nestedConfig: KonnectPluginListConfig = {
         ...redesignConfig,
@@ -1267,7 +1316,7 @@ describe('<PluginList />', () => {
           url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/plugins/search*`,
         },
         { statusCode: 200, body: { data: plugins.data, offset: null } },
-      ).as('searchPluginsNested')
+      ).as('searchPlugins')
 
       cy.mount(PluginList, {
         props: {
@@ -1289,7 +1338,7 @@ describe('<PluginList />', () => {
       // Once the user searches, the request goes through /plugins/search and still carries the
       // entity scope (now as a forced, hidden filter param) alongside the free-text search
       cy.getTestId('search-input').filter(':visible').type('basic')
-      cy.wait('@searchPluginsNested').its('request.url')
+      cy.wait('@searchPlugins').its('request.url')
         .should('include', 'filter%5Broute%5D%5Beq%5D=route-1')
         .and('include', 'filter%5Bname%5D%5Bcontains%5D=basic')
     })

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -596,6 +596,7 @@ const activeFetcherUrl = computed<string>(() => {
     const konnectConfig = props.config as KonnectPluginListConfig
     return `${konnectConfig.apiBaseUrl}${endpoints.search.konnect.all}`
       .replace(/{controlPlaneId}/gi, konnectConfig.controlPlaneId || '')
+      .replace(/\/{workspace}/gi, konnectConfig.workspace ? `/${konnectConfig.workspace}` : '')
   }
 
   return fetcherBaseUrl.value

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -65,7 +65,7 @@
       "search_plugins": "Search plugins",
       "search": "Search",
       "tags_filter": "Type part of a tag and press Enter",
-      "scope_filter": "Select a scope"
+      "scope_filter": "Select scopes"
     },
     "filter": {
       "field": {

--- a/packages/entities/entities-plugins/src/plugins-endpoints.ts
+++ b/packages/entities/entities-plugins/src/plugins-endpoints.ts
@@ -16,7 +16,7 @@ export default {
   },
   search: {
     konnect: {
-      all: `${konnectNoWorkspaceBaseApiUrl}/plugins/search`,
+      all: `${konnectBaseApiUrl}/plugins/search`,
     },
   },
   select: {


### PR DESCRIPTION
[KM-2942]

## Summary
- Add multiselect support for scope filtering in the plugin list.
- Support the workspace path segment in the new Konnect plugin search endpoint (`/v2/control-planes/{controlPlaneId}/core-entities/{workspace}/plugins/search`), same params as the non-workspace version.

## Test plan
- [x] Verify plugin list scope filter supports selecting multiple scopes.
- [x] Verify searching plugins in a Konnect workspace hits the workspace-scoped search endpoint.
- [x] Verify searching plugins with no workspace configured still hits the non-workspace search endpoint (existing Cypress specs in PluginList.cy.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KM-2942]: https://konghq.atlassian.net/browse/KM-2942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ