### PR TITLE
fix(analytics): remove excluded classes from dom completely

### DIFF
--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.spec.ts
@@ -264,6 +264,8 @@ describe('exportPdf WebGL capture protocol', () => {
     expect(events[1]).toBe('restore')
     expect(vi.mocked(snapdom.toCanvas).mock.calls[0][1]).toMatchObject({
       embedFonts: true,
+      exclude: ['.tile-actions', '.tooltip', '.popover', '.dropdown-popover'],
+      excludeMode: 'remove',
       plugins: [expect.objectContaining({ name: 'kong-webgl-snapshot' })],
     })
   })

--- a/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useExportPdf.ts
@@ -218,6 +218,7 @@ function useExportPdf(layoutContainerRef: Ref<HTMLElement | undefined>) {
       const canvas = await snapdom.toCanvas(element, {
         scale,
         exclude,
+        excludeMode: 'remove',
         embedFonts: true,
         plugins: [webglSnapshotPlugin],
       })


### PR DESCRIPTION
# Summary

This will add the[ `excludeMode` option ](https://snapdom.dev/docs/options/)to the snapdom pdf generation to ensure the excluded classes are removed from the dom rather than just hidden.

Dashboard tiles can have a badge declaring the timeframe per tile, the tile actions are typically there but were previously just hidden causing them to be weirdly aligned.

<details open>
<summary>Before</summary>

<img width="1344" height="851" alt="before" src="https://github.com/user-attachments/assets/43b85146-dc1e-4ea3-b02e-17764ab57f8e" />


</details>

<details open>
<summary>After</summary>

<img width="1344" height="851" alt="after" src="https://github.com/user-attachments/assets/4d7b7ff8-01a8-44ec-9176-a5771bf2e4f9" />


</details>


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
