### PR TITLE
fix(plugins): show inline redis create [khcp-21412]

### DIFF
--- a/packages/core/forms/src/components/RedisConfigSelect.vue
+++ b/packages/core/forms/src/components/RedisConfigSelect.vue
@@ -16,15 +16,16 @@
     <div class="shared-redis-config-title" />
     <!-- TODO: Refactor this select to use the packages/entities/entities-redis-configurations/src/components/RedisConfigurationSelector.vue -->
     <KSelect
+      :key="createOpen ? 'redis-select-creating' : 'redis-select'"
       class="redis-config-select-trigger"
       data-testid="redis-config-select-trigger"
       enable-filtering
       :filter-function="() => true"
       :items="availableRedisConfigs"
       :loading="(loadingRedisConfigs as any)"
-      :model-value="defaultRedisConfigItem"
+      :model-value="createOpen ? undefined : defaultRedisConfigItem"
       :placeholder="redisSelectPlaceholderText"
-      @change="(item) => redisConfigSelected(item?.value)"
+      @change="onSelectChange"
       @query-change="debouncedRedisConfigsQuery"
     >
       <template #selected-item-template="{ item }">
@@ -211,6 +212,14 @@ const onCreateNew = () => {
   }
   // KM/legacy Konnect
   emit('showNewPartialModal')
+}
+
+// Close inline create when a redis is picked (createOpen is only set for inline path)
+const onSelectChange = (item: SelectItem | null) => {
+  if (!item?.value) return
+
+  createOpen.value = false
+  redisConfigSelected(item.value)
 }
 
 const onInlineCreated = (data: { id: string }) => {

--- a/packages/core/forms/src/components/RedisConfigSelect.vue
+++ b/packages/core/forms/src/components/RedisConfigSelect.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="selectEl"
     class="redis-config-select"
     data-testid="redis-config-select"
   >
@@ -106,7 +107,7 @@
 
 <script setup lang="ts">
 import { FORMS_CONFIG, REDIS_CONFIGURATION_FORM, REDIS_PARTIAL_FETCHER_KEY } from '../const'
-import { onBeforeMount, inject, computed, ref, watch, type Component, type Ref, type PropType } from 'vue'
+import { onBeforeMount, inject, computed, ref, watch, nextTick, type Component, type Ref, type PropType } from 'vue'
 import {
   useAxios,
   useDebouncedFilter,
@@ -188,6 +189,7 @@ const formConfig : KonnectBaseFormConfig | KongManagerBaseFormConfig | KonnectBa
 
 const useInlineCreate = computed(() => shouldInlineRedisCreate(formConfig) && !!RedisConfigurationForm)
 const createOpen = ref(false)
+const selectEl = ref<HTMLElement | null>(null)
 
 const inlineFormConfig = computed(() => ({
   ...formConfig,
@@ -218,6 +220,10 @@ const onInlineCreated = (data: { id: string }) => {
   }
   props.updateRedisModel(data.id)
   redisConfigSelected(data.id)
+  // Inline form unmounts below; scroll back into view
+  nextTick(() => {
+    selectEl.value?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  })
 }
 
 const pageSize = '1000' // the API returns all partials, so we have to set a high page size to filter them on the frontend

--- a/packages/core/forms/src/components/RedisConfigSelect.vue
+++ b/packages/core/forms/src/components/RedisConfigSelect.vue
@@ -59,13 +59,13 @@
         </div>
       </template>
       <template
-        v-if="!shouldHideNewRedisConfiguration(formConfig)"
+        v-if="!shouldHideNewRedis(formConfig)"
         #dropdown-footer-text
       >
         <div
           class="new-redis-config-area"
           data-testid="new-redis-config-area"
-          @click="$emit('showNewPartialModal')"
+          @click="onCreateNew"
         >
           <AddIcon :size="`var(--kui-icon-size-20, ${KUI_ICON_SIZE_20})`" />
           <span>{{ createNewRedisConfigurationFooterText }}</span>
@@ -73,6 +73,23 @@
       </template>
     </KSelect>
   </div>
+
+  <!-- Konnect + FF + non-cloud: managed form inline (injected to avoid forms-redis cycle) -->
+  <div
+    v-if="useInlineCreate && createOpen && RedisConfigurationForm"
+    class="redis-inline-create"
+    data-testid="redis-inline-create"
+  >
+    <component
+      :is="RedisConfigurationForm"
+      :config="inlineFormConfig"
+      :disabled-partial-type="disabledPartialType"
+      :slidout-top-offset="0"
+      @cancel="createOpen = false"
+      @update="onInlineCreated"
+    />
+  </div>
+
   <RedisConfigCard
     v-if="selectedRedisConfig"
     :config-fields="selectedRedisConfig"
@@ -88,8 +105,8 @@
 </template>
 
 <script setup lang="ts">
-import { FORMS_CONFIG, REDIS_PARTIAL_FETCHER_KEY } from '../const'
-import { onBeforeMount, inject, computed, ref, watch, type Ref, type PropType } from 'vue'
+import { FORMS_CONFIG, REDIS_CONFIGURATION_FORM, REDIS_PARTIAL_FETCHER_KEY } from '../const'
+import { onBeforeMount, inject, computed, ref, watch, type Component, type Ref, type PropType } from 'vue'
 import {
   useAxios,
   useDebouncedFilter,
@@ -112,16 +129,17 @@ import {
   type RedisConfigurationSource,
   redisManagedSourceFromTags,
 } from '../utils/redisPartialManagedSource'
-import { shouldHideNewRedisConfiguration } from '../utils/hideNewRedisConfiguration'
+import { shouldHideNewRedis, shouldInlineRedisCreate } from '../utils/hideNewRedisConfiguration'
 import RedisConfigCard from './RedisConfigCard.vue'
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'showNewPartialModal'): void
 }>()
 
 const { t } = createI18n<typeof english>('en-us', english)
 
 const redisPartialFetcherKey: Ref<number, number> | undefined = inject(REDIS_PARTIAL_FETCHER_KEY)
+const RedisConfigurationForm = inject<Component | null>(REDIS_CONFIGURATION_FORM, null)
 
 const endpoints = {
   konnect: {
@@ -167,6 +185,41 @@ const selectedRedisConfig = ref(null)
 const { getMessageFromError } = useErrors()
 
 const formConfig : KonnectBaseFormConfig | KongManagerBaseFormConfig | KonnectBaseTableConfig | KongManagerBaseTableConfig = inject(FORMS_CONFIG)!
+
+const useInlineCreate = computed(() => shouldInlineRedisCreate(formConfig) && !!RedisConfigurationForm)
+const createOpen = ref(false)
+
+const inlineFormConfig = computed(() => ({
+  ...formConfig,
+  cancelRoute: undefined,
+  useKonnectManagedRedisUi: true,
+  isCloudGateway: false,
+}))
+
+const disabledPartialType = computed(() => {
+  if (props.redisType === 'redis-ce') return 'redis-ee'
+  if (props.redisType === 'redis-ee') return 'redis-ce'
+  return undefined
+})
+
+const onCreateNew = () => {
+  if (useInlineCreate.value) {
+    createOpen.value = true
+    return
+  }
+  // KM/legacy Konnect
+  emit('showNewPartialModal')
+}
+
+const onInlineCreated = (data: { id: string }) => {
+  createOpen.value = false
+  if (redisPartialFetcherKey) {
+    redisPartialFetcherKey.value++
+  }
+  props.updateRedisModel(data.id)
+  redisConfigSelected(data.id)
+}
+
 const pageSize = '1000' // the API returns all partials, so we have to set a high page size to filter them on the frontend
 const {
   debouncedQueryChange: debouncedRedisConfigsQuery,
@@ -200,7 +253,7 @@ const redisSelectPlaceholderText = computed(() =>
 )
 
 const createNewRedisConfigurationFooterText = computed(() =>
-  props.isKonnectManagedRedisEnabled
+  props.isKonnectManagedRedisEnabled || shouldInlineRedisCreate(formConfig)
     ? t('redis.managed_ui.shared_configuration.create_new_configuration')
     : t('redis.shared_configuration.create_new_configuration', { type: getPartialTypeDisplay(props.redisType as PartialType) }),
 )
@@ -368,5 +421,9 @@ onBeforeMount(() => {
 
 .redis-shared-config-error-message {
   color: var(--kui-color-text-danger, $kui-color-text-danger);
+}
+
+.redis-inline-create {
+  margin-top: var(--kui-space-60, $kui-space-60);
 }
 </style>

--- a/packages/core/forms/src/const.ts
+++ b/packages/core/forms/src/const.ts
@@ -6,6 +6,8 @@ export const REDIS_PARTIAL_FETCHER_KEY = 'redis-partial-list-fetcher-key'
 
 export const REDIS_PARTIAL_INFO = 'redis-partial-info'
 
+export const REDIS_CONFIGURATION_FORM = 'kong-ui-redis-configuration-form'
+
 /** Used by `template` and `slot` */
 export const AUTOFILL_SLOT_NAME = 'autofill'
 

--- a/packages/core/forms/src/index.ts
+++ b/packages/core/forms/src/index.ts
@@ -19,6 +19,10 @@ export const getSharedFormName = (modelName: string): string => {
 
 export * from './const'
 export * from './types'
+export {
+  shouldHideNewRedis,
+  shouldInlineRedisCreate,
+} from './utils/hideNewRedisConfiguration'
 export * as abstractField from './components/fields/abstractField'
 
 export { default as composables } from './composables'

--- a/packages/core/forms/src/utils/hideNewRedisConfiguration.spec.ts
+++ b/packages/core/forms/src/utils/hideNewRedisConfiguration.spec.ts
@@ -3,13 +3,24 @@ import { describe, expect, it } from 'vitest'
 import { shouldHideNewRedisConfiguration } from './hideNewRedisConfiguration'
 
 describe('shouldHideNewRedisConfiguration', () => {
-  it('is true for Konnect when managed-redis FF is enabled', () => {
+  it('is true for Konnect when managed-redis FF is enabled on Cloud Gateway', () => {
     expect(shouldHideNewRedisConfiguration({
       app: 'konnect',
       apiBaseUrl: '/us/kong-api',
       controlPlaneId: 'cp-1',
       isKonnectManagedRedisEnabled: true,
+      isCloudGateway: true,
     })).toBe(true)
+  })
+
+  it('is false for Konnect when managed-redis FF is enabled on non-cloud gateway', () => {
+    expect(shouldHideNewRedisConfiguration({
+      app: 'konnect',
+      apiBaseUrl: '/us/kong-api',
+      controlPlaneId: 'cp-1',
+      isKonnectManagedRedisEnabled: true,
+      isCloudGateway: false,
+    })).toBe(false)
   })
 
   it('is false for Konnect when managed-redis FF is disabled', () => {
@@ -18,6 +29,7 @@ describe('shouldHideNewRedisConfiguration', () => {
       apiBaseUrl: '/us/kong-api',
       controlPlaneId: 'cp-1',
       isKonnectManagedRedisEnabled: false,
+      isCloudGateway: true,
     })).toBe(false)
   })
 
@@ -27,6 +39,7 @@ describe('shouldHideNewRedisConfiguration', () => {
       apiBaseUrl: '/kong-manager',
       workspace: 'default',
       isKonnectManagedRedisEnabled: true,
+      isCloudGateway: true,
     })).toBe(false)
   })
 })

--- a/packages/core/forms/src/utils/hideNewRedisConfiguration.spec.ts
+++ b/packages/core/forms/src/utils/hideNewRedisConfiguration.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldHideNewRedisConfiguration } from './hideNewRedisConfiguration'
+import { shouldHideNewRedis } from './hideNewRedisConfiguration'
 
-describe('shouldHideNewRedisConfiguration', () => {
+describe('shouldHideNewRedis', () => {
   it('is true for Konnect when managed-redis FF is enabled on Cloud Gateway', () => {
-    expect(shouldHideNewRedisConfiguration({
+    expect(shouldHideNewRedis({
       app: 'konnect',
       apiBaseUrl: '/us/kong-api',
       controlPlaneId: 'cp-1',
@@ -14,7 +14,7 @@ describe('shouldHideNewRedisConfiguration', () => {
   })
 
   it('is false for Konnect when managed-redis FF is enabled on non-cloud gateway', () => {
-    expect(shouldHideNewRedisConfiguration({
+    expect(shouldHideNewRedis({
       app: 'konnect',
       apiBaseUrl: '/us/kong-api',
       controlPlaneId: 'cp-1',
@@ -24,7 +24,7 @@ describe('shouldHideNewRedisConfiguration', () => {
   })
 
   it('is false for Konnect when managed-redis FF is disabled', () => {
-    expect(shouldHideNewRedisConfiguration({
+    expect(shouldHideNewRedis({
       app: 'konnect',
       apiBaseUrl: '/us/kong-api',
       controlPlaneId: 'cp-1',
@@ -34,7 +34,7 @@ describe('shouldHideNewRedisConfiguration', () => {
   })
 
   it('is false for Kong Manager', () => {
-    expect(shouldHideNewRedisConfiguration({
+    expect(shouldHideNewRedis({
       app: 'kongManager',
       apiBaseUrl: '/kong-manager',
       workspace: 'default',

--- a/packages/core/forms/src/utils/hideNewRedisConfiguration.ts
+++ b/packages/core/forms/src/utils/hideNewRedisConfiguration.ts
@@ -2,9 +2,17 @@ import type { KongManagerBaseFormConfig, KonnectBaseFormConfig } from '@kong-ui-
 
 type PluginFormsConfig = (KonnectBaseFormConfig | KongManagerBaseFormConfig) & {
   isKonnectManagedRedisEnabled?: boolean
+  isCloudGateway?: boolean
 }
 
-// Konnect + managed-redis FF: hide inline "+ New Redis" in plugin forms
+/**
+ * Hide "+ New Redis" in plugin forms when Konnect-managed Redis is available on Cloud Gateway.
+ * Non-cloud Konnect (FF on) still shows create >>> inline form. KM/legacy Konnect (FF off) unchanged.
+ */
 export function shouldHideNewRedisConfiguration(config: PluginFormsConfig): boolean {
-  return config.app === 'konnect' && !!config.isKonnectManagedRedisEnabled
+  return (
+    config.app === 'konnect' &&
+    !!config.isKonnectManagedRedisEnabled &&
+    config.isCloudGateway === true
+  )
 }

--- a/packages/core/forms/src/utils/hideNewRedisConfiguration.ts
+++ b/packages/core/forms/src/utils/hideNewRedisConfiguration.ts
@@ -5,14 +5,21 @@ type PluginFormsConfig = (KonnectBaseFormConfig | KongManagerBaseFormConfig) & {
   isCloudGateway?: boolean
 }
 
-/**
- * Hide "+ New Redis" in plugin forms when Konnect-managed Redis is available on Cloud Gateway.
- * Non-cloud Konnect (FF on) still shows create >>> inline form. KM/legacy Konnect (FF off) unchanged.
- */
-export function shouldHideNewRedisConfiguration(config: PluginFormsConfig): boolean {
+/** Hide "+ New Redis" for Konnect + FF + Cloud Gateway.
+ * Non-cloud + FF still shows create. */
+export function shouldHideNewRedis(config: PluginFormsConfig): boolean {
   return (
     config.app === 'konnect' &&
     !!config.isKonnectManagedRedisEnabled &&
     config.isCloudGateway === true
+  )
+}
+
+/** Konnect + FF + non-cloud: inline managed create, else KM/legacy modal */
+export function shouldInlineRedisCreate(config: PluginFormsConfig): boolean {
+  return (
+    config.app === 'konnect' &&
+    !!config.isKonnectManagedRedisEnabled &&
+    config.isCloudGateway === false
   )
 }

--- a/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
+++ b/packages/entities/entities-plugins/src/components/PluginEntityForm.vue
@@ -130,6 +130,7 @@ import {
   AUTOFILL_SLOT_NAME,
   FORMS_API_KEY,
   FORMS_CONFIG,
+  REDIS_CONFIGURATION_FORM,
   customFields,
   getSharedFormName,
   sharedForms,
@@ -137,6 +138,8 @@ import {
   type AutofillSlotProps,
 } from '@kong-ui-public/forms'
 import '@kong-ui-public/forms/dist/style.css'
+import { RedisConfigurationForm } from '@kong-ui-public/entities-redis-configurations'
+import '@kong-ui-public/entities-redis-configurations/dist/style.css'
 import type { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { computed, inject, onBeforeMount, onBeforeUnmount, provide, reactive, ref, shallowReactive, shallowRef, watch, type PropType } from 'vue'
 import composables from '../composables'
@@ -452,6 +455,9 @@ watch(() => props.config, (newConfig) => {
   Object.assign(liveConfig, newConfig)
 })
 provide(FORMS_CONFIG, liveConfig)
+
+// VFG RedisConfigSelect injects this for non-cloud + FF inline create
+provide(REDIS_CONFIGURATION_FORM, RedisConfigurationForm)
 
 const sharedFormName = ref('')
 const pluginConfig = ref<ResolvedPluginFormConfig | undefined>()

--- a/packages/entities/entities-plugins/src/components/free-form/shared/RedisSelector.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/RedisSelector.vue
@@ -204,9 +204,17 @@ const { value: redisFieldsValue, hide } = useField<Redis | undefined>(formRedisP
 
 const formConfig: KonnectBaseFormConfig | KongManagerBaseFormConfig = inject(FORMS_CONFIG)!
 
+// hide create only for Konnect + FF + Cloud Gateway
 const shouldHideNewRedisConfiguration = (
-  config: (KonnectBaseFormConfig | KongManagerBaseFormConfig) & { isKonnectManagedRedisEnabled?: boolean },
-) => config.app === 'konnect' && !!config.isKonnectManagedRedisEnabled
+  config: (KonnectBaseFormConfig | KongManagerBaseFormConfig) & {
+    isKonnectManagedRedisEnabled?: boolean
+    isCloudGateway?: boolean
+  },
+) => (
+  config.app === 'konnect' &&
+  !!config.isKonnectManagedRedisEnabled &&
+  config.isCloudGateway === true
+)
 
 const redisCardTitle = computed(() =>
   props.isKonnectManagedRedisEnabled ? t('redis.managed_ui.title') : t('redis.title'),

--- a/packages/entities/entities-plugins/src/components/free-form/shared/RedisSelector.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/RedisSelector.vue
@@ -65,7 +65,7 @@
           :model-value="selectedRedisConfigItem"
           :placeholder="redisSelectorPlaceholderText"
           :redis-type="redisType"
-          :show-create-button="!shouldHideNewRedisConfiguration(formConfig)"
+          :show-create-button="!shouldHideNewRedis(formConfig)"
           @error-change="onRedisSelectorFetchError"
           @toast="toaster"
           @update:model-value="redisConfigSelected"
@@ -110,7 +110,7 @@ import RedisConfigCard from './RedisConfigCard.vue'
 import { onBeforeMount, inject, computed, ref, watch } from 'vue'
 import english from '../../../locales/en.json'
 import { createI18n } from '@kong-ui-public/i18n'
-import { FORMS_CONFIG } from '@kong-ui-public/forms'
+import { FORMS_CONFIG, shouldHideNewRedis, shouldInlineRedisCreate } from '@kong-ui-public/forms'
 import { KCard } from '@kong/kongponents'
 import { useAxios, useErrors, type KongManagerBaseFormConfig, type KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
 import type { RedisPartialType, Redis, RenderRules } from './types'
@@ -204,18 +204,6 @@ const { value: redisFieldsValue, hide } = useField<Redis | undefined>(formRedisP
 
 const formConfig: KonnectBaseFormConfig | KongManagerBaseFormConfig = inject(FORMS_CONFIG)!
 
-// hide create only for Konnect + FF + Cloud Gateway
-const shouldHideNewRedisConfiguration = (
-  config: (KonnectBaseFormConfig | KongManagerBaseFormConfig) & {
-    isKonnectManagedRedisEnabled?: boolean
-    isCloudGateway?: boolean
-  },
-) => (
-  config.app === 'konnect' &&
-  !!config.isKonnectManagedRedisEnabled &&
-  config.isCloudGateway === true
-)
-
 const redisCardTitle = computed(() =>
   props.isKonnectManagedRedisEnabled ? t('redis.managed_ui.title') : t('redis.title'),
 )
@@ -245,7 +233,9 @@ const dedicatedRedisRadioLabel = computed(() =>
 )
 
 const redisSelectorCreateButtonText = computed(() =>
-  props.isKonnectManagedRedisEnabled ? t('redis.managed_ui.selector.create_new') : undefined,
+  props.isKonnectManagedRedisEnabled || shouldInlineRedisCreate(formConfig)
+    ? t('redis.managed_ui.selector.create_new')
+    : undefined,
 )
 
 const redisSelectorPlaceholderText = computed(() =>

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationSelector.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationSelector.vue
@@ -4,12 +4,13 @@
     class="redis-config-select-wrap"
   >
     <KSelect
+      :key="useInlineCreate && createOpen ? 'redis-select-creating' : 'redis-select'"
       class="redis-config-select-trigger"
       enable-filtering
       :filter-function="() => true"
       :items="items"
       :loading="loading"
-      :model-value="modelValue"
+      :model-value="useInlineCreate && createOpen ? undefined : modelValue"
       :placeholder="placeholder || t('selector.placeholder')"
       v-bind="$attrs"
       @change="onSelectionChange"
@@ -174,7 +175,20 @@ const createOpen = ref(false)
 const selectEl = ref<HTMLElement | null>(null)
 
 const onSelectionChange = (item: SelectItem<string | number> | null) => {
-  emit('update:modelValue', item === null ? undefined : String(item.value))
+  // Inline create only, remount clears the select
+  if (item === null) {
+    if (useInlineCreate.value && createOpen.value) return
+    emit('update:modelValue', undefined)
+    emit('change', null)
+    return
+  }
+
+  // Inline create only, picking an existing redis dismisses the form
+  if (useInlineCreate.value) {
+    createOpen.value = false
+  }
+
+  emit('update:modelValue', String(item.value))
   emit('change', item as SelectItem | null)
 }
 

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationSelector.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationSelector.vue
@@ -58,25 +58,47 @@
     </template>
   </KSelect>
 
-  <!-- New Redis Configuration Modal -->
+  <!-- Konnect + FF + non-cloud -->
+  <div
+    v-if="useInlineCreate && createOpen"
+    class="redis-inline-create"
+    data-testid="redis-inline-create"
+  >
+    <RedisConfigurationForm
+      :config="inlineFormConfig"
+      :disabled-partial-type="redisType === PartialType.REDIS_CE ? PartialType.REDIS_EE : PartialType.REDIS_CE"
+      :slidout-top-offset="0"
+      @cancel="createOpen = false"
+      @error="onInlineError"
+      @update="onCreated"
+    />
+  </div>
+
+  <!-- KM/legacy Konnect -->
   <RedisConfigurationFormModal
+    v-else-if="!useInlineCreate"
     :partial-type="redisType"
-    :visible="isModalVisible"
-    @created="onPartialCreated"
+    :visible="createOpen"
+    @created="onCreated"
     @modal-close="onModalClose"
     @toast="payload => emit('toast', payload)"
   />
 </template>
 
 <script setup lang="ts">
-import { watch, ref } from 'vue'
+import { computed, inject, watch, ref } from 'vue'
 import { AddIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_20 } from '@kong/design-tokens'
+import { FORMS_CONFIG } from '@kong-ui-public/forms'
+import { useErrors, type KongManagerBaseFormConfig, type KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
 import type { SelectItem } from '@kong/kongponents'
 import { useRedisConfigurationSelector } from '../composables/useRedisConfigurationSelector'
 import useI18n from '../composables/useI18n'
+import RedisConfigurationForm from './RedisConfigurationForm.vue'
 import RedisConfigurationFormModal from './RedisConfigurationFormModal.vue'
-import type { RedisConfigurationResponse } from '../types'
+import { PartialType, type KonnectRedisConfigurationFormConfig, type RedisConfigurationResponse } from '../types'
+
+import type { AxiosError } from 'axios'
 
 defineOptions({
   inheritAttrs: false,
@@ -116,6 +138,25 @@ const emit = defineEmits<{
 }>()
 
 const { i18n: { t } } = useI18n()
+const { getMessageFromError } = useErrors()
+
+const formConfig = inject<(KonnectBaseFormConfig | KongManagerBaseFormConfig) & {
+  isKonnectManagedRedisEnabled?: boolean
+  isCloudGateway?: boolean
+}>(FORMS_CONFIG)!
+
+const useInlineCreate = computed(() => (
+  formConfig.app === 'konnect' &&
+  !!formConfig.isKonnectManagedRedisEnabled &&
+  formConfig.isCloudGateway === false
+))
+
+const inlineFormConfig = computed(() => ({
+  ...formConfig,
+  cancelRoute: undefined,
+  useKonnectManagedRedisUi: true,
+  isCloudGateway: false,
+} as KonnectRedisConfigurationFormConfig))
 
 const {
   items,
@@ -128,8 +169,7 @@ const {
   isKonnectManagedRedisEnabled,
 })
 
-// Modal state
-const isModalVisible = ref(false)
+const createOpen = ref(false)
 
 const onSelectionChange = (item: SelectItem<string | number> | null) => {
   emit('update:modelValue', item === null ? undefined : String(item.value))
@@ -137,24 +177,36 @@ const onSelectionChange = (item: SelectItem<string | number> | null) => {
 }
 
 const onCreateNew = () => {
-  isModalVisible.value = true
+  createOpen.value = true
 }
 
-// Modal event handlers
 const onModalClose = () => {
-  isModalVisible.value = false
+  createOpen.value = false
   emit('modal-close')
 }
 
-// After successful create- close modal, refetch options, select the new partial
-const onPartialCreated = (data: RedisConfigurationResponse) => {
-  isModalVisible.value = false
-  loadItems() // Refresh the list
+const onInlineError = (error: AxiosError) => {
+  emit('toast', {
+    message: getMessageFromError(error),
+    appearance: 'danger',
+  })
+}
+
+const onCreated = (data: RedisConfigurationResponse) => {
+  createOpen.value = false
+  loadItems()
   onSelectionChange({
     name: data.name,
     value: data.id,
     label: data.name,
   })
+
+  if (useInlineCreate.value) {
+    emit('toast', {
+      message: t('form.partial_created_success_message'),
+      appearance: 'success',
+    })
+  }
 }
 
 watch(error, (newError) => {
@@ -196,5 +248,9 @@ watch(error, (newError) => {
     font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
     line-height: var(--kui-line-height-40, $kui-line-height-40);
   }
+}
+
+.redis-inline-create {
+  margin-top: var(--kui-space-60, $kui-space-60);
 }
 </style>

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationSelector.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationSelector.vue
@@ -89,7 +89,7 @@
 import { computed, inject, watch, ref } from 'vue'
 import { AddIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_20 } from '@kong/design-tokens'
-import { FORMS_CONFIG } from '@kong-ui-public/forms'
+import { FORMS_CONFIG, shouldInlineRedisCreate } from '@kong-ui-public/forms'
 import { useErrors, type KongManagerBaseFormConfig, type KonnectBaseFormConfig } from '@kong-ui-public/entities-shared'
 import type { SelectItem } from '@kong/kongponents'
 import { useRedisConfigurationSelector } from '../composables/useRedisConfigurationSelector'
@@ -145,11 +145,7 @@ const formConfig = inject<(KonnectBaseFormConfig | KongManagerBaseFormConfig) & 
   isCloudGateway?: boolean
 }>(FORMS_CONFIG)!
 
-const useInlineCreate = computed(() => (
-  formConfig.app === 'konnect' &&
-  !!formConfig.isKonnectManagedRedisEnabled &&
-  formConfig.isCloudGateway === false
-))
+const useInlineCreate = computed(() => shouldInlineRedisCreate(formConfig))
 
 const inlineFormConfig = computed(() => ({
   ...formConfig,

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationSelector.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationSelector.vue
@@ -1,62 +1,67 @@
 <template>
-  <KSelect
-    class="redis-config-select-trigger"
-    enable-filtering
-    :filter-function="() => true"
-    :items="items"
-    :loading="loading"
-    :model-value="modelValue"
-    :placeholder="placeholder || t('selector.placeholder')"
-    v-bind="$attrs"
-    @change="onSelectionChange"
-    @query-change="onQueryChange"
+  <div
+    ref="selectEl"
+    class="redis-config-select-wrap"
   >
-    <template #selected-item-template="{ item }">
-      <div class="selected-redis-config">
-        {{ (item as SelectItem).name }}
-      </div>
-    </template>
-    <template #item-template="{ item }">
-      <div
-        class="plugin-form-redis-configuration-dropdown-item"
-        :data-testid="`redis-configuration-dropdown-item-${item.name}`"
-      >
-        <span
-          class="select-item-name"
-          data-testid="selected-redis-config"
-        >{{ item.name }}</span>
-        <!-- Omit badge when tag is unset -->
-        <KBadge
-          v-if="item.tag"
-          appearance="info"
-          class="select-item-label"
-        >
-          {{ item.tag }}
-        </KBadge>
-      </div>
-    </template>
-    <template #empty>
-      <div
-        class="empty-redis-config"
-        data-testid="empty-redis-config"
-      >
-        {{ emptyStateText || t('selector.empty_state') }}
-      </div>
-    </template>
-    <template
-      v-if="showCreateButton"
-      #dropdown-footer-text
+    <KSelect
+      class="redis-config-select-trigger"
+      enable-filtering
+      :filter-function="() => true"
+      :items="items"
+      :loading="loading"
+      :model-value="modelValue"
+      :placeholder="placeholder || t('selector.placeholder')"
+      v-bind="$attrs"
+      @change="onSelectionChange"
+      @query-change="onQueryChange"
     >
-      <div
-        class="new-redis-config-area"
-        data-testid="new-redis-config-area"
-        @click="onCreateNew"
+      <template #selected-item-template="{ item }">
+        <div class="selected-redis-config">
+          {{ (item as SelectItem).name }}
+        </div>
+      </template>
+      <template #item-template="{ item }">
+        <div
+          class="plugin-form-redis-configuration-dropdown-item"
+          :data-testid="`redis-configuration-dropdown-item-${item.name}`"
+        >
+          <span
+            class="select-item-name"
+            data-testid="selected-redis-config"
+          >{{ item.name }}</span>
+          <!-- Omit badge when tag is unset -->
+          <KBadge
+            v-if="item.tag"
+            appearance="info"
+            class="select-item-label"
+          >
+            {{ item.tag }}
+          </KBadge>
+        </div>
+      </template>
+      <template #empty>
+        <div
+          class="empty-redis-config"
+          data-testid="empty-redis-config"
+        >
+          {{ emptyStateText || t('selector.empty_state') }}
+        </div>
+      </template>
+      <template
+        v-if="showCreateButton"
+        #dropdown-footer-text
       >
-        <AddIcon :size="`var(--kui-icon-size-20, ${KUI_ICON_SIZE_20})`" />
-        <span>{{ createButtonText || t('selector.create_new') }}</span>
-      </div>
-    </template>
-  </KSelect>
+        <div
+          class="new-redis-config-area"
+          data-testid="new-redis-config-area"
+          @click="onCreateNew"
+        >
+          <AddIcon :size="`var(--kui-icon-size-20, ${KUI_ICON_SIZE_20})`" />
+          <span>{{ createButtonText || t('selector.create_new') }}</span>
+        </div>
+      </template>
+    </KSelect>
+  </div>
 
   <!-- Konnect + FF + non-cloud -->
   <div
@@ -86,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, watch, ref } from 'vue'
+import { computed, inject, nextTick, watch, ref } from 'vue'
 import { AddIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_20 } from '@kong/design-tokens'
 import { FORMS_CONFIG, shouldInlineRedisCreate } from '@kong-ui-public/forms'
@@ -166,6 +171,7 @@ const {
 })
 
 const createOpen = ref(false)
+const selectEl = ref<HTMLElement | null>(null)
 
 const onSelectionChange = (item: SelectItem<string | number> | null) => {
   emit('update:modelValue', item === null ? undefined : String(item.value))
@@ -201,6 +207,10 @@ const onCreated = (data: RedisConfigurationResponse) => {
     emit('toast', {
       message: t('form.partial_created_success_message'),
       appearance: 'success',
+    })
+    // Inline form unmounts above; scroll back into view
+    nextTick(() => {
+      selectEl.value?.scrollIntoView({ behavior: 'smooth', block: 'center' })
     })
   }
 }


### PR DESCRIPTION
# Summary
Addresses: [https://konghq.atlassian.net/browse/KHCP-21412](https://konghq.atlassian.net/browse/KHCP-21412)

- **Konnect + FF enabled + Cloud Gateway**: Continue hiding “+ New Redis” in the plugin Redis select. No change in behavior.

- **Konnect + FF enabled + non-Cloud Gateway**: Show “+ New Redis” again and open the managed Redis form under the select. This skips the Konnect-managed vs. self-managed choice step because konnect managed Redis is not available for non-Cloud gateways.

- **KM + legacy Konnect with FF disabled**: No change.

`Hybrid control plane` with `proxy-cache-advanced`

<img width="1706" height="1014" alt="screen capture 2026-08-04 at 5 38 12 PM" src="https://github.com/user-attachments/assets/486b8a55-edfb-4aca-95f7-7a3170097190" />

<img width="1706" height="1014" alt="screen capture 2026-08-04 at 5 40 33 PM" src="https://github.com/user-attachments/assets/e0a4d668-be0a-4d03-9de4-a867fc64cbd9" />

<img width="1706" height="1014" alt="screen capture 2026-08-04 at 5 41 09 PM" src="https://github.com/user-attachments/assets/87eb3cc1-b877-4bab-8a5d-83c39c57fb49" />

<img width="1706" height="1014" alt="screen capture 2026-08-04 at 5 41 15 PM" src="https://github.com/user-attachments/assets/f0db7545-12e4-43a0-a363-bd5584f046a8" />

`Serverless control plane` with `service protection`

<img width="1706" height="1014" alt="screen capture 2026-08-04 at 5 42 40 PM" src="https://github.com/user-attachments/assets/ac1ace72-ec24-4164-b90a-132823bd3c7e" />

<img width="1706" height="1014" alt="screen capture 2026-08-04 at 5 42 56 PM" src="https://github.com/user-attachments/assets/4587209f-0efb-412c-8a5b-cbddfb9c40d6" />

<img width="1706" height="1014" alt="screen capture 2026-08-04 at 5 43 03 PM" src="https://github.com/user-attachments/assets/c1e95ebc-a9fe-4617-a0c0-c5e937330181" />


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
