### PR TITLE
fix(page-layout): truncate title at first line

### DIFF
--- a/packages/core/page-layout/src/components/PageLayout.vue
+++ b/packages/core/page-layout/src/components/PageLayout.vue
@@ -301,11 +301,16 @@ watch([() => pageShortcutData, () => route?.fullPath], () => {
 
           .page-layout-title-wrapper {
             > * {
+              -webkit-box-orient: vertical;
               color: var(--kui-color-text, $kui-color-text);
+              display: -webkit-box;
               font-size: var(--kui-font-size-50, $kui-font-size-50);
               font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+              -webkit-line-clamp: 1;
+              line-clamp: 1;
               line-height: var(--kui-line-height-40, $kui-line-height-40);
               margin: var(--kui-space-0, $kui-space-0);
+              overflow: hidden;
             }
           }
 

--- a/packages/core/page-layout/src/components/PageLayout.vue
+++ b/packages/core/page-layout/src/components/PageLayout.vue
@@ -258,6 +258,9 @@ watch([() => pageShortcutData, () => route?.fullPath], () => {
       padding: var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60) var(--kui-space-0, $kui-space-0) var(--kui-space-60, $kui-space-60);
 
       .page-header-start {
+        // Allow this flex item to shrink below its content size so the title can truncate
+        min-width: 0;
+
         .header-breadcrumbs {
           &:deep(.breadcrumbs-item-container) {
             // Override first breadcrumb padding left
@@ -300,17 +303,19 @@ watch([() => pageShortcutData, () => route?.fullPath], () => {
           }
 
           .page-layout-title-wrapper {
+            // Allow this flex item to shrink so its child title can truncate with an ellipsis
+            min-width: 0;
+            overflow: hidden;
+
             > * {
-              -webkit-box-orient: vertical;
               color: var(--kui-color-text, $kui-color-text);
-              display: -webkit-box;
               font-size: var(--kui-font-size-50, $kui-font-size-50);
               font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
-              -webkit-line-clamp: 1;
-              line-clamp: 1;
               line-height: var(--kui-line-height-40, $kui-line-height-40);
               margin: var(--kui-space-0, $kui-space-0);
               overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
             }
           }
 


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-21147

Truncate PageLayout title at first line

Before

<img width="1553" height="704" alt="Screenshot 2026-07-23 at 3 08 18 PM" src="https://github.com/user-attachments/assets/f17fe4f0-3006-42cb-bd26-3c3b7fde1a9d" />

After

<img width="1552" height="680" alt="Screenshot 2026-07-23 at 3 08 47 PM" src="https://github.com/user-attachments/assets/0db9d394-ef90-4b20-93b1-89b730be5e18" />

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
