### PR TITLE
fix(entities-plugins): stop trimming string field input

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/StringField.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/StringField.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h, defineComponent } from 'vue'
+import Form from './Form.vue'
+import StringField from './StringField.vue'
+import type { FormSchema } from 'src/types/plugins/form-schema'
+
+const FIELD_NAME = 'name'
+
+const schema: FormSchema = {
+  type: 'record',
+  fields: [
+    { [FIELD_NAME]: { type: 'string' } },
+  ],
+}
+
+function mountStringField(data?: Record<string, unknown>) {
+  const onChangeSpy = (value: unknown) => onChangeSpy.calls.push(value)
+  onChangeSpy.calls = [] as unknown[]
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () => h(
+        Form,
+        { schema, data, onChange: onChangeSpy },
+        { default: () => h(StringField, { name: FIELD_NAME }) },
+      )
+    },
+  })
+
+  const wrapper = mount(Wrapper)
+
+  return { wrapper, onChangeSpy }
+}
+
+function lastChange(onChangeSpy: { calls: unknown[] }) {
+  return onChangeSpy.calls[onChangeSpy.calls.length - 1]
+}
+
+describe('StringField', () => {
+  it('should emit null when clearing a field that has no initial value', async () => {
+    const { wrapper, onChangeSpy } = mountStringField()
+
+    const input = wrapper.get('input')
+    await input.setValue('n')
+    expect(lastChange(onChangeSpy)).toEqual({ [FIELD_NAME]: 'n' })
+
+    await input.setValue('')
+    expect(lastChange(onChangeSpy)).toEqual({ [FIELD_NAME]: null })
+  })
+
+  it('should emit null when clearing a field that has an initial value', async () => {
+    const { wrapper, onChangeSpy } = mountStringField({ [FIELD_NAME]: 'Initial Name' })
+
+    const input = wrapper.get('input')
+    await input.setValue('')
+    expect(lastChange(onChangeSpy)).toEqual({ [FIELD_NAME]: null })
+  })
+
+  it('should preserve surrounding whitespace instead of trimming it', async () => {
+    const { wrapper, onChangeSpy } = mountStringField()
+
+    const input = wrapper.get('input')
+    await input.setValue('  hello  ')
+    expect(lastChange(onChangeSpy)).toEqual({ [FIELD_NAME]: '  hello  ' })
+  })
+
+  it('should preserve a whitespace-only value instead of coercing it to null', async () => {
+    const { wrapper, onChangeSpy } = mountStringField()
+
+    const input = wrapper.get('input')
+    await input.setValue('   ')
+    expect(lastChange(onChangeSpy)).toEqual({ [FIELD_NAME]: '   ' })
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
@@ -132,9 +132,7 @@ const { value: fieldValue, hide, ...field } = useField<string | null>(toRef(() =
 const fieldAttrs = useFieldAttrs(field.path!, toRef({ ...props, ...attrs }))
 
 function handleUpdate(value: string) {
-  const trimmedValue = value.trim()
-
-  fieldValue!.value = trimmedValue === '' ? null : trimmedValue
+  fieldValue!.value = value === '' ? null : value
   emit('update:modelValue', fieldValue!.value)
 }
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
@@ -130,16 +130,12 @@ const emit = defineEmits<{
 
 const { value: fieldValue, hide, ...field } = useField<string | null>(toRef(() => name))
 const fieldAttrs = useFieldAttrs(field.path!, toRef({ ...props, ...attrs }))
-const initialValue = fieldValue?.value
 
 function handleUpdate(value: string) {
-  if (initialValue !== undefined && value === '' && value !== initialValue) {
-    fieldValue!.value = null
-    emit('update:modelValue', null)
-  } else {
-    fieldValue!.value = value.trim()
-    emit('update:modelValue', value.trim())
-  }
+  const trimmedValue = value.trim()
+
+  fieldValue!.value = trimmedValue === '' ? null : trimmedValue
+  emit('update:modelValue', fieldValue!.value)
 }
 
 const encrypted = computed(() => {


### PR DESCRIPTION
## Summary
- `StringField` used to trim leading/trailing whitespace on every keystroke. For multiline fields (Lua scripts in `pre-function`/`post-function`, AI prompt templates, etc.) this silently stripped whitespace the user was actively typing.
- Only an empty string is now coerced to `null`; all other input, including whitespace, is passed through unchanged.

## Test plan
- [x] Added `StringField.spec.ts` (vitest + `@vue/test-utils`) covering: clearing a field with no initial value emits `null`, clearing a field with an initial value emits `null`, and whitespace (both surrounding and whitespace-only) is preserved instead of trimmed.
- [x] `pnpm test:unit` passes for `entities-plugins` (161/161).