### PR TITLE
feat(entities-plugins): redesign ACL access policy selection

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLForm.cy.ts
@@ -60,15 +60,41 @@ describe('<ACLForm /> - mode switching', () => {
   it('shows the correct field label after switching modes (no stale label from a reused Field instance)', () => {
     mountForm()
 
-    cy.getTestId('ff-label-config.allow').should('contain.text', 'Allow')
+    cy.getTestId('ff-label-config.allow').should('contain.text', 'Allowed list')
 
     cy.getTestId('ff-acl-mode-deny').click()
-    cy.getTestId('ff-label-config.deny').should('contain.text', 'Deny')
+    cy.getTestId('ff-label-config.deny').should('contain.text', 'Denied list')
     cy.getTestId('ff-label-config.allow').should('not.exist')
 
     cy.getTestId('ff-acl-mode-allow_when').click()
-    cy.getTestId('ff-label-config.allow_when').should('contain.text', 'Allow when')
+    cy.getTestId('ff-label-config.allow_when').should('contain.text', 'Kong plug-in conditional expression')
     cy.getTestId('ff-label-config.deny').should('not.exist')
+  })
+
+  it('labels the add-item button per mode', () => {
+    mountForm()
+
+    cy.getTestId('ff-add-item-btn-config.allow').should('contain.text', 'Add allow')
+
+    cy.getTestId('ff-acl-mode-deny_when').click()
+    cy.getTestId('ff-add-item-btn-config.deny_when').should('contain.text', 'Add expression')
+  })
+
+  it('renders group modes as inputs and expression modes as textareas with help', () => {
+    mountForm()
+
+    cy.getTestId('ff-add-item-btn-config.allow').click()
+    cy.getTestId('ff-array-item-config.allow.0').find('input').should('exist')
+    cy.getTestId('ff-array-item-config.allow.0').find('textarea').should('not.exist')
+    cy.getTestId('ff-config.allow.0').should('have.attr', 'placeholder', 'Enter group names')
+    cy.getTestId('ff-array-item-config.allow.0').find('a[href]').should('not.exist')
+
+    cy.getTestId('ff-acl-mode-allow_when').click()
+    cy.getTestId('ff-add-item-btn-config.allow_when').click()
+    cy.getTestId('ff-array-item-config.allow_when.0').find('textarea').should('exist')
+    cy.getTestId('ff-array-item-config.allow_when.0')
+      .find('a[href]')
+      .should('contain.text', 'Learn more')
   })
 
   it('clears the previous mode\'s data when switching', () => {

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLModeCard.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/acl/ACLModeCard.vue
@@ -1,48 +1,77 @@
 <template>
-  <KCard class="ff-acl-mode-card">
-    <div class="ff-acl-mode">
+  <div class="ff-acl-mode">
+    <KLabel
+      class="ff-acl-mode-label"
+      :info="hasExpressionModes ? t('plugins.free-form.acl.mode.title.description') : undefined"
+      :tooltip-attributes="{ maxWidth: '300px' }"
+    >
+      {{ t('plugins.free-form.acl.mode.title.label') }}
+    </KLabel>
+    <div class="ff-acl-mode-options">
       <KRadio
         v-for="item in MODES"
         :key="item"
         v-model="mode"
+        card
+        card-orientation="horizontal"
         :data-testid="`ff-acl-mode-${item}`"
-        :label="t(`plugins.free-form.acl.mode.${item}`)"
+        :description="t(`plugins.free-form.acl.mode.${item}.description`)"
+        :label="t(`plugins.free-form.acl.mode.${item}.label`)"
         :selected-value="item"
         @update:model-value="handleModeChange"
       />
     </div>
+  </div>
 
-    <!--
-      An explicit v-if/v-else-if chain (rather than one Field with a dynamic :name)
-      is intentional: Vue 3 gives each conditional branch an implicit unique key, so
-      switching modes always fully unmounts/remounts the Field instead of patching
-      props onto a reused one — which is what a single dynamic :name would do here,
-      since all four config fields render via the same underlying component.
-    -->
-    <Field
-      v-if="mode === 'allow'"
-      name="config.allow"
-    />
-    <Field
-      v-else-if="mode === 'deny'"
-      name="config.deny"
-    />
-    <Field
-      v-else-if="mode === 'allow_when'"
-      name="config.allow_when"
-    />
-    <Field
-      v-else
-      name="config.deny_when"
-    />
-  </KCard>
+  <!--
+    `:key="mode"` is required, not cosmetic: all four config fields render through
+    the same component, so without an explicit key Vue would patch props onto the
+    reused instance rather than unmounting/remounting it when the mode changes,
+    leaving stale per-field state (label, input value) behind.
+  -->
+  <ArrayField
+    :key="mode"
+    :add-item-label="t(`plugins.free-form.acl.field.${mode}.add`)"
+    :label="t(`plugins.free-form.acl.field.${mode}.label`)"
+    :label-attributes="labelAttributes"
+    :name="`config.${mode}`"
+  >
+    <template #item="{ autofocus, fieldName }">
+      <StringField
+        :autofocus="autofocus"
+        :multiline="isExpressionMode"
+        :name="fieldName"
+        :placeholder="t(`plugins.free-form.acl.field.${mode}.placeholder`)"
+        :rows="isExpressionMode ? 2 : undefined"
+      >
+        <!-- Only the CEL modes need the syntax hint; allow/deny take plain group names. -->
+        <template
+          v-if="isExpressionMode"
+          #help
+        >
+          <i18nT :keypath="expressionKeys.helpText">
+            <template #link>
+              <KExternalLink
+                hide-icon
+                :href="externalLinks.condition"
+              >
+                {{ t(expressionKeys.helpLearn) }}
+              </KExternalLink>
+            </template>
+          </i18nT>
+        </template>
+      </StringField>
+    </template>
+  </ArrayField>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { KCard, KRadio } from '@kong/kongponents'
+import { KExternalLink, KRadio } from '@kong/kongponents'
 import { useFormShared } from '../../shared/composables'
-import Field from '../../shared/Field.vue'
+import ArrayField from '../../shared/ArrayField.vue'
+import StringField from '../../shared/StringField.vue'
+import externalLinks from '../../../../external-links'
 import useI18n from '../../../../composables/useI18n'
 
 import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
@@ -61,8 +90,12 @@ type AclMode = keyof AclConfig
 // used to detect the active mode on initial load.
 const ALL_MODES: AclMode[] = ['allow', 'deny', 'allow_when', 'deny_when']
 
-const { formData, getSchema } = useFormShared<FreeFormPluginData<AclConfig>>()
-const { i18n: { t } } = useI18n()
+// The two `*_when` modes hold CEL expressions, which are long enough to warrant a
+// textarea instead of the single-line input the schema type would otherwise get.
+const EXPRESSION_MODES: AclMode[] = ['allow_when', 'deny_when']
+
+const { formData, getLabelAttributes, getSchema } = useFormShared<FreeFormPluginData<AclConfig>>()
+const { i18n: { t }, i18nT } = useI18n()
 
 // allow_when/deny_when are newer additions to the ACL plugin's schema; a Gateway
 // version that predates them simply won't declare the fields, so hide those modes
@@ -70,6 +103,37 @@ const { i18n: { t } } = useI18n()
 const MODES = computed(() => ALL_MODES.filter((m) => !!getSchema(`config.${m}`)))
 
 const mode = ref<AclMode>('allow')
+const isExpressionMode = computed(() => EXPRESSION_MODES.includes(mode.value))
+
+// With only allow/deny available the radios are self-explanatory, and the tooltip
+// copy talks about a choice the Gateway version cannot offer — so drop it entirely.
+const hasExpressionModes = computed(() => MODES.value.some((m) => EXPRESSION_MODES.includes(m)))
+
+// Spelled out rather than interpolated from `mode`: only the two expression modes
+// declare these keys, and literal keys keep the i18n key type-checking meaningful.
+const expressionKeys = computed(() => mode.value === 'deny_when'
+  ? {
+    description: 'plugins.free-form.acl.field.deny_when.description',
+    helpText: 'plugins.free-form.acl.field.deny_when.help.text',
+    helpLearn: 'plugins.free-form.acl.field.deny_when.help.learn',
+  } as const
+  : {
+    description: 'plugins.free-form.acl.field.allow_when.description',
+    helpText: 'plugins.free-form.acl.field.allow_when.help.text',
+    helpLearn: 'plugins.free-form.acl.field.allow_when.help.learn',
+  } as const)
+
+// allow/deny keep the tooltip the schema's own `description` generates. The CEL modes
+// override it, because their schema text describes the API contract rather than the
+// concept the form needs to explain.
+const labelAttributes = computed(() => {
+  const schemaAttributes = getLabelAttributes(`config.${mode.value}`)
+
+  return isExpressionMode.value
+    ? { ...schemaAttributes, info: t(expressionKeys.value.description) }
+    : schemaAttributes
+})
+
 const userSelectedMode = ref(false)
 const cache = ref<Partial<Record<AclMode, string[]>>>({})
 
@@ -112,11 +176,19 @@ function handleModeChange() {
 <style lang="scss" scoped>
 .ff-acl-mode {
   display: flex;
+  flex-direction: column;
   gap: var(--kui-space-50, $kui-space-50);
-  margin-bottom: var(--kui-space-60, $kui-space-60);
-}
 
-.ff-acl-mode-card {
-  margin-bottom: var(--kui-space-50, $kui-space-50);
+  // The container gap owns the label-to-cards spacing.
+  // `.k-label` is required to override styles correctly in KM.
+  &-label.k-label {
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+
+  &-options {
+    display: flex;
+    gap: var(--kui-space-50, $kui-space-50);
+  }
 }
 </style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
@@ -48,7 +48,7 @@
       <KButton
         v-if="appearance === 'tabs'"
         appearance="tertiary"
-        :aria-label="t('actions.add_entity', { entity: fieldName })"
+        :aria-label="realAddItemLabel"
         :data-testid="`ff-add-item-btn-${field.path.value}`"
         icon
         @click="addItem"
@@ -110,13 +110,13 @@
 
       <KButton
         appearance="tertiary"
-        :aria-label="t('actions.add_entity', { entity: fieldName })"
+        :aria-label="realAddItemLabel"
         class="ff-array-field-add-item-btn"
         :data-testid="`ff-add-item-btn-${field.path.value}`"
         @click="addItem"
       >
         <AddIcon />
-        {{ t('actions.add_entity', { entity: fieldName }) }}
+        {{ realAddItemLabel }}
       </KButton>
     </template>
 
@@ -193,6 +193,10 @@ const props = defineProps<{
   label?: string
   labelAttributes?: LabelAttributes
   itemLabel?: string | ((item: T, index: number) => string)
+  /**
+   * Overrides the "Add {field name}" text (and aria-label) of the add-item button.
+   */
+  addItemLabel?: string
   appearance?: 'default' | 'card' | 'tabs'
   stickyTabs?: boolean | string | number
   hideLabel?: boolean
@@ -230,6 +234,9 @@ const fieldName = computed(() => {
   const name = utils.getName(field.path.value)
   return replaceByDictionaryInFieldName(name)
 })
+
+const realAddItemLabel = computed(() =>
+  props.addItemLabel ?? t('actions.add_entity', { entity: fieldName.value }))
 
 const realItems = computed(() => props.items ?? toValue(fieldValue) ?? [])
 

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -808,10 +808,58 @@
       },
       "acl": {
         "mode": {
-          "allow": "Use allow list",
-          "deny": "Use deny list",
-          "allow_when": "Use allow expression list",
-          "deny_when": "Use deny expression list"
+          "title": {
+            "label": "Access policy",
+            "description": "Select how requests are authorized. Choose one access policy: allow or deny by ACL group, or define a CEL expression. Only one policy type can be configured at a time."
+          },
+          "allow": {
+            "label": "Allow list",
+            "description": "Allow requests from the specified ACL groups."
+          },
+          "deny": {
+            "label": "Deny list",
+            "description": "Deny requests from the specified ACL groups."
+          },
+          "allow_when": {
+            "label": "Allow expression",
+            "description": "Allow requests when the CEL expression evaluates to true."
+          },
+          "deny_when": {
+            "label": "Deny expression",
+            "description": "Deny requests when the CEL expression evaluates to true."
+          }
+        },
+        "field": {
+          "allow": {
+            "label": "Allowed list",
+            "placeholder": "Enter group names",
+            "add": "Add allow"
+          },
+          "deny": {
+            "label": "Denied list",
+            "placeholder": "Enter group names",
+            "add": "Add deny"
+          },
+          "allow_when": {
+            "label": "Kong plug-in conditional expression",
+            "description": "A Kong plug-in conditional expression is a CEL expression that determines whether the plugin runs for a request. If the expression evaluates to true, the plugin executes. If it evaluates to false, the plugin is skipped.",
+            "placeholder": "eg: 'consumer.username == \"alice\"'",
+            "add": "Add expression",
+            "help": {
+              "learn": "Learn more",
+              "text": "Define a Kong plug-in conditional expression to evaluate each request. The expression must return a boolean value (true or false). {link}"
+            }
+          },
+          "deny_when": {
+            "label": "Kong plug-in conditional expression",
+            "description": "A Kong plug-in conditional expression is a CEL expression that determines whether the plugin runs for a request. If the expression evaluates to true, the plugin executes. If it evaluates to false, the plugin is skipped.",
+            "placeholder": "eg: 'consumer.username == \"alice\"'",
+            "add": "Add expression",
+            "help": {
+              "learn": "Learn more",
+              "text": "Define a Kong plug-in conditional expression to evaluate each request. The expression must return a boolean value (true or false). {link}"
+            }
+          }
         }
       },
       "ai-mcp-proxy": {


### PR DESCRIPTION
# Summary

Present the ACL modes as radio cards under an "Access policy" label, and render the selected mode's field through ArrayField directly so its label, placeholder and add-item button can carry ACL-specific copy. The CEL expression modes render a textarea with help text linking to the plugin expressions docs; allow/deny keep the tooltip generated from the schema description.

Add an optional `addItemLabel` prop to the shared ArrayField, defaulting to the existing "Add {field name}" string.

