### PR TITLE
feat(entities-plugins): add allow_when/deny_when modes to ACL plugin

### DIFF
--- a/packages/entities/entities-plugins/fixtures/schemas/acl.ts
+++ b/packages/entities/entities-plugins/fixtures/schemas/acl.ts
@@ -1,0 +1,127 @@
+import type { FormSchema } from '../../src/types/plugins/form-schema'
+
+// Mirrors the real Kong Gateway ACL plugin schema (`kong.plugins.acl.schema`).
+const aclSchema: FormSchema = {
+  type: 'record',
+  entity_checks: [
+    {
+      only_one_of: ['config.allow', 'config.deny', 'config.allow_when', 'config.deny_when'],
+    },
+  ],
+  fields: [
+    {
+      consumer: {
+        description: 'Custom type for representing a foreign key with a null value allowed.',
+        eq: null,
+        type: 'foreign',
+        reference: 'consumers',
+      },
+    },
+    {
+      consumer_group: {
+        description: 'Custom type for representing a foreign key with a null value allowed.',
+        eq: null,
+        type: 'foreign',
+        reference: 'consumer_groups',
+      },
+    },
+    {
+      protocols: {
+        default: ['grpc', 'grpcs', 'http', 'https'],
+        type: 'set',
+        elements: {
+          one_of: ['grpc', 'grpcs', 'http', 'https', 'ws', 'wss'],
+          type: 'string',
+          len_min: 1,
+          required: true,
+        },
+        required: true,
+      },
+    },
+    {
+      config: {
+        type: 'record',
+        required: true,
+        fields: [
+          {
+            allow: {
+              description: 'Arbitrary group names that are allowed to consume the service or route. Exactly one of `config.allow`, `config.deny`, `config.allow_when`, or `config.deny_when` must be specified.',
+              elements: { type: 'string' },
+              type: 'array',
+            },
+          },
+          {
+            deny: {
+              description: 'Arbitrary group names that are not allowed to consume the service or route. Exactly one of `config.allow`, `config.deny`, `config.allow_when`, or `config.deny_when` must be specified.',
+              elements: { type: 'string' },
+              type: 'array',
+            },
+          },
+          {
+            hide_groups_header: {
+              description: 'If enabled (`true`), prevents the `X-Consumer-Groups` header from being sent in the request to the upstream service. This header is not set when allow_when or deny_when is used.',
+              default: false,
+              type: 'boolean',
+              required: true,
+            },
+          },
+          {
+            include_consumer_groups: {
+              description: 'If enabled (`true`), allows the consumer-groups to be used in the `allow|deny` fields. This option is ignored when `allow_when` or `deny_when` is used.',
+              default: false,
+              type: 'boolean',
+              required: false,
+            },
+          },
+          {
+            always_use_authenticated_groups: {
+              description: 'If enabled (`true`), the authenticated groups will always be used even when an authenticated consumer already exists. If the authenticated groups don\'t exist, it will fallback to use the groups associated with the consumer. By default the authenticated groups will only be used when there is no consumer or the consumer is anonymous. This option is ignored when `allow_when` or `deny_when` is effective.',
+              default: false,
+              type: 'boolean',
+              required: true,
+            },
+          },
+          {
+            allow_when: {
+              description: 'Allow the request if it matches any of these CEL boolean expressions evaluated against the request context (consumer, principal, HTTP attributes, consumer groups, etc.). Exactly one of `config.allow`, `config.deny`, `config.allow_when`, or `config.deny_when` must be specified.',
+              elements: { type: 'string', len_min: 1, len_max: 1024 },
+              type: 'array',
+            },
+          },
+          {
+            deny_when: {
+              description: 'Deny the request if it matches any of these CEL boolean expressions evaluated against the request context (consumer, principal, HTTP attributes, consumer groups, etc.). Exactly one of `config.allow`, `config.deny`, `config.allow_when`, or `config.deny_when` must be specified.',
+              elements: { type: 'string', len_min: 1, len_max: 1024 },
+              type: 'array',
+            },
+          },
+        ],
+      },
+    },
+  ],
+}
+
+export default aclSchema
+
+// A Gateway version that predates the `allow_when`/`deny_when` schema fields, so
+// ACLModeCard should only offer the allow/deny modes.
+export const aclSchemaWithoutWhenModes: FormSchema = {
+  ...aclSchema,
+  entity_checks: [
+    {
+      only_one_of: ['config.allow', 'config.deny'],
+    },
+  ],
+  fields: aclSchema.fields.map((field) => {
+    if (!('config' in field)) return field
+
+    return {
+      config: {
+        ...field.config,
+        fields: field.config.fields.filter((configField: Record<string, unknown>) => (
+          !('allow_when' in configField) && !('deny_when' in configField)
+        )),
+      },
+    }
+  }),
+}

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLForm.cy.ts
@@ -1,0 +1,104 @@
+import ACLForm from './ACLForm.vue'
+import aclSchema, { aclSchemaWithoutWhenModes } from '../../../../../fixtures/schemas/acl'
+import type { FormSchema } from '../../../../types/plugins/form-schema'
+
+interface MountOptions {
+  schema?: FormSchema
+  model?: Record<string, any>
+}
+
+const mountForm = (options: MountOptions = {}) => {
+  const { schema = aclSchema, model = { config: {} } } = options
+
+  cy.mount(ACLForm as any, {
+    props: {
+      schema,
+      formSchema: { fields: [] },
+      formModel: {},
+      model,
+      isEditing: false,
+      pluginName: 'acl',
+      onFormChange: cy.spy().as('onFormChange'),
+    },
+  })
+}
+
+const lastFormChange = () => cy.get('@onFormChange').its('lastCall').its('args.0')
+
+describe('<ACLForm /> - mode switching', () => {
+  it('defaults to the allow mode with the allow field visible', () => {
+    mountForm()
+
+    cy.getTestId('ff-acl-mode-allow').should('be.checked')
+    cy.getTestId('ff-array-config.allow').should('exist')
+    cy.getTestId('ff-array-config.deny').should('not.exist')
+  })
+
+  it('pre-selects the mode that already has data on load', () => {
+    mountForm({ model: { config: { deny_when: ['request.method == "GET"'] } } })
+
+    cy.getTestId('ff-acl-mode-deny_when').should('be.checked')
+    cy.getTestId('ff-array-config.deny_when').should('exist')
+  })
+
+  it('switches the checked radio and the rendered field when a new mode is picked', () => {
+    mountForm()
+
+    cy.getTestId('ff-acl-mode-deny').click()
+    cy.getTestId('ff-acl-mode-allow').should('not.be.checked')
+    cy.getTestId('ff-acl-mode-deny').should('be.checked')
+    cy.getTestId('ff-array-config.deny').should('exist')
+    cy.getTestId('ff-array-config.allow').should('not.exist')
+
+    cy.getTestId('ff-acl-mode-allow_when').click()
+    cy.getTestId('ff-acl-mode-deny').should('not.be.checked')
+    cy.getTestId('ff-acl-mode-allow_when').should('be.checked')
+    cy.getTestId('ff-array-config.allow_when').should('exist')
+    cy.getTestId('ff-array-config.deny').should('not.exist')
+  })
+
+  it('shows the correct field label after switching modes (no stale label from a reused Field instance)', () => {
+    mountForm()
+
+    cy.getTestId('ff-label-config.allow').should('contain.text', 'Allow')
+
+    cy.getTestId('ff-acl-mode-deny').click()
+    cy.getTestId('ff-label-config.deny').should('contain.text', 'Deny')
+    cy.getTestId('ff-label-config.allow').should('not.exist')
+
+    cy.getTestId('ff-acl-mode-allow_when').click()
+    cy.getTestId('ff-label-config.allow_when').should('contain.text', 'Allow when')
+    cy.getTestId('ff-label-config.deny').should('not.exist')
+  })
+
+  it('clears the previous mode\'s data when switching', () => {
+    mountForm({ model: { config: { allow: ['group-a', 'group-b'] } } })
+
+    cy.getTestId('ff-acl-mode-deny').click()
+    lastFormChange().its('config.allow').should('be.null')
+    lastFormChange().its('config.allow_when').should('be.null')
+    lastFormChange().its('config.deny_when').should('be.null')
+    // `deny` is the newly-active mode and was never assigned a value in this
+    // scenario, so it may come back as `null` or simply be absent — either is fine.
+    lastFormChange().its('config').should('satisfy', (config: Record<string, unknown>) => config.deny == null)
+  })
+
+  it('restores cached data when switching back to a previously-filled mode', () => {
+    mountForm({ model: { config: { allow: ['group-a'] } } })
+
+    cy.getTestId('ff-acl-mode-deny').click()
+    cy.getTestId('ff-acl-mode-allow').click()
+
+    cy.getTestId('ff-array-item-config.allow.0').should('exist')
+    cy.getTestId('ff-config.allow.0').should('have.value', 'group-a')
+  })
+
+  it('hides the allow_when/deny_when modes when the schema does not declare them', () => {
+    mountForm({ schema: aclSchemaWithoutWhenModes })
+
+    cy.getTestId('ff-acl-mode-allow').should('exist')
+    cy.getTestId('ff-acl-mode-deny').should('exist')
+    cy.getTestId('ff-acl-mode-allow_when').should('not.exist')
+    cy.getTestId('ff-acl-mode-deny_when').should('not.exist')
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLForm.vue
@@ -5,7 +5,7 @@
     <ObjectField
       as-child
       name="config"
-      :omit="['allow', 'deny']"
+      :omit="['allow', 'deny', 'allow_when', 'deny_when']"
       reset-label-path="reset"
     />
   </DynamicLayout>

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLModeCard.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLModeCard.vue
@@ -2,34 +2,44 @@
   <KCard class="ff-acl-mode-card">
     <div class="ff-acl-mode">
       <KRadio
+        v-for="item in MODES"
+        :key="item"
         v-model="mode"
-        data-testid="ff-acl-mode-allow"
-        :label="t('plugins.free-form.acl.mode.allow')"
-        :selected-value="'allow'"
-        @update:model-value="handleModeChange"
-      />
-      <KRadio
-        v-model="mode"
-        data-testid="ff-acl-mode-deny"
-        :label="t('plugins.free-form.acl.mode.deny')"
-        :selected-value="'deny'"
+        :data-testid="`ff-acl-mode-${item}`"
+        :label="t(`plugins.free-form.acl.mode.${item}`)"
+        :selected-value="item"
         @update:model-value="handleModeChange"
       />
     </div>
 
+    <!--
+      An explicit v-if/v-else-if chain (rather than one Field with a dynamic :name)
+      is intentional: Vue 3 gives each conditional branch an implicit unique key, so
+      switching modes always fully unmounts/remounts the Field instead of patching
+      props onto a reused one — which is what a single dynamic :name would do here,
+      since all four config fields render via the same underlying component.
+    -->
     <Field
       v-if="mode === 'allow'"
       name="config.allow"
     />
     <Field
-      v-else
+      v-else-if="mode === 'deny'"
       name="config.deny"
+    />
+    <Field
+      v-else-if="mode === 'allow_when'"
+      name="config.allow_when"
+    />
+    <Field
+      v-else
+      name="config.deny_when"
     />
   </KCard>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { KCard, KRadio } from '@kong/kongponents'
 import { useFormShared } from '../../shared/composables'
 import Field from '../../shared/Field.vue'
@@ -40,56 +50,61 @@ import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
 type AclConfig = {
   allow?: string[] | null
   deny?: string[] | null
+  // allow_when and deny_when are CEL expressions
+  allow_when?: string[] | null
+  deny_when?: string[] | null
 }
 
-type AclMode = 'allow' | 'deny'
+type AclMode = keyof AclConfig
 
-const { formData } = useFormShared<FreeFormPluginData<AclConfig>>()
+// Order matters: radios are rendered in this order, and it is also the priority
+// used to detect the active mode on initial load.
+const ALL_MODES: AclMode[] = ['allow', 'deny', 'allow_when', 'deny_when']
+
+const { formData, getSchema } = useFormShared<FreeFormPluginData<AclConfig>>()
 const { i18n: { t } } = useI18n()
+
+// allow_when/deny_when are newer additions to the ACL plugin's schema; a Gateway
+// version that predates them simply won't declare the fields, so hide those modes
+// instead of offering a selection that has nowhere to write its data.
+const MODES = computed(() => ALL_MODES.filter((m) => !!getSchema(`config.${m}`)))
 
 const mode = ref<AclMode>('allow')
 const userSelectedMode = ref(false)
-const cache = ref<{ allow?: string[], deny?: string[] }>({})
+const cache = ref<Partial<Record<AclMode, string[]>>>({})
 
 // Watch formData to detect which mode has data on initial load
 watch(() => formData.config, (config) => {
   if (userSelectedMode.value) return
   if (!config) return
 
-  const deny = config.deny
-  const allow = config.allow
-
-  if (Array.isArray(deny) && deny.length > 0) {
-    mode.value = 'deny'
-  } else if (Array.isArray(allow) && allow.length > 0) {
-    mode.value = 'allow'
+  // The modes are mutually exclusive, so at most one of them should hold data
+  const active = MODES.value.find((m) => Array.isArray(config[m]) && config[m]!.length > 0)
+  if (active) {
+    mode.value = active
   }
 }, { deep: true, immediate: true })
 
 function handleModeChange() {
   userSelectedMode.value = true
 
-  if (!formData.config) return
+  const config = formData.config
+  if (!config) return
 
-  // Cache the current field before deleting
-  if (mode.value === 'allow') {
-    if (formData.config.deny) {
-      cache.value.deny = [...formData.config.deny]
+  // Cache the other fields before clearing them, so switching back is lossless
+  for (const m of MODES.value) {
+    if (m === mode.value) continue
+
+    if (config[m]) {
+      cache.value[m] = [...config[m]!]
     }
-    formData.config.deny = null
-    // Restore cached allow data if exists
-    if (cache.value.allow) {
-      formData.config.allow = [...cache.value.allow]
-    }
-  } else {
-    if (formData.config.allow) {
-      cache.value.allow = [...formData.config.allow]
-    }
-    formData.config.allow = null
-    // Restore cached deny data if exists
-    if (cache.value.deny) {
-      formData.config.deny = [...cache.value.deny]
-    }
+    config[m] = null
+  }
+
+  // Restore cached data for the selected mode if it exists
+  const cached = cache.value[mode.value]
+  if (cached) {
+    config[mode.value] = [...cached]
   }
 }
 </script>

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -809,7 +809,9 @@
       "acl": {
         "mode": {
           "allow": "Use allow list",
-          "deny": "Use deny list"
+          "deny": "Use deny list",
+          "allow_when": "Use allow expression list",
+          "deny_when": "Use deny expression list"
         }
       },
       "ai-mcp-proxy": {


### PR DESCRIPTION
# Summary

Extend ACLModeCard to support the ACL plugin's newer allow_when/deny_when CEL-expression fields alongside allow/deny, gated on whether the active schema actually declares them (older Gateway versions won't). Switching modes uses an explicit v-if/v-else-if chain so each mode gets its own Field instance instead of reusing one across mode switches, which was causing the field label to freeze on whatever mode was active at first mount.

**Schema with no allow_when/deny_when field**
<img width="917" height="656" alt="截屏2026-08-06 14 27 25" src="https://github.com/user-attachments/assets/b8a2840a-c35f-467c-9403-5b79070fee83" />

**Schema with allow_when/deny_when field**
<img width="917" height="690" alt="截屏2026-08-06 14 27 58" src="https://github.com/user-attachments/assets/9a0b9fb0-3174-4d96-aa04-25eeb086572e" />
