### PR TITLE
fix(entities): cap code block height and skip highlighting for large configs

### DIFF
--- a/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCodeBlockInternal.vue
@@ -84,6 +84,7 @@
       :copy-code="unredactedDeckCommand"
       data-dd-privacy="mask"
       :language="shell"
+      :max-height="CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT"
       :theme="isCustomizing ? 'light' : 'dark'"
       @code-block-render="highlightCodeBlock"
     />
@@ -121,6 +122,7 @@
 </template>
 
 <script setup lang="ts">
+import { CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT } from '../../constants'
 import { InfoIcon, LanguageBashIcon, LanguageShellIcon } from '@kong/icons'
 import { KExternalLink } from '@kong/kongponents'
 import yaml from 'js-yaml'

--- a/packages/entities/entities-shared/src/components/common/JsonCodeBlock.cy.ts
+++ b/packages/entities/entities-shared/src/components/common/JsonCodeBlock.cy.ts
@@ -1,4 +1,5 @@
 import JsonCodeBlock from './JsonCodeBlock.vue'
+import { SHIKI_MAX_HIGHLIGHT_LENGTH } from '../../constants'
 
 const record = {
   destinations: [{ ip: '255.255.255.255', port: 123 }],
@@ -45,6 +46,28 @@ describe('<JsonCodeBlock />', () => {
       cy.get('.json-endpoint').should('contain.text', 'get')
       cy.get('.json-endpoint').should('contain.text', fetcherUrl)
       cy.get('.json-endpoint').should('contain.text', 'Copy')
+    })
+
+    it('syntax highlights JSON content within the shiki size limit', () => {
+      cy.mount(JsonCodeBlock, {
+        props: {
+          entityRecord: record,
+        },
+      })
+
+      cy.get('#json-codeblock .highlighted-code-block code span').should('exist')
+    })
+
+    it('skips syntax highlighting and still renders plain text for content over the shiki size limit', () => {
+      const largeRecord = { note: 'a'.repeat(SHIKI_MAX_HIGHLIGHT_LENGTH) }
+      cy.mount(JsonCodeBlock, {
+        props: {
+          entityRecord: largeRecord,
+        },
+      })
+
+      cy.get('#json-codeblock .highlighted-code-block code span').should('not.exist')
+      cy.get('#json-codeblock .highlighted-code-block code').should('contain.text', largeRecord.note)
     })
   })
 })

--- a/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/JsonCodeBlock.vue
@@ -11,6 +11,7 @@
         id="json-endpoint-codeblock"
         :code="fetcherUrl"
         language="plaintext"
+        :max-height="CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT"
         single-line
         theme="dark"
       />
@@ -23,6 +24,7 @@
       :copy-code="JSON.stringify(unredactedRecord || jsonContent, null, 2)"
       data-dd-privacy="mask"
       language="json"
+      :max-height="CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT"
       theme="dark"
       @code-block-render="highlightCodeBlock"
     />
@@ -30,6 +32,7 @@
 </template>
 
 <script setup lang="ts">
+import { CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT } from '../../constants'
 import { computed, type PropType } from 'vue'
 import type { BadgeAppearance } from '@kong/kongponents'
 import type { KonnectBaseEntityConfig, KongManagerBaseEntityConfig, KonnectBaseFormConfig, KongManagerBaseFormConfig } from '../../types'

--- a/packages/entities/entities-shared/src/components/common/TerraformCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/TerraformCodeBlock.vue
@@ -7,6 +7,7 @@
       :copy-code="unredactedTerraformContent"
       data-dd-privacy="mask"
       language="terraform"
+      :max-height="CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT"
       theme="dark"
       @code-block-render="highlightCodeBlock"
     />
@@ -14,6 +15,7 @@
 </template>
 
 <script setup lang="ts">
+import { CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT } from '../../constants'
 import { type PropType, computed } from 'vue'
 import { EventGatewayTypesArray, SupportedEntityType, SupportedEntityTypesArray, IdentityTypesArray } from '../../types'
 import { highlightCodeBlock } from '../../utils/code-block'

--- a/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
+++ b/packages/entities/entities-shared/src/components/common/YamlCodeBlock.vue
@@ -16,6 +16,7 @@
       :copy-code="unredactedYamlContent"
       data-dd-privacy="mask"
       language="yaml"
+      :max-height="CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT"
       theme="dark"
       @code-block-render="highlightCodeBlock"
     />
@@ -23,6 +24,7 @@
 </template>
 
 <script setup lang="ts">
+import { CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT } from '../../constants'
 import yaml from 'js-yaml'
 import { computed, ref, watch } from 'vue'
 

--- a/packages/entities/entities-shared/src/constants.ts
+++ b/packages/entities/entities-shared/src/constants.ts
@@ -25,3 +25,16 @@ export const PLUGIN_FORM_LAYOUT_STATE: InjectionKey<Ref<boolean>> = Symbol('PLUG
 export const DECK_COMMAND_EDITOR_KEY: InjectionKey<typeof DeckCommandEditor> = Symbol('DECK_COMMAND_EDITOR')
 
 export const DECK_COMMAND_EDITOR_MISSING_WARNING = '[entities-shared] DeckCommandEditor was not provided. Provide it via the `DECK_COMMAND_EDITOR_KEY` injection key or the `provideDeckCommandEditor` helper (see @kong-ui-public/entities-shared/deck-editor).'
+
+/**
+ * Code block needs a max height to enable virtual scrolling.
+ */
+export const CONFIG_CARD_CODE_BLOCK_MAX_HEIGHT = '50vh'
+
+/**
+ * Shiki's JS regex engine tokenizes synchronously on the main thread and emits one DOM element
+ * per token, so very large documents (e.g. a decK YAML dump with tens of thousands of lines)
+ * can block the tab for a long time and bloat the DOM. Past this size, skip highlighting and
+ * keep the plain-text rendering that KCodeBlock already produces via `v-html`.
+ */
+export const SHIKI_MAX_HIGHLIGHT_LENGTH = 200_000

--- a/packages/entities/entities-shared/src/utils/code-block.ts
+++ b/packages/entities/entities-shared/src/utils/code-block.ts
@@ -1,7 +1,12 @@
 import { codeToHtml } from './shiki'
 import type { CodeBlockEventData } from '@kong/kongponents'
+import { SHIKI_MAX_HIGHLIGHT_LENGTH } from '../constants'
 
 export function highlightCodeBlock({ codeElement, code, language }: CodeBlockEventData) {
+  if (code.length > SHIKI_MAX_HIGHLIGHT_LENGTH) {
+    return
+  }
+
   /*
    * Emit both palettes so appearance is driven by the Konnect theme, not a prop: shiki inlines
    * the light colors on each token and adds a `--shiki-dark` custom property. A single scoped


### PR DESCRIPTION
## Summary
- Cap `DeckCodeBlockInternal`/`JsonCodeBlock`/`TerraformCodeBlock`/`YamlCodeBlock` code blocks to `50vh` so KCodeBlock's virtualizer only renders visible rows instead of the whole document.
- Skip shiki syntax highlighting once the code exceeds 200k characters (`SHIKI_MAX_HIGHLIGHT_LENGTH`), falling back to the plain-text rendering KCodeBlock already produces via `v-html`, avoiding a long main-thread block on huge decK/YAML/JSON dumps.

Fixes performance issues when viewing entity config cards for very large configurations (e.g. decK YAML dumps with tens of thousands of lines).

[KM-2992](https://konghq.atlassian.net/browse/KM-2992)

## Test plan
- [x] `pnpm lint` on changed files
- [x] `pnpm typecheck` (`vue-tsc`)
- [x] Added Cypress component tests to `JsonCodeBlock.cy.ts` covering both the normal-highlighting path and the skip-highlighting path for oversized content
- [x] CI Cypress run (could not execute Cypress locally in this environment due to a broken local binary/cache)

[KM-2992]: https://konghq.atlassian.net/browse/KM-2992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ