### PR TITLE
fix(entities-certificates): skip card wrapper for multi-step certificate form layout

### DIFF
--- a/packages/entities/entities-certificates/src/components/CertificateForm.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateForm.vue
@@ -10,6 +10,7 @@
       :fetch-url="fetchUrl"
       :form-fields="requestBody"
       :is-readonly="form.isReadonly"
+      :wrapper-component="config.azureCertsVaultAvailable ? 'div' : undefined"
       @cancel="handleClickCancel"
       @fetch:error="(err: any) => $emit('error', err)"
       @fetch:success="initForm"


### PR DESCRIPTION
## What
Adds the wrapper-component prop to CertificateForm's EntityBaseForm usage so the card wrapper is skipped when the multi-step layout (Azure Certs Vault) is active, matching the pattern already used in RedisConfigurationForm and PluginForm.

[KM-3045]

[KM-3045]: https://konghq.atlassian.net/browse/KM-3045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ