### PR TITLE
fix: rename authenticated_entity -> oidc_credential

### DIFF
--- a/packages/analytics/analytics-utilities/src/types/explore/advanced.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/advanced.ts
@@ -5,7 +5,6 @@ import { basicExploreAggregations, queryableBasicExploreDimensions } from './bas
 export const queryableExploreDimensions = [
   ...queryableBasicExploreDimensions,
   'application',
-  'authenticated_entity',
   'bot_info_action',
   'bot_info_detection_reason',
   'bot_info_ban_type',
@@ -13,6 +12,7 @@ export const queryableExploreDimensions = [
   'consumer',
   'consumer_group',
   'country_code',
+  'oidc_credential',
   'upstream_status_code',
   'upstream_status_code_grouped',
   'response_source',

--- a/packages/analytics/analytics-utilities/src/types/explore/ai.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/ai.ts
@@ -7,7 +7,7 @@ export const queryableAiExploreDimensions = [
   'gateway_service',
   'consumer',
   'application',
-  'authenticated_entity',
+  'oidc_credential',
   'route',
   'ai_provider',
   'ai_response_model',

--- a/packages/analytics/analytics-utilities/src/types/explore/all.spec.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/all.spec.ts
@@ -46,7 +46,7 @@ describe('stripUnknownFilters', () => {
   // a filter that's only in the managed_cache_usage datasource
   const managedCacheFilter = {
     operator: 'in',
-    field: 'region',
+    field: 'provider_region',
     value: ['foo'],
   }
 

--- a/packages/analytics/analytics-utilities/src/types/explore/managed-cache.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/managed-cache.ts
@@ -8,7 +8,6 @@ export const queryableManagedCacheExploreDimensions = [
   'network',
   'provider',
   'provider_region',
-  'region',
   'time',
 ] as const
 

--- a/packages/analytics/analytics-utilities/src/types/explore/requests.ts
+++ b/packages/analytics/analytics-utilities/src/types/explore/requests.ts
@@ -12,7 +12,6 @@ export const queryableRequestDimensions = [
   'api_product',
   'api_product_version',
   'application',
-  'authenticated_entity',
   'auth_type',
   'bot_info_action',
   'bot_info_detection_reason',
@@ -36,6 +35,7 @@ export const queryableRequestDimensions = [
   'mcp_method',
   'mcp_session_id',
   'mcp_tool_name',
+  'oidc_credential',
   'portal',
   'principal',
   'realm',
@@ -62,13 +62,13 @@ export const filterableRequestDimensions = makeFilterable(queryableRequestDimens
 export type FilterableRequestDimensions = typeof filterableRequestDimensions[number]
 
 export const queryableRequestWildcardDimensions = [
-  'authenticated_entity',
   'auth_type',
   'client_ip',
   'data_plane_node_version',
   'header_host',
   'header_user_agent',
   'http_method',
+  'oidc_credential',
   'request_id',
   'request_uri',
   'response_header_content_type',


### PR DESCRIPTION
# Summary
- Rename `authenticated_entity` to `oidc_credential` per Christian's comment: https://konghq.atlassian.net/browse/MA-5279?focusedCommentId=250457
- Remove `region` from managed cache datasource. This was replaced by `provider_region` and we only left `region` for temporary support. 


[TEST_COVERAGE_EXEMPT_REASON] This change only adds literal values to existing dimension tuples.
<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

## Test Coverage Exemption (Optional)
[TEST_COVERAGE_EXEMPT_REASON] This change only adds literal values to existing dimension tuples.
