### PR TITLE
feat(entities-plugins): add typed plugin context provide/inject mechanism

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginFormPage.vue
@@ -70,7 +70,7 @@
 import { computed, defineComponent, provide, ref, type PropType } from 'vue'
 import { useRouter } from 'vue-router'
 
-import { PluginForm, TOASTER_PROVIDER, useProvideExperimentalFreeForms } from '../../src'
+import { PluginForm, providePluginContext, TOASTER_PROVIDER, useProvideExperimentalFreeForms } from '../../src'
 import { FEATURE_FLAGS } from '../../src/constants'
 
 import { ToastManager } from '@kong/kongponents'
@@ -126,6 +126,10 @@ const FeatureFlagProvider = defineComponent({
 })
 
 provideDeckCommandEditor()
+
+providePluginContext('key-auth', {
+  identityRealmsEnabled: true,
+})
 
 useProvideExperimentalFreeForms([
   'ace',

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -4,6 +4,7 @@ import Form from '../../free-form/shared/Form.vue'
 import ConfigFormContent from './ConfigFormContent.vue'
 import { BEFORE_SAVE_KEY } from '../../const'
 import { FEATURE_FLAGS } from '../../../constants'
+import { PLUGIN_CONTEXT_KEY } from '../../free-form/shared/plugin-context'
 import type { FormSchema } from '../../../types/plugins/form-schema'
 
 // Schema with both principals and identity_realms (like key-auth)
@@ -251,6 +252,8 @@ function mountContent(
     principalsCreationGuideVisible?: boolean
     /** Kong Gateway versions of connected data plane nodes. */
     dataPlaneVersions?: string[]
+    /** key-auth context: set to `false` to disable the identity_realms flow entirely. */
+    identityRealmsEnabled?: boolean
   },
   data?: Record<string, any>,
 ) {
@@ -295,6 +298,9 @@ function mountContent(
         [BEFORE_SAVE_KEY as symbol]: (cb: () => boolean) => {
           beforeSaveCallbacks.push(cb); return () => {}
         },
+        ...(options.identityRealmsEnabled !== undefined
+          ? { [PLUGIN_CONTEXT_KEY]: { 'key-auth': { identityRealmsEnabled: options.identityRealmsEnabled } } }
+          : {}),
       },
     },
   })
@@ -709,6 +715,41 @@ describe('ConfigFormContent', () => {
             && val.config?.principals?.directory === 'my-custom-dir'
             && val.config?.principals?.error_on_miss === false
         }))
+      })
+    })
+
+    describe('identityRealmsEnabled context (key-auth)', () => {
+      it('hides the "Centrally managed consumers" option when disabled', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, identityRealmsEnabled: false })
+
+        cy.getTestId('kong-identity-mode-consumers').should('exist')
+        cy.getTestId('kong-identity-mode-kong-identity').should('exist')
+        cy.getTestId('kong-identity-mode-centrally-managed').should('not.exist')
+      })
+
+      it('hides the identity_realms field even when saved data is already centrally-managed', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, identityRealmsEnabled: false }, {
+          config: {
+            principals: null,
+            identity_realms: [{ scope: 'realm', id: 'some-id', region: 'us' }],
+          },
+        })
+
+        cy.getTestId('ff-identity-realms-field').should('not.exist')
+        cy.getTestId('ff-array-config.identity_realms').should('not.exist')
+      })
+
+      it('does not fetch realms when disabled', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, identityRealmsEnabled: false })
+
+        cy.get('@fetchRealms.all').should('have.length', 0)
+      })
+
+      it('still shows the option and fetches realms when left unset (defaults to enabled)', () => {
+        mountContent(schemaWithRealms, { isKonnect: true })
+
+        cy.getTestId('kong-identity-mode-centrally-managed').should('exist')
+        cy.wait('@fetchRealms')
       })
     })
   })

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -16,7 +16,7 @@
   />
 
   <div
-    v-if="isKonnect && identityRealmsInSchema && selectedMode === 'centrally-managed'"
+    v-if="isKonnect && identityRealmsInSchema && identityRealmsEnabled && selectedMode === 'centrally-managed'"
     class="identity-realms-section"
     data-testid="identity-realms-section"
     @click="handleRealmFieldTouch"
@@ -89,6 +89,7 @@ import KongIdentityField from './KongIdentityField.vue'
 import IdentityRealmsField from '../../free-form/plugins/key-auth/IdentityRealmsField.vue'
 import PrincipalsCreationGuide from './PrincipalsCreationGuide.vue'
 import { useFormShared } from '../../free-form/shared/composables'
+import { usePluginContext } from '../../free-form/shared/plugin-context'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import { useAxios } from '@kong-ui-public/entities-shared'
 import { KLabel, KRadio } from '@kong/kongponents'
@@ -127,6 +128,11 @@ const appConfig = inject<KongManagerBaseFormConfig | KonnectBaseFormConfig | und
 const isKonnect = computed(() => appConfig?.app === 'konnect')
 const { axiosInstance } = useAxios(appConfig?.axiosRequestConfig)
 
+// Host opt-out: disables the identity_realms field, its realms fetch, and the "Centrally
+// managed consumers" mode option entirely, regardless of schema.
+const keyAuthContext = usePluginContext('key-auth')
+const identityRealmsEnabled = computed(() => keyAuthContext?.identityRealmsEnabled ?? true)
+
 const { formData, getSchema } = useFormShared()
 
 const hasPrincipalsErrorOnMiss = computed(() => !!getSchema('$.config.principals.error_on_miss'))
@@ -154,7 +160,7 @@ const fetchedRealms = ref<MultiselectItem[]>([])
 const isLoadingRealms = ref(false)
 
 const fetchRealms = async () => {
-  if (appConfig?.app !== 'konnect' || !identityRealmsInSchema.value) return
+  if (appConfig?.app !== 'konnect' || !identityRealmsInSchema.value || !identityRealmsEnabled.value) return
 
   try {
     isLoadingRealms.value = true
@@ -324,7 +330,7 @@ const advancedOmit = computed(() => {
   if (!realmRequired.value && selectedMode.value !== 'kong-identity') {
     advancedSet.add('realm')
   }
-  if (isKonnect.value && identityRealmsInSchema.value && !hasPrincipals.value) {
+  if (isKonnect.value && identityRealmsInSchema.value && identityRealmsEnabled.value && !hasPrincipals.value) {
     advancedSet.add('identity_realms')
   }
 

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
@@ -76,6 +76,7 @@ import { KLabel, KRadio, KSkeletonBox } from '@kong/kongponents'
 import { TeamIcon, AccountTreeIcon, KeyIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
 import { useFormShared } from '../../free-form/shared/composables'
+import { usePluginContext } from '../../free-form/shared/plugin-context'
 import composables from '../../../composables'
 
 import type { AuthMode } from './types'
@@ -97,10 +98,14 @@ const identityRealmsInSchema = computed(() => {
   return !!getSchema('$.config.identity_realms')
 })
 
+// Host opt-out: hides the "Centrally managed consumers" option entirely, regardless of schema.
+const keyAuthContext = usePluginContext('key-auth')
+const identityRealmsEnabled = computed(() => keyAuthContext?.identityRealmsEnabled ?? true)
+
 // Launch decision: Centrally Managed is shown unconditionally whenever the schema
 // supports identity_realms — we intentionally do NOT hide it when no realms exist yet.
 // Hiding it (platform-wide) is deferred to a fast-follow.
-const showCentrallyManaged = computed(() => identityRealmsInSchema.value)
+const showCentrallyManaged = computed(() => identityRealmsInSchema.value && identityRealmsEnabled.value)
 
 const descriptionText = computed(() => {
   return identityRealmsInSchema.value

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/key-auth/context.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/key-auth/context.ts
@@ -1,0 +1,8 @@
+export interface KeyAuthContext {
+  /**
+   * Enables the Kong Identity "centrally managed consumers" flow: the `identity_realms`
+   * field, its realms fetch, and the "Centrally managed consumers" mode option.
+   * Defaults to `true` when no context is provided.
+   */
+  identityRealmsEnabled?: boolean
+}

--- a/packages/entities/entities-plugins/src/components/free-form/shared/plugin-context/README.md
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/plugin-context/README.md
@@ -1,0 +1,52 @@
+# Plugin Context
+
+Use this when a plugin's form needs a flag or data from the **host app** — a
+feature flag, options fetched from an API, a callback — that doesn't belong
+in the plugin's schema. Prefer it over reaching into the catch-all
+`FORMS_CONFIG` blob or adding one-off `inject()` calls scattered across
+plugin components.
+
+## Usage
+
+**1. Define the type in the plugin's own directory**, e.g.
+`plugins/key-auth/context.ts`:
+
+```ts
+export interface KeyAuthContext {
+  identityRealmsEnabled?: boolean
+}
+```
+
+Then import it as a type and add one entry to `PluginContextRegistry` in
+[index.ts](./index.ts):
+
+```ts
+import type { KeyAuthContext } from '../../plugins/key-auth/context'
+
+export interface PluginContextRegistry {
+  'key-auth': KeyAuthContext
+}
+```
+
+`PluginName` (`keyof PluginContextRegistry`) is derived from this, so
+`providePluginContext`/`usePluginContext` only accept plugin names listed
+here, with the value type inferred from the name.
+
+**2. Provide it** from an ancestor of the plugin's form — usually a host
+wrapper around `PluginEntityForm`, since `provide`/`inject` only flows from
+ancestor to descendant:
+
+```ts
+providePluginContext('key-auth', { identityRealmsEnabled: false })
+```
+
+**3. Read it** inside that plugin's own form:
+
+```ts
+const context = usePluginContext('key-auth')
+```
+
+`usePluginContext` returns `undefined` if nothing was provided — handle that
+yourself (fall back to a default, throw, etc.). It only warns when some
+ancestor provided context for another plugin but forgot this one; it stays
+silent if nothing was ever provided at all.

--- a/packages/entities/entities-plugins/src/components/free-form/shared/plugin-context/index.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/plugin-context/index.spec.ts
@@ -1,0 +1,98 @@
+/* eslint-disable vue/one-component-per-file */
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { providePluginContext, usePluginContext } from '.'
+
+declare module '.' {
+  interface PluginContextRegistry {
+    'test-plugin-a': { foo: string }
+    'test-plugin-b': { bar: number }
+  }
+}
+
+function mountWithProvider(setup: () => void, slotSetup: () => unknown) {
+  const Child = defineComponent({
+    setup: slotSetup,
+    render: () => null,
+  })
+
+  const Parent = defineComponent({
+    setup() {
+      setup()
+      return () => h(Child)
+    },
+  })
+
+  return mount(Parent)
+}
+
+describe('providePluginContext / usePluginContext', () => {
+  it('lets a descendant read context registered by an ancestor', () => {
+    let received: { foo: string } | undefined
+
+    mountWithProvider(
+      () => providePluginContext('test-plugin-a', { foo: 'hello' }),
+      () => {
+        received = usePluginContext('test-plugin-a')
+      },
+    )
+
+    expect(received).toEqual({ foo: 'hello' })
+  })
+
+  it('merges multiple calls in the same component instead of clobbering earlier ones', () => {
+    let receivedA: { foo: string } | undefined
+    let receivedB: { bar: number } | undefined
+
+    mountWithProvider(
+      () => {
+        providePluginContext('test-plugin-a', { foo: 'hello' })
+        providePluginContext('test-plugin-b', { bar: 42 })
+      },
+      () => {
+        receivedA = usePluginContext('test-plugin-a')
+        receivedB = usePluginContext('test-plugin-b')
+      },
+    )
+
+    expect(receivedA).toEqual({ foo: 'hello' })
+    expect(receivedB).toEqual({ bar: 42 })
+  })
+
+  it('warns and returns undefined when nothing was registered for the requested plugin', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let received: unknown
+
+    mountWithProvider(
+      () => providePluginContext('test-plugin-a', { foo: 'hello' }),
+      () => {
+        received = usePluginContext('test-plugin-b')
+      },
+    )
+
+    expect(received).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no context registered for plugin "test-plugin-b"'))
+    warnSpy.mockRestore()
+  })
+
+  it('stays silent and returns undefined when no ancestor ever provided any context', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let received: unknown
+
+    mountWithProvider(
+      () => {},
+      () => {
+        received = usePluginContext('test-plugin-a')
+      },
+    )
+
+    expect(received).toBeUndefined()
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('throws when called outside setup()', () => {
+    expect(() => providePluginContext('test-plugin-a', { foo: 'hello' })).toThrow('must be called inside setup()')
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/shared/plugin-context/index.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/plugin-context/index.ts
@@ -1,0 +1,72 @@
+import { getCurrentInstance, inject, provide, reactive } from 'vue'
+
+import type { ComponentInternalInstance, InjectionKey } from 'vue'
+import type { KeyAuthContext } from '../../plugins/key-auth/context'
+
+/**
+ * Central registry mapping each plugin that needs host-injected context to its context type.
+ * Add one entry per plugin here.
+ */
+export interface PluginContextRegistry {
+  'key-auth': KeyAuthContext
+}
+
+export type PluginName = keyof PluginContextRegistry
+
+/** Exported for tests that need to provide context via `global.provide` without a wrapper component. */
+export const PLUGIN_CONTEXT_KEY = Symbol('free-form-plugin-context') as InjectionKey<Partial<PluginContextRegistry>>
+
+// Tracks the store a given component instance has already provided, so repeated
+// `providePluginContext` calls in the same setup() (one per plugin) merge into a
+// single store instead of each clobbering the last. This can't be detected via
+// `inject()` alone: a component's own `inject()` reads its *parent's* provides,
+// never its own, so a naive `inject(KEY, null) ?? reactive({})` would silently
+// create a fresh store — and lose earlier registrations — on every call.
+const ownStores = new WeakMap<ComponentInternalInstance, Partial<PluginContextRegistry>>()
+
+/**
+ * Registers context for a specific plugin, to be read by that plugin's form via
+ * `usePluginContext`. Safe to call multiple times — once per plugin — from the
+ * same component.
+ */
+export function providePluginContext<K extends PluginName>(
+  pluginName: K,
+  context: PluginContextRegistry[K],
+): void {
+  const instance = getCurrentInstance()
+  if (!instance) {
+    throw new Error('providePluginContext() must be called inside setup().')
+  }
+
+  let store = ownStores.get(instance)
+  if (!store) {
+    store = reactive({}) as Partial<PluginContextRegistry>
+    ownStores.set(instance, store)
+    provide(PLUGIN_CONTEXT_KEY, store)
+  }
+
+  const record = store as Record<PluginName, unknown>
+  record[pluginName] = context
+}
+
+/**
+ * Reads the context registered for a plugin via `providePluginContext` in an
+ * ancestor component. Returns `undefined` (and logs a warning) if nothing was
+ * registered for `pluginName` — callers decide for themselves whether a
+ * missing context is fatal.
+ */
+export function usePluginContext<K extends PluginName>(pluginName: K): PluginContextRegistry[K] | undefined {
+  const store = inject(PLUGIN_CONTEXT_KEY, null)
+  const context = store?.[pluginName]
+  // Only warn when some ancestor did establish the store (i.e. adopted this mechanism for at
+  // least one plugin) but forgot this one. Stay silent when no store exists at all, so hosts
+  // and component tests that don't use this mechanism yet aren't spammed with warnings for
+  // context fields that are meant to be optional.
+  if (store && context === undefined) {
+    console.warn(
+      `usePluginContext(): no context registered for plugin "${String(pluginName)}". ` +
+      `Call providePluginContext('${String(pluginName)}', ...) in an ancestor component first.`,
+    )
+  }
+  return context as PluginContextRegistry[K] | undefined
+}

--- a/packages/entities/entities-plugins/src/index.ts
+++ b/packages/entities/entities-plugins/src/index.ts
@@ -58,6 +58,16 @@ export type {
   ResolvedPluginFormConfig,
 } from './components/free-form/shared/plugin-registry'
 
+export {
+  providePluginContext,
+  usePluginContext,
+} from './components/free-form/shared/plugin-context'
+
+export type {
+  PluginContextRegistry,
+  PluginName as PluginContextName,
+} from './components/free-form/shared/plugin-context'
+
 export { provideEditorStore, useEditorStore } from './components/free-form/plugins/datakit/composables'
 
 export type { DatakitPluginData, NodeInstance, NodePhase } from './components/free-form/plugins/datakit/types'


### PR DESCRIPTION
# Summary

- Adds a generic, typed provide/inject mechanism (`providePluginContext`/`usePluginContext`) under `free-form/shared/plugin-context/` for handing a plugin's free-form component host-supplied data (feature flags, API-fetched options, callbacks). Each plugin registers its own context type in a central `PluginContextRegistry`, so both functions are fully typed from the plugin name — no casts needed at call sites.
- This converges what was previously scattered across the catch-all `FORMS_CONFIG` blob and one-off `inject()` calls per plugin.
- `usePluginContext` returns `undefined` (never throws) when nothing was registered, and only logs a `console.warn` when some ancestor did provide context for at least one plugin but forgot this one — silent when the mechanism isn't in use at all, so existing hosts/tests aren't spammed with warnings for context that's meant to be optional.
- Adopts the new mechanism for `key-auth`: a `identityRealmsEnabled` context flag (default `true`) lets a host disable the Kong Identity "centrally managed consumers" flow entirely — hides the `identity_realms` field, skips the realms fetch, and hides the "Centrally managed consumers" mode option. `basic-auth` is unaffected since its schema never has `identity_realms`.
- Wires the sandbox `PluginFormPage` to call `providePluginContext('key-auth', { identityRealmsEnabled: true })` as a live usage example.
- New exports from the package entry (`src/index.ts`): `providePluginContext`, `usePluginContext`, `PluginContextRegistry`, `PluginContextName`.

## Test plan

- [x] `plugin-context/index.spec.ts` (vitest): covers ancestor→descendant read, multiple `providePluginContext` calls in one component merging instead of clobbering, warn-vs-silent behavior, and the setup()-only guard.
- [x] `ConfigFormContent.cy.ts` (Cypress component): new `identityRealmsEnabled context (key-auth)` describe block — hides the mode option, hides the field even with pre-existing centrally-managed data, skips the realms fetch, and confirms default-enabled behavior is unchanged. All 58 specs in the file pass (no regressions).
- [x] `npx eslint` and `npx vue-tsc -p tsconfig.build.json --noEmit` clean on all touched/added files (one pre-existing, unrelated `metadata.ts` error remains).