### PR TITLE
chore(ci): bumping pr-audit action [KHCP-21463]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,3 +10,10 @@
   - Link to Figma, if applicable
   - Conventional Commits
 -->
+
+<!--
+## Test Coverage Exemption (Optional)
+If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.
+
+[TEST_COVERAGE_EXEMPT_REASON] give it a reason
+-->

--- a/.github/workflows/pr-audit.yaml
+++ b/.github/workflows/pr-audit.yaml
@@ -9,15 +9,10 @@ on:
       - reopened
       - labeled
       - unlabeled
-
-  pull_request_review:
-    types:
-      - submitted
       - edited
-      - dismissed
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -42,6 +37,6 @@ jobs:
 
       - name: PR Audit
         if: github.actor != 'renovate[bot]'
-        uses: Kong/public-shared-actions/pr-previews/audit@8d98bc15a5143332a36f206e6699296e6cc2adac
+        uses: Kong/public-shared-actions/pr-previews/audit@cbbbf31a69c4f38d1803ededb69acb2a86836f85
         with:
           renovate-pr-author: renovate[bot]


### PR DESCRIPTION
# Description

as per manager complains: "but every time I approve one of these I feel like I’m rubber stamping to get past a gate."

So: no longer PR without test coverage requires manager's approval. Instead it requires PR author to put test-exempt-reason into PR description:

<img width="936" height="432" alt="image" src="https://github.com/user-attachments/assets/42e624a9-693f-4db0-97c7-fa7e69cc7def" />