### PR TITLE
feat(analytics): mobile styles for golden signals [MA-5312]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="metric-card-tile-wrapper"
-    :class="{ 'titled': !!props.chartOptions.chart_title }"
+    :class="{ 'titled': hasTitleBar }"
   >
     <MetricsProvider v-bind="options">
       <MetricsConsumer />
@@ -37,19 +37,26 @@ const options = computed<ProviderProps>(() => {
     refreshCounter: props.refreshCounter,
   }
 })
+
+const hasTitleBar = computed(() => {
+  return Boolean(props.chartOptions.chart_title || props.chartOptions.description)
+})
 </script>
 
 <style scoped lang="scss">
 .metric-card-tile-wrapper {
+  padding: var(--kui-space-60, $kui-space-60);
+
+  &.titled {
+    // this is always true, regardless of breakpoint
+    padding-top: 0;
+  }
+
   @media (min-width: ($kui-breakpoint-phablet - 1px)) {
     align-items: center;
     display: flex;
     height: 100%;
     padding: var(--kui-space-60, $kui-space-60);
-  }
-
-  &.titled {
-    padding: var(--kui-space-20, $kui-space-20) var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60);
   }
 }
 </style>


### PR DESCRIPTION
Satisfies [MA-5312](https://konghq.atlassian.net/browse/MA-5312)

# Summary

On mobile screens, the summary page in konnect has displayed golden signals in a not-ideal way for quite some time. This should fix it.

### Screenshots in konnect

**Before**

<img width="389" height="464" alt="Screenshot 2026-08-12 at 10 22 35 AM" src="https://github.com/user-attachments/assets/0975b2ff-cc42-4798-adb9-5c5f7540d509" />

**After**

<img width="385" height="502" alt="Screenshot 2026-08-12 at 10 21 39 AM" src="https://github.com/user-attachments/assets/83789699-bfc9-4d8a-b746-e9ebb2aa1b21" />

---

### Mobile screenshots from sandbox (before/after)

With title and description (very slight difference in top padding below title/description)

<img width="306" height="345" alt="Screenshot 2026-08-12 at 10 34 21 AM" src="https://github.com/user-attachments/assets/d6f6ba0b-ea2f-4124-b157-685cc748fb25" />

<img width="307" height="342" alt="Screenshot 2026-08-12 at 10 29 50 AM" src="https://github.com/user-attachments/assets/529efe1b-3ba5-4aa9-99b4-209a84cc2c21" />

---

With just title (very slight difference in top padding below title/description)

<img width="305" height="336" alt="Screenshot 2026-08-12 at 10 34 32 AM" src="https://github.com/user-attachments/assets/7a87ca7a-df4f-4ea2-88fa-24766ed7b7a8" />

<img width="308" height="337" alt="Screenshot 2026-08-12 at 10 29 58 AM" src="https://github.com/user-attachments/assets/cd6295b2-61dd-4678-9151-5d331bc30e69" />

---

With just description (large changes/improvements)

<img width="305" height="309" alt="Screenshot 2026-08-12 at 10 34 45 AM" src="https://github.com/user-attachments/assets/7c669580-e14e-441c-89f5-2ad94d753aa8" />

<img width="307" height="325" alt="Screenshot 2026-08-12 at 10 30 09 AM" src="https://github.com/user-attachments/assets/f62aaa3e-b29b-401d-8cae-c7b15a6d65ea" />

---

With no title or description (large changes/improvements)

<img width="304" height="274" alt="Screenshot 2026-08-12 at 10 34 53 AM" src="https://github.com/user-attachments/assets/f4f71caf-1c48-4b4e-a303-de4d1548252a" />

<img width="305" height="309" alt="Screenshot 2026-08-12 at 10 30 19 AM" src="https://github.com/user-attachments/assets/f84813c2-9643-4058-887f-16f65a5b4186" />

---

### Full screen screenshots from sandbox (before/after)

With title and description (no changes)

<img width="1019" height="176" alt="Screenshot 2026-08-12 at 10 32 07 AM" src="https://github.com/user-attachments/assets/94deea77-5d3a-457e-8730-044a1dd53748" />

<img width="1022" height="179" alt="Screenshot 2026-08-12 at 10 26 55 AM" src="https://github.com/user-attachments/assets/04781a58-640a-4846-b5c8-bf8515b47c8e" />

---

With just title (very slight difference in top padding below title/description)

<img width="1022" height="181" alt="Screenshot 2026-08-12 at 10 32 26 AM" src="https://github.com/user-attachments/assets/55b3d83f-38d6-43b7-bea4-2820a4a1788f" />

<img width="1019" height="178" alt="Screenshot 2026-08-12 at 10 28 07 AM" src="https://github.com/user-attachments/assets/7eedc5f9-e85a-49f5-a440-725828ad9304" />

---

With just description (very slight difference in top padding below title/description)

<img width="1019" height="178" alt="Screenshot 2026-08-12 at 10 32 35 AM" src="https://github.com/user-attachments/assets/8fa2c741-7516-4968-af96-3c92ad8bef1a" />

<img width="1022" height="181" alt="Screenshot 2026-08-12 at 10 27 48 AM" src="https://github.com/user-attachments/assets/7cd2d87d-b802-4de3-b932-8f06b8b6d8a0" />

---

With no title or description (no changes)

<img width="1019" height="176" alt="Screenshot 2026-08-12 at 10 32 50 AM" src="https://github.com/user-attachments/assets/7df0ecd4-0fcc-40c7-abb0-cf6b7cc302ee" />

<img width="1018" height="179" alt="Screenshot 2026-08-12 at 10 27 58 AM" src="https://github.com/user-attachments/assets/80944b5a-1bfe-4297-a985-1bc050dd366e" />

---

[MA-5312]: https://konghq.atlassian.net/browse/MA-5312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ