### PR TITLE
feat: add cache translations MA-5131

### DIFF
--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -220,7 +220,18 @@
     "request_type": "Request type",
     "topic_name": "Topic name",
     "partition_index": "Partition index",
-    "api_key": "API key"
+    "api_key": "API key",
+    "data_plane_group": "Data plane group",
+    "managed_cache": "Managed cache",
+    "network": "Network",
+    "provider": "Provider",
+    "region": "Region",
+    "cache_eviction_rate": "Cache eviction rate",
+    "cache_expiration_rate": "Cache expiration rate",
+    "cache_items_average": "Cache items (avg)",
+    "cache_memory_utilization_max": "Cache memory utilization (max)",
+    "cache_status": "Cache status",
+    "cache_hit_rate": "Cache hit rate"
   },
   "metricAxisTitles": {
     "error_rate": "Error rate in {unit}",
@@ -303,7 +314,11 @@
     "route_count": "Route count",
     "consumer_count": "Consumer count",
     "plugin_count": "Plugin count",
-    "node_count": "Data plane node count"
+    "node_count": "Data plane node count",
+    "cache_eviction_rate": "Cache eviction rate in {unit}",
+    "cache_expiration_rate": "Cache expiration rate in {unit}",
+    "cache_items_average": "Cache items (avg) in {unit}",
+    "cache_memory_utilization_max": "Cache memory utilization (max) in {unit}"
   },
   "granularityAxisTitles": {
     "tenSecondly": "@timestamp per 10 seconds",

--- a/packages/analytics/analytics-geo-map/src/locales/en.json
+++ b/packages/analytics/analytics-geo-map/src/locales/en.json
@@ -31,7 +31,8 @@
     "request_size_p99": "Request size (p99)",
     "request_size_p95": "Request size (p95)",
     "request_size_p50": "Request size (p50)",
-    "request_size_sum": "Request size (sum)"
+    "request_size_sum": "Request size (sum)",
+    "cache_hit_rate": "Cache hit rate"
   },
   "cooperative_gestures": {
     "windows_zoom_help_text": "Use Ctrl + Scroll to zoom the map",

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -214,7 +214,17 @@
     "request_type": "Request type",
     "topic_name": "Topic name",
     "partition_index": "Partition index",
-    "api_key": "API key"
+    "api_key": "API key",
+    "data_plane_group": "Data plane group",
+    "managed_cache": "Managed cache",
+    "network": "Network",
+    "provider": "Provider",
+    "cache_eviction_rate": "Cache eviction rate",
+    "cache_expiration_rate": "Cache expiration rate",
+    "cache_items_average": "Cache items (avg)",
+    "cache_memory_utilization_max": "Cache memory utilization (max)",
+    "cache_status": "Cache status",
+    "cache_hit_rate": "Cache hit rate"
   },
   "jumpToExplore": "Explore",
   "jumpToRequests": "View requests",


### PR DESCRIPTION
# Summary
Add translations for new managed cache datasource and new fields (`cache_status`, `cache_hit_rate`) in API usage datasource


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
