### PR TITLE
fix: remove region (replaced by provider_region)

### DIFF
--- a/packages/analytics/analytics-utilities/src/types/explore/managed-cache.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/managed-cache.ts
@@ -8,7 +8,6 @@ export const queryableManagedCacheExploreDimensions = [
   'network',
   'provider',
   'provider_region',
-  'region',
   'time',
 ] as const
 


### PR DESCRIPTION
# Summary
Remove `region` dimension as it is replaced by `provider_region` in managed cache usage datasource. Both existed for a time while core-ui updated their filters in Redis contextual analytics charts (PR: https://github.com/kong-konnect/konnect-ui-apps/pull/13204)

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
