### PR TITLE
feat(entities-gateway-services): require force delete confirmation for services with routes

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -880,7 +880,7 @@ describe('<GatewayServiceList />', () => {
 
       openDeleteModal()
 
-      cy.get(`${modal} .message`).should('contain.text', `Are you sure you want to delete this service ${serviceName}? This action cannot be reversed.`)
+      cy.get(`${modal} .message`).should('contain.text', `Are you sure you want to delete this service ${serviceName}?`)
       cy.get(`${modal} .extra`).should('not.exist')
       cy.getTestId('gateway-service-delete-force-checkbox').should('not.exist')
 
@@ -899,7 +899,8 @@ describe('<GatewayServiceList />', () => {
 
       openDeleteModal()
 
-      cy.get(`${modal} .extra`).should('contain.text', '2 routes').and('contain.text', '1 plugin')
+      cy.get(`${modal} .extra`).should('contain.text', 'Force delete')
+        .and('contain.text', 'Check this box to force deletion of all routes and plugins on linked service.')
       cy.getTestId('gateway-service-delete-force-checkbox').should('exist')
 
       cy.getTestId('confirmation-input').type(serviceName)
@@ -930,9 +931,10 @@ describe('<GatewayServiceList />', () => {
     })
 
     it('prefers a server-provided total over the fetched page length', () => {
+      // The routes page happens to come back empty, but the server-reported total says otherwise
       cy.intercept(
         { method: 'GET', url: `${servicesUrl}/${serviceId}/routes*` },
-        { statusCode: 200, body: { data: [{ id: 'route-1' }], total: 5 } },
+        { statusCode: 200, body: { data: [], total: 5 } },
       ).as('getRoutes')
       cy.intercept(
         { method: 'GET', url: `${servicesUrl}/${serviceId}/plugins*` },
@@ -941,7 +943,7 @@ describe('<GatewayServiceList />', () => {
 
       openDeleteModal()
 
-      cy.get(`${modal} .extra`).should('contain.text', '5 routes')
+      cy.getTestId('gateway-service-delete-force-checkbox').should('exist')
     })
 
     it('fails closed and requires force delete when the related-entities check errors out', () => {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -6,6 +6,7 @@ import type { KongManagerGatewayServiceListConfig, KonnectGatewayServiceListConf
 import type { FetcherRawResponse } from '../../fixtures/mockData'
 import {
   paginate,
+  gatewayService1,
   gatewayServices,
   gatewayServices100,
 } from '../../fixtures/mockData'
@@ -819,6 +820,112 @@ describe('<GatewayServiceList />', () => {
       cy.get(`${l} tbody tr[data-testid="gateway-service-50"]`).should('exist')
 
       cy.get(`${l} ${p} [data-testid="page-size-dropdown"]`).contains('50 items per page')
+    })
+  })
+
+  describe('delete flow (Konnect)', () => {
+    const serviceId = gatewayService1.id
+    const serviceName = gatewayService1.name
+    const servicesUrl = `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/services`
+    const modal = '.kong-ui-entity-delete-modal'
+
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${servicesUrl}*`,
+        },
+        {
+          statusCode: 200,
+          body: gatewayServices,
+        },
+      )
+    })
+
+    const interceptRelatedEntities = (routes: any[], plugins: any[]) => {
+      cy.intercept(
+        { method: 'GET', url: `${servicesUrl}/${serviceId}/routes*` },
+        { statusCode: 200, body: { data: routes } },
+      ).as('getRoutes')
+      cy.intercept(
+        { method: 'GET', url: `${servicesUrl}/${serviceId}/plugins*` },
+        { statusCode: 200, body: { data: plugins } },
+      ).as('getPlugins')
+    }
+
+    const openDeleteModal = () => {
+      cy.mount(GatewayServiceList, {
+        props: {
+          cacheIdentifier: `gateway-service-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => true,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.getTestId('row-actions-dropdown-trigger').eq(0).click()
+      cy.get(`[data-testid="${serviceName}-actions-dropdown-popover"] [data-testid="action-entity-delete"]`).click()
+
+      cy.wait(['@getRoutes', '@getPlugins'])
+    }
+
+    it('keeps the existing behavior when the service has no routes or plugins', () => {
+      interceptRelatedEntities([], [])
+      cy.intercept(
+        { method: 'DELETE', url: `${servicesUrl}/${serviceId}*` },
+        { statusCode: 204 },
+      ).as('deleteService')
+
+      openDeleteModal()
+
+      cy.get(`${modal} .extra`).should('not.exist')
+      cy.getTestId('gateway-service-delete-force-checkbox').should('not.exist')
+
+      cy.getTestId('confirmation-input').type(serviceName)
+      cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled').click()
+
+      cy.wait('@deleteService').its('request.url').should('not.include', 'force')
+    })
+
+    it('requires the force-delete checkbox and sends force=true when the service has routes', () => {
+      interceptRelatedEntities([{ id: 'route-1' }, { id: 'route-2' }], [{ id: 'plugin-1' }])
+      cy.intercept(
+        { method: 'DELETE', url: `${servicesUrl}/${serviceId}*` },
+        { statusCode: 204 },
+      ).as('deleteService')
+
+      openDeleteModal()
+
+      cy.get(`${modal} .extra`).should('contain.text', '2 routes').and('contain.text', '1 plugin')
+      cy.getTestId('gateway-service-delete-force-checkbox').should('exist')
+
+      cy.getTestId('confirmation-input').type(serviceName)
+      cy.get(`${modal} [data-testid="modal-action-button"]`).should('be.disabled')
+
+      cy.getTestId('gateway-service-delete-force-checkbox').click()
+      cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled').click()
+
+      cy.wait('@deleteService').its('request.url').should('include', 'force=true')
+    })
+
+    it('shows the plugin count without a checkbox and deletes without force when the service only has plugins', () => {
+      interceptRelatedEntities([], [{ id: 'plugin-1' }])
+      cy.intercept(
+        { method: 'DELETE', url: `${servicesUrl}/${serviceId}*` },
+        { statusCode: 204 },
+      ).as('deleteService')
+
+      openDeleteModal()
+
+      cy.get(`${modal} .extra`).should('contain.text', '1 plugin')
+      cy.getTestId('gateway-service-delete-force-checkbox').should('not.exist')
+
+      cy.getTestId('confirmation-input').type(serviceName)
+      cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled').click()
+
+      cy.wait('@deleteService').its('request.url').should('not.include', 'force')
     })
   })
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -880,6 +880,7 @@ describe('<GatewayServiceList />', () => {
 
       openDeleteModal()
 
+      cy.get(`${modal} .message`).should('contain.text', `Are you sure you want to delete this service ${serviceName}? This action cannot be reversed.`)
       cy.get(`${modal} .extra`).should('not.exist')
       cy.getTestId('gateway-service-delete-force-checkbox').should('not.exist')
 
@@ -919,7 +920,7 @@ describe('<GatewayServiceList />', () => {
 
       openDeleteModal()
 
-      cy.get(`${modal} .extra`).should('contain.text', '1 plugin')
+      cy.get(`${modal} .extra`).should('contain.text', '1 associated plugin will be deleted')
       cy.getTestId('gateway-service-delete-force-checkbox').should('not.exist')
 
       cy.getTestId('confirmation-input').type(serviceName)

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -927,6 +927,49 @@ describe('<GatewayServiceList />', () => {
 
       cy.wait('@deleteService').its('request.url').should('not.include', 'force')
     })
+
+    it('prefers a server-provided total over the fetched page length', () => {
+      cy.intercept(
+        { method: 'GET', url: `${servicesUrl}/${serviceId}/routes*` },
+        { statusCode: 200, body: { data: [{ id: 'route-1' }], total: 5 } },
+      ).as('getRoutes')
+      cy.intercept(
+        { method: 'GET', url: `${servicesUrl}/${serviceId}/plugins*` },
+        { statusCode: 200, body: { data: [] } },
+      ).as('getPlugins')
+
+      openDeleteModal()
+
+      cy.get(`${modal} .extra`).should('contain.text', '5 routes')
+    })
+
+    it('fails closed and requires force delete when the related-entities check errors out', () => {
+      cy.intercept(
+        { method: 'GET', url: `${servicesUrl}/${serviceId}/routes*` },
+        { statusCode: 500, body: {} },
+      ).as('getRoutes')
+      cy.intercept(
+        { method: 'GET', url: `${servicesUrl}/${serviceId}/plugins*` },
+        { statusCode: 200, body: { data: [] } },
+      ).as('getPlugins')
+      cy.intercept(
+        { method: 'DELETE', url: `${servicesUrl}/${serviceId}*` },
+        { statusCode: 204 },
+      ).as('deleteService')
+
+      openDeleteModal()
+
+      cy.get(`${modal} .extra`).should('be.visible')
+      cy.getTestId('gateway-service-delete-force-checkbox').should('exist')
+
+      cy.getTestId('confirmation-input').type(serviceName)
+      cy.get(`${modal} [data-testid="modal-action-button"]`).should('be.disabled')
+
+      cy.getTestId('gateway-service-delete-force-checkbox').click()
+      cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled').click()
+
+      cy.wait('@deleteService').its('request.url').should('include', 'force=true')
+    })
   })
 
   describe('Konnect - workspace URL building', () => {

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -240,26 +240,18 @@
       @cancel="hideDeleteModal"
       @proceed="deleteRow"
     >
-      <template #message>
-        <i18nT
-          class="message"
-          keypath="actions.delete.confirm_message"
-          tag="p"
-        >
-          <template #entityName>
-            <strong>{{ gatewayServiceToBeDeleted && (gatewayServiceToBeDeleted.name || gatewayServiceToBeDeleted.id) }}</strong>
-          </template>
-        </i18nT>
-      </template>
       <template
         v-if="hasRelatedEntities"
         #extra
       >
-        <p>{{ relatedEntitiesMessage }}</p>
+        <p v-if="relatedEntitiesCheckFailed || !requiresForceDelete">
+          {{ relatedEntitiesMessage }}
+        </p>
         <KCheckbox
           v-if="requiresForceDelete"
           v-model="forceDeleteConfirmed"
           data-testid="gateway-service-delete-force-checkbox"
+          :description="t('actions.delete.related_entities.force_delete_help')"
           :label="t('actions.delete.related_entities.force_delete_checkbox')"
         />
       </template>
@@ -379,7 +371,7 @@ const props = defineProps({
   },
 })
 
-const { i18n: { t, formatUnixTimeStamp }, i18nT } = composables.useI18n()
+const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)
@@ -684,29 +676,13 @@ const hasRelatedEntities = computed((): boolean =>
 // requires an explicit force delete confirmation
 const requiresForceDelete = computed((): boolean => relatedEntitiesCheckFailed.value || relatedRoutesCount.value > 0)
 
+// Only shown when the service has no routes (the checkbox + help text cover the routes case)
 const relatedEntitiesMessage = computed((): string => {
   if (relatedEntitiesCheckFailed.value) {
     return t('actions.delete.related_entities.check_failed')
   }
 
-  const routeCount = relatedRoutesCount.value
   const pluginCount = relatedPluginsCount.value
-
-  if (routeCount > 0 && pluginCount > 0) {
-    return t('actions.delete.related_entities.both', {
-      routeCount,
-      route: t('actions.delete.related_entities.route', { count: routeCount }),
-      pluginCount,
-      plugin: t('actions.delete.related_entities.plugin', { count: pluginCount }),
-    })
-  }
-
-  if (routeCount > 0) {
-    return t('actions.delete.related_entities.routes_only', {
-      routeCount,
-      route: t('actions.delete.related_entities.route', { count: routeCount }),
-    })
-  }
 
   return t('actions.delete.related_entities.plugins_only', {
     pluginCount,

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -232,7 +232,6 @@
     <EntityDeleteModal
       :action-pending="isDeletePending"
       :confirm-disabled="requiresForceDelete && !forceDeleteConfirmed"
-      :description="t('actions.delete.description')"
       :entity-name="gatewayServiceToBeDeleted && (gatewayServiceToBeDeleted.name || gatewayServiceToBeDeleted.id)"
       :entity-type="EntityTypes.GatewayService"
       :error="deleteModalError"
@@ -241,6 +240,17 @@
       @cancel="hideDeleteModal"
       @proceed="deleteRow"
     >
+      <template #message>
+        <i18nT
+          class="message"
+          keypath="actions.delete.confirm_message"
+          tag="p"
+        >
+          <template #entityName>
+            <strong>{{ gatewayServiceToBeDeleted && (gatewayServiceToBeDeleted.name || gatewayServiceToBeDeleted.id) }}</strong>
+          </template>
+        </i18nT>
+      </template>
       <template
         v-if="hasRelatedEntities"
         #extra
@@ -369,7 +379,7 @@ const props = defineProps({
   },
 })
 
-const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
+const { i18n: { t, formatUnixTimeStamp }, i18nT } = composables.useI18n()
 const router = useRouter()
 
 const { axiosInstance } = useAxios(props.config?.axiosRequestConfig)

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -664,12 +664,21 @@ const buildDeleteUrl = useDeleteUrlBuilder(props.config, fetcherBaseUrl.value)
 const relatedRoutesCount = ref<number>(0)
 const relatedPluginsCount = ref<number>(0)
 const forceDeleteConfirmed = ref<boolean>(false)
+// If the related-entities check fails, fail closed: treat the service as if it has routes
+// attached rather than silently allowing an unprotected delete
+const relatedEntitiesCheckFailed = ref<boolean>(false)
 
-const hasRelatedEntities = computed((): boolean => relatedRoutesCount.value > 0 || relatedPluginsCount.value > 0)
-// A service that still has routes attached requires an explicit force delete confirmation
-const requiresForceDelete = computed((): boolean => relatedRoutesCount.value > 0)
+const hasRelatedEntities = computed((): boolean =>
+  relatedEntitiesCheckFailed.value || relatedRoutesCount.value > 0 || relatedPluginsCount.value > 0)
+// A service that still has routes attached (or whose related-entities count couldn't be verified)
+// requires an explicit force delete confirmation
+const requiresForceDelete = computed((): boolean => relatedEntitiesCheckFailed.value || relatedRoutesCount.value > 0)
 
 const relatedEntitiesMessage = computed((): string => {
+  if (relatedEntitiesCheckFailed.value) {
+    return t('actions.delete.related_entities.check_failed')
+  }
+
   const routeCount = relatedRoutesCount.value
   const pluginCount = relatedPluginsCount.value
 
@@ -700,15 +709,10 @@ const RELATED_ENTITIES_FETCH_SIZE = 1000
 
 const fetchRelatedEntityCount = async (endpoint: string, serviceId: string): Promise<number> => {
   const url = buildFetcherUrl(endpoint).replace(/{id}/gi, serviceId)
+  const { data } = await axiosInstance.get(url, { params: { size: RELATED_ENTITIES_FETCH_SIZE } })
 
-  try {
-    const { data } = await axiosInstance.get(url, { params: { size: RELATED_ENTITIES_FETCH_SIZE } })
-
-    return data?.data?.length ?? 0
-  } catch {
-    // If the count can't be determined, fall back to the existing (no-related-entities) behavior
-    return 0
-  }
+  // Prefer a server-provided total if the endpoint returns one; it may exceed the fetched page size
+  return data?.total ?? data?.data?.length ?? 0
 }
 
 const confirmDelete = async (row: EntityRow): Promise<void> => {
@@ -717,15 +721,20 @@ const confirmDelete = async (row: EntityRow): Promise<void> => {
   forceDeleteConfirmed.value = false
   relatedRoutesCount.value = 0
   relatedPluginsCount.value = 0
+  relatedEntitiesCheckFailed.value = false
 
   if (props.config.app === 'konnect') {
-    const [routesCount, pluginsCount] = await Promise.all([
-      fetchRelatedEntityCount(endpoints.relatedEntities.konnect.routes, row.id as string),
-      fetchRelatedEntityCount(endpoints.relatedEntities.konnect.plugins, row.id as string),
-    ])
+    try {
+      const [routesCount, pluginsCount] = await Promise.all([
+        fetchRelatedEntityCount(endpoints.relatedEntities.konnect.routes, row.id as string),
+        fetchRelatedEntityCount(endpoints.relatedEntities.konnect.plugins, row.id as string),
+      ])
 
-    relatedRoutesCount.value = routesCount
-    relatedPluginsCount.value = pluginsCount
+      relatedRoutesCount.value = routesCount
+      relatedPluginsCount.value = pluginsCount
+    } catch {
+      relatedEntitiesCheckFailed.value = true
+    }
   }
 
   isDeleteModalVisible.value = true
@@ -745,7 +754,9 @@ const deleteRow = async (): Promise<void> => {
 
   try {
     await axiosInstance.delete(buildDeleteUrl(gatewayServiceToBeDeleted.value.id), {
-      ...(requiresForceDelete.value ? { params: { force: true } } : {}),
+      // Only ever send force=true when the user has explicitly confirmed it via the checkbox,
+      // not merely because routes/plugins were detected
+      ...(forceDeleteConfirmed.value ? { params: { force: true } } : {}),
     })
 
     // Emit the success event for the host app

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -231,6 +231,7 @@
 
     <EntityDeleteModal
       :action-pending="isDeletePending"
+      :confirm-disabled="requiresForceDelete && !forceDeleteConfirmed"
       :description="t('actions.delete.description')"
       :entity-name="gatewayServiceToBeDeleted && (gatewayServiceToBeDeleted.name || gatewayServiceToBeDeleted.id)"
       :entity-type="EntityTypes.GatewayService"
@@ -239,7 +240,20 @@
       :visible="isDeleteModalVisible"
       @cancel="hideDeleteModal"
       @proceed="deleteRow"
-    />
+    >
+      <template
+        v-if="hasRelatedEntities"
+        #extra
+      >
+        <p>{{ relatedEntitiesMessage }}</p>
+        <KCheckbox
+          v-if="requiresForceDelete"
+          v-model="forceDeleteConfirmed"
+          data-testid="gateway-service-delete-force-checkbox"
+          :label="t('actions.delete.related_entities.force_delete_checkbox')"
+        />
+      </template>
+    </EntityDeleteModal>
   </div>
 </template>
 
@@ -646,10 +660,75 @@ const deleteModalError = ref<string>('')
 
 const buildDeleteUrl = useDeleteUrlBuilder(props.config, fetcherBaseUrl.value)
 
-const confirmDelete = (row: EntityRow): void => {
+// Number of routes/plugins currently attached to the gateway service being deleted (Konnect only)
+const relatedRoutesCount = ref<number>(0)
+const relatedPluginsCount = ref<number>(0)
+const forceDeleteConfirmed = ref<boolean>(false)
+
+const hasRelatedEntities = computed((): boolean => relatedRoutesCount.value > 0 || relatedPluginsCount.value > 0)
+// A service that still has routes attached requires an explicit force delete confirmation
+const requiresForceDelete = computed((): boolean => relatedRoutesCount.value > 0)
+
+const relatedEntitiesMessage = computed((): string => {
+  const routeCount = relatedRoutesCount.value
+  const pluginCount = relatedPluginsCount.value
+
+  if (routeCount > 0 && pluginCount > 0) {
+    return t('actions.delete.related_entities.both', {
+      routeCount,
+      route: t('actions.delete.related_entities.route', { count: routeCount }),
+      pluginCount,
+      plugin: t('actions.delete.related_entities.plugin', { count: pluginCount }),
+    })
+  }
+
+  if (routeCount > 0) {
+    return t('actions.delete.related_entities.routes_only', {
+      routeCount,
+      route: t('actions.delete.related_entities.route', { count: routeCount }),
+    })
+  }
+
+  return t('actions.delete.related_entities.plugins_only', {
+    pluginCount,
+    plugin: t('actions.delete.related_entities.plugin', { count: pluginCount }),
+  })
+})
+
+// Cap on the number of related entities we'll count before showing the delete modal
+const RELATED_ENTITIES_FETCH_SIZE = 1000
+
+const fetchRelatedEntityCount = async (endpoint: string, serviceId: string): Promise<number> => {
+  const url = buildFetcherUrl(endpoint).replace(/{id}/gi, serviceId)
+
+  try {
+    const { data } = await axiosInstance.get(url, { params: { size: RELATED_ENTITIES_FETCH_SIZE } })
+
+    return data?.data?.length ?? 0
+  } catch {
+    // If the count can't be determined, fall back to the existing (no-related-entities) behavior
+    return 0
+  }
+}
+
+const confirmDelete = async (row: EntityRow): Promise<void> => {
   gatewayServiceToBeDeleted.value = row
-  isDeleteModalVisible.value = true
   deleteModalError.value = ''
+  forceDeleteConfirmed.value = false
+  relatedRoutesCount.value = 0
+  relatedPluginsCount.value = 0
+
+  if (props.config.app === 'konnect') {
+    const [routesCount, pluginsCount] = await Promise.all([
+      fetchRelatedEntityCount(endpoints.relatedEntities.konnect.routes, row.id as string),
+      fetchRelatedEntityCount(endpoints.relatedEntities.konnect.plugins, row.id as string),
+    ])
+
+    relatedRoutesCount.value = routesCount
+    relatedPluginsCount.value = pluginsCount
+  }
+
+  isDeleteModalVisible.value = true
 }
 
 const hideDeleteModal = (): void => {
@@ -665,7 +744,9 @@ const deleteRow = async (): Promise<void> => {
   isDeletePending.value = true
 
   try {
-    await axiosInstance.delete(buildDeleteUrl(gatewayServiceToBeDeleted.value.id))
+    await axiosInstance.delete(buildDeleteUrl(gatewayServiceToBeDeleted.value.id), {
+      ...(requiresForceDelete.value ? { params: { force: true } } : {}),
+    })
 
     // Emit the success event for the host app
     emit('delete:success', gatewayServiceToBeDeleted.value)

--- a/packages/entities/entities-gateway-services/src/gateway-services-endpoints.ts
+++ b/packages/entities/entities-gateway-services/src/gateway-services-endpoints.ts
@@ -21,4 +21,10 @@ export default {
       edit: `${KMBaseApiUrl}/services/{id}`,
     },
   },
+  relatedEntities: {
+    konnect: {
+      routes: `${konnectBaseApiUrl}/services/{id}/routes`,
+      plugins: `${konnectBaseApiUrl}/services/{id}/plugins`,
+    },
+  },
 }

--- a/packages/entities/entities-gateway-services/src/locales/en.json
+++ b/packages/entities/entities-gateway-services/src/locales/en.json
@@ -10,16 +10,13 @@
     "view": "View details",
     "delete": {
       "title": "Delete a gateway service",
-      "confirm_message": "Are you sure you want to delete this service {entityName}? This action cannot be reversed.",
       "menu_label": "Delete",
       "related_entities": {
-        "both": "This gateway service currently has {routeCount} {route} and {pluginCount} {plugin}.",
-        "routes_only": "This gateway service currently has {routeCount} {route}.",
         "plugins_only": "{pluginCount} associated {plugin} will be deleted along with this gateway service.",
         "check_failed": "We couldn't verify whether this gateway service has routes or plugins attached. Check the box below to force delete it anyway.",
-        "route": "{count, plural, one {route} other {routes}}",
         "plugin": "{count, plural, one {plugin} other {plugins}}",
-        "force_delete_checkbox": "Force delete all entities"
+        "force_delete_checkbox": "Force delete",
+        "force_delete_help": "Check this box to force deletion of all routes and plugins on linked service."
       }
     }
   },

--- a/packages/entities/entities-gateway-services/src/locales/en.json
+++ b/packages/entities/entities-gateway-services/src/locales/en.json
@@ -10,12 +10,12 @@
     "view": "View details",
     "delete": {
       "title": "Delete a gateway service",
-      "description": "Deleting this gateway service will also remove any associated plugins. This action cannot be reversed.",
+      "confirm_message": "Are you sure you want to delete this service {entityName}? This action cannot be reversed.",
       "menu_label": "Delete",
       "related_entities": {
         "both": "This gateway service currently has {routeCount} {route} and {pluginCount} {plugin}.",
         "routes_only": "This gateway service currently has {routeCount} {route}.",
-        "plugins_only": "This gateway service currently has {pluginCount} {plugin}.",
+        "plugins_only": "{pluginCount} associated {plugin} will be deleted along with this gateway service.",
         "check_failed": "We couldn't verify whether this gateway service has routes or plugins attached. Check the box below to force delete it anyway.",
         "route": "{count, plural, one {route} other {routes}}",
         "plugin": "{count, plural, one {plugin} other {plugins}}",

--- a/packages/entities/entities-gateway-services/src/locales/en.json
+++ b/packages/entities/entities-gateway-services/src/locales/en.json
@@ -16,6 +16,7 @@
         "both": "This gateway service currently has {routeCount} {route} and {pluginCount} {plugin}.",
         "routes_only": "This gateway service currently has {routeCount} {route}.",
         "plugins_only": "This gateway service currently has {pluginCount} {plugin}.",
+        "check_failed": "We couldn't verify whether this gateway service has routes or plugins attached. Check the box below to force delete it anyway.",
         "route": "{count, plural, one {route} other {routes}}",
         "plugin": "{count, plural, one {plugin} other {plugins}}",
         "force_delete_checkbox": "Force delete all entities"

--- a/packages/entities/entities-gateway-services/src/locales/en.json
+++ b/packages/entities/entities-gateway-services/src/locales/en.json
@@ -11,7 +11,15 @@
     "delete": {
       "title": "Delete a gateway service",
       "description": "Deleting this gateway service will also remove any associated plugins. This action cannot be reversed.",
-      "menu_label": "Delete"
+      "menu_label": "Delete",
+      "related_entities": {
+        "both": "This gateway service currently has {routeCount} {route} and {pluginCount} {plugin}.",
+        "routes_only": "This gateway service currently has {routeCount} {route}.",
+        "plugins_only": "This gateway service currently has {pluginCount} {plugin}.",
+        "route": "{count, plural, one {route} other {routes}}",
+        "plugin": "{count, plural, one {plugin} other {plugins}}",
+        "force_delete_checkbox": "Force delete all entities"
+      }
     }
   },
   "search": {

--- a/packages/entities/entities-shared/src/components/entity-delete-modal/EntityDeleteModal.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-delete-modal/EntityDeleteModal.cy.ts
@@ -100,4 +100,43 @@ describe('<EntityDeleteModal />', () => {
     cy.get('.modal-header').should('contain.text', title)
     cy.get('.kong-ui-entity-delete-modal .description').should('contain.text', description)
   })
+
+  it('should show extra slot content', () => {
+    const extraContent = 'Force delete all entities'
+
+    cy.mount(EntityDeleteModalMount, {
+      props: {
+        visible: true,
+        entityType,
+      },
+      slots: {
+        extra: h('span', extraContent),
+      },
+    })
+
+    cy.get('.kong-ui-entity-delete-modal .extra').should('contain.text', extraContent)
+  })
+
+  it('should not render extra container when extra slot is not used', () => {
+    cy.mount(EntityDeleteModalMount, {
+      props: {
+        visible: true,
+        entityType,
+      },
+    })
+
+    cy.get('.kong-ui-entity-delete-modal .extra').should('not.exist')
+  })
+
+  it('should disable action button when confirmDisabled is true', () => {
+    cy.mount(EntityDeleteModalMount, {
+      props: {
+        visible: true,
+        entityType,
+        confirmDisabled: true,
+      },
+    })
+
+    cy.getTestId('modal-action-button').should('be.disabled')
+  })
 })

--- a/packages/entities/entities-shared/src/components/entity-delete-modal/EntityDeleteModal.vue
+++ b/packages/entities/entities-shared/src/components/entity-delete-modal/EntityDeleteModal.vue
@@ -1,7 +1,7 @@
 <template>
   <KPrompt
     action-button-appearance="danger"
-    :action-button-disabled="actionPending"
+    :action-button-disabled="actionPending || confirmDisabled"
     action-button-text="Yes, delete"
     :class="['kong-ui-entity-delete-modal', { 'kong-ui-entity-delete-modal-stacked-copy': stackedCopy }]"
     :confirmation-prompt="confirmationPrompt || undefined"
@@ -56,6 +56,12 @@
             </p>
           </slot>
         </div>
+        <div
+          v-if="$slots.extra"
+          class="extra"
+        >
+          <slot name="extra" />
+        </div>
       </div>
     </template>
   </KPrompt>
@@ -99,6 +105,11 @@ const props = defineProps({
     default: '',
   },
   actionPending: {
+    type: Boolean,
+    default: false,
+  },
+  // Disables the confirm button regardless of `actionPending` or the confirmation text, e.g. while a required checkbox is unchecked
+  confirmDisabled: {
     type: Boolean,
     default: false,
   },
@@ -150,6 +161,10 @@ const proceed = () => {
   }
 
   .description {
+    margin-top: var(--kui-space-90, $kui-space-90);
+  }
+
+  .extra {
     margin-top: var(--kui-space-90, $kui-space-90);
   }
 


### PR DESCRIPTION
## Summary
- In Konnect, deleting a gateway service now checks whether it has attached routes and/or plugins before confirming deletion.
- If the service has routes, the delete confirmation shows the route/plugin counts and requires checking a "Force delete all entities" checkbox before the delete button enables; the DELETE request is sent with `force=true`.
- If the service only has plugins (no routes), the plugin count is shown but deletion proceeds normally, without the checkbox or `force` param.
- If the service has neither routes nor plugins, behavior is unchanged.
- `EntityDeleteModal` (entities-shared) gains a `confirmDisabled` prop and an `extra` slot to support this without forking the shared component.

KM-3028


https://github.com/user-attachments/assets/0eef2c8f-94e3-4c1e-a378-ae4d98c968bc

