### PR TITLE
fix(entities-plugins): propagate array-level encrypted flag to string elements

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.spec.ts
@@ -1,8 +1,51 @@
 import { describe, expect, it } from 'vitest'
 
-import { useSchemaHelpers } from './schema'
+import { buildArraySchemaMap, useSchemaHelpers } from './schema'
 
-import type { FormSchema } from '../../../../types/plugins/form-schema'
+import type { ArrayFieldSchema, FormSchema, StringFieldSchema } from '../../../../types/plugins/form-schema'
+
+describe('buildArraySchemaMap', () => {
+  it('propagates encrypted from the array schema to string elements', () => {
+    const arraySchema: ArrayFieldSchema = {
+      type: 'array',
+      encrypted: true,
+      elements: {
+        type: 'string',
+      },
+    }
+
+    const schemaMap = buildArraySchemaMap(arraySchema, 'introspection_headers_values')
+
+    expect((schemaMap['introspection_headers_values.*'] as StringFieldSchema).encrypted).toBe(true)
+  })
+
+  it('does not add encrypted to non-string elements', () => {
+    const arraySchema: ArrayFieldSchema = {
+      type: 'array',
+      encrypted: true,
+      elements: {
+        type: 'number',
+      },
+    }
+
+    const schemaMap = buildArraySchemaMap(arraySchema, 'numbers')
+
+    expect('encrypted' in schemaMap['numbers.*']).toBe(false)
+  })
+
+  it('does not add encrypted to elements when the array is not encrypted', () => {
+    const arraySchema: ArrayFieldSchema = {
+      type: 'array',
+      elements: {
+        type: 'string',
+      },
+    }
+
+    const schemaMap = buildArraySchemaMap(arraySchema, 'plain_values')
+
+    expect((schemaMap['plain_values.*'] as StringFieldSchema).encrypted).toBeUndefined()
+  })
+})
 
 describe('useSchemaHelpers', () => {
   describe('getLabelAttributes', () => {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/schema.ts
@@ -65,8 +65,17 @@ export function buildRecordSchemaMap(recordSchema: RecordFieldSchema, pathPrefix
 export function buildArraySchemaMap(arraySchema: ArrayFieldSchema, pathPrefix: string = ''): Record<string, UnionFieldSchema> {
   const schemaMap: Record<string, UnionFieldSchema> = {}
   if (arraySchema.elements) {
-    const elementProps = arraySchema.elements
+    let elementProps = arraySchema.elements
     const elementPath = utils.resolve(pathPrefix, utils.arraySymbol)
+
+    // In kong-ee, `encrypted` on an array field (e.g. openid-connect's introspection_headers_values)
+    // is expected/by-design and means every element must be encrypted, not just the array itself.
+    // The schema puts `encrypted` on the array field rather than nested in `elements`, so propagate
+    // it down to string elements here.
+    if (arraySchema.encrypted && elementProps.type === 'string') {
+      elementProps = { ...elementProps, encrypted: true }
+    }
+
     schemaMap[elementPath] = elementProps
 
     if (elementProps.type === 'record' && Array.isArray(elementProps.fields)) {

--- a/packages/entities/entities-plugins/src/types/plugins/form-schema.ts
+++ b/packages/entities/entities-plugins/src/types/plugins/form-schema.ts
@@ -124,6 +124,8 @@ export interface ArrayLikeFieldSchema extends FieldSchema {
   elements: UnionFieldSchema
   len_min?: number
   len_max?: number
+
+  encrypted?: boolean
 }
 
 export interface ArrayFieldSchema extends ArrayLikeFieldSchema {


### PR DESCRIPTION
## Summary
- Kong schemas (e.g. openid-connect's `introspection_headers_values`) mark `encrypted` on the array field itself rather than nested in `elements`, meaning every element must be encrypted — this is expected/by-design in kong-ee, not a schema bug.
- `buildArraySchemaMap` now propagates the array-level `encrypted` flag down to `string` elements, so `StringField.vue`'s encrypted check (which reads the element's own schema) renders these fields as password inputs.
- Added `encrypted?: boolean` to `ArrayLikeFieldSchema` type.