### PR TITLE
fix(entities): remove flaky post-remount cy.wait in list page-size tests

### DIFF
--- a/packages/entities/entities-certificates/src/components/CACertificateList.cy.ts
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.cy.ts
@@ -400,6 +400,7 @@ describe('<CACertificateList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(CACertificateList, {
         props: {
           cacheIdentifier,
@@ -410,8 +411,6 @@ describe('<CACertificateList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getCaCertificateMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="ca-certificate-1"]`).should('exist')
@@ -700,6 +699,7 @@ describe('<CACertificateList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(CACertificateList, {
         props: {
           cacheIdentifier,
@@ -710,8 +710,6 @@ describe('<CACertificateList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getCaCertificateMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="ca-certificate-1"]`).should('exist')

--- a/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
+++ b/packages/entities/entities-certificates/src/components/CertificateList.cy.ts
@@ -441,6 +441,7 @@ describe('<CertificateList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(CertificateList, {
         props: {
           cacheIdentifier,
@@ -451,8 +452,6 @@ describe('<CertificateList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getCertificateMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="certificate-1"]`).should('exist')
@@ -748,6 +747,7 @@ describe('<CertificateList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(CertificateList, {
         props: {
           cacheIdentifier,
@@ -758,8 +758,6 @@ describe('<CertificateList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getCertificateMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="certificate-1"]`).should('exist')

--- a/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.cy.ts
+++ b/packages/entities/entities-consumer-credentials/src/components/ConsumerCredentialList.cy.ts
@@ -500,6 +500,7 @@ describe('<ConsumerCredentialList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(ConsumerCredentialList, {
         props: {
           cacheIdentifier,
@@ -510,8 +511,6 @@ describe('<ConsumerCredentialList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getCredentialsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
@@ -794,6 +793,7 @@ describe('<ConsumerCredentialList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(ConsumerCredentialList, {
         props: {
           cacheIdentifier,
@@ -803,8 +803,6 @@ describe('<ConsumerCredentialList />', () => {
           canDelete: () => false,
         },
       })
-
-      cy.wait('@getCredentialsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.cy.ts
@@ -347,6 +347,7 @@ describe('<ConsumerGroupList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(ConsumerGroupList, {
         props: {
           cacheIdentifier,
@@ -357,8 +358,6 @@ describe('<ConsumerGroupList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getConsumerGroupsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="1"]`).should('exist')
@@ -948,6 +947,7 @@ describe('<ConsumerGroupList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(ConsumerGroupList, {
         props: {
           cacheIdentifier,
@@ -958,8 +958,6 @@ describe('<ConsumerGroupList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getConsumerGroupsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="1"]`).should('exist')

--- a/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.cy.ts
@@ -347,6 +347,7 @@ describe('<ConsumerList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(ConsumerList, {
         props: {
           cacheIdentifier,
@@ -357,8 +358,6 @@ describe('<ConsumerList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getConsumersMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="consumer.1"]`).should('exist')
@@ -964,6 +963,7 @@ describe('<ConsumerList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(ConsumerList, {
         props: {
           cacheIdentifier,
@@ -974,8 +974,6 @@ describe('<ConsumerList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getConsumersMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="consumer.1"]`).should('exist')

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -462,6 +462,7 @@ describe('<GatewayServiceList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(GatewayServiceList, {
         props: {
           cacheIdentifier,
@@ -472,8 +473,6 @@ describe('<GatewayServiceList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getGatewayServicesMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="gateway-service-1"]`).should('exist')
@@ -786,6 +785,7 @@ describe('<GatewayServiceList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(GatewayServiceList, {
         props: {
           cacheIdentifier,
@@ -796,8 +796,6 @@ describe('<GatewayServiceList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getGatewayServicesMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="gateway-service-1"]`).should('exist')

--- a/packages/entities/entities-key-sets/src/components/KeySetList.cy.ts
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.cy.ts
@@ -425,6 +425,7 @@ describe('<KeySetList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(KeySetList, {
         props: {
           cacheIdentifier,
@@ -435,8 +436,6 @@ describe('<KeySetList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getKeySetsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="key-set-1"]`).should('exist')
@@ -725,6 +724,7 @@ describe('<KeySetList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(KeySetList, {
         props: {
           cacheIdentifier,
@@ -735,8 +735,6 @@ describe('<KeySetList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getKeySetsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="key-set-1"]`).should('exist')

--- a/packages/entities/entities-keys/src/components/KeyList.cy.ts
+++ b/packages/entities/entities-keys/src/components/KeyList.cy.ts
@@ -429,6 +429,7 @@ describe('<KeyList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(KeyList, {
         props: {
           cacheIdentifier,
@@ -439,8 +440,6 @@ describe('<KeyList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getKeysMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="key-1"]`).should('exist')
@@ -729,6 +728,7 @@ describe('<KeyList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(KeyList, {
         props: {
           cacheIdentifier,
@@ -739,8 +739,6 @@ describe('<KeyList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getKeysMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="key-1"]`).should('exist')

--- a/packages/entities/entities-plugins/src/components/PluginList.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginList.cy.ts
@@ -680,6 +680,7 @@ describe('<PluginList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(PluginList, {
         props: {
           cacheIdentifier,
@@ -690,8 +691,6 @@ describe('<PluginList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getRoutesMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="plugin-1"]`).should('exist')
@@ -1009,6 +1008,7 @@ describe('<PluginList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(PluginList, {
         props: {
           cacheIdentifier,
@@ -1019,8 +1019,6 @@ describe('<PluginList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getRoutesMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="plugin-1"]`).should('exist')

--- a/packages/entities/entities-routes/src/components/RouteList.cy.ts
+++ b/packages/entities/entities-routes/src/components/RouteList.cy.ts
@@ -589,6 +589,7 @@ describe('<RouteList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(RouteList, {
         props: {
           cacheIdentifier,
@@ -599,8 +600,6 @@ describe('<RouteList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getRoutesMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="route-1"]`).should('exist')
@@ -889,6 +888,7 @@ describe('<RouteList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(RouteList, {
         props: {
           cacheIdentifier,
@@ -899,8 +899,6 @@ describe('<RouteList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getRoutesMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="route-1"]`).should('exist')

--- a/packages/entities/entities-snis/src/components/SniList.cy.ts
+++ b/packages/entities/entities-snis/src/components/SniList.cy.ts
@@ -385,6 +385,7 @@ describe('<SniList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(SniList, {
         props: {
           cacheIdentifier,
@@ -395,8 +396,6 @@ describe('<SniList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getSnisMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="sni-1"]`).should('exist')
@@ -681,6 +680,7 @@ describe('<SniList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(SniList, {
         props: {
           cacheIdentifier,
@@ -691,8 +691,6 @@ describe('<SniList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getSnisMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="sni-1"]`).should('exist')

--- a/packages/entities/entities-upstreams-targets/src/components/TargetsList.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/TargetsList.cy.ts
@@ -493,6 +493,7 @@ describe('<TargetsList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(TargetsList, {
         props: {
           cacheIdentifier,
@@ -503,8 +504,6 @@ describe('<TargetsList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getTargetsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')
@@ -793,6 +792,7 @@ describe('<TargetsList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(TargetsList, {
         props: {
           cacheIdentifier,
@@ -803,8 +803,6 @@ describe('<TargetsList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getTargetsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-rowid="1"]`).should('exist')

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.cy.ts
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.cy.ts
@@ -428,6 +428,7 @@ describe('<UpstreamsList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(UpstreamsList, {
         props: {
           cacheIdentifier,
@@ -438,8 +439,6 @@ describe('<UpstreamsList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getUpstreamsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="upstream-1"]`).should('exist')
@@ -728,6 +727,7 @@ describe('<UpstreamsList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(UpstreamsList, {
         props: {
           cacheIdentifier,
@@ -738,8 +738,6 @@ describe('<UpstreamsList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getUpstreamsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="upstream-1"]`).should('exist')

--- a/packages/entities/entities-vaults/src/components/SecretList.cy.ts
+++ b/packages/entities/entities-vaults/src/components/SecretList.cy.ts
@@ -390,6 +390,7 @@ describe('<SecretList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(SecretList, {
         props: {
           cacheIdentifier,
@@ -400,8 +401,6 @@ describe('<SecretList />', () => {
           canDelete: () => false,
         },
       })
-
-      cy.wait('@getSecretsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="secret-1"]`).should('exist')

--- a/packages/entities/entities-vaults/src/components/VaultList.cy.ts
+++ b/packages/entities/entities-vaults/src/components/VaultList.cy.ts
@@ -422,6 +422,7 @@ describe('<VaultList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(VaultList, {
         props: {
           cacheIdentifier,
@@ -432,8 +433,6 @@ describe('<VaultList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getVaultsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="vault-1"]`).should('exist')
@@ -722,6 +721,7 @@ describe('<VaultList />', () => {
 
       // Unmount and mount
       cy.get('@vueWrapper').then(wrapper => wrapper.unmount())
+      cy.get(l).should('not.exist')
       cy.mount(VaultList, {
         props: {
           cacheIdentifier,
@@ -732,8 +732,6 @@ describe('<VaultList />', () => {
           canRetrieve: () => false,
         },
       })
-
-      cy.wait('@getVaultsMultiPage')
 
       cy.get(`${l} tbody tr`).should('have.length', 15)
       cy.get(`${l} tbody tr[data-testid="vault-1"]`).should('exist')


### PR DESCRIPTION
[KM-3088]

## Summary
- Several `*List.cy.ts` "should allow picking different page sizes and persist the preference" specs intermittently failed in CI with `cy.wait()` timing out on a 3rd network request that never occurred (seen for entities-certificates, entities-consumer-groups, entities-upstreams-targets in https://github.com/Kong/public-ui-components/actions/runs/31667690278).
- Root cause: `KTableData` caches fetch responses via swrv keyed by `cacheIdentifier` (+ `fetcherCacheKey`), not by pageSize. When the test unmounts and immediately remounts the same list with the same `cacheIdentifier`, the remount can be served from cache and legitimately skip the network request — the `cy.wait('@...MultiPage')` assertion after remount was asserting on a network call the framework isn't guaranteed to make.
- Fix: drop the unreliable post-remount `cy.wait`, and instead assert directly on the DOM state (row count, `data-testid` rows, page-size dropdown value) which reflects the persisted preference regardless of whether the data came from cache or the network. Added `cy.get(l).should('not.exist')` right after `unmount()` so the following assertions can't vacuously pass against the pre-remount DOM.
- Applied the same fix to all 15 list specs that share this exact remount pattern (only 3 failed in this particular run, but all are equally flaky by construction).

## Test plan
- [x] Reproduced and confirmed root cause via `KTableData`/`useFetcher` swrv caching behavior
- [x] Ran `ConsumerGroupList.cy.ts` locally (Cypress 15.20.0) — 31/31 passing
- [x] Ran `UpstreamsList.cy.ts` locally — 24/24 passing
- [x] Ran `CACertificateList.cy.ts` locally — 21/21 passing
- [x] ESLint clean on all changed files

[KM-3088]: https://konghq.atlassian.net/browse/KM-3088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ