### PR TITLE
feat(entities-plugins): rank and highlight plugin search matches

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginCatalog.vue
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.vue
@@ -187,7 +187,7 @@ import { useAxios, useHelpers, useErrors } from '@kong-ui-public/entities-shared
 import { fetchAllPages } from '../composables/useCustomPluginApi'
 import { KUI_ICON_COLOR_PRIMARY } from '@kong/design-tokens'
 import { GridIcon, ListIcon } from '@kong/icons'
-import { lcsRecursive } from '../utils/helper'
+import { matchPluginName } from '../utils/helper'
 import PluginCatalogListView from './select/PluginCatalogListView.vue'
 import { FEATURE_FLAGS as PLUGIN_FEATURE_FLAGS } from '../constants'
 
@@ -359,36 +359,34 @@ const filteredPlugins = computed((): PluginCardListExtended => {
 
   const results: PluginCardList = JSON.parse(JSON.stringify(filtered))
 
-  for (const type in filtered) {
-    const matches = filtered[type]?.filter((plugin: PluginType) => {
-      const fields = [
-        plugin.name.toLowerCase(),
-        plugin.id.toLowerCase(),
-        // plugin.group.toLowerCase(),
-      ]
-      return fields.some(field => {
-        const lcs = lcsRecursive(query, field)
-        return lcs.length === query.length
-      })
-    }) || []
-    if (!matches.length) {
-      delete results[type]
-    } else {
-      results[type] = matches
+  // Score every matching plugin so we can both rank and highlight the matches.
+  const scored: Array<{ plugin: PluginType, score: number }> = []
+  for (const type in results) {
+    for (const plugin of results[type] ?? []) {
+      const match = matchPluginName(query, plugin.name)
+      if (match.matched) {
+        plugin.matchedIndices = match.indices
+        scored.push({ plugin, score: match.score })
+      } else if (query === plugin.id.toLowerCase()) {
+        plugin.matchedIndices = []
+        scored.push({ plugin, score: Number.MAX_SAFE_INTEGER })
+      }
     }
   }
 
-  const queryResults = Object.values(results)
-    .flat()
-    .filter((p): p is PluginType => Boolean(p))
+  // dedupe by id (keeping the strongest score), then rank: stronger match first,
+  // ties broken alphabetically for a stable order.
+  const byId = new Map<string, { plugin: PluginType, score: number }>()
+  for (const entry of scored) {
+    const existing = byId.get(entry.plugin.id)
+    if (!existing || entry.score < existing.score) {
+      byId.set(entry.plugin.id, entry)
+    }
+  }
 
-  // dedupe by id preserving first-seen order using Map + Array.from
-  const uniqueResults = Array.from(
-    queryResults.reduce((m, plugin) => {
-      if (!m.has(plugin.id)) m.set(plugin.id, plugin)
-      return m
-    }, new Map<string, PluginType>()).values(),
-  )
+  const uniqueResults = Array.from(byId.values())
+    .sort((a, b) => a.score - b.score || a.plugin.name.localeCompare(b.plugin.name))
+    .map(entry => entry.plugin)
 
   return uniqueResults.length ? { 'Query Result': uniqueResults } : { }
 })

--- a/packages/entities/entities-plugins/src/components/PluginCatalog.vue
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.vue
@@ -358,16 +358,16 @@ const filteredPlugins = computed((): PluginCardListExtended => {
   }
 
   // A plugin can appear under multiple keys (e.g. featured + its own group), so
-  // collect name matches into one id-keyed map to flatten and de-duplicate.
-  // Matching is name-only; plugin ids are not searched. Duplicates share the
-  // same name (hence the same score), so first-seen wins.
+  // collect matches into one id-keyed map to flatten and de-duplicate. Matching
+  // is on the name (with highlights); id is a strict prefix-only fallback.
+  // Duplicates share the same name/id (hence the same score), so first-seen wins.
   const matches = new Map<string, { plugin: PluginType, score: number }>()
   for (const group of Object.values(filtered)) {
     for (const plugin of group ?? []) {
       if (matches.has(plugin.id)) {
         continue
       }
-      const match = matchPluginName(query, plugin.name)
+      const match = matchPluginName(query, plugin.name, plugin.id)
       if (match.matched) {
         // shallow clone so we can attach highlight data without mutating the source
         matches.set(plugin.id, {

--- a/packages/entities/entities-plugins/src/components/PluginCatalog.vue
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.vue
@@ -357,34 +357,29 @@ const filteredPlugins = computed((): PluginCardListExtended => {
     return filtered
   }
 
-  const results: PluginCardList = JSON.parse(JSON.stringify(filtered))
-
-  // Score every matching plugin so we can both rank and highlight the matches.
-  const scored: Array<{ plugin: PluginType, score: number }> = []
-  for (const type in results) {
-    for (const plugin of results[type] ?? []) {
+  // A plugin can appear under multiple keys (e.g. featured + its own group), so
+  // collect name matches into one id-keyed map to flatten and de-duplicate.
+  // Matching is name-only; plugin ids are not searched. Duplicates share the
+  // same name (hence the same score), so first-seen wins.
+  const matches = new Map<string, { plugin: PluginType, score: number }>()
+  for (const group of Object.values(filtered)) {
+    for (const plugin of group ?? []) {
+      if (matches.has(plugin.id)) {
+        continue
+      }
       const match = matchPluginName(query, plugin.name)
       if (match.matched) {
-        plugin.matchedIndices = match.indices
-        scored.push({ plugin, score: match.score })
-      } else if (query === plugin.id.toLowerCase()) {
-        plugin.matchedIndices = []
-        scored.push({ plugin, score: Number.MAX_SAFE_INTEGER })
+        // shallow clone so we can attach highlight data without mutating the source
+        matches.set(plugin.id, {
+          plugin: { ...plugin, matchedIndices: match.indices },
+          score: match.score,
+        })
       }
     }
   }
 
-  // dedupe by id (keeping the strongest score), then rank: stronger match first,
-  // ties broken alphabetically for a stable order.
-  const byId = new Map<string, { plugin: PluginType, score: number }>()
-  for (const entry of scored) {
-    const existing = byId.get(entry.plugin.id)
-    if (!existing || entry.score < existing.score) {
-      byId.set(entry.plugin.id, entry)
-    }
-  }
-
-  const uniqueResults = Array.from(byId.values())
+  // rank: stronger match first, ties broken alphabetically for a stable order
+  const uniqueResults = Array.from(matches.values())
     .sort((a, b) => a.score - b.score || a.plugin.name.localeCompare(b.plugin.name))
     .map(entry => entry.plugin)
 

--- a/packages/entities/entities-plugins/src/components/select/HighlightedText.vue
+++ b/packages/entities/entities-plugins/src/components/select/HighlightedText.vue
@@ -1,0 +1,34 @@
+<template>
+  <span>
+    <template
+      v-for="(segment, index) in segments"
+      :key="index"
+    ><span
+      v-if="segment.highlighted"
+      class="highlighted-match"
+    >{{ segment.text }}</span><template v-else>{{ segment.text }}</template></template>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { buildHighlightSegments } from '../../utils/helper'
+
+const props = defineProps<{
+  /** The full text to render. */
+  text: string
+  /** Character indices within `text` to highlight. */
+  indices?: number[]
+}>()
+
+const segments = computed(() => buildHighlightSegments(props.text, props.indices))
+</script>
+
+<style lang="scss" scoped>
+.highlighted-match {
+  background-color: var(--kui-color-background-warning-weakest, $kui-color-background-warning-weakest);
+  border-radius: var(--kui-border-radius-10, $kui-border-radius-10);
+  color: inherit;
+  font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/select/HighlightedText.vue
+++ b/packages/entities/entities-plugins/src/components/select/HighlightedText.vue
@@ -26,7 +26,7 @@ const segments = computed(() => buildHighlightSegments(props.text, props.indices
 
 <style lang="scss" scoped>
 .highlighted-match {
-  background-color: var(--kui-color-background-warning-weakest, $kui-color-background-warning-weakest);
+  background-color: var(--kui-color-background-warning-weaker, $kui-color-background-warning-weaker);
   border-radius: var(--kui-border-radius-10, $kui-border-radius-10);
   color: inherit;
   font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);

--- a/packages/entities/entities-plugins/src/components/select/PluginCatalogCard.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginCatalogCard.vue
@@ -19,7 +19,10 @@
               :size="55"
             />
             <span :class="{ 'non-custom-title': !isCustomPlugin }">
-              {{ plugin.name }}
+              <HighlightedText
+                :indices="plugin.matchedIndices"
+                :text="plugin.name"
+              />
             </span>
           </div>
 
@@ -119,6 +122,7 @@ import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { MoreIcon } from '@kong/icons'
 import composables from '../../composables'
 import { PluginIcon } from '@kong-ui-public/entities-plugins-icon'
+import HighlightedText from './HighlightedText.vue'
 
 const emit = defineEmits<{
   (e: 'plugin-clicked', plugin: PluginType) : void

--- a/packages/entities/entities-plugins/src/components/select/PluginCatalogListView.vue
+++ b/packages/entities/entities-plugins/src/components/select/PluginCatalogListView.vue
@@ -30,7 +30,10 @@
             class="plugin-name-text"
             data-testid="plugin-catalog-list-view-name-text"
             :title="row.name"
-          >{{ row.name }}</span>
+          ><HighlightedText
+            :indices="row.plugin?.matchedIndices"
+            :text="row.name"
+          /></span>
           <KBadge
             v-if="row.badge"
             appearance="info"
@@ -123,6 +126,7 @@ import { MoreIcon } from '@kong/icons'
 import DeleteCustomPluginSchemaModal from '../custom-plugins/DeleteCustomPluginSchemaModal.vue'
 import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { PluginIcon } from '@kong-ui-public/entities-plugins-icon'
+import HighlightedText from './HighlightedText.vue'
 import type {
   PluginType,
   KongManagerPluginSelectConfig,

--- a/packages/entities/entities-plugins/src/types/plugin.ts
+++ b/packages/entities/entities-plugins/src/types/plugin.ts
@@ -145,6 +145,7 @@ export interface PluginType extends PluginMetaData {
   disabledMessage?: string // An optional field for plugin's disabled message.
   customPluginType?: CustomPluginType // custom plugin type
   clonedFromRef?: string
+  matchedIndices?: number[] // character indices in `name` to highlight for the current search query
 }
 
 export type DisabledPlugin = {

--- a/packages/entities/entities-plugins/src/utils/helper.spec.ts
+++ b/packages/entities/entities-plugins/src/utils/helper.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import { matchPluginName, buildHighlightSegments } from './helper'
+
+describe('matchPluginName', () => {
+  // Convenience: render the matched characters so assertions read clearly.
+  const highlighted = (name: string, indices: number[]) => indices.map(i => name[i]).join('')
+
+  describe('empty query', () => {
+    it('matches everything with an empty query', () => {
+      const result = matchPluginName('', 'Basic Authentication')
+      expect(result.matched).toBe(true)
+      expect(result.indices).toEqual([])
+      expect(result.score).toBe(0)
+    })
+  })
+
+  describe('tier 0 — prefix', () => {
+    it('matches when the name starts with the query', () => {
+      const result = matchPluginName('acc', 'Access Control')
+      expect(result.matched).toBe(true)
+      expect(result.indices).toEqual([0, 1, 2])
+      expect(highlighted('Access Control', result.indices)).toBe('Acc')
+    })
+
+    it('is case-insensitive', () => {
+      const result = matchPluginName('ACCESS', 'Access Control')
+      expect(result.matched).toBe(true)
+      expect(result.indices).toEqual([0, 1, 2, 3, 4, 5])
+    })
+
+    it('ranks a prefix match above every other tier', () => {
+      const prefix = matchPluginName('ace', 'Ace Redirect')
+      const acronym = matchPluginName('ace', 'Access Control Enforcement')
+      expect(prefix.score).toBeLessThan(acronym.score)
+    })
+  })
+
+  describe('tier 1 — acronym (word initials)', () => {
+    it('matches the leading letters of consecutive words', () => {
+      const name = 'Access Control Enforcement'
+      const result = matchPluginName('ace', name)
+      expect(result.matched).toBe(true)
+      expect(highlighted(name, result.indices)).toBe('ACE')
+      // A@0, C@7, E@15
+      expect(result.indices).toEqual([0, 7, 15])
+    })
+
+    it('allows intervening words to be skipped', () => {
+      const name = 'Access Control Enforcement'
+      const result = matchPluginName('ae', name)
+      expect(result.matched).toBe(true)
+      expect(highlighted(name, result.indices)).toBe('AE')
+      expect(result.indices).toEqual([0, 15])
+    })
+
+    it('ranks acronym matches above substring matches', () => {
+      const acronym = matchPluginName('ace', 'Access Control Enforcement')
+      const substring = matchPluginName('ace', 'Palace Entrance')
+      expect(acronym.score).toBeLessThan(substring.score)
+    })
+  })
+
+  describe('tier 2 — substring', () => {
+    it('matches a consecutive run that is not at the start', () => {
+      const name = 'Rate Limiting'
+      const result = matchPluginName('imit', name)
+      expect(result.matched).toBe(true)
+      expect(highlighted(name, result.indices)).toBe('imit')
+    })
+
+    it('ranks an earlier substring position higher', () => {
+      const early = matchPluginName('at', 'Rate Control') // "r[at]e..." -> index 1
+      const late = matchPluginName('at', 'Corporate') // "corpor[at]e" -> index 6
+      expect(early.score).toBeLessThan(late.score)
+    })
+  })
+
+  describe('tier 3 — scattered subsequence', () => {
+    it('matches letters in order but scattered', () => {
+      const name = 'Basic Authentication'
+      const result = matchPluginName('ace', name)
+      expect(result.matched).toBe(true)
+      // greedy leftmost: a@1, c@4, e in "authentication"
+      expect(highlighted(name, result.indices)).toBe('ace')
+      expect(result.score).toBeGreaterThanOrEqual(3000)
+    })
+
+    it('does not match when letters are out of order', () => {
+      const result = matchPluginName('ba', 'Cab') // needs b then a, but 'a' precedes 'b'
+      expect(result.matched).toBe(false)
+      expect(result.score).toBe(Infinity)
+    })
+
+    it('ranks a subsequence match below acronym and substring', () => {
+      const subsequence = matchPluginName('ace', 'Basic Authentication')
+      const acronym = matchPluginName('ace', 'Access Control Enforcement')
+      expect(subsequence.score).toBeGreaterThan(acronym.score)
+    })
+  })
+
+  describe('tier 4 — id prefix fallback', () => {
+    it('matches when the id starts with the query and the name does not match', () => {
+      const result = matchPluginName('ai-prompt-decorator', 'AI Prompt Decorator', 'ai-prompt-decorator')
+      expect(result.matched).toBe(true)
+      // id matches carry no highlight (the UI highlights the name only)
+      expect(result.indices).toEqual([])
+      expect(result.score).toBe(4000)
+    })
+
+    it('matches a partial id prefix', () => {
+      const result = matchPluginName('ai-prompt', 'AI Prompt Decorator', 'ai-prompt-decorator')
+      expect(result.matched).toBe(true)
+      expect(result.indices).toEqual([])
+    })
+
+    it('is strict: does not match the middle of an id', () => {
+      const result = matchPluginName('prompt-decorator', 'AI Prompt Decorator', 'ai-prompt-decorator')
+      expect(result.matched).toBe(false)
+    })
+
+    it('prefers a name match over the id fallback', () => {
+      // "ai" matches the name prefix, so we should get a strong (name) match, not the id tier
+      const result = matchPluginName('ai', 'AI Prompt Decorator', 'ai-prompt-decorator')
+      expect(result.matched).toBe(true)
+      expect(result.indices).toEqual([0, 1])
+      expect(result.score).toBe(0)
+    })
+
+    it('ignores the id when it is not provided', () => {
+      const result = matchPluginName('ai-prompt-decorator', 'AI Prompt Decorator')
+      expect(result.matched).toBe(false)
+    })
+
+    it('ranks an id-prefix match below every name match', () => {
+      const idMatch = matchPluginName('ai-prompt-decorator', 'AI Prompt Decorator', 'ai-prompt-decorator')
+      const worstNameMatch = matchPluginName('ace', 'Basic Authentication') // tier 3
+      expect(idMatch.score).toBeGreaterThan(worstNameMatch.score)
+    })
+  })
+
+  describe('no match', () => {
+    it('returns unmatched when nothing lines up', () => {
+      const result = matchPluginName('zzz', 'Rate Limiting', 'rate-limiting')
+      expect(result.matched).toBe(false)
+      expect(result.indices).toEqual([])
+      expect(result.score).toBe(Infinity)
+    })
+  })
+})
+
+describe('buildHighlightSegments', () => {
+  it('returns a single plain segment when there are no indices', () => {
+    expect(buildHighlightSegments('Rate Limiting')).toEqual([
+      { text: 'Rate Limiting', highlighted: false },
+    ])
+  })
+
+  it('returns an empty array for empty text', () => {
+    expect(buildHighlightSegments('', [])).toEqual([])
+  })
+
+  it('highlights a leading run', () => {
+    expect(buildHighlightSegments('Access', [0, 1, 2])).toEqual([
+      { text: 'Acc', highlighted: true },
+      { text: 'ess', highlighted: false },
+    ])
+  })
+
+  it('highlights a trailing run', () => {
+    expect(buildHighlightSegments('Access', [4, 5])).toEqual([
+      { text: 'Acce', highlighted: false },
+      { text: 'ss', highlighted: true },
+    ])
+  })
+
+  it('highlights scattered single characters', () => {
+    // indices 0, 2, 4 of "abcde" -> a, c, e highlighted
+    expect(buildHighlightSegments('abcde', [0, 2, 4])).toEqual([
+      { text: 'a', highlighted: true },
+      { text: 'b', highlighted: false },
+      { text: 'c', highlighted: true },
+      { text: 'd', highlighted: false },
+      { text: 'e', highlighted: true },
+    ])
+  })
+
+  it('is order-independent for the indices', () => {
+    expect(buildHighlightSegments('Access', [2, 0, 1])).toEqual([
+      { text: 'Acc', highlighted: true },
+      { text: 'ess', highlighted: false },
+    ])
+  })
+
+  it('ignores out-of-range indices', () => {
+    expect(buildHighlightSegments('AI', [0, 5])).toEqual([
+      { text: 'A', highlighted: true },
+      { text: 'I', highlighted: false },
+    ])
+  })
+})

--- a/packages/entities/entities-plugins/src/utils/helper.ts
+++ b/packages/entities/entities-plugins/src/utils/helper.ts
@@ -98,6 +98,135 @@ export const stripEmptyBasicFields = (schemaRegistry: SchemaRegistry) => {
   }
 }
 
+/** Result of matching a search query against a plugin name. */
+export interface PluginNameMatch {
+  /** Whether the query matches the name at all. */
+  matched: boolean
+  /** Character indices in the (original) name that should be highlighted. */
+  indices: number[]
+  /** Ranking score, lower is a better/stronger match. `Infinity` when unmatched. */
+  score: number
+}
+
+// Match tiers, used as the score base so stronger match types always sort first.
+const MATCH_TIER_PREFIX = 0 // name starts with the query
+const MATCH_TIER_ACRONYM = 1000 // query matches the leading letters of words in order
+const MATCH_TIER_SUBSTRING = 2000 // query appears as a consecutive substring
+const MATCH_TIER_SUBSEQUENCE = 3000 // query letters appear in order but scattered
+
+const isWordChar = (char: string): boolean => /[a-z0-9]/i.test(char)
+
+/** Return the leading character of every word in `name`, with its index. */
+function wordInitials(name: string): Array<{ char: string, index: number }> {
+  const initials: Array<{ char: string, index: number }> = []
+  for (let i = 0; i < name.length; i++) {
+    if (isWordChar(name[i]) && (i === 0 || !isWordChar(name[i - 1]))) {
+      initials.push({ char: name[i], index: i })
+    }
+  }
+  return initials
+}
+
+/**
+ * Greedy leftmost subsequence match: return the index (into `chars`) of each
+ * query character in order, or `null` if `query` is not a subsequence.
+ */
+function subsequenceIndices(query: string, chars: string[]): number[] | null {
+  const indices: number[] = []
+  let pos = 0
+  for (const q of query) {
+    while (pos < chars.length && chars[pos] !== q) {
+      pos++
+    }
+    if (pos >= chars.length) {
+      return null
+    }
+    indices.push(pos)
+    pos++
+  }
+  return indices
+}
+
+/**
+ * Match a search query against a plugin name and describe how strong the match
+ * is (for ranking) and which characters matched (for highlighting).
+ *
+ * Ranking, strongest first:
+ *  - prefix: the name starts with the query
+ *  - acronym: the query matches the leading letters of consecutive words
+ *  - substring: the query appears as a consecutive run
+ *  - subsequence: the query letters appear in order but scattered
+ */
+export function matchPluginName(rawQuery: string, name: string): PluginNameMatch {
+  const query = rawQuery.toLowerCase()
+  if (!query) {
+    return { matched: true, indices: [], score: 0 }
+  }
+
+  const lcName = name.toLowerCase()
+  const range = (start: number, length: number) =>
+    Array.from({ length }, (_, i) => start + i)
+
+  // Tier 0 — prefix substring
+  if (lcName.startsWith(query)) {
+    return { matched: true, indices: range(0, query.length), score: MATCH_TIER_PREFIX }
+  }
+
+  // Tier 1 — word initials (acronym)
+  const initials = wordInitials(lcName)
+  const acronym = subsequenceIndices(query, initials.map(i => i.char))
+  if (acronym) {
+    const indices = acronym.map(i => initials[i].index)
+    return { matched: true, indices, score: MATCH_TIER_ACRONYM + indices[0] }
+  }
+
+  // Tier 2 — consecutive substring anywhere
+  const at = lcName.indexOf(query)
+  if (at >= 0) {
+    return { matched: true, indices: range(at, query.length), score: MATCH_TIER_SUBSTRING + at }
+  }
+
+  // Tier 3 — scattered subsequence
+  const subseq = subsequenceIndices(query, lcName.split(''))
+  if (subseq) {
+    return { matched: true, indices: subseq, score: MATCH_TIER_SUBSEQUENCE + subseq[0] }
+  }
+
+  return { matched: false, indices: [], score: Infinity }
+}
+
+/**
+ * Split `text` into consecutive segments flagged as highlighted or not, based
+ * on the (sorted) matched character `indices`.
+ */
+export function buildHighlightSegments(
+  text: string,
+  indices: number[] = [],
+): Array<{ text: string, highlighted: boolean }> {
+  if (!indices.length) {
+    return text ? [{ text, highlighted: false }] : []
+  }
+
+  const highlighted = new Set(indices)
+  const segments: Array<{ text: string, highlighted: boolean }> = []
+  let current = ''
+  let currentHighlighted = highlighted.has(0)
+
+  for (let i = 0; i < text.length; i++) {
+    const isHighlighted = highlighted.has(i)
+    if (isHighlighted !== currentHighlighted && current) {
+      segments.push({ text: current, highlighted: currentHighlighted })
+      current = ''
+    }
+    currentHighlighted = isHighlighted
+    current += text[i]
+  }
+  if (current) {
+    segments.push({ text: current, highlighted: currentHighlighted })
+  }
+  return segments
+}
+
 export function lcsRecursive(a: string, b: string): string {
   const arrA = a.split('')
   const arrB = b.split('')

--- a/packages/entities/entities-plugins/src/utils/helper.ts
+++ b/packages/entities/entities-plugins/src/utils/helper.ts
@@ -153,7 +153,9 @@ function subsequenceIndices(query: string, chars: string[]): number[] | null {
  *
  * Ranking, strongest first:
  *  - prefix: the name starts with the query
- *  - acronym: the query matches the leading letters of consecutive words
+ *  - acronym: the query is a subsequence of the words' leading letters, in
+ *    order (intervening words may be skipped, e.g. "ae" matches
+ *    "Access Control Enforcement")
  *  - substring: the query appears as a consecutive run
  *  - subsequence: the query letters appear in order but scattered
  */

--- a/packages/entities/entities-plugins/src/utils/helper.ts
+++ b/packages/entities/entities-plugins/src/utils/helper.ts
@@ -113,6 +113,7 @@ const MATCH_TIER_PREFIX = 0 // name starts with the query
 const MATCH_TIER_ACRONYM = 1000 // query matches the leading letters of words in order
 const MATCH_TIER_SUBSTRING = 2000 // query appears as a consecutive substring
 const MATCH_TIER_SUBSEQUENCE = 3000 // query letters appear in order but scattered
+const MATCH_TIER_ID_PREFIX = 4000 // the plugin id starts with the query (name did not match)
 
 const isWordChar = (char: string): boolean => /[a-z0-9]/i.test(char)
 
@@ -158,8 +159,13 @@ function subsequenceIndices(query: string, chars: string[]): number[] | null {
  *    "Access Control Enforcement")
  *  - substring: the query appears as a consecutive run
  *  - subsequence: the query letters appear in order but scattered
+ *
+ * When a `id` is supplied and the name does not match, a stricter fallback is
+ * tried: the plugin id must *start with* the query (e.g. "ai-prompt-decorator").
+ * Id matches are returned with no highlight indices (the UI highlights the name
+ * only) and rank below every name match.
  */
-export function matchPluginName(rawQuery: string, name: string): PluginNameMatch {
+export function matchPluginName(rawQuery: string, name: string, id?: string): PluginNameMatch {
   const query = rawQuery.toLowerCase()
   if (!query) {
     return { matched: true, indices: [], score: 0 }
@@ -192,6 +198,11 @@ export function matchPluginName(rawQuery: string, name: string): PluginNameMatch
   const subseq = subsequenceIndices(query, lcName.split(''))
   if (subseq) {
     return { matched: true, indices: subseq, score: MATCH_TIER_SUBSEQUENCE + subseq[0] }
+  }
+
+  // Tier 4 — id prefix (strict fallback, no highlight)
+  if (id && id.toLowerCase().startsWith(query)) {
+    return { matched: true, indices: [], score: MATCH_TIER_ID_PREFIX }
   }
 
   return { matched: false, indices: [], score: Infinity }


### PR DESCRIPTION
# Summary

KM-3029

Rank search results by match strength (prefix > word-initial acronym > consecutive substring > scattered subsequence) and highlight the matched characters in both the catalog grid card and list view.
