### PR TITLE
fix(analytics): embed fonts when exporting dashboard as PDF

### DIFF
--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
@@ -263,6 +263,7 @@ describe('exportPdf WebGL capture protocol', () => {
     expect(events[0]).toBe('prepare')
     expect(events[1]).toBe('restore')
     expect(vi.mocked(snapdom.toCanvas).mock.calls[0][1]).toMatchObject({
+      embedFonts: true,
       plugins: [expect.objectContaining({ name: 'kong-webgl-snapshot' })],
     })
   })

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
@@ -215,7 +215,12 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
         afterClone: () => restoreAfterCapture(),
       }
 
-      const canvas = await snapdom.toCanvas(element, { scale, exclude, plugins: [webglSnapshotPlugin] })
+      const canvas = await snapdom.toCanvas(element, {
+        scale,
+        exclude,
+        embedFonts: true,
+        plugins: [webglSnapshotPlugin],
+      })
 
       // Measure the rendered rows and the real scale after the snapdom captures
       // the canvas. If the capture is oversized, snapdom will scale it down to fit


### PR DESCRIPTION
# Summary

This will ensure that webfonts (like the 'Inter' used by Kong) will be provided in the PDF export of dashboards. Two issues will be fixed by adding the proper font:

1. The titles will correctly condense tile titles that do not fit the width of the container
2. SingleValue charts will maintain the units on the correct row

<details open>
<summary>Before</summary>

<img width="1346" height="555" alt="before" src="https://github.com/user-attachments/assets/8e0e0dcb-4257-4826-9e38-90e964276efa" />


</details>


<details open>
<summary>After</summary>

<img width="1356" height="566" alt="after" src="https://github.com/user-attachments/assets/eacc5e7c-06e7-4fda-9fda-f51295834358" />

</details>

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
