### PR TITLE
feat(entities-gateway-services): gate force-delete confirmation behind a feature flag

### DIFF
--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -862,6 +862,7 @@ describe('<GatewayServiceList />', () => {
           canEdit: () => false,
           canDelete: () => true,
           canRetrieve: () => false,
+          enableForceDeleteConfirmation: true,
         },
       })
 
@@ -972,6 +973,46 @@ describe('<GatewayServiceList />', () => {
       cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled').click()
 
       cy.wait('@deleteService').its('request.url').should('include', 'force=true')
+    })
+
+    it('skips the related-entities check and deletes normally when the feature flag is disabled', () => {
+      cy.intercept(
+        { method: 'GET', url: `${servicesUrl}/${serviceId}/routes*` },
+        { statusCode: 200, body: { data: [{ id: 'route-1' }] } },
+      ).as('getRoutes')
+      cy.intercept(
+        { method: 'GET', url: `${servicesUrl}/${serviceId}/plugins*` },
+        { statusCode: 200, body: { data: [{ id: 'plugin-1' }] } },
+      ).as('getPlugins')
+      cy.intercept(
+        { method: 'DELETE', url: `${servicesUrl}/${serviceId}*` },
+        { statusCode: 204 },
+      ).as('deleteService')
+
+      // enableForceDeleteConfirmation defaults to false
+      cy.mount(GatewayServiceList, {
+        props: {
+          cacheIdentifier: `gateway-service-list-${uuidv4()}`,
+          config: baseConfigKonnect,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => true,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.getTestId('row-actions-dropdown-trigger').eq(0).click()
+      cy.get(`[data-testid="${serviceName}-actions-dropdown-popover"] [data-testid="action-entity-delete"]`).click()
+
+      cy.get('@getRoutes.all').should('have.length', 0)
+      cy.get('@getPlugins.all').should('have.length', 0)
+      cy.get(`${modal} .extra`).should('not.exist')
+      cy.getTestId('gateway-service-delete-force-checkbox').should('not.exist')
+
+      cy.getTestId('confirmation-input').type(serviceName)
+      cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled').click()
+
+      cy.wait('@deleteService').its('request.url').should('not.include', 'force')
     })
   })
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -369,6 +369,11 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  /** Feature flag KM-3028-service-force-delete: when enabled, checks for attached routes/plugins before deleting a Konnect gateway service and requires a force-delete confirmation if any are found */
+  enableForceDeleteConfirmation: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const { i18n: { t, formatUnixTimeStamp } } = composables.useI18n()
@@ -671,10 +676,12 @@ const forceDeleteConfirmed = ref<boolean>(false)
 const relatedEntitiesCheckFailed = ref<boolean>(false)
 
 const hasRelatedEntities = computed((): boolean =>
-  relatedEntitiesCheckFailed.value || relatedRoutesCount.value > 0 || relatedPluginsCount.value > 0)
+  props.enableForceDeleteConfirmation &&
+  (relatedEntitiesCheckFailed.value || relatedRoutesCount.value > 0 || relatedPluginsCount.value > 0))
 // A service that still has routes attached (or whose related-entities count couldn't be verified)
 // requires an explicit force delete confirmation
-const requiresForceDelete = computed((): boolean => relatedEntitiesCheckFailed.value || relatedRoutesCount.value > 0)
+const requiresForceDelete = computed((): boolean =>
+  props.enableForceDeleteConfirmation && (relatedEntitiesCheckFailed.value || relatedRoutesCount.value > 0))
 
 // Only shown when the service has no routes (the checkbox + help text cover the routes case)
 const relatedEntitiesMessage = computed((): string => {
@@ -709,7 +716,7 @@ const confirmDelete = async (row: EntityRow): Promise<void> => {
   relatedPluginsCount.value = 0
   relatedEntitiesCheckFailed.value = false
 
-  if (props.config.app === 'konnect') {
+  if (props.enableForceDeleteConfirmation && props.config.app === 'konnect') {
     try {
       const [routesCount, pluginsCount] = await Promise.all([
         fetchRelatedEntityCount(endpoints.relatedEntities.konnect.routes, row.id as string),


### PR DESCRIPTION
## Summary
- Follows up on #3642 (merged): the routes/plugins check + "Force delete" confirmation on Konnect gateway service deletion is now gated behind a new `enableForceDeleteConfirmation` prop on `GatewayServiceList`, defaulting to `false`.
- When the prop is `false` (default), `GatewayServiceList` behaves exactly as it did before #3642 — no related-entities lookup, no checkbox, plain delete.
- When `true`, behavior is unchanged from #3642's merged implementation.
- Intended LaunchDarkly flag key for consuming apps: `KM-3028-service-force-delete`.

KM-3028
