### PR TITLE
fix(table-data-grid): show tooltips for truncated cells

### DIFF
--- a/packages/core/table-data-grid/sandbox/App.vue
+++ b/packages/core/table-data-grid/sandbox/App.vue
@@ -237,6 +237,7 @@ import { computed, ref } from 'vue'
 import { TableDataGrid } from '../src'
 
 type SandboxRow = {
+  description: string
   id: string
   name: string
   status: string
@@ -295,6 +296,7 @@ const collapsedSections = ref<Record<SandboxSectionId, boolean>>({
 
 const headers: Array<TableDataGridHeader<SandboxRow>> = [
   { key: 'name', label: 'Name', minWidth: 220 },
+  { key: 'description', label: 'Description', width: 240 },
   { key: 'status', label: 'Status', minWidth: 140 },
   { key: 'latency', label: 'Latency', minWidth: 140 },
   { key: 'region', label: 'Region', minWidth: 140 },
@@ -304,6 +306,7 @@ const generatedRows: SandboxRow[] = Array.from({ length: 140 }, (_, index) => {
   const rowNumber = index + 1
 
   return {
+    description: `This deliberately long description for Service ${rowNumber} demonstrates cell truncation and the full-content tooltip on hover.`,
     id: `row-${rowNumber}`,
     latency: 35 + ((index * 29) % 800),
     name: `Service ${rowNumber}`,
@@ -561,9 +564,10 @@ const toggleSectionOnHeaderClick = (sectionId: SandboxSectionId, event: MouseEve
   min-width: 0;
 
   :deep(.kong-ui-public-table-data-grid) {
-    flex: 0 0 760px;
+    flex: 1 1 auto;
     height: 760px;
     min-height: 0;
+    width: 100%;
   }
 }
 

--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -197,6 +197,22 @@ const expectRenderedColumnWidths = (
   })
 }
 
+const expectCellContentGeometry = ({
+  overflowing,
+  value,
+}: {
+  overflowing: boolean
+  value: string
+}) => {
+  cy.contains('.table-data-grid-cell-content', value).then(($content) => {
+    if (overflowing) {
+      expect($content[0].scrollWidth).to.be.greaterThan($content[0].clientWidth)
+    } else {
+      expect($content[0].scrollWidth).to.be.at.most($content[0].clientWidth)
+    }
+  })
+}
+
 const scrollToSecondBlock = ({
   fetcher,
   onState,
@@ -267,6 +283,151 @@ describe('<TableDataGrid />', () => {
     cy.contains('.ag-cell', 'Gateway service').should('be.visible')
     cy.contains('.ag-header-cell-text', 'Name').should('have.css', 'color', 'rgb(18, 52, 86)')
     cy.contains('.ag-cell', 'Gateway service').should('have.css', 'color', 'rgb(171, 205, 239)')
+  })
+
+  it('truncates overflowing cell content and shows the full value in a tooltip', () => {
+    const longName = 'A gateway service name that is much wider than its table column'
+    const fetcher = cy.stub().resolves({
+      data: [{ ...rows[0], name: longName }],
+      total: 1,
+    })
+
+    mountTestTableDataGrid({
+      fetcher,
+      headers: [
+        { key: 'name', label: 'Name', width: 160 },
+        { key: 'status', label: 'Status' },
+      ],
+    })
+
+    expectCellContentGeometry({ overflowing: true, value: longName })
+    cy.contains('.table-data-grid-cell-content', longName)
+      .should('have.css', 'overflow', 'hidden')
+      .and('have.css', 'text-overflow', 'ellipsis')
+      .and('have.css', 'white-space', 'nowrap')
+
+    cy.contains('.table-data-grid-cell-content', longName).trigger('mouseenter')
+
+    cy.contains('.popover', longName)
+      .should('be.visible')
+      .and(($tooltip) => {
+        expect($tooltip.closest('.ag-cell')).to.have.length(0)
+      })
+  })
+
+  it('does not show a tooltip when the full cell value fits', () => {
+    const fetcher = cy.stub().resolves({
+      data: [rows[0]],
+      total: 1,
+    })
+
+    mountTestTableDataGrid({ fetcher })
+
+    expectCellContentGeometry({ overflowing: false, value: rows[0].name })
+    cy.contains('.table-data-grid-cell-content', rows[0].name).trigger('mouseenter')
+
+    cy.contains('.popover', rows[0].name).should('not.exist')
+  })
+
+  it('keeps the tooltip anchored after AG Grid virtualizes rows while scrolling', () => {
+    const virtualizedRows = createRows(1, 50).map(row => ({
+      ...row,
+      name: `${row.name} has intentionally long content that overflows the column`,
+    }))
+    const scrolledName = virtualizedRows[30].name
+    const fetcher = cy.stub().resolves({
+      data: virtualizedRows,
+      total: virtualizedRows.length,
+    })
+    let gridApi: GridApi<TestRow> | undefined
+
+    mountTestTableDataGrid({
+      fetcher,
+      headers: [
+        { key: 'name', label: 'Name', width: 160 },
+        { key: 'status', label: 'Status' },
+      ],
+      onGridReady: (api) => {
+        gridApi = api
+      },
+      pageSize: virtualizedRows.length,
+    })
+
+    cy.contains('.table-data-grid-cell-content', virtualizedRows[0].name).should('be.visible')
+    cy.then(() => gridApi?.ensureIndexVisible(30, 'middle'))
+    expectCellContentGeometry({ overflowing: true, value: scrolledName })
+    cy.contains('.table-data-grid-cell-content', scrolledName)
+      .should('be.visible')
+    cy.contains('.table-data-grid-cell-content', scrolledName).trigger('mouseenter')
+
+    cy.contains('.popover', scrolledName)
+      .should('be.visible')
+      .then(($tooltip) => {
+        cy.contains('.table-data-grid-cell-content', scrolledName).then(($content) => {
+          const contentRect = $content[0].getBoundingClientRect()
+          const tooltipRect = $tooltip[0].getBoundingClientRect()
+
+          expect($tooltip.parent()[0]).to.equal($content[0].ownerDocument.body)
+          expect(tooltipRect.left).to.be.closeTo(contentRect.left, 1)
+          expect(tooltipRect.top).to.be.closeTo(contentRect.bottom, 1)
+        })
+      })
+  })
+
+  it('updates truncation and tooltip content when AG Grid refreshes a reused cell renderer', () => {
+    const refreshedName = 'A refreshed gateway service name that overflows its table column'
+    const refreshedRows = [{ ...rows[0] }]
+    const fetcher = cy.stub().resolves({
+      data: refreshedRows,
+      total: 1,
+    })
+    const getGridApi = mountTableWithGridApi({
+      fetcher,
+      headers: [
+        { key: 'name', label: 'Name', width: 160 },
+        { key: 'status', label: 'Status' },
+      ],
+    })
+
+    expectCellContentGeometry({ overflowing: false, value: rows[0].name })
+    cy.then(() => {
+      refreshedRows[0].name = refreshedName
+      getGridApi()?.refreshCells({ force: true })
+    })
+
+    cy.contains('.table-data-grid-cell-content', refreshedName).should('be.visible')
+    expectCellContentGeometry({ overflowing: true, value: refreshedName })
+    cy.contains('.table-data-grid-cell-content', refreshedName).trigger('mouseenter')
+
+    cy.contains('.popover', refreshedName).should('be.visible')
+  })
+
+  it('clears the tooltip when a column resize makes the full cell value fit', () => {
+    const longName = 'A gateway service name that initially overflows its table column'
+    const fetcher = cy.stub().resolves({
+      data: [{ ...rows[0], name: longName }],
+      total: 1,
+    })
+    const getGridApi = mountTableWithGridApi({
+      fetcher,
+      headers: [
+        { key: 'name', label: 'Name', width: 160 },
+        { key: 'status', label: 'Status' },
+      ],
+    })
+
+    expectCellContentGeometry({ overflowing: true, value: longName })
+
+    cy.then(() => {
+      getGridApi()?.setColumnWidths([{ key: 'name', newWidth: 600 }])
+    })
+    expectCellContentGeometry({ overflowing: false, value: longName })
+    cy.window().then(win => new Promise<void>((resolve) => {
+      win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve()))
+    }))
+    cy.contains('.table-data-grid-cell-content', longName).trigger('mouseenter')
+
+    cy.contains('.popover', longName).should('not.exist')
   })
 
   it('fills a taller parent height by default', () => {

--- a/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.cy.ts
@@ -157,15 +157,18 @@ const mountTableInFixedHeightContainer = ({
 }
 
 const mountTableWithGridApi = ({
+  containerStyle,
   fetcher,
   headers: tableHeaders,
 }: {
+  containerStyle?: Record<string, string>
   fetcher: TableDataGridFetcher<TestRow>
   headers: Array<TableDataGridHeader<TestRow>>
 }) => {
   let gridApi: GridApi<TestRow> | undefined
 
   mountTestTableDataGrid({
+    containerStyle,
     fetcher,
     headers: tableHeaders,
     onGridReady: (api) => {
@@ -197,20 +200,32 @@ const expectRenderedColumnWidths = (
   })
 }
 
-const expectCellContentGeometry = ({
-  overflowing,
-  value,
-}: {
-  overflowing: boolean
-  value: string
-}) => {
-  cy.contains('.table-data-grid-cell-content', value).then(($content) => {
-    if (overflowing) {
-      expect($content[0].scrollWidth).to.be.greaterThan($content[0].clientWidth)
-    } else {
-      expect($content[0].scrollWidth).to.be.at.most($content[0].clientWidth)
-    }
+const expectOverflowingCellContent = (value: string) => {
+  cy.contains('.table-data-grid-cell-content', value).should(($content) => {
+    expect($content[0].scrollWidth).to.be.greaterThan($content[0].clientWidth)
   })
+}
+
+const expectOverflowTooltip = (value: string) => {
+  expectOverflowingCellContent(value)
+  cy.contains('.table-data-grid-cell-content', value).trigger('mouseenter')
+  cy.contains('.popover', value).should('be.visible')
+}
+
+const expectColumnWidthAndOverflowTooltip = ({
+  getGridApi,
+  value,
+  width,
+}: {
+  getGridApi: () => GridApi<TestRow> | undefined
+  value: string
+  width: number
+}) => {
+  cy.contains('.table-data-grid-cell-content', value).should('be.visible')
+  cy.then(() => {
+    expect(getColumnWidthsById(getGridApi()).name).to.equal(width)
+  })
+  expectOverflowTooltip(value)
 }
 
 const scrollToSecondBlock = ({
@@ -285,48 +300,61 @@ describe('<TableDataGrid />', () => {
     cy.contains('.ag-cell', 'Gateway service').should('have.css', 'color', 'rgb(171, 205, 239)')
   })
 
-  it('truncates overflowing cell content and shows the full value in a tooltip', () => {
-    const longName = 'A gateway service name that is much wider than its table column'
+  it('truncates overflowing cell content in unconstrained flex columns', () => {
+    const longName = 'A gateway service name that is much wider than its flexible table column'
     const fetcher = cy.stub().resolves({
       data: [{ ...rows[0], name: longName }],
       total: 1,
     })
 
-    mountTestTableDataGrid({
+    mountTestTableDataGrid({ fetcher })
+
+    expectOverflowTooltip(longName)
+  })
+
+  it('truncates overflowing cell content in columns with minWidth', () => {
+    const longName = 'A gateway service name that is much wider than its minimum-width table column'
+    const fetcher = cy.stub().resolves({
+      data: [{ ...rows[0], name: longName }],
+      total: 1,
+    })
+    const getGridApi = mountTableWithGridApi({
+      containerStyle: {
+        width: '300px',
+      },
       fetcher,
       headers: [
-        { key: 'name', label: 'Name', width: 160 },
+        { key: 'name', label: 'Name', minWidth: 160 },
+        { key: 'status', label: 'Status', minWidth: 160 },
+      ],
+    })
+
+    expectColumnWidthAndOverflowTooltip({
+      getGridApi,
+      value: longName,
+      width: 160,
+    })
+  })
+
+  it('truncates overflowing cell content in columns with maxWidth', () => {
+    const longName = 'A gateway service name that is much wider than its maximum-width table column'
+    const fetcher = cy.stub().resolves({
+      data: [{ ...rows[0], name: longName }],
+      total: 1,
+    })
+    const getGridApi = mountTableWithGridApi({
+      fetcher,
+      headers: [
+        { key: 'name', label: 'Name', maxWidth: 160 },
         { key: 'status', label: 'Status' },
       ],
     })
 
-    expectCellContentGeometry({ overflowing: true, value: longName })
-    cy.contains('.table-data-grid-cell-content', longName)
-      .should('have.css', 'overflow', 'hidden')
-      .and('have.css', 'text-overflow', 'ellipsis')
-      .and('have.css', 'white-space', 'nowrap')
-
-    cy.contains('.table-data-grid-cell-content', longName).trigger('mouseenter')
-
-    cy.contains('.popover', longName)
-      .should('be.visible')
-      .and(($tooltip) => {
-        expect($tooltip.closest('.ag-cell')).to.have.length(0)
-      })
-  })
-
-  it('does not show a tooltip when the full cell value fits', () => {
-    const fetcher = cy.stub().resolves({
-      data: [rows[0]],
-      total: 1,
+    expectColumnWidthAndOverflowTooltip({
+      getGridApi,
+      value: longName,
+      width: 160,
     })
-
-    mountTestTableDataGrid({ fetcher })
-
-    expectCellContentGeometry({ overflowing: false, value: rows[0].name })
-    cy.contains('.table-data-grid-cell-content', rows[0].name).trigger('mouseenter')
-
-    cy.contains('.popover', rows[0].name).should('not.exist')
   })
 
   it('keeps the tooltip anchored after AG Grid virtualizes rows while scrolling', () => {
@@ -355,7 +383,7 @@ describe('<TableDataGrid />', () => {
 
     cy.contains('.table-data-grid-cell-content', virtualizedRows[0].name).should('be.visible')
     cy.then(() => gridApi?.ensureIndexVisible(30, 'middle'))
-    expectCellContentGeometry({ overflowing: true, value: scrolledName })
+    expectOverflowingCellContent(scrolledName)
     cy.contains('.table-data-grid-cell-content', scrolledName)
       .should('be.visible')
     cy.contains('.table-data-grid-cell-content', scrolledName).trigger('mouseenter')
@@ -374,35 +402,7 @@ describe('<TableDataGrid />', () => {
       })
   })
 
-  it('updates truncation and tooltip content when AG Grid refreshes a reused cell renderer', () => {
-    const refreshedName = 'A refreshed gateway service name that overflows its table column'
-    const refreshedRows = [{ ...rows[0] }]
-    const fetcher = cy.stub().resolves({
-      data: refreshedRows,
-      total: 1,
-    })
-    const getGridApi = mountTableWithGridApi({
-      fetcher,
-      headers: [
-        { key: 'name', label: 'Name', width: 160 },
-        { key: 'status', label: 'Status' },
-      ],
-    })
-
-    expectCellContentGeometry({ overflowing: false, value: rows[0].name })
-    cy.then(() => {
-      refreshedRows[0].name = refreshedName
-      getGridApi()?.refreshCells({ force: true })
-    })
-
-    cy.contains('.table-data-grid-cell-content', refreshedName).should('be.visible')
-    expectCellContentGeometry({ overflowing: true, value: refreshedName })
-    cy.contains('.table-data-grid-cell-content', refreshedName).trigger('mouseenter')
-
-    cy.contains('.popover', refreshedName).should('be.visible')
-  })
-
-  it('clears the tooltip when a column resize makes the full cell value fit', () => {
+  it('clears the tooltip when AG Grid expands the column to fit the full value', () => {
     const longName = 'A gateway service name that initially overflows its table column'
     const fetcher = cy.stub().resolves({
       data: [{ ...rows[0], name: longName }],
@@ -416,17 +416,14 @@ describe('<TableDataGrid />', () => {
       ],
     })
 
-    expectCellContentGeometry({ overflowing: true, value: longName })
-
+    expectOverflowingCellContent(longName)
     cy.then(() => {
       getGridApi()?.setColumnWidths([{ key: 'name', newWidth: 600 }])
     })
-    expectCellContentGeometry({ overflowing: false, value: longName })
-    cy.window().then(win => new Promise<void>((resolve) => {
-      win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve()))
-    }))
+    cy.contains('.table-data-grid-cell-content', longName).should(($content) => {
+      expect($content[0].scrollWidth).to.be.at.most($content[0].clientWidth)
+    })
     cy.contains('.table-data-grid-cell-content', longName).trigger('mouseenter')
-
     cy.contains('.popover', longName).should('not.exist')
   })
 

--- a/packages/core/table-data-grid/src/components/TableDataGrid.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGrid.vue
@@ -62,6 +62,7 @@ import {
   themeQuartz,
 } from 'ag-grid-community'
 import { computed } from 'vue'
+import TableDataGridCellRenderer from './TableDataGridCellRenderer.vue'
 import { useEmitState } from '../composables/useEmitState'
 import { useFetchInfinite } from '../composables/useFetchInfinite'
 import useI18n from '../composables/useI18n'
@@ -96,6 +97,7 @@ const emit = defineEmits<{
 const { i18n: { t } } = useI18n()
 
 const defaultColDef: ColDef<Row> = {
+  cellRenderer: TableDataGridCellRenderer,
   resizable: false,
   sortable: false,
   suppressMovable: true,
@@ -185,5 +187,12 @@ const onGridReady = (event: GridReadyEvent<Row>) => {
 .table-data-grid-grid :global(.ag-cell) {
   align-items: center;
   display: flex;
+  min-width: 0;
+}
+
+.table-data-grid-grid :global(.ag-cell-wrapper),
+.table-data-grid-grid :global(.ag-cell-value) {
+  min-width: 0;
+  width: 100%;
 }
 </style>

--- a/packages/core/table-data-grid/src/components/TableDataGridCellRenderer.cy.ts
+++ b/packages/core/table-data-grid/src/components/TableDataGridCellRenderer.cy.ts
@@ -1,0 +1,131 @@
+import type { ICellRendererParams } from 'ag-grid-community'
+import { defineComponent, h } from 'vue'
+import TableDataGridCellRenderer from './TableDataGridCellRenderer.vue'
+
+type CellRendererParams = ICellRendererParams<Record<string, unknown>>
+
+type CellRendererExposed = {
+  refresh: (params: CellRendererParams) => boolean
+}
+
+const createParams = (
+  value: unknown,
+  valueFormatted?: string | null,
+): CellRendererParams => ({
+  value,
+  valueFormatted,
+} as CellRendererParams)
+
+const mountCellRenderer = ({
+  value,
+  valueFormatted,
+  width = '160px',
+}: {
+  value: unknown
+  valueFormatted?: string | null
+  width?: string
+}) => cy.mount(TableDataGridCellRenderer, {
+  attrs: {
+    style: {
+      width,
+    },
+  },
+  props: {
+    params: createParams(value, valueFormatted),
+  },
+})
+
+const expectCellContentGeometry = ({
+  overflowing,
+  value,
+}: {
+  overflowing: boolean
+  value: string
+}) => {
+  cy.contains('.table-data-grid-cell-content', value).should(($content) => {
+    if (overflowing) {
+      expect($content[0].scrollWidth).to.be.greaterThan($content[0].clientWidth)
+    } else {
+      expect($content[0].scrollWidth).to.be.at.most($content[0].clientWidth)
+    }
+  })
+}
+
+describe('<TableDataGridCellRenderer />', () => {
+  it('truncates overflowing content and shows the full value in a tooltip', () => {
+    const longValue = 'A gateway service name that is much wider than its table column'
+
+    mountCellRenderer({ value: longValue })
+
+    expectCellContentGeometry({ overflowing: true, value: longValue })
+    cy.contains('.table-data-grid-cell-content', longValue)
+      .should('have.css', 'overflow', 'hidden')
+      .and('have.css', 'text-overflow', 'ellipsis')
+      .and('have.css', 'white-space', 'nowrap')
+
+    cy.contains('.table-data-grid-cell-content', longValue).trigger('mouseenter')
+    cy.contains('.popover', longValue)
+      .should('be.visible')
+      .and(($tooltip) => {
+        expect($tooltip.parent()[0]).to.equal($tooltip[0].ownerDocument.body)
+      })
+  })
+
+  it('does not show a tooltip when the full value fits', () => {
+    const value = 'Gateway service'
+
+    mountCellRenderer({ value, width: '320px' })
+
+    expectCellContentGeometry({ overflowing: false, value })
+    cy.contains('.table-data-grid-cell-content', value).trigger('mouseenter')
+    cy.contains('.popover', value).should('not.exist')
+  })
+
+  it('updates truncation and tooltip content when refreshed', () => {
+    const initialValue = 'Gateway service'
+    const refreshedValue = 'A refreshed gateway service name that overflows its table column'
+
+    mountCellRenderer({ value: initialValue }).then(({ wrapper }) => {
+      const exposed = wrapper.vm.$.exposed as CellRendererExposed
+
+      expect(exposed.refresh(createParams(refreshedValue))).to.equal(true)
+    })
+
+    expectCellContentGeometry({ overflowing: true, value: refreshedValue })
+    cy.contains('.table-data-grid-cell-content', refreshedValue).trigger('mouseenter')
+    cy.contains('.popover', refreshedValue).should('be.visible')
+  })
+
+  it('clears the tooltip when resizing makes the full value fit', () => {
+    const longValue = 'A gateway service name that initially overflows its table column'
+
+    // eslint-disable-next-line vue/one-component-per-file -- Cypress harness models the AG Grid cell boundary.
+    cy.mount(defineComponent({
+      name: 'TableDataGridCellRendererTestHarness',
+      setup() {
+        return () => h('div', {
+          class: 'ag-cell',
+          style: {
+            width: '160px',
+          },
+        }, [
+          h(TableDataGridCellRenderer, {
+            params: createParams(longValue),
+          }),
+        ])
+      },
+    }))
+    expectCellContentGeometry({ overflowing: true, value: longValue })
+
+    cy.get('.ag-cell').then(($cell) => {
+      $cell[0].style.width = '600px'
+    })
+
+    expectCellContentGeometry({ overflowing: false, value: longValue })
+    cy.window().then(win => new Promise<void>((resolve) => {
+      win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve()))
+    }))
+    cy.contains('.table-data-grid-cell-content', longValue).trigger('mouseenter')
+    cy.contains('.popover', longValue).should('not.exist')
+  })
+})

--- a/packages/core/table-data-grid/src/components/TableDataGridCellRenderer.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGridCellRenderer.vue
@@ -3,6 +3,7 @@
     <KTooltip
       class="table-data-grid-cell-tooltip"
       :disabled="!isOverflowing"
+      :kpop-attributes="{ popoverDelay: 400 }"
       max-width="300"
       placement="bottom-start"
       target="body"

--- a/packages/core/table-data-grid/src/components/TableDataGridCellRenderer.vue
+++ b/packages/core/table-data-grid/src/components/TableDataGridCellRenderer.vue
@@ -1,0 +1,125 @@
+<template>
+  <span class="table-data-grid-cell-renderer">
+    <KTooltip
+      class="table-data-grid-cell-tooltip"
+      :disabled="!isOverflowing"
+      max-width="300"
+      placement="bottom-start"
+      target="body"
+      :text="displayValue"
+    >
+      <span
+        ref="contentElement"
+        class="table-data-grid-cell-content"
+      >{{ displayValue }}</span>
+    </KTooltip>
+  </span>
+</template>
+
+<script setup lang="ts">
+import type { ICellRendererParams } from 'ag-grid-community'
+import { computed, nextTick, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
+
+type CellRendererParams = ICellRendererParams<Record<string, unknown>>
+
+defineOptions({
+  name: 'TableDataGridCellRenderer',
+})
+
+const {
+  params,
+} = defineProps<{
+  params: CellRendererParams
+}>()
+
+// AG Grid refreshes reused renderers through the exposed refresh hook, not by
+// updating Vue props. Keep only the top-level params reference reactive.
+const currentParams = shallowRef(params)
+const contentElement = ref<HTMLElement | null>(null)
+const isOverflowing = ref(false)
+const displayValue = computed(() => (
+  currentParams.value.valueFormatted ?? String(currentParams.value.value ?? '')
+))
+
+let resizeObserver: ResizeObserver | undefined
+let animationFrame: number | undefined
+let isUnmounted = false
+
+const measureOverflow = () => {
+  const element = contentElement.value
+  isOverflowing.value = !!element && element.scrollWidth > element.clientWidth
+}
+
+const scheduleOverflowMeasurement = () => {
+  if (isUnmounted) {
+    return
+  }
+
+  if (animationFrame !== undefined) {
+    cancelAnimationFrame(animationFrame)
+  }
+
+  animationFrame = requestAnimationFrame(() => {
+    animationFrame = undefined
+    measureOverflow()
+  })
+}
+
+const observeContentElement = (element: HTMLElement | null) => {
+  resizeObserver?.disconnect()
+
+  if (element) {
+    resizeObserver?.observe(element)
+
+    const cellElement = element.closest<HTMLElement>('.ag-cell')
+    if (cellElement) {
+      resizeObserver?.observe(cellElement)
+    }
+  }
+
+  scheduleOverflowMeasurement()
+}
+
+onMounted(() => {
+  resizeObserver = new ResizeObserver(scheduleOverflowMeasurement)
+  observeContentElement(contentElement.value)
+})
+
+watch(contentElement, observeContentElement, { flush: 'post' })
+
+onUnmounted(() => {
+  isUnmounted = true
+  resizeObserver?.disconnect()
+
+  if (animationFrame !== undefined) {
+    cancelAnimationFrame(animationFrame)
+  }
+})
+
+defineExpose({
+  refresh(nextParams: CellRendererParams) {
+    currentParams.value = nextParams
+    nextTick(scheduleOverflowMeasurement)
+
+    return true
+  },
+})
+</script>
+
+<style lang="scss">
+/* AG Grid separately mounts framework renderers, so parent-scoped selectors do not reach this DOM. */
+.table-data-grid-cell-renderer,
+.table-data-grid-cell-tooltip,
+.table-data-grid-cell-content {
+  display: block;
+  min-width: 0;
+  width: 100%;
+}
+
+.table-data-grid-cell-content {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>


### PR DESCRIPTION
## Summary

Closes [MA-5198](https://konghq.atlassian.net/browse/MA-5198).

Truncates overflowing TableDataGrid cell content and shows the full value in a KTooltip. The tooltip is teleported to the document body so AG Grid cells do not clip it during normal rendering or row virtualization.

The sandbox now includes a long-content column and lets the table fill the available width.

Preview PR: https://github.com/kong-konnect/konnect-ui-apps/pull/12805

<img width="1341" height="343" alt="image" src="https://github.com/user-attachments/assets/34c87dd6-4613-4a18-a54c-54ddd7bd2a2a" />


[MA-5198]: https://konghq.atlassian.net/browse/MA-5198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ