### PR TITLE
fix(entities): monaco editors active color mode theme [KHCP-21398]

### DIFF
--- a/packages/core/expressions/README.md
+++ b/packages/core/expressions/README.md
@@ -7,6 +7,7 @@ Reusable components to support [Kong's expressions language](https://developer.k
 - [Usage](#usage)
   - [Install](#install)
   - [Import and use](#import-and-use)
+  - [Color mode (light/dark theme)](#color-mode-lightdark-theme)
 - [Individual component documentation](#individual-component-documentation)
 
 ## Features
@@ -68,6 +69,20 @@ asyncInit.then(() => {
 ```
 
 You can also make use of Vue's experimental [Suspense](https://vuejs.org/guide/built-ins/suspense.html) component to load async components that use this package.
+
+### Color mode (light/dark theme)
+
+The Monaco-based editors in this package automatically match the host application's active color mode. To enable this, the host application should `provide` a `ComputedRef<'light' | 'dark'>` under the `app:konnectColorMode` injection key. When provided, the editors reactively switch between their light and dark themes as the value changes. When the key is not provided, the editors fall back to the `'light'` theme.
+
+```ts
+// In the host application (e.g. within your root component's setup)
+import { computed, provide } from 'vue'
+
+// `isDarkMode` is however your app tracks its current theme
+const colorMode = computed<'light' | 'dark'>(() => (isDarkMode.value ? 'dark' : 'light'))
+
+provide('app:konnectColorMode', colorMode)
+```
 
 ## Individual component documentation
 

--- a/packages/core/expressions/src/components/ExpressionsEditor.vue
+++ b/packages/core/expressions/src/components/ExpressionsEditor.vue
@@ -1,5 +1,6 @@
 <template>
   <MonacoEditor
+    :key="activeColorMode"
     ref="monacoEditor"
     v-model="expression"
     appearance="standalone"
@@ -8,6 +9,7 @@
     :options="editorOptions"
     :show-empty-state="false"
     :show-loading-state="false"
+    :theme="activeColorMode"
     @ready="onReady"
   />
 </template>
@@ -18,12 +20,15 @@ import { useDebounce } from '@kong-ui-public/core'
 import type { AstType, Schema as AtcSchema, ParseResult, ParseResultOk } from '@kong/atc-router'
 import { Parser } from '@kong/atc-router'
 import * as monaco from 'monaco-editor'
-import { computed, ref, toRef, useTemplateRef, watch } from 'vue'
+import { computed, inject, ref, toRef, useTemplateRef, watch } from 'vue'
 import { buildLanguageId, getTokensRange, locateStringLhsIdent, locateToken, registerLanguage, scanTokenBackward, scanTokensBidirectional, TokenType, transformTokens } from '../monaco'
 import { createSchema, type Schema } from '../schema'
 import type { ProvideCompletionItems, RhsValueCompletion } from '../types'
+import type { ComputedRef } from 'vue'
 
 import '@kong-ui-public/monaco-editor/dist/runtime/style.css'
+
+const activeColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 const { debounce } = useDebounce()
 

--- a/packages/core/expressions/src/components/RequestImportModal.vue
+++ b/packages/core/expressions/src/components/RequestImportModal.vue
@@ -20,6 +20,7 @@
     </KAlert>
 
     <MonacoEditor
+      :key="activeColorMode"
       ref="editors"
       v-model="json"
       appearance="standalone"
@@ -29,6 +30,7 @@
       :options="options"
       :show-empty-state="false"
       :show-loading-state="false"
+      :theme="activeColorMode"
     />
 
     <KAlert
@@ -40,14 +42,17 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, inject, ref } from 'vue'
 import { transformCheckRequest } from '../utils'
 import { MonacoEditor } from '@kong-ui-public/monaco-editor'
 import type { Request } from '../definitions'
 import type * as Monaco from 'monaco-editor'
 import composables from '../composables'
+import type { ComputedRef } from 'vue'
 
 import '@kong-ui-public/monaco-editor/dist/runtime/style.css'
+
+const activeColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 const { i18n, i18nT } = composables.useI18n()
 

--- a/packages/entities/entities-plugins/README.md
+++ b/packages/entities/entities-plugins/README.md
@@ -7,6 +7,7 @@ Plugin entity components.
 - [Usage](#usage)
   - [Install](#install)
   - [Registration](#registration)
+  - [Color mode (light/dark theme)](#color-mode-lightdark-theme)
 - [Individual component documentation](#individual-component-documentation)
 
 ## Requirements
@@ -41,6 +42,20 @@ Import the component(s) in your host application as well as the package styles
 ```ts
 import { PluginList, PluginSelect, PluginForm, PluginConfigCard } from '@kong-ui-public/entities-plugins'
 import '@kong-ui-public/entities-plugins/dist/style.css'
+```
+
+### Color mode (light/dark theme)
+
+Components in this package that embed a Monaco-based editor (for example the plugin free-form code editors) automatically match the host application's active color mode. To enable this, the host application should `provide` a `ComputedRef<'light' | 'dark'>` under the `app:konnectColorMode` injection key. When provided, the editors reactively switch between their light and dark themes as the value changes. When the key is not provided, the editors fall back to the `'light'` theme.
+
+```ts
+// In the host application (e.g. within your root component's setup)
+import { computed, provide } from 'vue'
+
+// `isDarkMode` is however your app tracks its current theme
+const colorMode = computed<'light' | 'dark'>(() => (isDarkMode.value ? 'dark' : 'light'))
+
+provide('app:konnectColorMode', colorMode)
 ```
 
 ## Individual component documentation

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/CodeEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/CodeEditor.vue
@@ -26,7 +26,7 @@
       class="editor"
       language="yaml"
       :options="monacoOptions"
-      theme="light"
+      :theme="activeColorMode"
       @ready="handleEditorReady"
     />
 
@@ -43,7 +43,7 @@
 </template>
 
 <script setup lang="ts">
-import { shallowRef, toRaw } from 'vue'
+import { computed, inject, shallowRef, toRaw } from 'vue'
 import { isEqual, omit } from 'lodash-es'
 import * as monaco from 'monaco-editor'
 import yaml, { JSON_SCHEMA } from 'js-yaml'
@@ -58,9 +58,12 @@ import { useFormShared } from '../../shared/composables'
 import examples from './examples'
 import { extractors } from './config-extractors'
 
+import type { ComputedRef } from 'vue'
 import type { YAMLException } from 'js-yaml'
 import type { DatakitPluginData } from './types'
 import type { DatakitExample } from './examples'
+
+const activeColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 const { t } = createI18n<typeof english>('en-us', english)
 type TranslationKey = Parameters<typeof t>[0]

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/CodeEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/CodeEditor.vue
@@ -20,6 +20,7 @@
       </template>
     </KAlert>
     <MonacoEditor
+      :key="activeColorMode"
       ref="editor"
       v-model="code"
       appearance="standalone"

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/side-panel/CacheField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/side-panel/CacheField.vue
@@ -116,7 +116,7 @@
             appearance="standalone"
             class="redis-editor"
             language="yaml"
-            theme="light"
+            :theme="activeColorMode"
           />
           <p
             v-if="redisYamlError"
@@ -151,8 +151,11 @@ import Field from '../../../../shared/Field.vue'
 import RadioField from '../../../../shared/RadioField.vue'
 import { useField, useFormShared } from '../../../../shared/composables'
 
+import type { ComputedRef } from 'vue'
 import type { CodeBlockEventData } from '@kong/kongponents'
 import type { CacheConfigFormData } from '../../types'
+
+const activeColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 const DEFAULT_REDIS_YAML = yaml.dump({ host: '127.0.0.1', port: 6379 }, { indent: 2 })
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/side-panel/CacheField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/side-panel/CacheField.vue
@@ -112,6 +112,7 @@
             {{ t('plugins.free-form.datakit.flow_editor.panel_segments.resources.cache.inline_config') }}
           </KLabel>
           <MonacoEditor
+            :key="activeColorMode"
             v-model="redisYaml"
             appearance="standalone"
             class="redis-editor"

--- a/packages/entities/entities-plugins/src/components/free-form/shared/CodeEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/CodeEditor.vue
@@ -4,6 +4,7 @@
     data-testid="plugin-code-editor"
   >
     <MonacoEditor
+      :key="activeColorMode"
       ref="editor"
       v-model="code"
       class="editor"

--- a/packages/entities/entities-plugins/src/components/free-form/shared/CodeEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/CodeEditor.vue
@@ -9,7 +9,7 @@
       class="editor"
       language="yaml"
       :options="monacoOptions"
-      theme="light"
+      :theme="activeColorMode"
       @ready="handleEditorReady"
     />
   </div>
@@ -21,7 +21,7 @@ import { MonacoEditor } from '@kong-ui-public/monaco-editor'
 import yaml, { JSON_SCHEMA } from 'js-yaml'
 import { omit } from 'lodash-es'
 import * as monaco from 'monaco-editor'
-import { inject, shallowRef, toRaw } from 'vue'
+import { computed, inject, shallowRef, toRaw, type ComputedRef } from 'vue'
 
 import { useFormShared } from '../shared/composables'
 import { useCodeLensProviders } from './composables/code-lens-providers'
@@ -29,6 +29,8 @@ import { useCodeLensProviders } from './composables/code-lens-providers'
 import '@kong-ui-public/monaco-editor/dist/runtime/style.css'
 
 import type { KongManagerPluginFormConfig, KonnectPluginFormConfig } from '../../../types'
+
+const activeColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 const config = inject<KonnectPluginFormConfig | KongManagerPluginFormConfig>(FORMS_CONFIG)!
 const { formData, setValue } = useFormShared()

--- a/packages/entities/entities-shared/README.md
+++ b/packages/entities/entities-shared/README.md
@@ -9,6 +9,7 @@ Shared components for Kong entities.
 - [Usage](#usage)
   - [Install](#install)
   - [Registration](#registration)
+  - [Color mode (light/dark theme)](#color-mode-lightdark-theme)
 - [Individual component documentation](#individual-component-documentation)
 - [Individual composables documentation](#individual-composables-documentation)
 - [Sandbox shared utilities](#sandbox-shared-utilities)
@@ -67,6 +68,20 @@ Import the component in your host application
 ```ts
 import { EntityDeleteModal, EntityBaseTable } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
+```
+
+### Color mode (light/dark theme)
+
+Components in this package that embed a Monaco-based editor (for example `DeckCommandEditor`) automatically match the host application's active color mode. To enable this, the host application should `provide` a `ComputedRef<'light' | 'dark'>` under the `app:konnectColorMode` injection key. When provided, the editors reactively switch between their light and dark themes as the value changes. When the key is not provided, the editors fall back to the `'light'` theme.
+
+```ts
+// In the host application (e.g. within your root component's setup)
+import { computed, provide } from 'vue'
+
+// `isDarkMode` is however your app tracks its current theme
+const colorMode = computed<'light' | 'dark'>(() => (isDarkMode.value ? 'dark' : 'light'))
+
+provide('app:konnectColorMode', colorMode)
 ```
 
 ## Individual component documentation

--- a/packages/entities/entities-shared/src/components/common/DeckCommandEditor.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCommandEditor.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="deck-command-editor-wrapper">
     <MonacoEditor
+      :key="activeColorMode"
       v-model="code"
       appearance="standalone"
       class="deck-command-editor"

--- a/packages/entities/entities-shared/src/components/common/DeckCommandEditor.vue
+++ b/packages/entities/entities-shared/src/components/common/DeckCommandEditor.vue
@@ -6,7 +6,7 @@
       class="deck-command-editor"
       :language="language"
       :options="monacoOptions"
-      theme="light"
+      :theme="activeColorMode"
     />
     <div class="deck-command-copy-button">
       <KCodeBlockIconButton
@@ -31,6 +31,10 @@ import '@kong-ui-public/monaco-editor/dist/runtime/style.css'
 import composables from '../../composables'
 
 import type * as monaco from 'monaco-editor'
+import { computed, inject } from 'vue'
+import type { ComputedRef } from 'vue'
+
+const activeColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 defineProps<{
   language: 'bash' | 'powershell'


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-21398

Before

<img width="1505" height="1005" alt="Screenshot 2026-07-31 at 9 38 52 AM" src="https://github.com/user-attachments/assets/bb3a5c99-9f55-4431-b9ad-22a2bc8a2b8a" />

After

<img width="1504" height="1007" alt="Screenshot 2026-07-31 at 9 39 28 AM" src="https://github.com/user-attachments/assets/bd436cea-7da4-412f-aaf7-1ae07e35cf03" />

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
