### PR TITLE
fix(dashboard-renderer): strip unsupported platform filters [MA-5344]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
@@ -145,6 +145,103 @@ describe('useIssueQuery', () => {
     })
   })
 
+  it.each(['platform_usage', 'platform'])('strips empty operators from %s query filters', async (datasource) => {
+    const queryFn = vi.fn().mockResolvedValue({})
+    const wrapper = mountComposable({
+      queryFn,
+    } as any)
+    const inFilter = {
+      field: 'name',
+      operator: 'in',
+      value: ['example'],
+    }
+    const notInFilter = {
+      field: 'name',
+      operator: 'not_in',
+      value: ['other'],
+    }
+
+    await wrapper.vm.issueQuery({
+      datasource,
+      metrics: [],
+      dimensions: [],
+      filters: [
+        { field: 'name', operator: 'empty' },
+        { field: 'name', operator: 'not_empty' },
+        inFilter,
+        notInFilter,
+      ],
+    } as any, {
+      ...context,
+      filters: [],
+    })
+
+    expect(queryFn.mock.calls[0][0]).toMatchObject({
+      query: {
+        filters: [inFilter, notInFilter],
+      },
+    })
+  })
+
+  it.each(['platform_usage', 'platform'])('strips empty operators from %s context filters', async (datasource) => {
+    const queryFn = vi.fn().mockResolvedValue({})
+    const wrapper = mountComposable({
+      queryFn,
+    } as any)
+    const inFilter = {
+      field: 'name',
+      operator: 'in',
+      value: ['example'],
+    }
+
+    await wrapper.vm.issueQuery({
+      datasource,
+      metrics: [],
+      dimensions: [],
+      filters: [],
+    } as any, {
+      ...context,
+      filters: [
+        { field: 'name', operator: 'empty' },
+        { field: 'name', operator: 'not_empty' },
+        inFilter,
+      ],
+    })
+
+    expect(queryFn.mock.calls[0][0]).toMatchObject({
+      query: {
+        filters: [inFilter],
+      },
+    })
+  })
+
+  it('preserves empty operators for non-platform datasources', async () => {
+    const queryFn = vi.fn().mockResolvedValue({})
+    const wrapper = mountComposable({
+      queryFn,
+    } as any)
+    const filters = [
+      { field: 'name', operator: 'empty' },
+      { field: 'name', operator: 'not_empty' },
+    ]
+
+    await wrapper.vm.issueQuery({
+      datasource: 'custom_datasource',
+      metrics: [],
+      dimensions: [],
+      filters,
+    } as any, {
+      ...context,
+      filters: [],
+    })
+
+    expect(queryFn.mock.calls[0][0]).toMatchObject({
+      query: {
+        filters,
+      },
+    })
+  })
+
   it('aborts the previous occurring query when a new one is issued', async () => {
     const queryFn = vi.fn().mockReturnValue(new Promise(() => {}))
     const wrapper = mountComposable({

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
@@ -145,100 +145,104 @@ describe('useIssueQuery', () => {
     })
   })
 
-  it.each(['platform_usage', 'platform'])('strips empty operators from %s query filters', async (datasource) => {
-    const queryFn = vi.fn().mockResolvedValue({})
-    const wrapper = mountComposable({
-      queryFn,
-    } as any)
-    const inFilter = {
-      field: 'name',
-      operator: 'in',
-      value: ['example'],
-    }
-    const notInFilter = {
-      field: 'name',
-      operator: 'not_in',
-      value: ['other'],
-    }
+  // TODO(MA-5255): Remove these tests with the temporary frontend shim when platform
+  // aggregation queries support `empty` and `not_empty` filters.
+  describe('non-table platform aggregation filter shim', () => {
+    it.each(['platform_usage', 'platform'])('strips empty operators from %s query filters', async (datasource) => {
+      const queryFn = vi.fn().mockResolvedValue({})
+      const wrapper = mountComposable({
+        queryFn,
+      } as any)
+      const inFilter = {
+        field: 'name',
+        operator: 'in',
+        value: ['example'],
+      }
+      const notInFilter = {
+        field: 'name',
+        operator: 'not_in',
+        value: ['other'],
+      }
 
-    await wrapper.vm.issueQuery({
-      datasource,
-      metrics: [],
-      dimensions: [],
-      filters: [
+      await wrapper.vm.issueQuery({
+        datasource,
+        metrics: [],
+        dimensions: [],
+        filters: [
+          { field: 'name', operator: 'empty' },
+          { field: 'name', operator: 'not_empty' },
+          inFilter,
+          notInFilter,
+        ],
+      } as any, {
+        ...context,
+        filters: [],
+      })
+
+      expect(queryFn.mock.calls[0][0]).toMatchObject({
+        query: {
+          filters: [inFilter, notInFilter],
+        },
+      })
+    })
+
+    it.each(['platform_usage', 'platform'])('strips empty operators from %s context filters', async (datasource) => {
+      const queryFn = vi.fn().mockResolvedValue({})
+      const wrapper = mountComposable({
+        queryFn,
+      } as any)
+      const inFilter = {
+        field: 'name',
+        operator: 'in',
+        value: ['example'],
+      }
+
+      await wrapper.vm.issueQuery({
+        datasource,
+        metrics: [],
+        dimensions: [],
+        filters: [],
+      } as any, {
+        ...context,
+        filters: [
+          { field: 'name', operator: 'empty' },
+          { field: 'name', operator: 'not_empty' },
+          inFilter,
+        ],
+      })
+
+      expect(queryFn.mock.calls[0][0]).toMatchObject({
+        query: {
+          filters: [inFilter],
+        },
+      })
+    })
+
+    it('preserves empty operators for non-platform datasources', async () => {
+      const queryFn = vi.fn().mockResolvedValue({})
+      const wrapper = mountComposable({
+        queryFn,
+      } as any)
+      const filters = [
         { field: 'name', operator: 'empty' },
         { field: 'name', operator: 'not_empty' },
-        inFilter,
-        notInFilter,
-      ],
-    } as any, {
-      ...context,
-      filters: [],
-    })
+      ]
 
-    expect(queryFn.mock.calls[0][0]).toMatchObject({
-      query: {
-        filters: [inFilter, notInFilter],
-      },
-    })
-  })
-
-  it.each(['platform_usage', 'platform'])('strips empty operators from %s context filters', async (datasource) => {
-    const queryFn = vi.fn().mockResolvedValue({})
-    const wrapper = mountComposable({
-      queryFn,
-    } as any)
-    const inFilter = {
-      field: 'name',
-      operator: 'in',
-      value: ['example'],
-    }
-
-    await wrapper.vm.issueQuery({
-      datasource,
-      metrics: [],
-      dimensions: [],
-      filters: [],
-    } as any, {
-      ...context,
-      filters: [
-        { field: 'name', operator: 'empty' },
-        { field: 'name', operator: 'not_empty' },
-        inFilter,
-      ],
-    })
-
-    expect(queryFn.mock.calls[0][0]).toMatchObject({
-      query: {
-        filters: [inFilter],
-      },
-    })
-  })
-
-  it('preserves empty operators for non-platform datasources', async () => {
-    const queryFn = vi.fn().mockResolvedValue({})
-    const wrapper = mountComposable({
-      queryFn,
-    } as any)
-    const filters = [
-      { field: 'name', operator: 'empty' },
-      { field: 'name', operator: 'not_empty' },
-    ]
-
-    await wrapper.vm.issueQuery({
-      datasource: 'custom_datasource',
-      metrics: [],
-      dimensions: [],
-      filters,
-    } as any, {
-      ...context,
-      filters: [],
-    })
-
-    expect(queryFn.mock.calls[0][0]).toMatchObject({
-      query: {
+      await wrapper.vm.issueQuery({
+        datasource: 'custom_datasource',
+        metrics: [],
+        dimensions: [],
         filters,
-      },
+      } as any, {
+        ...context,
+        filters: [],
+      })
+
+      expect(queryFn.mock.calls[0][0]).toMatchObject({
+        query: {
+          filters,
+        },
+      })
     })
   })
 

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
@@ -1,6 +1,6 @@
 import {
   type AllFilters, type AnalyticsBridge, type DatasourceAwareQuery, type ExploreFilterAll, type ExploreQuery,
-  type TimeRangeV4,
+  isPlatformDatasource, requestFilterTypeEmptyV2, type TimeRangeV4,
   type ValidDashboardChartQuery,
 } from '@kong-ui-public/analytics-utilities'
 import { useDatasourceConfigStore } from '@kong-ui-public/analytics-config-store'
@@ -40,6 +40,7 @@ export default function useIssueQuery() {
     } = query
 
     const datasource = originalDatasource || 'basic'
+    const isPlatformQuery = isPlatformDatasource(datasource)
 
     const mergedFilters = stripUnknownFilters.value({
       datasource,
@@ -48,7 +49,7 @@ export default function useIssueQuery() {
         ...context.filters,
       ],
       queryFields: query.metrics,
-    })
+    }).filter(({ operator }) => !isPlatformQuery || !requestFilterTypeEmptyV2.some(emptyOperator => emptyOperator === operator))
 
     // TODO: the cast is necessary because TimeRangeV4 specifies date objects for absolute time ranges.
     // If they're coming from a definition, they're strings; should clean this up as part of the dashboard type work.

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
@@ -42,6 +42,8 @@ export default function useIssueQuery() {
     const datasource = originalDatasource || 'basic'
     const isPlatformQuery = isPlatformDatasource(datasource)
 
+    // TODO(MA-5255): Remove this temporary frontend shim when platform aggregation queries
+    // support `empty` and `not_empty` filters.
     const mergedFilters = stripUnknownFilters.value({
       datasource,
       filters: [

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
@@ -42,8 +42,6 @@ export default function useIssueQuery() {
     const datasource = originalDatasource || 'basic'
     const isPlatformQuery = isPlatformDatasource(datasource)
 
-    // TODO(MA-5255): Remove this temporary frontend shim when platform aggregation queries
-    // support `empty` and `not_empty` filters.
     const mergedFilters = stripUnknownFilters.value({
       datasource,
       filters: [
@@ -51,7 +49,10 @@ export default function useIssueQuery() {
         ...context.filters,
       ],
       queryFields: query.metrics,
-    }).filter(({ operator }) => !isPlatformQuery || !requestFilterTypeEmptyV2.some(emptyOperator => emptyOperator === operator))
+    })
+      // TODO(MA-5255): Remove this temporary frontend shim when platform aggregation queries
+      // support `empty` and `not_empty` filters.
+      .filter(({ operator }) => !isPlatformQuery || !requestFilterTypeEmptyV2.some(emptyOperator => emptyOperator === operator))
 
     // TODO: the cast is necessary because TimeRangeV4 specifies date objects for absolute time ranges.
     // If they're coming from a definition, they're strings; should clean this up as part of the dashboard type work.


### PR DESCRIPTION
# Summary

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

[MA-5344](https://konghq.atlassian.net/browse/MA-5344)

Although `ui-apps` hides these operators for non-table platform tile filters, preset and dashboard-level filters can still reach the tile aggregation query. The aggregation endpoint rejects them.

- For non-table visualizations, remove `empty` and `not_empty` from `platform_usage` and legacy `platform` queries after query and dashboard context filters merge.
- Keep other platform operators and all non-platform filters.
- Add regression tests for both datasource aliases, query filters, and dashboard context filters.

[MA-5344]: https://konghq.atlassian.net/browse/MA-5344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
