### PR TITLE
fix(analytics): csv export modal text color

### DIFF
--- a/packages/analytics/analytics-chart/src/components/CsvExportModal.vue
+++ b/packages/analytics/analytics-chart/src/components/CsvExportModal.vue
@@ -271,7 +271,6 @@ watch(tableData, () => {
     }
 
     .text-muted {
-      color: rgba(0, 0, 0, 0.45) !important;
       font-size: var(--kui-font-size-30, $kui-font-size-30);
     }
 


### PR DESCRIPTION
# Summary

Fix CSV export modal text color

Before

<img width="1065" height="819" alt="image" src="https://github.com/user-attachments/assets/aa41670e-1945-417d-a326-31b31940d957" />

After

<img width="661" height="526" alt="Screenshot 2026-07-30 at 2 44 23 PM" src="https://github.com/user-attachments/assets/e7a58d9a-30cb-4f35-bc61-06c3a5cea1a9" />

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
