### PR TITLE
fix(entities-plugins): replace key input with SensitiveInput

### DIFF
--- a/packages/entities/entities-plugins/src/components/CreateConsumerCredentialForm.vue
+++ b/packages/entities/entities-plugins/src/components/CreateConsumerCredentialForm.vue
@@ -13,6 +13,9 @@
         :description="t('onboarding.steps.consumer.description')"
         :title="t('onboarding.steps.consumer.title')"
       >
+        <div class="consumer-note">
+          {{ t('onboarding.steps.consumer.note') }}
+        </div>
         <KInput
           v-model.trim="consumerFields.username"
           autocomplete="off"
@@ -199,6 +202,10 @@ const onSecondaryAction = () => {
   border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
   display: flex;
   flex-direction: column;
+
+  .consumer-note {
+    font-size: var(--kui-font-size-30, $kui-font-size-30);
+  }
 
   .onboarding-wizard-header {
     border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);

--- a/packages/entities/entities-plugins/src/components/CredentialConfigurationForm.vue
+++ b/packages/entities/entities-plugins/src/components/CredentialConfigurationForm.vue
@@ -18,6 +18,7 @@
 import { computed, ref, watch } from 'vue'
 import { useAxios } from '@kong-ui-public/entities-shared'
 import composables from '../composables'
+import CredentialSecretField from './free-form/shared/CredentialSecretField.vue'
 import PluginConfigurationForm from './free-form/shared/layout/PluginConfigurationForm.vue'
 import StringArrayField from './free-form/shared/StringArrayField.vue'
 import { CREDENTIAL_METADATA, CREDENTIAL_SCHEMAS } from '../definitions/metadata'
@@ -88,6 +89,17 @@ const fieldRenderers: FieldRenderer[] = [
     propsOverrides: {
       help: t('plugins.form.fields.tags.help'),
       placeholder: t('plugins.form.fields.tags.placeholder'),
+    },
+  },
+  {
+    match: 'key',
+    component: CredentialSecretField,
+  },
+  {
+    match: 'secret',
+    component: CredentialSecretField,
+    propsOverrides: {
+      labels: { generateLabel: t('plugins.form.fields.secret.generateLabel') },
     },
   },
 ]

--- a/packages/entities/entities-plugins/src/components/free-form/shared/CredentialSecretField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/CredentialSecretField.vue
@@ -1,0 +1,74 @@
+<template>
+  <!-- missing schema alert -->
+  <KAlert
+    v-if="field.error"
+    appearance="danger"
+    :message="field.error.message"
+  />
+
+  <SensitiveInput
+    v-else
+    v-show="!hide"
+    v-bind="fieldAttrs"
+    class="ff-credential-secret-field"
+    :data-testid="`ff-${field.path.value}`"
+    :generator="generator ?? generateCredentialSecret"
+    mode="create"
+    :model-value="fieldValue ?? ''"
+    @update:model-value="handleUpdate"
+  >
+    <template
+      v-if="fieldAttrs.labelAttributes?.info"
+      #label-tooltip
+    >
+      <slot name="tooltip">
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <div v-html="fieldAttrs.labelAttributes.info" />
+      </slot>
+    </template>
+  </SensitiveInput>
+</template>
+
+<script setup lang="ts">
+import { toRef, useAttrs } from 'vue'
+import { SensitiveInput } from '@kong-ui-public/entities-shared'
+import type { SensitiveInputLabels } from '@kong-ui-public/entities-shared'
+import { useField, useFieldAttrs } from './composables'
+import { generateCredentialSecret } from './utils'
+import type { BaseFieldProps } from './types'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const attrs = useAttrs()
+
+interface CredentialSecretFieldProps extends BaseFieldProps {
+  placeholder?: string
+  help?: string
+  labels?: SensitiveInputLabels
+}
+
+const { name, generator, ...props } = defineProps<CredentialSecretFieldProps & {
+  generator?: () => string | Promise<string>
+}>()
+const emit = defineEmits<{
+  'update:modelValue': [value: string | null]
+}>()
+
+const { value: fieldValue, hide, ...field } = useField<string | null>(toRef(() => name))
+const fieldAttrs = useFieldAttrs(field.path!, toRef({ ...props, ...attrs }))
+
+function handleUpdate(value: string) {
+  fieldValue!.value = value === '' ? null : value
+  emit('update:modelValue', fieldValue!.value)
+}
+</script>
+
+<style lang="scss" scoped>
+.ff-credential-secret-field {
+  :deep(.k-tooltip p) {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/utils.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/utils.ts
@@ -282,3 +282,30 @@ export function normalizeMatch(match: FieldRenderer['match']): Match {
     ? ({ genericPath }) => genericPath === match
     : match
 }
+
+const CREDENTIAL_SECRET_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+// Largest multiple of the alphabet's length that fits in a byte - bytes at or
+// above it are rejected so `byte % alphabet.length` stays uniformly distributed.
+const CREDENTIAL_SECRET_BYTE_LIMIT = 256 - (256 % CREDENTIAL_SECRET_ALPHABET.length)
+
+/**
+ * Generates a random alphanumeric string resembling the credentials Kong's
+ * admin API auto-generates for `key`/`secret` fields (e.g. key-auth, hmac-auth, JWT).
+ */
+export function generateCredentialSecret(length = 32): string {
+  const bytes = new Uint8Array(length)
+  let result = ''
+
+  while (result.length < length) {
+    crypto.getRandomValues(bytes)
+
+    for (const byte of bytes) {
+      if (result.length >= length) break
+      if (byte >= CREDENTIAL_SECRET_BYTE_LIMIT) continue
+
+      result += CREDENTIAL_SECRET_ALPHABET[byte % CREDENTIAL_SECRET_ALPHABET.length]
+    }
+  }
+
+  return result
+}

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -837,6 +837,9 @@
           "label": "Tags",
           "help": "An optional set of strings for grouping and filtering, separated by commas.",
           "placeholder": "Tag1, Tag2, Tag3"
+        },
+        "secret": {
+          "generateLabel": "Generate secret"
         }
       },
       "scoping": {

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -83,7 +83,8 @@
       "consumer": {
         "step":"Consumer",
         "title": "Create a consumer",
-        "description": "Consumers represent the users or applications calling your API. Add a name or tags to help you identify and manage this consumer later."
+        "description": "Consumers represent the users or applications calling your API. Add a name or tags to help you identify and manage this consumer later.",
+        "note": "A consumer can have both unique username and unique custom ID or one of them."
       },
       "credential": {
         "step":"Credential",
@@ -92,9 +93,9 @@
     },
     "consumer_fields": {
       "username_label": "Username",
-      "username_placeholder": "Enter a username",
+      "username_placeholder": "Enter a unique username",
       "custom_id_label": "Custom ID",
-      "custom_id_placeholder": "Enter a custom ID"
+      "custom_id_placeholder": "Enter a unique custom ID"
     },
     "choose_consumer": {
       "title": "Choose a consumer",

--- a/packages/entities/entities-shared/docs/sensitive-input.md
+++ b/packages/entities/entities-shared/docs/sensitive-input.md
@@ -104,6 +104,25 @@ Emitted with the generated key once `generator` resolves.
 
 ### Slots
 
+#### label-tooltip
+
+Overrides the label tooltip's content. By default, `labelAttributes.info` is rendered as plain text (the underlying `KLabel` behavior) — use this slot when the info text contains HTML (for example, markdown rendered upstream) that needs to display as formatted content instead of literal tags.
+
+```html
+<template>
+  <SensitiveInput
+    v-model="apiKey"
+    label="API key"
+    :label-attributes="{ info: htmlInfo }"
+  >
+    <template #label-tooltip>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div v-html="htmlInfo" />
+    </template>
+  </SensitiveInput>
+</template>
+```
+
 #### alert
 
 Rendered at the bottom of the component. Use it to display additional content such as a `KAlert` — for example, surfacing a notice after the `rotate` event fires.

--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
@@ -1,3 +1,4 @@
+import { h } from 'vue'
 import SensitiveInput from './SensitiveInput.vue'
 import composables from '../../composables'
 
@@ -214,6 +215,39 @@ describe('<SensitiveInput />', () => {
       })
 
       cy.getTestId('sensitive-input-error-message').should('contain.text', 'This field is required')
+    })
+  })
+
+  describe('label tooltip', () => {
+    it('renders labelAttributes.info as plain text when no label-tooltip slot is provided', () => {
+      cy.mount(SensitiveInput, {
+        props: {
+          modelValue: '',
+          label: 'API key',
+          labelAttributes: { info: 'Plain info text' },
+        },
+      })
+
+      cy.get('.tooltip-trigger-icon').trigger('mouseenter')
+      cy.contains('Plain info text').should('exist')
+    })
+
+    it('renders custom HTML via the label-tooltip slot instead of the plain info text', () => {
+      cy.mount(SensitiveInput, {
+        props: {
+          modelValue: '',
+          label: 'API key',
+          labelAttributes: { info: 'Plain info text' },
+        },
+        slots: {
+          'label-tooltip': () => h('div', {}, [h('strong', {}, 'Bold tooltip')]),
+        },
+      })
+
+      cy.get('.tooltip-trigger-icon').trigger('mouseenter')
+      cy.contains('Bold tooltip').should('exist')
+      cy.get('strong').should('contain.text', 'Bold tooltip')
+      cy.contains('Plain info text').should('not.exist')
     })
   })
 

--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
@@ -20,6 +20,13 @@
       :type="inputType"
       @update:model-value="handleInput"
     >
+      <template
+        v-if="$slots['label-tooltip']"
+        #label-tooltip
+      >
+        <slot name="label-tooltip" />
+      </template>
+
       <template #after>
         <!-- Masked (editing an existing resource): only the Rotate key action -->
         <KButton
@@ -79,7 +86,14 @@
         :required="required || undefined"
         resizable
         @update:model-value="handleInput"
-      />
+      >
+        <template
+          v-if="$slots['label-tooltip']"
+          #label-tooltip
+        >
+          <slot name="label-tooltip" />
+        </template>
+      </KTextArea>
       <p
         v-if="error && errorMessage"
         class="sensitive-input-error-message"


### PR DESCRIPTION
[KM-3098]

## Summary
- Replaces the onboarding credential form's key/secret inputs with `SensitiveInput`, adding a "Generate key/secret" action and reveal toggle.

## Test plan
- [x] `pnpm typecheck` / `eslint` pass for entities-plugins and entities-shared
- [x] `SensitiveInput.cy.ts` component tests pass (20/20)
- [x] Manually verified in sandbox: generate button fills a 32-char key, reveal toggle works, tooltip renders formatted HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KM-3098]: https://konghq.atlassian.net/browse/KM-3098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ