### PR TITLE
feat(dp-nodes): poll operation results

### DIFF
--- a/packages/entities/entities-data-plane-nodes/docs/change-log-level-modal.md
+++ b/packages/entities/entities-data-plane-nodes/docs/change-log-level-modal.md
@@ -4,15 +4,32 @@ A modal used to temporarily change the log level for a group of Data Plane nodes
 target log level and an expiration (TTL, in seconds), after which the nodes revert to their default
 log level.
 
-On **Save**, a single batch request is sent to update the log level for all `nodes`:
+The modal has two stages:
+
+**1. Edit** — On **Save**, a single batch request creates a log-level operation for all `nodes`:
 
 - Konnect: `POST /v2/control-planes/{controlPlaneId}/nodes/log-level-operations`
 - Kong Manager: `POST /debug/cluster/data-planes/log-level-operations`
-- body: `{ log_level, ttl, targets: { node_ids } }`
+- body: `{ log_level, ttl, targets: { node_ids } }` → response: `{ id }`
 
 While the request is in flight the Save button is disabled. On success the component emits
-[`success`](#events); on failure it renders a danger alert with the error message at the bottom of
-the modal.
+[`success`](#events) and switches to the status stage; on failure it renders a danger alert with the
+error message at the bottom of the modal.
+
+**2. Status** — After a successful Save the modal polls the operation's results endpoint every 2
+seconds until every node has settled (no status is `in_progress`), showing a per-node status table:
+
+- Konnect: `GET /v2/control-planes/{controlPlaneId}/nodes/log-level-operations/{id}/results`
+- Kong Manager: `GET /debug/cluster/data-planes/log-level-operations/{id}/results`
+- response: `{ data: Array<{ node_id, status }> }` where `status` is one of `in_progress`, `applied`,
+  `reverted`, `superseded`, `failed`, `unsupported`.
+
+Each row's Node host links to the node's detail page in a new tab when `getNodeDetailRoute` is
+provided (otherwise it renders as plain text). Polling retries every 2 seconds even if a poll fails,
+and stops once every node has settled. Closing the modal does **not** stop polling — a still-running
+operation keeps polling in the background and is stopped (and the form reset) the next time the modal
+is opened, or when the component is unmounted. Cancel, the close icon, and the **Done** button all
+emit [`close`](#events).
 
 - [Requirements](#requirements)
 - [Usage](#usage)
@@ -62,14 +79,38 @@ The list of Data Plane nodes to change the log level for. Their `id`s are sent a
   - `id`: `string` - The ID of the Data Plane node.
   - `hostname`: `string` - The hostname of the Data Plane node.
 
+#### `getNodeDetailRoute`
+
+A function that returns the URL of a node's detail page, given its ID. When provided, each Node host
+in the status table links to it (opened in a new tab) and must be a valid absolute URL. When omitted,
+the Node host is rendered as plain text.
+
+- type: `(nodeId: string) => string`
+- required: `false`
+
 ### Events
 
 #### `success`
 
-Emitted after the log-level request succeeds. The modal does **not** close itself — the host
-application controls visibility via `v-model:visible`.
+Emitted when the log-level operation is created (the POST succeeds). The modal does **not** close
+itself — it switches to the status stage and starts polling.
 
 - payload: none
+
+#### `close`
+
+Emitted when the user dismisses the modal (Cancel, the close icon, or Done). The modal does **not**
+change its own visibility — the host must close it, typically by setting `v-model:visible` to `false`
+in response to this event.
+
+- payload: none
+
+#### `node-error`
+
+Emitted during polling the first time a node's status becomes `failed` or `unsupported`. Emitted at
+most once per node per operation.
+
+- payload: `{ id: string, hostname: string, status: 'failed' | 'unsupported' }`
 
 ### Usage example
 

--- a/packages/entities/entities-data-plane-nodes/sandbox/pages/ChangeLogLevel.vue
+++ b/packages/entities/entities-data-plane-nodes/sandbox/pages/ChangeLogLevel.vue
@@ -6,8 +6,9 @@
   <ChangeLogLevelModal
     v-model:visible="visible"
     :config="config"
+    :get-node-detail-route="getNodeDetailRoute"
     :nodes="nodes"
-    @success="visible = false"
+    @close="visible = false"
   />
 </template>
 
@@ -27,4 +28,6 @@ const nodes = [
   { id: '1', hostname: 'localhost-1' },
   { id: '2', hostname: 'localhost-2' },
 ]
+
+const getNodeDetailRoute = (nodeId: string): string => `${window.location.origin}/data-plane-nodes/${nodeId}`
 </script>

--- a/packages/entities/entities-data-plane-nodes/src/components/ChangeLogLevelModal.cy.ts
+++ b/packages/entities/entities-data-plane-nodes/src/components/ChangeLogLevelModal.cy.ts
@@ -1,10 +1,12 @@
 import ChangeLogLevelModal from './ChangeLogLevelModal.vue'
-import type { ChangeLogLevelConfig } from '../types'
+import type { ChangeLogLevelConfig, LogLevelOperationResult } from '../types'
 
 const nodes = [
   { id: 'node-1', hostname: 'dp-1' },
   { id: 'node-2', hostname: 'dp-2' },
 ]
+
+const getNodeDetailRoute = (nodeId: string): string => `https://example.com/nodes/${nodeId}`
 
 const konnectConfig: ChangeLogLevelConfig = {
   app: 'konnect',
@@ -36,18 +38,34 @@ const cancelButton = '.k-modal .footer-actions button[data-testid="modal-cancel-
 describe('<ChangeLogLevelModal />', { viewportHeight: 700, viewportWidth: 700 }, () => {
   cases.forEach(({ name, config, url }) => {
     describe(name, () => {
+      const resultsUrl = `${url}/*/results*`
+
       const interceptSubmission = (opts: { status?: number, delay?: number, body?: Record<string, any> } = {}): void => {
         cy.intercept('POST', url, {
           statusCode: opts.status ?? 200,
-          body: opts.body ?? {},
+          body: opts.body ?? { id: 'op-1' },
           delay: opts.delay,
         }).as('submit')
       }
 
-      it('renders the form fields, the always-on warning, and the action buttons', () => {
+      // Each entry is the response for one poll; the last entry is repeated for any further polls.
+      const interceptResults = (responses: Array<{ status?: number, data?: LogLevelOperationResult[] }> = [{ data: [] }]): void => {
+        let call = 0
+        cy.intercept('GET', resultsUrl, (req) => {
+          const response = responses[Math.min(call, responses.length - 1)]
+          call++
+          req.reply({ statusCode: response.status ?? 200, body: { data: response.data ?? [] } })
+        }).as('results')
+      }
+
+      const mountModal = (extraProps: Record<string, any> = {}) => {
         cy.mount(ChangeLogLevelModal, {
-          props: { config, visible: true, nodes },
+          props: { config, visible: true, nodes, getNodeDetailRoute, ...extraProps },
         })
+      }
+
+      it('renders the form fields, the always-on warning, and the action buttons', () => {
+        mountModal()
 
         cy.getTestId('change-log-level-modal').find('.modal-container').should('be.visible')
         cy.getTestId('log-level-warning').should('be.visible')
@@ -60,9 +78,7 @@ describe('<ChangeLogLevelModal />', { viewportHeight: 700, viewportWidth: 700 },
       })
 
       it('disables Save when the expiration is out of the 1-3600 range', () => {
-        cy.mount(ChangeLogLevelModal, {
-          props: { config, visible: true, nodes },
-        })
+        mountModal()
 
         cy.get(actionButton).should('be.enabled')
 
@@ -80,19 +96,16 @@ describe('<ChangeLogLevelModal />', { viewportHeight: 700, viewportWidth: 700 },
       })
 
       it('disables Save when there are no nodes', () => {
-        cy.mount(ChangeLogLevelModal, {
-          props: { config, visible: true, nodes: [] },
-        })
+        mountModal({ nodes: [] })
 
         cy.get(actionButton).should('be.disabled')
       })
 
       it('sends the batch request with the default values and emits "success"', () => {
         interceptSubmission()
+        interceptResults([{ data: [{ node_id: 'node-1', status: 'applied' }, { node_id: 'node-2', status: 'applied' }] }])
 
-        cy.mount(ChangeLogLevelModal, {
-          props: { config, visible: true, nodes, onSuccess: cy.spy().as('successSpy') },
-        })
+        mountModal({ onSuccess: cy.spy().as('successSpy') })
 
         cy.get(actionButton).click()
 
@@ -107,15 +120,13 @@ describe('<ChangeLogLevelModal />', { viewportHeight: 700, viewportWidth: 700 },
         cy.get('@successSpy').should('have.been.calledOnce')
         // The modal does not close itself - the host controls visibility.
         cy.getTestId('change-log-level-modal').find('.modal-container').should('be.visible')
-        cy.getTestId('log-level-error').should('not.exist')
       })
 
       it('sends the selected log level and expiration', () => {
         interceptSubmission()
+        interceptResults()
 
-        cy.mount(ChangeLogLevelModal, {
-          props: { config, visible: true, nodes },
-        })
+        mountModal()
 
         cy.getTestId('log-level-select').click()
         cy.getTestId('log-level-select-popover').find('button[value="debug"]').click()
@@ -136,39 +147,195 @@ describe('<ChangeLogLevelModal />', { viewportHeight: 700, viewportWidth: 700 },
 
       it('disables Save while the request is in flight', () => {
         interceptSubmission({ delay: 300 })
+        interceptResults()
 
-        cy.mount(ChangeLogLevelModal, {
-          props: { config, visible: true, nodes },
-        })
+        mountModal()
 
         cy.get(actionButton).click()
         cy.get(actionButton).should('be.disabled')
 
         cy.wait('@submit')
-        cy.get(actionButton).should('be.enabled')
       })
 
       it('shows a danger alert with the error message when the request fails', () => {
         interceptSubmission({ status: 500, body: { message: 'Something went wrong' } })
 
-        cy.mount(ChangeLogLevelModal, {
-          props: { config, visible: true, nodes, onSuccess: cy.spy().as('successSpy') },
-        })
+        mountModal({ onSuccess: cy.spy().as('successSpy') })
 
         cy.get(actionButton).click()
         cy.wait('@submit')
 
         cy.getTestId('log-level-error').should('be.visible').and('contain.text', 'Something went wrong')
         cy.get('@successSpy').should('not.have.been.called')
+        // Stays on the edit stage
+        cy.getTestId('log-level-select').should('be.visible')
       })
 
-      it('emits update:visible=false on cancel', () => {
-        cy.mount(ChangeLogLevelModal, {
-          props: { config, visible: true, nodes, 'onUpdate:visible': cy.spy().as('visibleSpy') },
-        })
+      it('emits "close" on cancel', () => {
+        mountModal({ onClose: cy.spy().as('closeSpy') })
 
         cy.get(cancelButton).click()
-        cy.get('@visibleSpy').should('have.been.calledWith', false)
+        cy.get('@closeSpy').should('have.been.calledOnce')
+      })
+
+      it('switches to the status view listing every node after Save', () => {
+        interceptSubmission()
+        interceptResults()
+
+        mountModal()
+
+        cy.get(actionButton).click()
+        cy.wait('@results')
+
+        // Title switches, form is gone, Cancel is hidden and the action button becomes "Done".
+        cy.getTestId('change-log-level-modal').should('contain.text', 'Change log level status')
+        cy.getTestId('log-level-select').should('not.exist')
+        cy.get(cancelButton).should('not.exist')
+        cy.get(actionButton).should('contain.text', 'Done')
+
+        // One row per node, showing the hostname; default status while polling is "in progress".
+        cy.getTestId('log-level-status-table').should('contain.text', 'dp-1').and('contain.text', 'dp-2')
+        cy.getTestId('log-level-status-in_progress').should('have.length', 2)
+      })
+
+      it('keeps polling after close, then stops it and resets to the edit stage on reopen', () => {
+        interceptSubmission()
+        // Never settles, so polling would continue indefinitely on its own.
+        interceptResults([{ data: [{ node_id: 'node-1', status: 'in_progress' }, { node_id: 'node-2', status: 'in_progress' }] }])
+
+        cy.mount(ChangeLogLevelModal, {
+          props: { config, visible: true, nodes, getNodeDetailRoute },
+        }).then(({ wrapper }) => wrapper).as('wrapper')
+
+        cy.get(actionButton).click()
+        cy.wait('@results')
+        cy.getTestId('log-level-status-table').should('be.visible')
+
+        // Close the modal (host controls visibility). Polling must keep running in the background.
+        cy.get('@wrapper').then((wrapper: any) => wrapper.setProps({ visible: false }))
+
+        const counts: { atClose?: number, atReopen?: number } = {}
+        cy.get('@results.all').then((calls) => {
+          counts.atClose = calls.length
+        })
+        cy.wait(2500) // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.get('@results.all').then((calls) => {
+          expect(calls.length, 'polling continues while closed').to.be.greaterThan(counts.atClose!)
+        })
+
+        // Reopen: the previous poll stops and the modal resets to the edit stage.
+        cy.get('@wrapper').then((wrapper: any) => wrapper.setProps({ visible: true }))
+        cy.getTestId('log-level-select').should('be.visible')
+        cy.getTestId('log-level-status-table').should('not.exist')
+
+        cy.get('@results.all').then((calls) => {
+          counts.atReopen = calls.length
+        })
+        cy.wait(2500) // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.get('@results.all').then((calls) => {
+          expect(calls.length, 'no more polls after reopen').to.equal(counts.atReopen!)
+        })
+      })
+
+      it('renders a status badge per node from the polled results', () => {
+        interceptSubmission()
+        interceptResults([{ data: [{ node_id: 'node-1', status: 'applied' }, { node_id: 'node-2', status: 'failed' }] }])
+
+        mountModal()
+
+        cy.get(actionButton).click()
+        cy.wait('@results')
+
+        cy.getTestId('log-level-status-applied').should('be.visible')
+        cy.getTestId('log-level-status-failed').should('be.visible')
+      })
+
+      it('stops polling once every node has settled', () => {
+        interceptSubmission()
+        interceptResults([{ data: [{ node_id: 'node-1', status: 'applied' }, { node_id: 'node-2', status: 'reverted' }] }])
+
+        mountModal()
+
+        cy.get(actionButton).click()
+        cy.wait('@results')
+
+        // No further polls after everything settled on the first response.
+        cy.wait(2500) // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.get('@results.all').should('have.length', 1)
+      })
+
+      it('keeps polling 2s after a failed results response', () => {
+        interceptSubmission()
+        interceptResults([
+          { status: 500 },
+          { data: [{ node_id: 'node-1', status: 'applied' }, { node_id: 'node-2', status: 'applied' }] },
+        ])
+
+        mountModal()
+
+        cy.get(actionButton).click()
+        cy.wait('@results') // first poll -> 500
+        cy.wait('@results') // retried ~2s later -> success
+
+        cy.getTestId('log-level-status-applied').should('have.length', 2)
+      })
+
+      it('emits "node-error" once per node when a node fails or is unsupported', () => {
+        interceptSubmission()
+        interceptResults([
+          { data: [{ node_id: 'node-1', status: 'failed' }, { node_id: 'node-2', status: 'in_progress' }] },
+          { data: [{ node_id: 'node-1', status: 'failed' }, { node_id: 'node-2', status: 'unsupported' }] },
+        ])
+
+        mountModal({ onNodeError: cy.spy().as('nodeErrorSpy') })
+
+        cy.get(actionButton).click()
+        cy.wait('@results') // poll 1: node-1 failed
+        cy.wait('@results') // poll 2 (~2s later): node-2 unsupported, node-1 still failed
+
+        // node-1 was failed in both polls but only fires once; node-2 fires once -> two total.
+        cy.get('@nodeErrorSpy').should('have.been.calledTwice')
+        cy.get('@nodeErrorSpy').should('have.been.calledWith', { id: 'node-1', hostname: 'dp-1', status: 'failed' })
+        cy.get('@nodeErrorSpy').should('have.been.calledWith', { id: 'node-2', hostname: 'dp-2', status: 'unsupported' })
+      })
+
+      it('links each Node host to getNodeDetailRoute', () => {
+        interceptSubmission()
+        interceptResults()
+
+        mountModal()
+
+        cy.get(actionButton).click()
+        cy.wait('@results')
+
+        cy.getTestId('log-level-status-table').find('a').first()
+          .should('have.attr', 'href', 'https://example.com/nodes/node-1')
+      })
+
+      it('renders the Node host as plain text when getNodeDetailRoute is not provided', () => {
+        interceptSubmission()
+        interceptResults()
+
+        mountModal({ getNodeDetailRoute: undefined })
+
+        cy.get(actionButton).click()
+        cy.wait('@results')
+
+        cy.getTestId('log-level-status-table').should('contain.text', 'dp-1')
+        cy.getTestId('log-level-status-table').find('a').should('not.exist')
+      })
+
+      it('emits "close" when Done is clicked', () => {
+        interceptSubmission()
+        interceptResults()
+
+        mountModal({ onClose: cy.spy().as('closeSpy') })
+
+        cy.get(actionButton).click()
+        cy.wait('@results')
+
+        cy.get(actionButton).should('contain.text', 'Done').click()
+        cy.get('@closeSpy').should('have.been.calledOnce')
       })
     })
   })

--- a/packages/entities/entities-data-plane-nodes/src/components/ChangeLogLevelModal.vue
+++ b/packages/entities/entities-data-plane-nodes/src/components/ChangeLogLevelModal.vue
@@ -1,18 +1,22 @@
 <template>
   <KModal
-    :action-button-disabled="isSaving || !expirationValid || props.nodes.length === 0"
-    :action-button-text="i18n.t('modal.save')"
+    :action-button-disabled="stage === 'edit' && (isSaving || !expirationValid || props.nodes.length === 0)"
+    :action-button-text="actionButtonText"
     :cancel-button-disabled="isSaving"
     :cancel-button-text="i18n.t('modal.cancel')"
     data-testid="change-log-level-modal"
+    :hide-cancel-button="stage === 'status'"
     :hide-close-icon="isSaving"
     max-width="640px"
-    :title="i18n.t('modal.title')"
+    :title="title"
     :visible="visible"
     @cancel="onCancel"
-    @proceed="save"
+    @proceed="onProceed"
   >
-    <div class="change-log-level-modal-content">
+    <div
+      v-if="stage === 'edit'"
+      class="change-log-level-modal-content"
+    >
       <p class="description">
         {{ i18n.t('modal.description') }}
       </p>
@@ -54,16 +58,69 @@
         :message="errorMessage"
       />
     </div>
+
+    <div
+      v-else
+      class="change-log-level-status"
+    >
+      <KTableView
+        class="change-log-level-status-table"
+        :data="rows"
+        data-testid="log-level-status-table"
+        :headers="statusHeaders"
+        hide-pagination
+        row-key="id"
+      >
+        <template #host="{ row }">
+          <KExternalLink
+            v-if="getNodeDetailRoute"
+            hide-icon
+            :href="getNodeDetailRoute(row.id)"
+          >
+            {{ row.hostname }}
+          </KExternalLink>
+          <template v-else>
+            {{ row.hostname }}
+          </template>
+        </template>
+        <template #status="{ row }">
+          <KBadge
+            :appearance="STATUS_APPEARANCE[row.status]"
+            :data-testid="`log-level-status-${row.status}`"
+          >
+            <template #icon>
+              <component :is="STATUS_ICON[row.status]" />
+            </template>
+            {{ i18n.t(`operation_status.${row.status}`) }}
+          </KBadge>
+        </template>
+      </KTableView>
+
+      <p class="status-note">
+        <InfoIcon :size="`var(--kui-icon-size-40, ${KUI_ICON_SIZE_40})`" />
+        <span>{{ i18n.t('modal.status_note') }}</span>
+      </p>
+    </div>
   </KModal>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useAxios, useErrors } from '@kong-ui-public/entities-shared'
+import { CheckCircleIcon, DangerCircleIcon, InfoIcon, ProgressIcon, WarningIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 import composables from '../composables'
 import endpoints from '../data-plane-nodes-endpoints'
 import { LogLevel, LOG_LEVELS } from '../types'
-import type { ChangeLogLevelConfig, LogLevelOperationPayload } from '../types'
+import type {
+  ChangeLogLevelConfig,
+  LogLevelOperationPayload,
+  LogLevelOperationResponse,
+  LogLevelOperationResultsResponse,
+  LogLevelOperationStatus,
+} from '../types'
+import type { Component } from 'vue'
+import type { BadgeAppearance } from '@kong/kongponents'
 
 defineOptions({
   name: 'ChangeLogLevelModal',
@@ -72,10 +129,13 @@ defineOptions({
 const props = defineProps<{
   config: ChangeLogLevelConfig
   nodes: Array<{ id: string, hostname: string }>
+  getNodeDetailRoute?: (nodeId: string) => string
 }>()
 
 const emit = defineEmits<{
   success: []
+  close: []
+  'node-error': [payload: { id: string, hostname: string, status: 'failed' | 'unsupported' }]
 }>()
 
 const visible = defineModel<boolean>('visible')
@@ -86,11 +146,39 @@ const { getMessageFromError } = useErrors()
 
 const DEFAULT_LOG_LEVEL = LogLevel.Notice
 const DEFAULT_EXPIRATION = 600 // seconds (10 minutes)
+const POLL_INTERVAL_MS = 2000
 
+const STATUS_APPEARANCE: Record<LogLevelOperationStatus, BadgeAppearance> = {
+  in_progress: 'info',
+  applied: 'success',
+  reverted: 'neutral',
+  superseded: 'neutral',
+  failed: 'danger',
+  unsupported: 'warning',
+}
+
+const STATUS_ICON: Record<LogLevelOperationStatus, Component> = {
+  in_progress: ProgressIcon,
+  applied: CheckCircleIcon,
+  reverted: InfoIcon,
+  superseded: InfoIcon,
+  failed: DangerCircleIcon,
+  unsupported: WarningIcon,
+}
+
+const stage = ref<'edit' | 'status'>('edit')
 const targetLogLevel = ref<LogLevel>(DEFAULT_LOG_LEVEL)
 const expiration = ref<number>(DEFAULT_EXPIRATION)
 const isSaving = ref<boolean>(false)
 const errorMessage = ref<string>('')
+const operationId = ref<string>('')
+const statusByNodeId = ref<Record<string, LogLevelOperationStatus>>({})
+const pollTimeoutId = ref<ReturnType<typeof setTimeout> | null>(null)
+// Whether a polling run is active. Guards against an in-flight request rescheduling after the run
+// was stopped (e.g. the modal was reopened) while its request was still awaiting a response.
+const isPolling = ref<boolean>(false)
+// Node ids that have already emitted `node-error`, so we only emit once per node per operation.
+const erroredNodeIds = new Set<string>()
 
 const logLevelItems = computed(() => LOG_LEVELS.map((level) => ({
   label: i18n.t(`log_level.${level}`),
@@ -100,12 +188,75 @@ const logLevelItems = computed(() => LOG_LEVELS.map((level) => ({
 const expirationValid = computed(() =>
   Number.isInteger(expiration.value) && expiration.value >= 1 && expiration.value <= 3600)
 
-const buildUrl = (template: string): string => {
+const title = computed(() =>
+  stage.value === 'status' ? i18n.t('modal.status_title') : i18n.t('modal.title'))
+
+const actionButtonText = computed(() =>
+  stage.value === 'status' ? i18n.t('modal.done') : i18n.t('modal.save'))
+
+const statusHeaders = computed(() => [
+  { key: 'host', label: i18n.t('modal.node_host') },
+  { key: 'status', label: i18n.t('modal.status') },
+])
+
+const rows = computed(() => props.nodes.map((node) => ({
+  id: node.id,
+  hostname: node.hostname,
+  status: statusByNodeId.value[node.id] ?? 'in_progress' as LogLevelOperationStatus,
+})))
+
+const buildUrl = (template: string, id?: string): string => {
   let url = `${props.config.apiBaseUrl}${template}`
   if (props.config.app === 'konnect') {
     url = url.replace(/{controlPlaneId}/gi, props.config.controlPlaneId)
   }
-  return url
+  return url.replace(/{operationId}/gi, id ?? '')
+}
+
+const clearPolling = () => {
+  isPolling.value = false
+  if (pollTimeoutId.value) {
+    clearTimeout(pollTimeoutId.value)
+    pollTimeoutId.value = null
+  }
+}
+
+const pollResults = async () => {
+  try {
+    const url = buildUrl(endpoints.logLevel[props.config.app].results, operationId.value)
+    const { data } = await axiosInstance.get<LogLevelOperationResultsResponse>(url)
+    for (const result of data.data) {
+      statusByNodeId.value[result.node_id] = result.status
+      // Emit `node-error` once per node when it fails or is unsupported.
+      if ((result.status === 'failed' || result.status === 'unsupported') && !erroredNodeIds.has(result.node_id)) {
+        erroredNodeIds.add(result.node_id)
+        const hostname = props.nodes.find((node) => node.id === result.node_id)?.hostname ?? ''
+        emit('node-error', { id: result.node_id, hostname, status: result.status })
+      }
+    }
+    // Stop once every node has settled (no node is still in progress).
+    if (data.data.length > 0 && data.data.every((result) => result.status !== 'in_progress')) {
+      clearPolling()
+      return
+    }
+  } catch {
+    // Ignore the error and keep polling.
+  }
+  // The run may have been stopped (e.g. the modal was reopened) while the request was in flight.
+  if (!isPolling.value) {
+    return
+  }
+  // Poll again 2 seconds after each response, regardless of success or failure.
+  pollTimeoutId.value = setTimeout(() => {
+    pollTimeoutId.value = null
+    pollResults()
+  }, POLL_INTERVAL_MS)
+}
+
+const startPolling = () => {
+  statusByNodeId.value = {}
+  isPolling.value = true
+  pollResults()
 }
 
 const save = async () => {
@@ -119,8 +270,11 @@ const save = async () => {
       ttl: expiration.value,
       targets: { node_ids: props.nodes.map((node) => node.id) },
     }
-    await axiosInstance.post(url, payload)
+    const { data } = await axiosInstance.post<LogLevelOperationResponse>(url, payload)
+    operationId.value = data.id
     emit('success')
+    stage.value = 'status'
+    startPolling()
   } catch (error: any) {
     errorMessage.value = getMessageFromError(error)
   } finally {
@@ -128,12 +282,40 @@ const save = async () => {
   }
 }
 
+const onProceed = () => {
+  if (stage.value === 'status') {
+    onCancel()
+  } else {
+    save()
+  }
+}
+
 const onCancel = () => {
-  visible.value = false
+  // The host is responsible for closing the modal (e.g. via `v-model:visible`) in response to this
+  // event. Closing does NOT stop polling on purpose - a still-running operation keeps polling in the
+  // background; polling is stopped (and the form reset) the next time the modal is opened.
+  emit('close')
+}
+
+const reset = () => {
+  clearPolling()
+  stage.value = 'edit'
   targetLogLevel.value = DEFAULT_LOG_LEVEL
   expiration.value = DEFAULT_EXPIRATION
   errorMessage.value = ''
+  operationId.value = ''
+  statusByNodeId.value = {}
+  erroredNodeIds.clear()
 }
+
+// Reset (and stop any leftover polling from a previous run) whenever the modal is opened.
+watch(visible, (isVisible) => {
+  if (isVisible) {
+    reset()
+  }
+})
+
+onBeforeUnmount(clearPolling)
 </script>
 
 <style lang="scss" scoped>
@@ -145,6 +327,26 @@ const onCancel = () => {
   .description {
     color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger);
     margin: 0;
+  }
+}
+
+.change-log-level-status {
+  .change-log-level-status-table {
+    background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
+    border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
+  }
+
+  .status-note {
+    color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger);
+    display: flex;
+    font-size: var(--kui-font-size-30, $kui-font-size-30);
+    gap: var(--kui-space-40, $kui-space-40);
+    margin: var(--kui-space-60, $kui-space-60) 0 0 !important;
+
+    :deep(svg) {
+      flex-shrink: 0;
+      margin-top: var(--kui-space-10, $kui-space-10);
+    }
   }
 }
 </style>

--- a/packages/entities/entities-data-plane-nodes/src/data-plane-nodes-endpoints.ts
+++ b/packages/entities/entities-data-plane-nodes/src/data-plane-nodes-endpoints.ts
@@ -5,9 +5,11 @@ export default {
   logLevel: {
     konnect: {
       update: `${konnectBaseApiUrl}/nodes/log-level-operations`,
+      results: `${konnectBaseApiUrl}/nodes/log-level-operations/{operationId}/results`,
     },
     kongManager: {
       update: `${kongManagerBaseApiUrl}/data-planes/log-level-operations`,
+      results: `${kongManagerBaseApiUrl}/data-planes/log-level-operations/{operationId}/results?size=1000`,
     },
   },
 }

--- a/packages/entities/entities-data-plane-nodes/src/locales/en.json
+++ b/packages/entities/entities-data-plane-nodes/src/locales/en.json
@@ -10,7 +10,12 @@
     },
     "warning": "Higher log levels can significantly increase log volume and disk usage. Use them only while troubleshooting.",
     "save": "Save",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "done": "Done",
+    "status_title": "Change log level status",
+    "node_host": "Node host",
+    "status": "Status",
+    "status_note": "Updates typically reach all data plane nodes in about 5 seconds. Keep this modal open to monitor progress while the update is in progress."
   },
   "log_level": {
     "debug": "Debug",
@@ -19,5 +24,13 @@
     "warn": "Warn",
     "error": "Error",
     "crit": "Critical"
+  },
+  "operation_status": {
+    "in_progress": "In progress",
+    "applied": "Applied",
+    "reverted": "Reverted",
+    "superseded": "Superseded",
+    "failed": "Failed",
+    "unsupported": "Unsupported"
   }
 }

--- a/packages/entities/entities-data-plane-nodes/src/types/log-level.ts
+++ b/packages/entities/entities-data-plane-nodes/src/types/log-level.ts
@@ -22,3 +22,24 @@ export interface LogLevelOperationPayload {
   ttl: number
   targets: { node_ids: string[] }
 }
+
+export interface LogLevelOperationResponse {
+  id: string
+}
+
+export type LogLevelOperationStatus =
+  | 'in_progress'
+  | 'applied'
+  | 'reverted'
+  | 'superseded'
+  | 'failed'
+  | 'unsupported'
+
+export interface LogLevelOperationResult {
+  node_id: string
+  status: LogLevelOperationStatus
+}
+
+export interface LogLevelOperationResultsResponse {
+  data: LogLevelOperationResult[]
+}


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

Adds the post-submit **status/polling** stage to `ChangeLogLevelModal`. After the log-level operation is created, the modal now tracks per-node progress instead of just closing.

<img width="3454" height="2086" alt="Kapture 2026-07-31 at 14 21 58" src="https://github.com/user-attachments/assets/e5220cf2-6d69-4104-9335-56b9ec7f48d7" />

KM-2985