### PR TITLE
fix(entities-vaults): remove redundant try/catch in createConfigStore

### DIFF
--- a/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
+++ b/packages/entities/entities-vaults/src/components/VaultForm.cy.ts
@@ -1351,6 +1351,36 @@ describe('<VaultForm />', () => {
       cy.wait('@createConfigStoreNoWorkspace')
       cy.wait('@createVaultNoWorkspace')
     })
+
+    it('should stop and emit error once when createConfigStore request fails, without firing the vault create request', () => {
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/config-stores`,
+        },
+        { statusCode: 500, body: {} },
+      ).as('createConfigStoreFailed')
+      cy.intercept(
+        {
+          method: 'POST',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/vaults`,
+        },
+        { statusCode: 201, body: vault },
+      ).as('createVault')
+
+      cy.mount(VaultForm, {
+        props: {
+          config: baseConfigKonnect,
+          onError: cy.spy().as('onErrorSpy'),
+        },
+      }).then(({ wrapper }) => wrapper).as('vueWrapper')
+
+      cy.get('@vueWrapper').then(wrapper => wrapper.findComponent(EntityBaseForm).vm.$emit('submit'))
+
+      cy.wait('@createConfigStoreFailed')
+      cy.get('@onErrorSpy').should('have.been.calledOnce')
+      cy.get('@createVault.all').should('have.length', 0)
+    })
   })
 
   describe('Kong AI Gateway', () => {

--- a/packages/entities/entities-vaults/src/components/VaultForm.vue
+++ b/packages/entities/entities-vaults/src/components/VaultForm.vue
@@ -1928,24 +1928,15 @@ const payloadWithConfigStoreId = computed<Record<string, any>>(() => (
 ))
 
 const createConfigStore = async (): Promise<string | undefined> => {
-  try {
-    form.isReadonly = true
+  // createConfigStore only applies to the konnect provider flow (konnect / AI Gateway apps).
+  const requestUrl = withAiGatewayId(`${props.config.apiBaseUrl}${endpoints.form[isAiGateway.value ? 'aiGateway' : 'konnect'].createConfigStore}`)
+    .replace(/{controlPlaneId}/gi, (props.config as KonnectVaultFormConfig)?.controlPlaneId || '')
+    .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 
-    // createConfigStore only applies to the konnect provider flow (konnect / AI Gateway apps).
-    const requestUrl = withAiGatewayId(`${props.config.apiBaseUrl}${endpoints.form[isAiGateway.value ? 'aiGateway' : 'konnect'].createConfigStore}`)
-      .replace(/{controlPlaneId}/gi, (props.config as KonnectVaultFormConfig)?.controlPlaneId || '')
-      .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
+  const body = isAiGateway.value ? { name: form.fields.prefix } : undefined
+  const response = await axiosInstance.post<KonnectConfigStore>(requestUrl, body)
 
-    const body = isAiGateway.value ? { name: form.fields.prefix } : undefined
-    const response = await axiosInstance.post<KonnectConfigStore>(requestUrl, body)
-
-    return response?.data.id
-  } catch (error: any) {
-    form.errorMessage = getMessageFromError(error)
-    emit('error', error as AxiosError)
-  } finally {
-    form.isReadonly = false
-  }
+  return response?.data.id
 }
 
 const saveFormData = async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- `createConfigStore` had its own try/catch/finally that duplicated the error handling already done by its only caller, `saveFormData`.
- Because the inner catch swallowed the error and returned `undefined`, `saveFormData` would continue past the failed `createConfigStore()` call with a missing `configStoreId`, firing a second request that was also doomed to fail — and overwriting `form.errorMessage` a second time in the process.
- Removed the inner try/catch so the error propagates and is handled exactly once, in `saveFormData`'s existing catch block.

## Test plan
- [x] Trigger a failure in the `createConfigStore` request (e.g. mock a 4xx/5xx from the create-config-store endpoint) for both create and edit flows, and confirm `saveFormData` stops immediately without firing the follow-up post/put request, and `form.errorMessage`/`error` emit only once.
- [x] Confirm the happy path (successful config store creation) still works for both konnect and AI Gateway flows.

KM-3053