### PR TITLE
feat(entities-plugins): add kong.client.principal properties to DataKit property node

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -109,6 +109,7 @@ const featureFlags = ref<Record<string, boolean>>({
   [FEATURE_FLAGS.KM_2503_CUSTOM_PLUGIN_FREEFORM]: true,
   [FEATURE_FLAGS.KM_2485_CLONED_PLUGINS]: true,
   [FEATURE_FLAGS.KHCP_20393_IDENTITY_PRINCIPALS_UI]: true,
+  [FEATURE_FLAGS.KM_3034_FEATURES_316]: true,
 })
 
 const FeatureFlagProvider = defineComponent({

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/node-forms/PropertiesField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/node-forms/PropertiesField.vue
@@ -59,7 +59,8 @@
 import type { SelectItem } from '@kong/kongponents'
 import useI18n from '../../../../../../composables/useI18n'
 import { useFormShared } from '../../../../shared/composables'
-import { computed, ref, watch } from 'vue'
+import { computed, inject, ref, watch } from 'vue'
+import { FEATURE_FLAGS } from '../../../../../../constants'
 import {
   extractKeyFromProperty,
   getPropertyWithoutKey,
@@ -71,6 +72,14 @@ import {
 import type { FieldValidationMethods, ValidatorFn } from '../composables/validation'
 
 const { i18n: { t } } = useI18n()
+
+const enableClientPrincipalProperty = inject<boolean>(
+  FEATURE_FLAGS.KM_3034_FEATURES_316,
+  false,
+)
+
+// `kong.client.principal` and its keyed variant are gated behind KM-3034-features-316.
+const CLIENT_PRINCIPAL_PROPERTIES = ['kong.client.principal', 'kong.client.principal.{key}']
 
 const props = defineProps<{
   validators: {
@@ -96,20 +105,22 @@ const key = ref<string | undefined>(extractKeyFromProperty(formData.property))
 const selectKey = computed(() => formData.property ?? '')
 
 const selectItems = computed<Array<SelectItem<string>>>(() => {
-  return Object.entries(KONG_CLIENT_SUPPORTED_PROPERTIES).map(([prop]) => {
-    const selected = identifyPropertyHasKey(prop)
-      ? formData.property?.startsWith(prop.replace(PROPERTY_KEY_PATTERN, ''))
-      : formData.property === prop
-    const label = selected
-      ? (key.value ? prop.replace(PROPERTY_KEY_PATTERN, key.value) : prop)
-      : prop
+  return Object.entries(KONG_CLIENT_SUPPORTED_PROPERTIES)
+    .filter(([prop]) => enableClientPrincipalProperty || !CLIENT_PRINCIPAL_PROPERTIES.includes(prop))
+    .map(([prop]) => {
+      const selected = identifyPropertyHasKey(prop)
+        ? formData.property?.startsWith(prop.replace(PROPERTY_KEY_PATTERN, ''))
+        : formData.property === prop
+      const label = selected
+        ? (key.value ? prop.replace(PROPERTY_KEY_PATTERN, key.value) : prop)
+        : prop
 
-    return ({
-      label,
-      value: prop,
-      selected,
+      return ({
+        label,
+        value: prop,
+        selected,
+      })
     })
-  })
 })
 
 function handleKeyChange(value: string | undefined) {

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/node/property.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/flow-editor/node/property.ts
@@ -56,6 +56,16 @@ export const KONG_CLIENT_SUPPORTED_PROPERTIES: Record<string, {
     writable: false,
     readable: true,
   },
+  'kong.client.principal': {
+    dataType: 'object',
+    writable: false,
+    readable: true,
+  },
+  'kong.client.principal.{key}': {
+    dataType: 'any',
+    writable: false,
+    readable: true,
+  },
   'kong.request.forwarded_host': {
     dataType: 'string',
     writable: false,

--- a/packages/entities/entities-plugins/src/constants/index.ts
+++ b/packages/entities/entities-plugins/src/constants/index.ts
@@ -7,6 +7,7 @@ export const FEATURE_FLAGS = {
   KM_2503_CUSTOM_PLUGIN_FREEFORM: 'KM-2503-custom-plugin-freeform',
   KM_2485_CLONED_PLUGINS: 'KM-2485-cloned-plugins',
   KHCP_20393_IDENTITY_PRINCIPALS_UI: 'khcp-20393-identity-principals-ui',
+  KM_3034_FEATURES_316: 'KM-3034-features-316',
 }
 
 export const TOASTER_PROVIDER = Symbol('TOASTER_PROVIDER')


### PR DESCRIPTION
## Summary
- Add `kong.client.principal` and `kong.client.principal.{key}` as get-only entries to the DataKit `property` node's supported properties.
- Gate both entries behind a new `KM_3034_FEATURES_316` feature flag (`KM-3034-features-316`), following the existing `inject`-and-filter pattern used for `KM_2446_DATAKIT_JWT_NODES`.

https://github.com/Kong/kong-ee/pull/19266

KM-3034

<img width="810" height="1264" alt="image" src="https://github.com/user-attachments/assets/afc99ffb-77e3-4055-97c8-062dd4fbc082" />
<img width="742" height="1100" alt="image" src="https://github.com/user-attachments/assets/765d0098-345c-4f2c-a907-9345793cd9f7" />
