### PR TITLE
feat(entities-plugins): governance feature select updates

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -271,6 +271,7 @@ const konnectConfig = computed<KonnectPluginFormConfig>(() => ({
   metering: {
     // Endpoint the governance FeatureSelectField fetches the OpenMeter features list from
     featuresEndpoint: '/us/kong-api/v3/openmeter/features',
+    canListFeatures: false,
   },
 }))
 
@@ -288,7 +289,7 @@ const kongManagerConfig = computed<KongManagerPluginFormConfig>(() => ({
   viewConsumerGroupRoute: (consumerGroupId: string) => ({ name: 'view-consumer_group', params: { id: consumerGroupId } }),
   viewCertificateRoute: (certId: string) => ({ name: 'view-certificate', params: { id: certId } }),
   deckCalloutPreferenceKey: enableDeckCallout.value ? 'kong-manager-entities-plugin-form-deck-callout-sandbox' : undefined,
-  // Kong Manager renders the governance feature key as a plain input, so no metering config is needed.
+  // Governance isn't configurable in Kong Manager yet (the form shows a notice), so no metering config is needed.
 }))
 
 const onUpdate = (payload: Record<string, any>) => {

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -271,7 +271,7 @@ const konnectConfig = computed<KonnectPluginFormConfig>(() => ({
   metering: {
     // Endpoint the governance FeatureSelectField fetches the OpenMeter features list from
     featuresEndpoint: '/us/kong-api/v3/openmeter/features',
-    canListFeatures: false,
+    // canListFeatures: false,
   },
 }))
 

--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -46,6 +46,7 @@
         :plugin-id="id"
         :plugin-type="plugin"
         use-custom-names-for-plugin
+        @click:create-entity="onCreateEntity"
         @global-action="handleGlobalAction"
         @update="onUpdate"
       />
@@ -75,7 +76,7 @@ import { FEATURE_FLAGS } from '../../src/constants'
 import { ToastManager } from '@kong/kongponents'
 import { provideDeckCommandEditor } from '@kong-ui-public/entities-shared/deck-editor'
 
-import type { KongManagerPluginFormConfig, KonnectPluginFormConfig } from '../../src'
+import type { EntityCreateEvent, KongManagerPluginFormConfig, KonnectPluginFormConfig } from '../../src'
 import type { GlobalAction } from '../../src/components/free-form/shared/types'
 
 const toaster = new ToastManager()
@@ -267,6 +268,10 @@ const konnectConfig = computed<KonnectPluginFormConfig>(() => ({
   dataPlaneVersions: ['3.14.0.1', '3.15.0.0'], // For testing the Kong Identity principals DP version alert
   principalsDirectoryName: 'my-directory', // Sandbox: simulate host-resolved directory name
   principalsCreationGuideVisible: false, // Sandbox: false = principals exist; true = show creation guide
+  metering: {
+    // Endpoint the governance FeatureSelectField fetches the OpenMeter features list from
+    featuresEndpoint: '/us/kong-api/v3/openmeter/features',
+  },
 }))
 
 const kongManagerConfig = computed<KongManagerPluginFormConfig>(() => ({
@@ -283,12 +288,18 @@ const kongManagerConfig = computed<KongManagerPluginFormConfig>(() => ({
   viewConsumerGroupRoute: (consumerGroupId: string) => ({ name: 'view-consumer_group', params: { id: consumerGroupId } }),
   viewCertificateRoute: (certId: string) => ({ name: 'view-certificate', params: { id: certId } }),
   deckCalloutPreferenceKey: enableDeckCallout.value ? 'kong-manager-entities-plugin-form-deck-callout-sandbox' : undefined,
+  // Kong Manager renders the governance feature key as a plain input, so no metering config is needed.
 }))
 
 const onUpdate = (payload: Record<string, any>) => {
   console.log('update', payload)
 
   router.push({ name: 'list-plugin' })
+}
+
+// Host app owns create-entity flows (e.g. the governance "Create feature" action)
+const onCreateEntity = (payload: EntityCreateEvent) => {
+  console.log('create entity', payload)
 }
 
 const handleGlobalAction = (action: GlobalAction, payload: any) => {

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/governance/FeatureSelectField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/governance/FeatureSelectField.vue
@@ -1,5 +1,15 @@
 <template>
+  <!-- Kong Manager (self-hosted) has no OpenMeter features endpoint to browse, so
+       the feature key is entered as free text instead of selected from a list. -->
+  <StringField
+    v-if="isKongManager"
+    :help="t('plugins.free-form.governance.fields.feature_key.help')"
+    :label="t('plugins.free-form.governance.fields.feature_key.label')"
+    name="config.feature.key"
+  />
+
   <EnumField
+    v-else
     enable-filtering
     :help="t('plugins.free-form.governance.fields.feature_key.help')"
     :items="allItems"
@@ -7,24 +17,28 @@
     :loading="loading"
     name="config.feature.key"
   >
-    <!-- Rich option: feature key + metered badge, with the human name beneath -->
+    <!-- Rich option: feature key as the title, human name as the description -->
     <template #item-label="item">
       <div class="ff-feature-option">
-        <div class="ff-feature-option-title">
-          <span class="ff-feature-option-key">{{ item.value }}</span>
-          <KBadge
-            v-if="metaFor(item.value)?.metered"
-            appearance="info"
-          >
-            {{ t('plugins.free-form.governance.fields.feature_key.metered_badge') }}
-          </KBadge>
-        </div>
+        <span class="ff-feature-option-key">{{ item.value }}</span>
         <span
-          v-if="metaFor(item.value)?.name && metaFor(item.value)?.name !== item.value"
+          v-if="item.name"
           class="ff-feature-option-name"
         >
-          {{ metaFor(item.value)?.name }}
+          {{ item.name }}
         </span>
+      </div>
+    </template>
+
+    <!-- Create action, pinned to the dropdown footer. Emits up to the host app,
+         which owns the creation flow (e.g. navigating to a create page). -->
+    <template #dropdown-footer-text>
+      <div
+        class="ff-feature-create"
+        data-testid="ff-feature-create-action"
+        @click="emit('click:create-entity', { type: 'feature' })"
+      >
+        <span>{{ t('plugins.free-form.governance.fields.feature_key.create_feature') }}</span>
       </div>
     </template>
   </EnumField>
@@ -33,12 +47,18 @@
 <script setup lang="ts">
 import { computed, inject, onMounted, ref } from 'vue'
 import { get } from 'lodash-es'
-import { KBadge, type SelectItem } from '@kong/kongponents'
+import type { SelectItem } from '@kong/kongponents'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import { useAxios, type KonnectBaseFormConfig, type KongManagerBaseFormConfig } from '@kong-ui-public/entities-shared'
 import EnumField from '../../shared/EnumField.vue'
+import StringField from '../../shared/StringField.vue'
 import { useFormShared } from '../../shared/composables'
 import useI18n from '../../../../composables/useI18n'
+import type { EntityCreateEvent } from '../../../../types'
+
+const emit = defineEmits<{
+  'click:create-entity': [payload: EntityCreateEvent]
+}>()
 
 const { i18n: { t } } = useI18n()
 
@@ -46,29 +66,18 @@ const appConfig = inject<KonnectBaseFormConfig | KongManagerBaseFormConfig | und
 const { axiosInstance } = useAxios(appConfig?.axiosRequestConfig)
 const { formData } = useFormShared()
 
-interface FeatureMeta {
-  name?: string
-  metered?: boolean
-}
+const isKongManager = computed(() => appConfig?.app === 'kongManager')
 
+// Each item carries the feature `name` alongside label/value for the option template.
 const items = ref<Array<SelectItem<string>>>([])
-// Per-key display metadata (name + metered flag) for the option template.
-const meta = ref<Record<string, FeatureMeta>>({})
 const loading = ref(false)
-
-function metaFor(value: unknown): FeatureMeta | undefined {
-  return typeof value === 'string' ? meta.value[value] : undefined
-}
 
 /**
  * OpenMeter features list. The response shape is `{ data: Feature[], meta }`
- * where each Feature has `key`, `name`, and an optional `meter` (metered feature).
- *
- * NOTE: the base URL and path are pending backend finalization — the governance
- * service proxies OpenMeter, so this is expected to resolve through the same
- * Konnect API base used elsewhere in the form.
+ * where each Feature has `key` and `name`. The endpoint is supplied by the host
+ * app via `config.metering.featuresEndpoint` rather than hardcoded here.
  */
-const featuresUrl = computed(() => `${appConfig?.apiBaseUrl ?? ''}/api/v3/openmeter/features`)
+const featuresUrl = computed(() => appConfig?.metering?.featuresEndpoint ?? '')
 
 // Ensure the currently-selected key is always selectable even before/without a
 // successful fetch (e.g. editing an existing plugin, or local dev with no backend).
@@ -82,16 +91,20 @@ const allItems = computed<Array<SelectItem<string>>>(() => {
   return list
 })
 
-onMounted(async () => {
+async function loadFeatures() {
+  // Kong Manager renders a plain input, and there's nothing to fetch when the host
+  // app hasn't configured a features endpoint — keep the current value selectable.
+  if (isKongManager.value || !featuresUrl.value) return
+
   loading.value = true
   try {
     const res = await axiosInstance.get(featuresUrl.value)
     const features = res.data?.data ?? []
-    items.value = features.map((feature: any): SelectItem<string> => ({ label: feature.key, value: feature.key }))
-    meta.value = features.reduce((acc: Record<string, FeatureMeta>, feature: any) => {
-      acc[feature.key] = { name: feature.name, metered: !!feature.meter }
-      return acc
-    }, {})
+    items.value = features.map((feature: any): SelectItem<string> => ({
+      label: feature.key,
+      value: feature.key,
+      name: feature.name,
+    }))
   } catch (error) {
     // The endpoint may be unavailable (e.g. local playground without a backend).
     // Degrade gracefully: keep the current value selectable and log for debugging.
@@ -99,7 +112,9 @@ onMounted(async () => {
   } finally {
     loading.value = false
   }
-})
+}
+
+onMounted(loadFeatures)
 </script>
 
 <style lang="scss" scoped>
@@ -107,12 +122,6 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   gap: var(--kui-space-10, $kui-space-10);
-
-  &-title {
-    align-items: center;
-    display: flex;
-    gap: var(--kui-space-40, $kui-space-40);
-  }
 
   &-key {
     font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
@@ -122,5 +131,14 @@ onMounted(async () => {
     color: var(--kui-color-text-neutral, $kui-color-text-neutral);
     font-size: var(--kui-font-size-20, $kui-font-size-20);
   }
+}
+
+.ff-feature-create {
+  align-items: center;
+  color: var(--kui-color-text-primary, $kui-color-text-primary);
+  cursor: pointer;
+  display: flex;
+  gap: var(--kui-space-10, $kui-space-10);
+  pointer-events: auto;
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/governance/FeatureSelectField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/governance/FeatureSelectField.vue
@@ -1,15 +1,17 @@
 <template>
-  <!-- Kong Manager (self-hosted) has no OpenMeter features endpoint to browse, so
-       the feature key is entered as free text instead of selected from a list. -->
-  <StringField
-    v-if="isKongManager"
-    :help="t('plugins.free-form.governance.fields.feature_key.help')"
-    :label="t('plugins.free-form.governance.fields.feature_key.label')"
-    name="config.feature.key"
+  <!-- When the user can't list features (Metering & Billing not enabled / no access),
+       the select is disabled and this alert points them to enable it in Konnect. -->
+  <KAlert
+    v-if="!canListFeatures"
+    appearance="warning"
+    class="ff-feature-unavailable"
+    data-testid="ff-feature-unavailable"
+    :message="t('plugins.free-form.governance.fields.feature_key.unavailable')"
+    show-icon
   />
 
   <EnumField
-    v-else
+    :disabled="!canListFeatures"
     enable-filtering
     :help="t('plugins.free-form.governance.fields.feature_key.help')"
     :items="allItems"
@@ -30,17 +32,21 @@
       </div>
     </template>
 
-    <!-- Create action, pinned to the dropdown footer. Emits up to the host app,
-         which owns the creation flow (e.g. navigating to a create page). -->
-    <template #dropdown-footer-text>
-      <div
-        class="ff-feature-create"
-        data-testid="ff-feature-create-action"
-        @click="emit('click:create-entity', { type: 'feature' })"
-      >
-        <span>{{ t('plugins.free-form.governance.fields.feature_key.create_feature') }}</span>
-      </div>
-    </template>
+    <!--
+      Create action, pinned to the dropdown footer — hidden for now. Emits up to the
+      host app (FeatureSelectField → GovernanceForm → host `click:create-entity`),
+      which owns the creation flow; the plumbing stays wired for when it's re-enabled.
+
+      <template #dropdown-footer-text>
+        <div
+          class="ff-feature-create"
+          data-testid="ff-feature-create-action"
+          @click="emit('click:create-entity', { type: 'feature' })"
+        >
+          <span>{{ t('plugins.free-form.governance.fields.feature_key.create_feature') }}</span>
+        </div>
+      </template>
+    -->
   </EnumField>
 </template>
 
@@ -51,12 +57,12 @@ import type { SelectItem } from '@kong/kongponents'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import { useAxios, type KonnectBaseFormConfig, type KongManagerBaseFormConfig } from '@kong-ui-public/entities-shared'
 import EnumField from '../../shared/EnumField.vue'
-import StringField from '../../shared/StringField.vue'
 import { useFormShared } from '../../shared/composables'
 import useI18n from '../../../../composables/useI18n'
 import type { EntityCreateEvent } from '../../../../types'
 
-const emit = defineEmits<{
+// Declared for the create action (commented out below); GovernanceForm forwards it to the host.
+defineEmits<{
   'click:create-entity': [payload: EntityCreateEvent]
 }>()
 
@@ -66,7 +72,10 @@ const appConfig = inject<KonnectBaseFormConfig | KongManagerBaseFormConfig | und
 const { axiosInstance } = useAxios(appConfig?.axiosRequestConfig)
 const { formData } = useFormShared()
 
-const isKongManager = computed(() => appConfig?.app === 'kongManager')
+// Host precomputes whether the user can list features (Metering & Billing enabled +
+// permission). Only an explicit `false` disables the field — omitted/true = allowed.
+// Guards the feature-list query only; unrelated to the (commented-out) create action.
+const canListFeatures = computed(() => appConfig?.metering?.canListFeatures !== false)
 
 // Each item carries the feature `name` alongside label/value for the option template.
 const items = ref<Array<SelectItem<string>>>([])
@@ -92,9 +101,9 @@ const allItems = computed<Array<SelectItem<string>>>(() => {
 })
 
 async function loadFeatures() {
-  // Kong Manager renders a plain input, and there's nothing to fetch when the host
-  // app hasn't configured a features endpoint — keep the current value selectable.
-  if (isKongManager.value || !featuresUrl.value) return
+  // Nothing to fetch when the user can't list features or the host hasn't configured
+  // a features endpoint — keep the current value selectable via `allItems`.
+  if (!canListFeatures.value || !featuresUrl.value) return
 
   loading.value = true
   try {
@@ -124,7 +133,8 @@ onMounted(loadFeatures)
   gap: var(--kui-space-10, $kui-space-10);
 
   &-key {
-    font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+    color: var(--kui-color-text, $kui-color-text);
+    font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
   }
 
   &-name {

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/governance/FeatureSelectField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/governance/FeatureSelectField.vue
@@ -32,21 +32,21 @@
       </div>
     </template>
 
-    <!--
-      Create action, pinned to the dropdown footer — hidden for now. Emits up to the
-      host app (FeatureSelectField → GovernanceForm → host `click:create-entity`),
-      which owns the creation flow; the plumbing stays wired for when it's re-enabled.
-
-      <template #dropdown-footer-text>
-        <div
-          class="ff-feature-create"
-          data-testid="ff-feature-create-action"
-          @click="emit('click:create-entity', { type: 'feature' })"
-        >
-          <span>{{ t('plugins.free-form.governance.fields.feature_key.create_feature') }}</span>
-        </div>
-      </template>
-    -->
+    <!-- New-feature action, pinned to the dropdown footer. Shown only when the host
+         says the user can create features. Emits up to the host app (FeatureSelectField
+         → GovernanceForm → host `click:create-entity`), which owns the creation flow. -->
+    <template
+      v-if="canCreateFeature"
+      #dropdown-footer-text
+    >
+      <div
+        class="ff-feature-create"
+        data-testid="ff-feature-create-action"
+        @click="emit('click:create-entity', { type: 'feature' })"
+      >
+        <span>{{ t('plugins.free-form.governance.fields.feature_key.create_feature') }}</span>
+      </div>
+    </template>
   </EnumField>
 </template>
 
@@ -61,8 +61,8 @@ import { useFormShared } from '../../shared/composables'
 import useI18n from '../../../../composables/useI18n'
 import type { EntityCreateEvent } from '../../../../types'
 
-// Declared for the create action (commented out below); GovernanceForm forwards it to the host.
-defineEmits<{
+// The new-feature action emits this; GovernanceForm forwards it to the host app.
+const emit = defineEmits<{
   'click:create-entity': [payload: EntityCreateEvent]
 }>()
 
@@ -74,8 +74,12 @@ const { formData } = useFormShared()
 
 // Host precomputes whether the user can list features (Metering & Billing enabled +
 // permission). Only an explicit `false` disables the field — omitted/true = allowed.
-// Guards the feature-list query only; unrelated to the (commented-out) create action.
+// Guards the feature-list query only.
 const canListFeatures = computed(() => appConfig?.metering?.canListFeatures !== false)
+
+// Host precomputes whether the user can create features. Only an explicit `false`
+// hides the "New feature" action — omitted/true = shown.
+const canCreateFeature = computed(() => appConfig?.metering?.canCreateFeature !== false)
 
 // Each item carries the feature `name` alongside label/value for the option template.
 const items = ref<Array<SelectItem<string>>>([])

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.cy.ts
@@ -7,7 +7,7 @@ const mountForm = (options: {
   model?: Record<string, any>
   geoApiServerUrl?: string
   app?: 'konnect' | 'kongManager'
-  metering?: { featuresEndpoint?: string, canListFeatures?: boolean }
+  metering?: { featuresEndpoint?: string, canListFeatures?: boolean, canCreateFeature?: boolean }
 }) => {
   const { isEditing = false, model = {}, geoApiServerUrl, app = 'konnect', metering } = options
 
@@ -24,6 +24,7 @@ const mountForm = (options: {
       isEditing,
       pluginName: 'governance',
       onFormChange: cy.spy().as('onFormChange'),
+      'onClick:create-entity': cy.spy().as('onCreateEntity'),
     },
     global: {
       provide: {
@@ -152,6 +153,36 @@ describe('GovernanceForm - feature select', () => {
     // EnumField's testid is `ff-${path}` (see EnumField.vue); when disabled it resolves to the input itself
     cy.getTestId('ff-config.feature.key').should('be.disabled')
     cy.get('@featuresRequest').should('not.have.been.called')
+  })
+
+  it('shows the create-feature action and emits click:create-entity when the user can create features', () => {
+    cy.intercept('GET', featuresEndpoint, {
+      statusCode: 200,
+      body: { data: [{ key: 'api_calls', name: 'API calls' }] },
+    }).as('features')
+
+    // canCreateFeature omitted → action shown
+    mountForm({ metering: { featuresEndpoint } })
+
+    cy.wait('@features')
+
+    cy.get('[data-testid="ff-config.feature.key"]').click()
+    cy.getTestId('ff-feature-create-action').should('be.visible').click()
+    cy.get('@onCreateEntity').should('have.been.calledOnceWith', { type: 'feature' })
+  })
+
+  it('hides the create-feature action when the user cannot create features', () => {
+    cy.intercept('GET', featuresEndpoint, {
+      statusCode: 200,
+      body: { data: [{ key: 'api_calls', name: 'API calls' }] },
+    }).as('features')
+
+    mountForm({ metering: { featuresEndpoint, canCreateFeature: false } })
+
+    cy.wait('@features')
+
+    cy.get('[data-testid="ff-config.feature.key"]').click()
+    cy.getTestId('ff-feature-create-action').should('not.exist')
   })
 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.cy.ts
@@ -149,7 +149,8 @@ describe('GovernanceForm - feature select', () => {
     mountForm({ metering: { featuresEndpoint, canListFeatures: false } })
 
     cy.getTestId('ff-feature-unavailable').should('be.visible')
-    cy.getTestId('ff-config.feature.key').findTestId('select-input').should('be.disabled')
+    // EnumField's testid is `ff-${path}` (see EnumField.vue); when disabled it resolves to the input itself
+    cy.getTestId('ff-config.feature.key').should('be.disabled')
     cy.get('@featuresRequest').should('not.have.been.called')
   })
 })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.cy.ts
@@ -7,12 +7,13 @@ const mountForm = (options: {
   model?: Record<string, any>
   geoApiServerUrl?: string
   app?: 'konnect' | 'kongManager'
+  metering?: { featuresEndpoint?: string, canListFeatures?: boolean }
 }) => {
-  const { isEditing = false, model = {}, geoApiServerUrl, app = 'konnect' } = options
+  const { isEditing = false, model = {}, geoApiServerUrl, app = 'konnect', metering } = options
 
   const formsConfig = app === 'konnect'
-    ? { app: 'konnect' as const, apiBaseUrl: '/us/kong-api', controlPlaneId: '123', ...(geoApiServerUrl ? { geoApiServerUrl } : {}) }
-    : { app: 'kongManager' as const, apiBaseUrl: '/kong-manager' }
+    ? { app: 'konnect' as const, apiBaseUrl: '/us/kong-api', controlPlaneId: '123', ...(geoApiServerUrl ? { geoApiServerUrl } : {}), ...(metering ? { metering } : {}) }
+    : { app: 'kongManager' as const, apiBaseUrl: '/kong-manager', ...(metering ? { metering } : {}) }
 
   cy.mount(GovernanceForm as any, {
     props: {
@@ -112,6 +113,54 @@ describe('GovernanceForm - customer field visibility', () => {
     })
 
     cy.getTestId('ff-config.customer.field').should('not.be.visible')
+  })
+})
+
+describe('GovernanceForm - feature select', () => {
+  const featuresEndpoint = '/us/kong-api/v3/openmeter/features'
+
+  it('lists features from the configured metering endpoint, showing key and name', () => {
+    cy.intercept('GET', featuresEndpoint, {
+      statusCode: 200,
+      body: {
+        data: [
+          { key: 'api_calls', name: 'API calls' },
+          { key: 'active_users', name: 'Active users' },
+        ],
+      },
+    }).as('features')
+
+    mountForm({ metering: { featuresEndpoint } })
+
+    cy.wait('@features')
+
+    // Open the select and assert the option renders both key (title) and name (description)
+    cy.get('[data-testid="ff-config.feature.key"]').click()
+    cy.get('[data-testid="ff-enum-config.feature.key-items"]')
+      .find('[data-testid="select-item-api_calls"]')
+      .should('contain.text', 'api_calls')
+      .and('contain.text', 'API calls')
+  })
+
+  it('disables the feature select and shows an alert when the user cannot list features', () => {
+    // Should not query the endpoint at all when the user can't list features
+    cy.intercept('GET', featuresEndpoint, cy.spy().as('featuresRequest'))
+
+    mountForm({ metering: { featuresEndpoint, canListFeatures: false } })
+
+    cy.getTestId('ff-feature-unavailable').should('be.visible')
+    cy.getTestId('ff-config.feature.key').findTestId('select-input').should('be.disabled')
+    cy.get('@featuresRequest').should('not.have.been.called')
+  })
+})
+
+describe('GovernanceForm - Kong Manager', () => {
+  it('shows an unavailable notice and does not render the config form', () => {
+    mountForm({ app: 'kongManager' })
+
+    cy.getTestId('ff-governance-unavailable').should('be.visible')
+    cy.getTestId('form-section-configuration').should('not.exist')
+    cy.getTestId('form-section-governance').should('not.exist')
   })
 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Not configurable in Kong Manager yet — show a notice instead of the form.
-       `onValidityChange(valid: false)` blocks saving (see script). -->
+       Saving is blocked via a before-save guard (BEFORE_SAVE_KEY; see script). -->
   <KAlert
     v-if="isKongManager"
     appearance="info"

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.vue
@@ -1,5 +1,16 @@
 <template>
+  <!-- Not configurable in Kong Manager yet — show a notice instead of the form.
+       `onValidityChange(valid: false)` blocks saving (see script). -->
+  <KAlert
+    v-if="isKongManager"
+    appearance="info"
+    class="ff-governance-unavailable"
+    data-testid="ff-governance-unavailable"
+    :message="t('plugins.free-form.governance.unavailable_kong_manager')"
+  />
+
   <DynamicLayout
+    v-else
     v-bind="props"
     :config-sections="configSections"
     :form-config="formConfig"
@@ -102,12 +113,15 @@
         <Field name="config.timeout" />
         <Field name="config.keepalive" />
       </div>
-      <!-- Redis — shared (partial) vs dedicated. Rendering a Field at the redis
-           path lets PluginConfigurationForm's built-in renderer swap in
-           RedisSelector. Requires the schema to declare
-           `supported_partials: { 'redis-ce': ['config.redis'] }` so the partial
-           machinery resolves this path. -->
-      <Field name="config.redis" />
+      <!-- Redis — shared (partial) vs dedicated. Rendered directly (rather than via
+           `<Field name="config.redis" />`) so we can pass `borderless`, which drops
+           the surrounding KCard chrome to sit flush in the form. Still requires the
+           schema to declare `supported_partials: { 'redis-ce': ['config.redis'] }`
+           so REDIS_PARTIAL_INFO resolves this path. -->
+      <RedisSelector
+        borderless
+        :is-konnect-managed-redis-enabled="props.isKonnectManagedRedisEnabled ?? false"
+      />
 
       <!-- Cache & sync settings (in AdvancedFields, grouped under a collapse) -->
       <AdvancedFields
@@ -196,7 +210,8 @@
 
 <script setup lang="ts">
 import { AUTOFILL_SLOT, AUTOFILL_SLOT_NAME, FORMS_CONFIG } from '@kong-ui-public/forms'
-import { computed, inject, provide } from 'vue'
+import { computed, inject, onUnmounted, provide } from 'vue'
+import { BEFORE_SAVE_KEY } from '../../../const'
 import type { KonnectBaseFormConfig, KongManagerBaseFormConfig } from '@kong-ui-public/entities-shared'
 import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 import FieldRenderer from '../../shared/FieldRenderer.vue'
@@ -207,6 +222,7 @@ import NumberField from '../../shared/NumberField.vue'
 import StringField from '../../shared/StringField.vue'
 import ObjectField from '../../shared/ObjectField.vue'
 import AdvancedFields from '../../shared/AdvancedFields.vue'
+import RedisSelector from '../../shared/RedisSelector.vue'
 import useI18n from '../../../../composables/useI18n'
 import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 import type { ConfigSection } from '../../shared/types'
@@ -230,6 +246,15 @@ provide(AUTOFILL_SLOT, slots?.[AUTOFILL_SLOT_NAME])
 const { i18n: { t } } = useI18n()
 
 const appConfig = inject<KonnectBaseFormConfig | KongManagerBaseFormConfig | undefined>(FORMS_CONFIG)
+
+// Governance isn't configurable in Kong Manager yet — render a notice instead of the
+// form (see template) and block Save via a before-save guard. Using the guard rather
+// than onValidityChange avoids surfacing a second, duplicate error alert.
+const isKongManager = computed(() => appConfig?.app === 'kongManager')
+
+const registerBeforeSave = inject(BEFORE_SAVE_KEY)
+const unregisterBeforeSave = registerBeforeSave?.(() => !isKongManager.value)
+onUnmounted(() => unregisterBeforeSave?.())
 
 const governanceEndpointUrl = computed(() => {
   const geo = (appConfig as KonnectBaseFormConfig)?.geoApiServerUrl
@@ -354,9 +379,6 @@ const denyUnknownCustomersOptions = computed(() => [
 }
 
 .ff-governance-advanced-fields-container {
-  border-top: 1px solid var(--kui-color-border, $kui-color-border);
-  padding-top: var(--kui-space-70, $kui-space-70);
-
   :deep(.collapse-heading) {
     margin: 0;
   }

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/governance/GovernanceForm.vue
@@ -85,7 +85,7 @@
       </div>
 
       <!-- Feature — async select backed by the OpenMeter features endpoint. -->
-      <FeatureSelectField />
+      <FeatureSelectField @click:create-entity="(payload) => emit('click:create-entity', payload)" />
 
       <!-- Connection -->
       <h3 class="ff-governance-connection-heading">
@@ -210,11 +210,16 @@ import AdvancedFields from '../../shared/AdvancedFields.vue'
 import useI18n from '../../../../composables/useI18n'
 import type { PluginFormLayoutProps as Props } from '../../shared/layout/provider'
 import type { ConfigSection } from '../../shared/types'
+import type { EntityCreateEvent } from '../../../../types'
 import ResponseMappingField from './ResponseMappingField.vue'
 import CardRadioField from './CardRadioField.vue'
 import FeatureSelectField from './FeatureSelectField.vue'
 
 const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'click:create-entity': [payload: EntityCreateEvent]
+}>()
 
 const slots = defineSlots<{
   [K in typeof AUTOFILL_SLOT_NAME]: () => any

--- a/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
@@ -38,6 +38,13 @@
         v-bind="item"
       />
     </template>
+
+    <template
+      v-if="$slots['dropdown-footer-text']"
+      #dropdown-footer-text
+    >
+      <slot name="dropdown-footer-text" />
+    </template>
   </SelectComponent>
 </template>
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/EnumField.vue
@@ -38,13 +38,6 @@
         v-bind="item"
       />
     </template>
-
-    <template
-      v-if="$slots['dropdown-footer-text']"
-      #dropdown-footer-text
-    >
-      <slot name="dropdown-footer-text" />
-    </template>
   </SelectComponent>
 </template>
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/RedisSelector.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/RedisSelector.vue
@@ -1,11 +1,20 @@
 <template>
-  <KCard
+  <component
+    :is="borderless ? 'div' : KCard"
     v-if="useRedisPartial"
     v-show="!hide"
     class="redis-config-card"
+    :class="{ 'redis-config-card--borderless': borderless }"
     data-testid="redis-config-card"
-    :title="redisCardTitle"
+    :title="borderless ? undefined : redisCardTitle"
   >
+    <!-- KCard renders `title` in its header; the borderless (div) variant renders it here. -->
+    <div
+      v-if="borderless"
+      class="redis-config-card-title"
+    >
+      {{ redisCardTitle }}
+    </div>
     <div
       class="redis-config-radio-group"
       data-testid="redis-config-radio-group"
@@ -83,7 +92,7 @@
       :render-rules="redisRenderRules"
       reset-label-path="reset"
     />
-  </KCard>
+  </component>
   <ObjectField
     v-else
     v-show="!hide"
@@ -102,6 +111,7 @@ import { onBeforeMount, inject, computed, ref, watch } from 'vue'
 import english from '../../../locales/en.json'
 import { createI18n } from '@kong-ui-public/i18n'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
+import { KCard } from '@kong/kongponents'
 import { useAxios, useErrors, type KongManagerBaseFormConfig, type KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
 import type { RedisPartialType, Redis, RenderRules } from './types'
 import { partialEndpoints, REDIS_PARTIAL_INFO } from './const'
@@ -151,6 +161,8 @@ interface RedisSelectorProps {
   redisPath?: string
   /** Set by parent from plugin form config */
   isKonnectManagedRedisEnabled?: boolean
+  /** Render the partial UI in a plain `div` (no KCard border/chrome) instead of a card */
+  borderless?: boolean
 }
 
 type PartialArray = Array<{ id: string, path?: string | undefined }>
@@ -352,6 +364,17 @@ watch(() => hide?.value, (newHide) => {
   :deep(.radio-card-wrapper) {
     box-sizing: border-box;
   }
+
+  &--borderless {
+    margin-bottom: 0;
+  }
+}
+
+// Title for the borderless (div) variant, mirroring the KCard header.
+.redis-config-card-title {
+  font-size: var(--kui-font-size-40, $kui-font-size-40);
+  font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+  margin-bottom: var(--kui-space-60, $kui-space-60);
 }
 
 .shared-redis-config-title {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -907,6 +907,7 @@
         }
       },
       "governance": {
+        "unavailable_kong_manager": "The Governance plugin can't be configured in Kong Manager yet.",
         "sections": {
           "configuration": {
             "title": "Plugin configuration",
@@ -947,6 +948,7 @@
             "label": "Feature to govern access",
             "help": "Feature that will control access to the scope where the plugin is applied.",
             "create_feature": "+ Create feature",
+            "unavailable": "You don't have access to metering features. Enable Metering & Billing in your Konnect organization to configure the feature to govern.",
             "load_error": "Could not load features from the governance service."
           },
           "governance_endpoint": {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -946,7 +946,7 @@
           "feature_key": {
             "label": "Feature to govern access",
             "help": "Feature that will control access to the scope where the plugin is applied.",
-            "metered_badge": "Metered feature",
+            "create_feature": "+ Create feature",
             "load_error": "Could not load features from the governance service."
           },
           "governance_endpoint": {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -947,7 +947,7 @@
           "feature_key": {
             "label": "Feature to govern access",
             "help": "Feature that will control access to the scope where the plugin is applied.",
-            "create_feature": "+ Create feature",
+            "create_feature": "+ Create new feature",
             "unavailable": "You don't have access to metering features. Enable Metering & Billing in your Konnect organization to configure the feature to govern.",
             "load_error": "Could not load features from the governance service."
           },

--- a/packages/entities/entities-plugins/src/types/plugin-form.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-form.ts
@@ -125,9 +125,10 @@ export interface KonnectPluginFormConfig extends BasePluginFormConfig, KonnectBa
 export interface KongManagerPluginFormConfig extends BasePluginFormConfig, KongManagerBaseFormConfig { }
 
 /**
- * Payload for the `click:create-entity` event emitted from the Kong Identity principals UI.
- * The consuming app navigates to the matching create page; `authServerId` is provided when
- * creating a client (scoped to the selected auth server).
+ * Payload for the `click:create-entity` event. The consuming app navigates to the
+ * matching create page. Emitted from the Kong Identity principals UI (`principal`,
+ * `auth-server`, `client`) and from the governance feature select (`feature`);
+ * `authServerId` is provided when creating a client (scoped to the selected auth server).
  */
 export type EntityCreateEvent = {
   type: 'principal'
@@ -136,6 +137,8 @@ export type EntityCreateEvent = {
 } | {
   type: 'client'
   authServerId?: string
+} | {
+  type: 'feature'
 }
 
 export interface PluginFormFields {

--- a/packages/entities/entities-shared/src/types/entity-base-form.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-form.ts
@@ -2,11 +2,19 @@ import type { RouteLocationRaw } from 'vue-router'
 import type { KonnectConfig, KongManagerConfig } from './index'
 import type { DeckConfigOptions } from './deck'
 
+/** Metering & billing related configuration, consumed by governance/metering plugin forms */
+export interface MeteringConfig {
+  /** Endpoint the governance FeatureSelectField fetches the OpenMeter features list from */
+  featuresEndpoint?: string
+}
+
 export interface BaseFormConfig {
   /** Route to return to if canceling create/edit an entity */
   cancelRoute?: RouteLocationRaw
   /** If showing an edit form, the ID of the entity to edit */
   editId?: string
+  /** Metering & billing related configuration */
+  metering?: MeteringConfig
 }
 
 /** Konnect base form config */

--- a/packages/entities/entities-shared/src/types/entity-base-form.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-form.ts
@@ -9,7 +9,7 @@ export interface MeteringConfig {
   /**
    * Whether the current user can list OpenMeter features (precomputed by the host app,
    * e.g. from Metering & Billing being enabled and the relevant permission). When
-   * explicitly `false`, the governance feature select is disabled and an info alert
+   * explicitly `false`, the governance feature select is disabled and a warning alert
    * guides the user to enable Metering & Billing in Konnect. Omitted/`true` = allowed.
    */
   canListFeatures?: boolean

--- a/packages/entities/entities-shared/src/types/entity-base-form.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-form.ts
@@ -6,6 +6,13 @@ import type { DeckConfigOptions } from './deck'
 export interface MeteringConfig {
   /** Endpoint the governance FeatureSelectField fetches the OpenMeter features list from */
   featuresEndpoint?: string
+  /**
+   * Whether the current user can list OpenMeter features (precomputed by the host app,
+   * e.g. from Metering & Billing being enabled and the relevant permission). When
+   * explicitly `false`, the governance feature select is disabled and an info alert
+   * guides the user to enable Metering & Billing in Konnect. Omitted/`true` = allowed.
+   */
+  canListFeatures?: boolean
 }
 
 export interface BaseFormConfig {

--- a/packages/entities/entities-shared/src/types/entity-base-form.ts
+++ b/packages/entities/entities-shared/src/types/entity-base-form.ts
@@ -13,6 +13,12 @@ export interface MeteringConfig {
    * guides the user to enable Metering & Billing in Konnect. Omitted/`true` = allowed.
    */
   canListFeatures?: boolean
+  /**
+   * Whether the current user can create OpenMeter features (precomputed by the host app).
+   * When explicitly `false`, the "New feature" action in the governance feature select is
+   * hidden. Omitted/`true` = shown; clicking it emits `click:create-entity`.
+   */
+  canCreateFeature?: boolean
 }
 
 export interface BaseFormConfig {


### PR DESCRIPTION
# Summary

Design + access-gating updates for the free-form Governance plugin form.

- Feature select: source the OpenMeter features list from config.metering.featuresEndpoint; render key as title + name as description. New config.metering.canListFeatures flag — when false, the select is disabled with a warning alert (and the endpoint isn't queried). WIP "Create feature" action hidden for now.
- Kong Manager: governance isn't configurable yet — shows a notice and blocks Save (before-save guard).
- Redis selector: added a borderless option (div vs KCard); governance uses it so the field sits flush.
- Tests: feature-select listing/gating + Kong Manager block.
New config (MeteringConfig): `featuresEndpoint?: string`, `canListFeatures?: boolean`.

**User with no metering&billing feature access**
<img width="1013" height="681" alt="截屏2026-07-30 18 01 32" src="https://github.com/user-attachments/assets/b1d17989-9eed-431d-91f8-89878e49f0e7" />
