### PR TITLE
refactor(analytics): use tile level header_description [MA-5142]

### DIFF
--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -15,7 +15,6 @@ import {
   slottableSchema,
   slottableTileConfigSchema,
   topNTableSchema,
-  metricCardSchema,
 } from './dashboardSchema.v2'
 import {
   agenticExploreAggregations,

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -623,8 +623,7 @@ describe('slottable tile config', () => {
     expect(validateDashboardConfigSchema({ tiles: [topN] })).toBe(true)
   })
 
-  it('marks the chart-level description as deprecated on top_n and golden_signals', () => {
+  it('marks the chart-level description as deprecated on top_n', () => {
     expect(topNTableSchema.properties.description.deprecated).toBe(true)
-    expect(metricCardSchema.properties.description.deprecated).toBe(true)
   })
 })

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -14,6 +14,8 @@ import {
   filterablePlatformPresetFilterDimensions,
   slottableSchema,
   slottableTileConfigSchema,
+  topNTableSchema,
+  metricCardSchema,
 } from './dashboardSchema.v2'
 import {
   agenticExploreAggregations,
@@ -558,5 +560,71 @@ describe('slottable tile config', () => {
 
   it('marks the legacy chart-level slottable schema as deprecated', () => {
     expect(slottableSchema.deprecated).toBe(true)
+  })
+
+  const headerDescriptionChartTile = {
+    type: 'chart',
+    definition: {
+      chart: {
+        type: 'top_n',
+        chart_title: 'Top N',
+      },
+      query: {
+        datasource: 'basic',
+        metrics: ['request_count'],
+        dimensions: ['route'],
+      },
+      header_description: '{timeframe}',
+    },
+    layout: slottableTile.layout,
+  }
+
+  const headerDescriptionTableTile = {
+    type: 'chart',
+    definition: {
+      chart: {
+        type: 'table',
+      },
+      query: {
+        datasource: 'platform',
+        entity: 'route',
+        columns: ['route'],
+      },
+      header_description: 'Static text',
+    },
+    layout: slottableTile.layout,
+  }
+
+  it('accepts a tile header_description on a chart tile', () => {
+    expect(validateDashboardConfigSchema({ tiles: [headerDescriptionChartTile] })).toBe(true)
+  })
+
+  it('accepts a tile header_description on a table tile', () => {
+    expect(validateDashboardConfigSchema({ tiles: [headerDescriptionTableTile] })).toBe(true)
+  })
+
+  it('rejects a non-string header_description', () => {
+    const invalidTile = {
+      ...headerDescriptionChartTile,
+      definition: { ...headerDescriptionChartTile.definition, header_description: 42 },
+    }
+    expect(validateDashboardConfigSchema({ tiles: [invalidTile] })).toBe(false)
+  })
+
+  it('still accepts the deprecated chart-level description', () => {
+    const topN = {
+      ...headerDescriptionChartTile,
+      definition: {
+        ...headerDescriptionChartTile.definition,
+        chart: { type: 'top_n', chart_title: 'Top N', description: '{timeframe}' },
+        header_description: undefined,
+      },
+    }
+    expect(validateDashboardConfigSchema({ tiles: [topN] })).toBe(true)
+  })
+
+  it('marks the chart-level description as deprecated on top_n and golden_signals', () => {
+    expect(topNTableSchema.properties.description.deprecated).toBe(true)
+    expect(metricCardSchema.properties.description.deprecated).toBe(true)
   })
 })

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -54,6 +54,17 @@ const allowCsvExport = {
   type: 'boolean',
 } as const
 
+const tileHeaderDescription = {
+  type: 'string',
+  description: 'Text rendered in the tile header. Supports the {timeframe} token, ',
+} as const
+
+const deprecatedDescription = {
+  type: 'string',
+  deprecated: true,
+  description: 'Deprecated: use `header_description` on the tile definition.',
+} as const
+
 const entityLinks = {
   type: 'object',
   additionalProperties: {
@@ -216,9 +227,7 @@ export const topNTableSchema = {
       type: 'string',
       enum: ['top_n'],
     },
-    description: {
-      type: 'string',
-    },
+    description: deprecatedDescription,
     entity_link: {
       type: 'string',
     },
@@ -256,9 +265,7 @@ export const metricCardSchema = {
     long_card_titles: {
       type: 'boolean',
     },
-    description: {
-      type: 'string',
-    },
+    description: deprecatedDescription,
     percentile_latency: {
       type: 'boolean',
     },
@@ -743,6 +750,7 @@ const chartTileDefinitionSchema = {
   properties: {
     query: validDashboardChartQuery,
     chart: dashboardTileChartSchema,
+    header_description: tileHeaderDescription,
   },
   required: ['query', 'chart'],
   additionalProperties: false,
@@ -755,6 +763,7 @@ const tableChartTileDefinitionSchema = {
   properties: {
     query: validDashboardTableQuery,
     chart: tableChartSchema,
+    header_description: tileHeaderDescription,
   },
   required: ['query', 'chart'],
   additionalProperties: false,

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -59,12 +59,6 @@ const tileHeaderDescription = {
   description: 'Text rendered in the tile header. Supports the {timeframe} token, ',
 } as const
 
-const deprecatedDescription = {
-  type: 'string',
-  deprecated: true,
-  description: 'Deprecated: use `header_description` on the tile definition.',
-} as const
-
 const entityLinks = {
   type: 'object',
   additionalProperties: {
@@ -227,7 +221,11 @@ export const topNTableSchema = {
       type: 'string',
       enum: ['top_n'],
     },
-    description: deprecatedDescription,
+    description: {
+      type: 'string',
+      deprecated: true,
+      description: 'Deprecated: use `header_description` on the tile definition.',
+    },
     entity_link: {
       type: 'string',
     },
@@ -235,7 +233,7 @@ export const topNTableSchema = {
   },
   required: ['type'],
   additionalProperties: false,
-} as const satisfies JSONSchema
+} as const
 
 export type TopNTableOptions = FromSchemaWithOptions<typeof topNTableSchema>
 

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -265,7 +265,6 @@ export const metricCardSchema = {
     long_card_titles: {
       type: 'boolean',
     },
-    description: deprecatedDescription,
     percentile_latency: {
       type: 'boolean',
     },

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -129,8 +129,8 @@ const config: DashboardConfig = {
         chart: {
           type: 'top_n',
           chart_title: 'Top N Table',
-          description: 'Table description',
         },
+        header_description: 'Table description',
         // Top 5 routes by request_count
         query: {
           metrics: ['request_count'],
@@ -289,8 +289,8 @@ const config: DashboardConfig = {
         chart: {
           type: 'top_n',
           chart_title: 'Top N chart of mock data',
-          description: 'Description'
         },
+        header_description: 'Description',
         query: {},
       },
       layout: {
@@ -311,8 +311,8 @@ const config: DashboardConfig = {
         chart: {
           type: 'top_n',
           chart_title: 'Top N chart of mock data',
-          description: 'Description',
         },
+        header_description: 'Description',
         query: {},
       },
       layout: {
@@ -504,13 +504,26 @@ type TileDefinition = ChartTileDefinition | TableChartTileDefinition
 interface ChartTileDefinition {
   chart: ChartOptions         // Configuration for a non-table chart type and options
   query: ValidDashboardChartQuery  // Configuration for the chart data query
+  header_description?: string  // Optional text rendered in the tile header
 }
 
 interface TableChartTileDefinition {
   chart: TableChartOptions    // Configuration for the table chart
   query: PlatformTabularQuery & { datasource: 'platform_usage' } // Configuration for the platform tabular query ('platform' also accepted)
+  header_description?: string  // Optional text rendered in the tile header
 }
 ```
+
+#### Header description
+
+`header_description` renders alongside the tile title in the tile header. It supports the
+`{timeframe}` token, which expands to a summary of the dashboard's active time range
+(e.g., `Last 7-day summary`). Only the `24h`, `7d`, and `30d` ranges have summary
+text, for any other range the token expands to nothing and the description is omitted.
+
+> **Deprecated:** `description` on the `top_n` and `golden_signals` chart options is the
+> former home of this field. It is still supported (for now), but will be removed the future.
+> Use `header_description` on the tile definition instead.
 
 ### Chart Options
 Chart type and options configuration.

--- a/packages/analytics/dashboard-renderer/README.md
+++ b/packages/analytics/dashboard-renderer/README.md
@@ -521,7 +521,7 @@ interface TableChartTileDefinition {
 (e.g., `Last 7-day summary`). Only the `24h`, `7d`, and `30d` ranges have summary
 text, for any other range the token expands to nothing and the description is omitted.
 
-> **Deprecated:** `description` on the `top_n` and `golden_signals` chart options is the
+> **Deprecated:** `description` on the `top_n` chart options is the
 > former home of this field. It is still supported (for now), but will be removed the future.
 > Use `header_description` on the tile definition instead.
 

--- a/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/mock-data.ts
@@ -248,8 +248,8 @@ export const summaryDashboardConfig: DashboardConfig = {
         chart: {
           type: 'golden_signals',
           chartTitle: 'Analytics',
-          description: '{timeframe}',
         },
+        header_description: '{timeframe}',
       },
       layout: {
         position: {
@@ -376,8 +376,8 @@ export const simpleConfigNoFilters: DashboardConfig = {
         chart: {
           type: 'golden_signals',
           chartTitle: 'Analytics',
-          description: '{timeframe}',
         },
+        header_description: '{timeframe}',
         query: {
           datasource: 'api_usage',
         },
@@ -430,8 +430,8 @@ export const simpleConfigGlobalFilters: DashboardConfig = {
         chart: {
           type: 'golden_signals',
           chartTitle: 'Analytics',
-          description: '{timeframe}',
         },
+        header_description: '{timeframe}',
         query: {
           datasource: 'api_usage',
         },

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -95,8 +95,8 @@ const dashboardConfig = ref<DashboardConfig>({
         chart: {
           type: 'golden_signals',
           chart_title: 'Analytics Golden Signals',
-          description: '{timeframe}',
         },
+        header_description: '{timeframe}',
         query: {
           datasource: 'basic',
         },
@@ -150,8 +150,8 @@ const dashboardConfig = ref<DashboardConfig>({
         chart: {
           type: 'top_n',
           chart_title: 'Top N chart of mock data',
-          description: '{timeframe}',
         },
+        header_description: '{timeframe}',
         query: {
           datasource: 'basic',
           limit: 1,
@@ -175,7 +175,7 @@ const dashboardConfig = ref<DashboardConfig>({
         chart: {
           type: 'top_n',
           chart_title: 'Top N chart of mock data',
-          description: 'Description',
+          description: 'Description', // Deprecated: use the tile.definition.header_description instead.
         },
         query: {
           datasource: 'basic',
@@ -366,9 +366,9 @@ const dashboardConfig = ref<DashboardConfig>({
         chart: {
           type: 'top_n',
           chart_title: 'Top N chart of mock data',
-          description: 'Description',
           entity_link: 'https://cloud.konghq.tech/us/analytics/entities/{id}',
         },
+        header_description: 'Description',
         query: {
           datasource: 'basic',
           limit: 3,

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.cy.ts
@@ -1357,4 +1357,89 @@ describe('<DashboardRenderer />', () => {
 
     cy.get('@fullscreen').should('have.been.called')
   })
+
+  describe('tile header description', () => {
+    const headerDescriptionConfig = (definitionOverrides: Record<string, any>): DashboardConfig => ({
+      tile_height: 185,
+      tiles: [
+        {
+          type: 'chart',
+          definition: {
+            chart: {
+              type: 'top_n',
+              chart_title: 'Top N',
+            },
+            query: {
+              datasource: 'basic',
+              metrics: ['request_count'],
+              dimensions: ['route'],
+            },
+            ...definitionOverrides,
+          },
+          layout: {
+            position: { col: 0, row: 0 },
+            size: { cols: 6, rows: 1 },
+          },
+        } as TileConfig,
+      ],
+    })
+
+    const mountWithConfig = (modelValue: DashboardConfig) => {
+      cy.mount(DashboardRenderer, {
+        props: {
+          context: {
+            filters: [],
+            timeSpec: { type: 'relative', time_range: '7d' },
+          },
+          modelValue,
+        },
+        global: {
+          provide: {
+            [INJECT_QUERY_PROVIDER]: mockQueryProvider(),
+          },
+        },
+      })
+    }
+
+    it('expands the timeframe token in a tile header description', () => {
+      mountWithConfig(headerDescriptionConfig({ header_description: '{timeframe}' }))
+      cy.get('.header-description').should('have.text', 'Last 7-day summary')
+    })
+
+    // TODO: remove the next two tests once we no longer support the chart-level descriptions.
+    it('still renders the deprecated chart-level description', () => {
+      mountWithConfig(headerDescriptionConfig({
+        chart: { type: 'top_n', chart_title: 'Top N', description: '{timeframe}' },
+      }))
+      cy.get('.header-description').should('have.text', 'Last 7-day summary')
+    })
+
+    it('prefers the tile field over the deprecated chart-level one', () => {
+      mountWithConfig(headerDescriptionConfig({
+        header_description: 'Tile level',
+        chart: { type: 'top_n', chart_title: 'Top N', description: 'Chart level' },
+      }))
+      cy.get('.header-description').should('have.text', 'Tile level')
+    })
+
+    it('omits the header description when the timeframe has no summary text', () => {
+      cy.mount(DashboardRenderer, {
+        props: {
+          context: {
+            filters: [],
+            timeSpec: { type: 'relative', time_range: '1h' },
+          },
+          modelValue: headerDescriptionConfig({ header_description: '{timeframe}' }),
+        },
+        global: {
+          provide: {
+            [INJECT_QUERY_PROVIDER]: mockQueryProvider(),
+          },
+        },
+      })
+
+      cy.get('.title').should('exist')
+      cy.get('.header-description').should('not.exist')
+    })
+  })
 })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardRenderer.vue
@@ -86,9 +86,9 @@ import DraggableGridLayout from './layout/DraggableGridLayout.vue'
 import {
   DEFAULT_TILE_HEIGHT,
   INJECT_QUERY_PROVIDER,
-  TIMEFRAME_TOKEN,
 } from '../constants'
 import { duplicateChartTile } from '../utils/duplicate-tile'
+import { tileDescription } from '../utils/tile-definition'
 import { KUI_SPACE_70 } from '@kong/design-tokens'
 
 const {
@@ -144,6 +144,22 @@ const onTileLoaded = (tile: GridTile<TileDefinition>) => {
   }
 }
 
+const timeframeLabel = computed<string>(() => {
+  const { timeSpec } = internalContext.value
+  const timeSpecKey = timeSpec.type === 'absolute' ? 'custom' : timeSpec.time_range
+  const key = `renderer.trendRange.${timeSpecKey}`
+
+  // Right now, we basically only support 2 ranges: 24 hours and 30 days.
+  // In case of a misconfiguration, don't render a translation at all.
+  // @ts-ignore: dynamic i18n key
+  if (i18n.te(key)) {
+    // @ts-ignore: dynamic i18n key
+    return i18n.t(key)
+  }
+
+  return ''
+})
+
 const tileSortFn = (a: TileConfig, b: TileConfig) => {
   const rowDiff = a.layout.position.row - b.layout.position.row
   if (rowDiff !== 0) {
@@ -173,32 +189,12 @@ const gridTiles = computed<Array<GridTile<TileDefinition>>>(() => {
     let tileMeta = tile.definition
     const tileType = tile.type ?? 'chart'
 
-    const chart = (tileMeta as ChartTileDefinition).chart
-    if (tileType === 'chart' && 'description' in chart) {
-      const chartMeta = tileMeta as ChartTileDefinition
-      // Replace tokens in tile descriptions
-      const description = chart.description?.replace(TIMEFRAME_TOKEN, () => {
-        const { timeSpec } = internalContext.value
-        const timeSpecKey = timeSpec.type === 'absolute' ? 'custom' : timeSpec.time_range
-        const key = `renderer.trendRange.${timeSpecKey}`
+    const description = tileDescription(tileMeta, timeframeLabel.value)
 
-        // Right now, we basically only support 2 ranges: 24 hours and 30 days.
-        // In case of a misconfiguration, don't render a translation at all.
-        // @ts-ignore: dynamic i18n key
-        if (i18n.te(key)) {
-          // @ts-ignore: dynamic i18n key
-          return i18n.t(key)
-        }
-
-        return ''
-      })
-
+    if (description !== tileMeta.header_description) {
       tileMeta = {
-        ...chartMeta,
-        chart: {
-          ...chart,
-          description,
-        },
+        ...tileMeta,
+        header_description: description,
       } as TileDefinition
     }
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
@@ -302,6 +302,48 @@ describe('<DashboardTile />', () => {
     cy.get('.title').should('contain.text', 'Test Chart')
   })
 
+  describe('header description', () => {
+    it('renders the header description alongside the header actions', () => {
+      mount({
+        definition: {
+          ...mockTileDefinition,
+          header_description: 'Last 7-day summary',
+        },
+      })
+
+      cy.getTestId('tile-actions-1').should('be.visible')
+      cy.getTestId('tile-description-1').should('be.visible').and('have.text', 'Last 7-day summary')
+    })
+
+    it('renders the tile header for a description with no other header content', () => {
+      mount({
+        definition: {
+          chart: {
+            type: 'top_n',
+          },
+          query: {
+            datasource: 'api_usage',
+            metrics: [],
+            filters: [],
+          },
+          header_description: 'Last 7-day summary',
+        },
+        context: { ...mockContext, editable: false },
+        extraProps: { hideActions: true },
+      })
+
+      cy.get('.tile-header').should('exist')
+      cy.get('.title').should('have.text', '')
+      cy.getTestId('tile-actions-1').should('not.exist')
+      cy.getTestId('tile-description-1').should('be.visible').and('have.text', 'Last 7-day summary')
+    })
+
+    it('does not render a header description when none is configured', () => {
+      mount()
+      cy.getTestId('tile-description-1').should('not.exist')
+    })
+  })
+
   it('should emit chart-data when query resolves', () => {
     const chartDataSpy = cy.spy().as('chartDataSpy')
     const queryFn = cy.stub().as('queryFn').callsFake(() => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -70,6 +70,14 @@
       </div>
 
       <div
+        v-if="tileDescription"
+        class="header-description"
+        :data-testid="`tile-description-${tileId}`"
+      >
+        {{ tileDescription }}
+      </div>
+
+      <div
         v-if="canShowHeaderActions"
         class="tile-actions"
         :data-testid="`tile-actions-${tileId}`"
@@ -134,13 +142,6 @@
             </KDropdownItem>
           </template>
         </KDropdown>
-      </div>
-      <div
-        v-else-if="tileDescription"
-        class="header-description"
-        :data-testid="`tile-description-${tileId}`"
-      >
-        {{ tileDescription }}
       </div>
       <CsvExportModal
         v-if="exportModalVisible"
@@ -257,7 +258,7 @@ const chart = computed(() => props.definition.chart)
 const tileTitle = computed<string | undefined>(() => {
   return 'chart_title' in chart.value ? chart.value.chart_title : undefined
 })
-const tileDescription = computed<string | undefined>(() => 'description' in chart.value ? chart.value.description : undefined)
+const tileDescription = computed<string | undefined>(() => props.definition.header_description)
 const isSlottableTile = computed<boolean>(() => chart.value.type === 'slottable')
 const canExportCsv = computed<boolean>(() => {
   if (isTableChartDefinition(props.definition)) {
@@ -312,7 +313,6 @@ const kebabMenuHasItems = computed((): boolean => !!exploreLinkKebabMenu.value |
 // The shared header action container is hidden when tile actions are globally disabled.
 const canShowHeaderActions = computed((): boolean => !props.hideActions && canShowKebabMenu.value && kebabMenuHasItems.value)
 const hasHeaderActions = computed<boolean>(() => canShowHeaderActions.value && kebabMenuHasItems.value && !props.isFullscreen)
-const hasSignalsDescription = computed<boolean>(() => chart.value.type === 'golden_signals' && Boolean(tileDescription.value))
 
 const rendererLookup: Record<DashboardTileType, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,
@@ -415,7 +415,7 @@ const hasTileHeader = computed<boolean>(() => {
     Boolean(tileTitle.value),
     hasHeaderActions.value,
     Boolean(badgeData.value),
-    hasSignalsDescription.value,
+    Boolean(tileDescription.value),
     props.showRefresh,
   ].some(Boolean)
 })

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -356,6 +356,7 @@ const componentData = computed(() => {
   }
   const chartRendererProps = {
     chartOptions: definition.chart,
+    headerDescription: tileDescription.value,
     requestsLink: props.hideZoomActions ? undefined : requestsLinkZoomActions.value,
     exploreLink: props.hideZoomActions ? undefined : exploreLinkZoomActions.value,
   }

--- a/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/GoldenSignalsRenderer.vue
@@ -39,7 +39,7 @@ const options = computed<ProviderProps>(() => {
 })
 
 const hasTitleBar = computed(() => {
-  return Boolean(props.chartOptions.chart_title || props.chartOptions.description)
+  return Boolean(props.chartOptions.chart_title || props.headerDescription)
 })
 </script>
 

--- a/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
@@ -74,6 +74,7 @@ export interface ChartRendererProps<T> {
   chartOptions: T
   height: number
   refreshCounter: number
+  headerDescription?: string
   requestsLink?: ExternalLink
   exploreLink?: ExternalLink
 }

--- a/packages/analytics/dashboard-renderer/src/utils/tile-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/tile-definition.ts
@@ -2,9 +2,24 @@ import type {
   TableChartTileDefinition,
   TileDefinition,
 } from '@kong-ui-public/analytics-utilities'
+import { TIMEFRAME_TOKEN } from '../constants'
 
 export const isTableChartDefinition = (
   definition: TileDefinition | undefined,
 ): definition is TableChartTileDefinition => {
   return definition?.chart.type === 'table'
+}
+
+export const tileDescription = (
+  definition: TileDefinition,
+  timeframeLabel: string,
+): string | undefined => {
+  // TODO: remove the definition.chart.description fallback once we're done supporting it.
+  const raw = definition.header_description ?? ('description' in definition.chart ? definition.chart.description : undefined)
+
+  if (!raw) {
+    return undefined
+  }
+
+  return raw.replaceAll(TIMEFRAME_TOKEN, timeframeLabel) || undefined
 }


### PR DESCRIPTION
# Summary

Satisfies [MA-5142](https://konghq.atlassian.net/browse/MA-5142)

This will add a new tile level `header_description` property and deprecate the `<tile>.definition.chart.description` property.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-5142]: https://konghq.atlassian.net/browse/MA-5142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MA-5142]: https://konghq.atlassian.net/browse/MA-5142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MA-5142]: https://konghq.atlassian.net/browse/MA-5142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ