### PR TITLE
refactor(analytics): dashboard slottable tile type [MA-5141]

### DIFF
--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -12,6 +12,8 @@ import {
   validDashboardTableQuery,
   platformQuerySchema,
   filterablePlatformPresetFilterDimensions,
+  slottableSchema,
+  slottableTileConfigSchema,
 } from './dashboardSchema.v2'
 import {
   agenticExploreAggregations,
@@ -41,6 +43,7 @@ const validateApiUsageQuerySchema = ajv.compile(apiUsageQuerySchema)
 const validateBasicQuerySchema = ajv.compile(basicQuerySchema)
 const validateLlmUsageQuerySchema = ajv.compile(llmUsageSchema)
 const validateAgenticUsageQuerySchema = ajv.compile(agenticUsageSchema)
+const validateSlottableTileSchema = ajv.compile(slottableTileConfigSchema)
 
 describe('dashboardSchema.v2', () => {
   const sharedPresetFilterableDimensions = [
@@ -487,5 +490,73 @@ describe('dashboardSchema.v2', () => {
       ...invalidStrictQuery,
       datasource: 'agentic_usage',
     })).toBe(false)
+  })
+})
+
+describe('slottable tile config', () => {
+  const slottableTile = {
+    id: 'slot-1',
+    type: 'slottable',
+    layout: {
+      position: {
+        col: 0,
+        row: 0,
+      },
+      size: {
+        cols: 1,
+        rows: 1,
+      },
+    },
+  }
+
+  const legacyChartSlottableTile = {
+    type: 'chart',
+    definition: {
+      chart: {
+        type: 'slottable',
+        id: 'slot-1',
+      },
+      query: {
+        datasource: 'basic',
+      },
+    },
+    layout: slottableTile.layout,
+  }
+
+  it('accepts a top-level slottable tile shape', () => {
+    expect(validateSlottableTileSchema(slottableTile)).toBe(true)
+    expect(validateDashboardConfigSchema({ tiles: [slottableTile] })).toBe(true)
+  })
+
+  it('rejects a top-level slottable tile with a definition present', () => {
+    const invalidTile = { ...slottableTile, definition: legacyChartSlottableTile.definition }
+    expect(validateSlottableTileSchema(invalidTile)).toBe(false)
+    expect(validateDashboardConfigSchema({ tiles: [invalidTile] })).toBe(false)
+  })
+
+  it('rejects a top-level slottable tile missing an id', () => {
+    const { id, ...invalidTile } = slottableTile
+    expect(validateSlottableTileSchema(invalidTile)).toBe(false)
+    expect(validateDashboardConfigSchema({ tiles: [invalidTile] })).toBe(false)
+  })
+
+  it('rejects a top-level slottable tile missing a layout', () => {
+    const { layout, ...invalidTile } = slottableTile
+    expect(validateSlottableTileSchema(invalidTile)).toBe(false)
+    expect(validateDashboardConfigSchema({ tiles: [invalidTile] })).toBe(false)
+  })
+
+  it('rejects a top-level slottable tile with an unknown property', () => {
+    const invalidTile = { ...slottableTile, foo: 'bar' }
+    expect(validateSlottableTileSchema(invalidTile)).toBe(false)
+    expect(validateDashboardConfigSchema({ tiles: [invalidTile] })).toBe(false)
+  })
+
+  it('validates the legacy chart-based slottable shape', () => {
+    expect(validateDashboardConfigSchema({ tiles: [legacyChartSlottableTile] })).toBe(true)
+  })
+
+  it('marks the legacy chart-level slottable schema as deprecated', () => {
+    expect(slottableSchema.deprecated).toBe(true)
   })
 })

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -73,6 +73,8 @@ const chartDatasetColorsSchema = {
 
 export const slottableSchema = {
   type: 'object',
+  deprecated: true,
+  description: 'Deprecated: use the top-level tile shape { type: \'slottable\', id, layout } instead of a chart-level \'slottable\' definition.',
   properties: {
     type: {
       type: 'string',
@@ -84,8 +86,12 @@ export const slottableSchema = {
   },
   required: ['type', 'id'],
   additionalProperties: false,
-} as const satisfies JSONSchema
+} as const
 
+/**
+ * @deprecated Use the top-level `{ type: 'slottable', id, layout }` tile config shape instead
+ * (see `SlottableTileConfig`).
+ */
 export type SlottableOptions = FromSchemaWithOptions<typeof slottableSchema>
 
 export const barChartSchema = {
@@ -825,7 +831,34 @@ export const chartTileConfigSchema = {
   additionalProperties: false,
 } as const satisfies JSONSchema
 
-export const tileConfigSchema = chartTileConfigSchema
+export type ChartTileConfig = FromSchemaWithOptions<typeof chartTileConfigSchema>
+
+export const slottableTileConfigSchema = {
+  type: 'object',
+  description: 'A tile that renders arbitrary content into a named slot instead of a chart. The slot name is the tile `id`.',
+  properties: {
+    type: {
+      type: 'string',
+      enum: ['slottable'],
+    },
+    id: {
+      type: 'string',
+      description: 'Unique identifier for the tile, and the name of the slot the host application should supply.',
+    },
+    layout: tileLayoutSchema,
+  },
+  required: ['type', 'id', 'layout'],
+  additionalProperties: false,
+} as const satisfies JSONSchema
+
+export type SlottableTileConfig = FromSchemaWithOptions<typeof slottableTileConfigSchema>
+
+export const tileConfigSchema = {
+  anyOf: [
+    chartTileConfigSchema,
+    slottableTileConfigSchema,
+  ],
+} as const satisfies JSONSchema
 
 export type TileConfig = FromSchemaWithOptions<typeof tileConfigSchema>
 

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -166,7 +166,7 @@ const onZoom = async (tileZoomEvent: TileZoomEvent) => {
   v-model="config"
   :context="context"
 >
-  <!-- use the `id` set in the tile config for the slot name -->
+  <!-- use the top-level tile `id` for the slot name -->
   <template #slot-1>
     <div>
       <h3>Custom Slot</h3>
@@ -217,15 +217,9 @@ const config: DashboardConfig = {
       }
     },
     {
-      // Slottable is a chart tile variant selected by definition.chart.type
-      type: 'chart',
-      definition: {
-        chart: {
-          type: 'slottable',
-          id: 'slot-1' // slot name
-        },
-        query: {},
-      },
+      // Slottable tile renders content into the named slot matching `id`.
+      id: 'slot-1', // slot name
+      type: 'slottable',
       layout: {
         // Position at column 3, row 0
         position: {
@@ -233,6 +227,29 @@ const config: DashboardConfig = {
           row: 0,
         },
         // Spans 3 columns and 1 rows
+        size: {
+          cols: 3,
+          rows: 1,
+        }
+      }
+    },
+    {
+      // Deprecated: legacy chart-based slottable tile. The slot name comes from
+      // `definition.chart.id`, not the top-level tile `id`. Use the top-level
+      // `{ type: 'slottable', id, layout }` shape above instead.
+      type: 'chart',
+      definition: {
+        chart: {
+          type: 'slottable',
+          id: 'slot-2' // slot name
+        },
+        query: {},
+      },
+      layout: {
+        position: {
+          col: 3,
+          row: 1,
+        },
         size: {
           cols: 3,
           rows: 1,
@@ -519,7 +536,7 @@ The following chart types are supported:
 - `timeseries_bar`: Bar chart for time series data
 - `golden_signals`: Metric cards showing key performance indicators
 - `top_n`: Table showing top N results
-- `slottable`: Custom content slot
+- `slottable` *(deprecated chart-level variant, use the top-level `{ type: 'slottable', id, layout }` tile instead of `definition.chart.type: 'slottable'`)*: Custom content slot
 
 Each chart type has its own configuration schema with specific options.
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -5,7 +5,7 @@
   >
     <div class="sandbox-container">
       <br>
-      <div style="display: flex; gap: 5px; margin: 5px;">
+      <div class="controls">
         <KButton
           appearance="primary"
           size="small"
@@ -33,7 +33,7 @@
           size="small"
         />
       </div>
-      <div style="max-height: 800px; overflow-y: auto;">
+      <div class="dashboard-scroll-container">
         <DashboardRenderer
           ref="dashboardRendererRef"
           v-model="dashboardConfig"
@@ -363,3 +363,16 @@ const handleZoom = (zoomEvent: TileZoomEvent) => {
 }
 
 </script>
+
+<style lang="scss" scoped>
+.controls {
+  display: flex;
+  gap: var(--kui-space-30, $kui-space-30);
+  margin: var(--kui-space-30, $kui-space-30);
+}
+
+.dashboard-scroll-container {
+  max-height: 800px;
+  overflow-y: auto;
+}
+</style>

--- a/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/EditableDashboardDemo.vue
@@ -230,6 +230,34 @@ const dashboardConfig = ref <DashboardConfig>({
         },
       },
     } satisfies TileConfig,
+    {
+      id: 'slot-1',
+      type: 'slottable',
+      layout: {
+        position: {
+          col: 0,
+          row: 4,
+        },
+        size: {
+          cols: 3,
+          rows: 1,
+        },
+      },
+    } satisfies TileConfig,
+    {
+      id: 'slot-2',
+      type: 'slottable',
+      layout: {
+        position: {
+          col: 3,
+          row: 4,
+        },
+        size: {
+          cols: 3,
+          rows: 1,
+        },
+      },
+    } satisfies TileConfig,
   ],
 })
 

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -287,16 +287,8 @@ const dashboardConfig = ref<DashboardConfig>({
       },
     } satisfies TileConfig,
     {
-      type: 'chart',
-      definition: {
-        chart: {
-          type: 'slottable',
-          id: 'slot-1',
-        },
-        query: {
-          datasource: 'basic',
-        },
-      },
+      id: 'slot-1',
+      type: 'slottable',
       layout: {
         position: {
           col: 1,
@@ -309,16 +301,8 @@ const dashboardConfig = ref<DashboardConfig>({
       },
     } satisfies TileConfig,
     {
-      type: 'chart',
-      definition: {
-        chart: {
-          type: 'slottable',
-          id: 'slot-2',
-        },
-        query: {
-          datasource: 'basic',
-        },
-      },
+      id: 'slot-2',
+      type: 'slottable',
       layout: {
         position: {
           col: 2,

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.spec.ts
@@ -45,7 +45,7 @@ vi.mock('./DashboardTile.vue', () => ({
         required: true,
       },
     },
-    emits: ['duplicate-tile'],
+    emits: ['duplicate-tile', 'tile-loaded'],
     setup(props, { emit }) {
       return () => h('button', {
         'data-testid': `duplicate-dashboard-tile-${props.tileId}`,
@@ -155,6 +155,174 @@ describe('Dashboard schemas', () => {
 
     // Note: Error messages aren't great right now because FromSchema doesn't understand
     // the `discriminator` field, and AJV has limited support for it.
+  })
+
+  it('accepts a config mixing a chart tile and a slottable tile', () => {
+    const definition: any = {
+      tiles: [
+        {
+          type: 'chart',
+          definition: {
+            chart: {
+              type: 'horizontal_bar',
+            },
+            query: {
+              datasource: 'basic',
+            },
+          },
+          layout: {
+            position: {
+              col: 0,
+              row: 0,
+            },
+            size: {
+              cols: 1,
+              rows: 1,
+            },
+          },
+        },
+        {
+          id: 'my-slot',
+          type: 'slottable',
+          layout: {
+            position: {
+              col: 1,
+              row: 0,
+            },
+            size: {
+              cols: 1,
+              rows: 1,
+            },
+          },
+        },
+      ],
+    }
+
+    expect(validate(definition)).toBe(true)
+  })
+})
+
+describe('Slottable tiles', () => {
+  const mountDashboardRenderer = (model: DashboardConfig, slots: Record<string, string>) => {
+    return mount(DashboardRenderer, {
+      props: {
+        context: {},
+        modelValue: model,
+      },
+      slots,
+      global: {
+        provide: {
+          [INJECT_QUERY_PROVIDER]: {
+            configFn: vi.fn().mockResolvedValue({ analytics: { percentiles: true } }),
+            datasourceConfigFn: vi.fn().mockResolvedValue([]),
+            evaluateFeatureFlagFn: vi.fn(),
+            queryFn: vi.fn(),
+          },
+        },
+        stubs: {
+          KAlert: true,
+        },
+      },
+    })
+  }
+
+  it('mounts slottable tiles to the named slot with tile.id', () => {
+    setupPiniaTestStore()
+
+    const model: DashboardConfig = {
+      tiles: [
+        {
+          id: 'my-slot',
+          type: 'slottable',
+          layout: {
+            position: { col: 0, row: 0 },
+            size: { cols: 1, rows: 1 },
+          },
+        },
+      ],
+    }
+
+    const wrapper = mountDashboardRenderer(model, {
+      'my-slot': '<span data-testid="slot-content">hi</span>',
+    })
+
+    expect(wrapper.find('[data-testid="slot-content"]').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'DashboardTile' }).exists()).toBe(false)
+  })
+
+  it('mounts legacy slottable tiles with definition.chart.id', () => {
+    setupPiniaTestStore()
+
+    const model: DashboardConfig = {
+      tiles: [
+        {
+          id: 'outer-id',
+          type: 'chart',
+          definition: {
+            chart: {
+              type: 'slottable',
+              id: 'legacy-slot',
+            },
+            query: {
+              datasource: 'basic',
+            },
+          },
+          layout: {
+            position: { col: 0, row: 0 },
+            size: { cols: 1, rows: 1 },
+          },
+        },
+      ],
+    }
+
+    const wrapper = mountDashboardRenderer(model, {
+      'legacy-slot': '<span data-testid="slot-content">hi</span>',
+    })
+
+    expect(wrapper.find('[data-testid="slot-content"]').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'DashboardTile' }).exists()).toBe(false)
+  })
+
+  it('excludes both slottable shapes from the loaded emit count', async () => {
+    setupPiniaTestStore()
+
+    const model: DashboardConfig = {
+      tiles: [
+        {
+          id: 'chart-1',
+          type: 'chart',
+          definition: {
+            chart: {
+              type: 'horizontal_bar',
+            },
+            query: {
+              datasource: 'basic',
+            },
+          },
+          layout: {
+            position: { col: 0, row: 0 },
+            size: { cols: 1, rows: 1 },
+          },
+        },
+        {
+          id: 'my-slot',
+          type: 'slottable',
+          layout: {
+            position: { col: 1, row: 0 },
+            size: { cols: 1, rows: 1 },
+          },
+        },
+      ],
+    }
+
+    const wrapper = mountDashboardRenderer(model, {})
+
+    const dashboardTiles = wrapper.findAllComponents({ name: 'DashboardTile' })
+    expect(dashboardTiles).toHaveLength(1)
+
+    await dashboardTiles[0].vm.$emit('tile-loaded')
+
+    expect(wrapper.emitted('tiles-loaded')).toEqual([[true]])
   })
 })
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -44,7 +44,7 @@
             v-model:refresh-counter="refreshCounter"
             class="tile-container"
             :context="internalContext"
-            :definition="tile.meta"
+            :definition="tile.meta as TileDefinition"
             :height="tile.layout.size.rows * (model.tile_height || DEFAULT_TILE_HEIGHT) + parseInt(KUI_SPACE_70, 10)"
             :hide-actions="!internalContext.showTileActions"
             :hide-zoom-actions="!internalContext.showTileZoomActions"
@@ -154,6 +154,22 @@ const tileSortFn = (a: TileConfig, b: TileConfig) => {
 
 const gridTiles = computed<Array<GridTile<TileDefinition>>>(() => {
   return model.value.tiles.map((tile: TileConfig) => {
+    if (internalContext.value.editable && !tile.id) {
+      console.warn(
+        'No id provided for tile. One will be generated automatically,',
+        'however tracking changes to this tile may not work as expected.',
+        tile,
+      )
+    }
+
+    if (tile.type === 'slottable') {
+      return {
+        layout: tile.layout,
+        type: tile.type,
+        id: tile.id ?? crypto.randomUUID(),
+      }
+    }
+
     let tileMeta = tile.definition
     const tileType = tile.type ?? 'chart'
 
@@ -186,14 +202,6 @@ const gridTiles = computed<Array<GridTile<TileDefinition>>>(() => {
       } as TileDefinition
     }
 
-    if (internalContext.value.editable && !tile.id) {
-      console.warn(
-        'No id provided for tile. One will be generated automatically,',
-        'however tracking changes to this tile may not work as expected.',
-        tile,
-      )
-    }
-
     return {
       layout: tile.layout,
       meta: tileMeta,
@@ -212,7 +220,11 @@ const onEditTile = (tile: GridTile<TileDefinition>) => {
 }
 
 const isSlottableTile = (tile: GridTile<TileDefinition>): boolean => {
-  return tile.type === 'chart' && (tile.meta as ChartTileDefinition).chart.type === 'slottable'
+  if (tile.type === 'slottable') {
+    return true
+  }
+
+  return (tile.meta as ChartTileDefinition)?.chart.type === 'slottable'
 }
 
 const isSlottable = (chart: any): chart is SlottableOptions => {
@@ -220,8 +232,13 @@ const isSlottable = (chart: any): chart is SlottableOptions => {
 }
 
 const getSlottableSlotName = (tile: GridTile<TileDefinition>): string | undefined => {
-  const chart = (tile.meta as ChartTileDefinition).chart
-  return isSlottable(chart) ? chart.id : undefined
+  if (tile.type === 'slottable') {
+    return tile.id as string
+  }
+
+  const chart = (tile.meta as ChartTileDefinition)?.chart
+
+  return chart && isSlottable(chart) ? chart.id : undefined
 }
 
 const onDuplicateTile = (tile: GridTile<TileDefinition>) => {
@@ -250,11 +267,19 @@ const refreshTiles = () => {
 
 const handleUpdateTiles = (tiles: Array<GridTile<TileDefinition>>) => {
   const updatedTiles = tiles.map(tile => {
+    if (tile.type === 'slottable') {
+      return {
+        id: tile.id,
+        type: tile.type,
+        layout: tile.layout,
+      } as TileConfig
+    }
+
     return {
       id: tile.id,
       type: tile.type,
       layout: tile.layout,
-      definition: tile.meta,
+      definition: tile.meta as TileDefinition,
     } as TileConfig
   })
 

--- a/packages/analytics/dashboard-renderer/src/types/grid-layout-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/grid-layout-types.ts
@@ -14,7 +14,7 @@ export interface GridTile<T> {
   id: string | number
   type: TileConfig['type']
   layout: TileLayout
-  meta: T
+  meta?: T
 }
 
 export interface Cell<T> {

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.spec.ts
@@ -366,6 +366,47 @@ describe('configureAllowedDefinition', () => {
     })
   })
 
+  describe('slottable tiles', () => {
+    const mockSlottableTile: TileConfig = {
+      id: 'slot_1',
+      type: 'slottable',
+      layout: {
+        size: { cols: 3, rows: 1 },
+        position: { col: 0, row: 0 },
+      },
+    }
+
+    it('keeps slottable tiles in advanced', () => {
+      const config: DashboardConfig = {
+        tiles: [mockSlottableTile],
+        tile_height: 167,
+      }
+
+      const result = configureAllowedDefinition(config, true)
+
+      expect(result.tiles).toHaveLength(1)
+      expect(result.tiles[0]).toEqual(mockSlottableTile)
+    })
+
+    it('keeps slottable tiles in the basic', () => {
+      const warnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const config: DashboardConfig = {
+        tiles: [mockSlottableTile, mockApiUsageTile],
+        tile_height: 167,
+      }
+
+      const result = configureAllowedDefinition(config, false)
+
+      expect(warnMock).toHaveBeenCalledOnce()
+      warnMock.mockRestore()
+
+      expect(result.tiles).toHaveLength(1)
+      expect(result.tiles[0]).toEqual(mockSlottableTile)
+      expect(result.tiles[0].id).toBe('slot_1')
+      expect(result.tiles[0].type).toBe('slottable')
+    })
+  })
+
   describe('Edge Cases', () => {
     it('should handle tiles with missing layout size properties', () => {
       const tileWithoutSize: TileConfig = {

--- a/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/configure-definition.ts
@@ -13,6 +13,10 @@ import { isTableChartDefinition } from './tile-definition'
  * @returns The updated tile configuration object.
  */
 const processTileForBasicTier = (tile: TileConfig): TileConfig | undefined => {
+  if (tile.type !== 'chart') {
+    return tile
+  }
+
   const query = tile.definition?.query
 
   if (!query) {
@@ -35,6 +39,10 @@ const processTileForBasicTier = (tile: TileConfig): TileConfig | undefined => {
  * @returns The updated tile configuration object.
  */
 const processTileForAdvancedTier = (tile: TileConfig): TileConfig => {
+  if (tile.type !== 'chart') {
+    return tile
+  }
+
   if (isTableChartDefinition(tile.definition)) {
     // Table chart queries use the platform tabular API, so leave their datasource unchanged.
     return tile

--- a/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.spec.ts
@@ -127,3 +127,24 @@ it('duplicates slottable chart tiles without prefixing a title', () => {
     },
   })
 })
+
+it('duplicates slottable tiles with a new id and reset position', () => {
+  vi.spyOn(crypto, 'randomUUID').mockReturnValue('new-slot-id')
+  const tile: GridTile<TileDefinition> = {
+    id: 'slot-1',
+    type: 'slottable',
+    layout: {
+      position: { col: 3, row: 4 },
+      size: { cols: 2, rows: 1 },
+    },
+  }
+
+  expect(duplicateChartTile(tile)).toEqual({
+    id: 'new-slot-id',
+    type: 'slottable',
+    layout: {
+      position: { col: 0, row: 0 },
+      size: { cols: 2, rows: 1 },
+    },
+  })
+})

--- a/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/duplicate-tile.ts
@@ -2,19 +2,37 @@ import type { GridTile } from '../types'
 import type {
   TileConfig,
   TileDefinition,
+  TileLayout,
 } from '@kong-ui-public/analytics-utilities'
 
 /**
- * Creates a chart tile copy with a new id, origin position, preserved size, and
- * copied chart metadata. Chart titles are prefixed when supported.
+ * Creates a tile copy with a new id, origin position, and preserved size. Slottable tiles get a new id (slot name).
+ * Legacy Chart tiles get copied chart metadata, with titles prefixed when supported.
  *
  * @param tile The existing dashboard grid tile to duplicate.
- * @returns A chart tile config ready to be inserted into the dashboard.
+ * @returns A tile config ready to be inserted into the dashboard.
  */
 export const duplicateChartTile = (tile: GridTile<TileDefinition>): TileConfig => {
+  const layout: TileLayout = {
+    position: {
+      col: 0,
+      row: 0,
+    },
+    size: tile.layout.size,
+  }
+
+  if (tile.type === 'slottable') {
+    return {
+      id: crypto.randomUUID(),
+      type: 'slottable',
+      layout,
+    }
+  }
+
+  const meta = tile.meta as TileDefinition
   const duplicatedDefinition = {
-    ...tile.meta,
-    chart: { ...tile.meta.chart },
+    ...meta,
+    chart: { ...meta.chart },
   } as TileDefinition
 
   if ('chart_title' in duplicatedDefinition.chart) {
@@ -27,12 +45,6 @@ export const duplicateChartTile = (tile: GridTile<TileDefinition>): TileConfig =
     id: crypto.randomUUID(),
     type: 'chart',
     definition: duplicatedDefinition,
-    layout: {
-      position: {
-        col: 0,
-        row: 0,
-      },
-      size: tile.layout.size,
-    },
+    layout,
   }
 }


### PR DESCRIPTION
# Summary

Close [MA-5141](https://konghq.atlassian.net/browse/MA-5141)

This will add the dashboard slottable tile type and deprecate the chart tile's `definition.chart.type: "slottable"` prop.
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-5141]: https://konghq.atlassian.net/browse/MA-5141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ