### PR TITLE
fix(analytics): respect app theme in map colors [MA-5263]

### DIFF
--- a/packages/analytics/analytics-geo-map/README.md
+++ b/packages/analytics/analytics-geo-map/README.md
@@ -7,6 +7,7 @@ Renders provided GeoJSON data into a choropleth style map.
 - [Requirements](#requirements)
 - [Usage](#usage)
   - [Install](#install)
+  - [Color mode (light/dark theme)](#color-mode-lightdark-theme)
   - [Props](#props)
   - [Example](#example)
 
@@ -33,6 +34,26 @@ First, ensure you have `maplibre-gl` installed:
 ```bash
 npm install maplibre-gl
 npm install @kong-ui-public/analytics-geo-map
+```
+
+### Color mode (light/dark theme)
+
+The map fills countries and water with design token colors, because `maplibre-gl` paint
+properties require literal color values rather than `var(--kui-*)`, the component reads those tokens
+off the document.
+
+To keep the map in step with the host's theme, `provide` a `ComputedRef<'light' | 'dark'>` under the
+`app:konnectColorMode` injection key. The component resolves its colors whenever the value
+changes.
+
+```ts
+// In the host application (e.g. within your root component's setup)
+import { computed, provide } from 'vue'
+
+// `isDarkMode` is however your app tracks its current theme
+const colorMode = computed<'light' | 'dark'>(() => (isDarkMode.value ? 'dark' : 'light'))
+
+provide('app:konnectColorMode', colorMode)
 ```
 
 ### Props

--- a/packages/analytics/analytics-geo-map/sandbox/App.vue
+++ b/packages/analytics/analytics-geo-map/sandbox/App.vue
@@ -65,6 +65,17 @@
               Reset bounds
             </KButton>
           </div>
+
+          <div class="theme-toggle">
+            <KLabel>Theme</KLabel>
+            <KSegmentedControl
+              v-model="theme"
+              :options="[
+                { label: 'Day', value: 'classic-day' },
+                { label: 'Night', value: 'classic-night' },
+              ]"
+            />
+          </div>
         </div>
       </div>
     </KCard>
@@ -91,7 +102,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, provide, ref, watch } from 'vue'
 import type { MetricUnits } from '../src'
 import { AnalyticsGeoMap, exploreResultToCountryMetrics } from '../src'
 import CodeText from './CodeText.vue'
@@ -109,6 +120,14 @@ function isValidJson(str: string): boolean {
   return true
 }
 
+
+const theme = ref<'classic-day' | 'classic-night'>('classic-day')
+
+watch(theme, (newTheme) => {
+  document.documentElement.setAttribute('data-kui-theme', newTheme)
+}, { immediate: true })
+
+provide('app:konnectColorMode', computed<'light' | 'dark'>(() => theme.value === 'classic-night' ? 'dark' : 'light'))
 
 const items = ref([
   { label: 'US', value: 'US' },
@@ -204,8 +223,8 @@ const importedCountryMetrics = computed(() => {
 
   .row {
     display: flex;
-    gap: 2em;
-    margin-top: 1em;
+    gap: 10px;
+    margin-top: 4px;
 
     .select-countries {
       width: 50%;
@@ -214,8 +233,12 @@ const importedCountryMetrics = computed(() => {
 
   .map-container {
     height: 700px;
-    margin-top: 1em;
+    margin-top: 4px;
     width: 900px;
+  }
+
+  .theme-toggle {
+    margin-top: 4px;
   }
 }
 </style>

--- a/packages/analytics/analytics-geo-map/sandbox/index.html
+++ b/packages/analytics/analytics-geo-map/sandbox/index.html
@@ -14,6 +14,11 @@
         font-family: "Inter", Helvetica, Arial, sans-serif;
       }
 
+      body {
+        background: var(--kui-color-background, #ffffff);
+        color: var(--kui-color-text, #000933);
+      }
+
     </style>
   </head>
 

--- a/packages/analytics/analytics-geo-map/sandbox/index.ts
+++ b/packages/analytics/analytics-geo-map/sandbox/index.ts
@@ -2,6 +2,8 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import Kongponents from '@kong/kongponents'
 import '@kong/kongponents/dist/style.css'
+import '@kong/design-tokens/themes/classic-day.css'
+import '@kong/design-tokens/themes/classic-night.css'
 
 const app = createApp(App)
 

--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
@@ -44,24 +44,29 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch, computed, useId, toRef } from 'vue'
-import { Map } from 'maplibre-gl'
+import type { ComputedRef } from 'vue'
 import type { ColorSpecification, DataDrivenPropertyValueSpecification, ExpressionSpecification, LngLatBoundsLike, MapOptions } from 'maplibre-gl'
-import type { MapFeatureCollection, MetricUnits } from '../types'
 import type { Feature, MultiPolygon, Geometry, GeoJsonProperties, FeatureCollection } from 'geojson'
-import composables from '../composables'
-import 'maplibre-gl/dist/maplibre-gl.css'
 import type { ExploreAggregations, CountryISOA2 } from '@kong-ui-public/analytics-utilities'
+import type { MapFeatureCollection, MetricUnits } from '../types'
+import type { MapTooltipData } from './MapTooltip.vue'
+import type { GeoMapColors } from '../utils/colors'
+
+import { inject, ref, onMounted, onUnmounted, watch, computed, useId, toRef } from 'vue'
+import { Map } from 'maplibre-gl'
 import { registerWebglCapture } from '@kong-ui-public/analytics-utilities'
-import lakes from '../ne_110m_lakes.json'
 import * as geobuf from 'geobuf'
 import Pbf from 'pbf'
-import { debounce } from '../utils'
 import { AnalyticsIcon } from '@kong/icons'
-import { KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER, KUI_ICON_COLOR_NEUTRAL, KUI_ICON_SIZE_60 } from '@kong/design-tokens'
+import { KUI_ICON_COLOR_NEUTRAL, KUI_ICON_SIZE_60 } from '@kong/design-tokens'
+
+import composables from '../composables'
+import { debounce } from '../utils'
+import { geoMapColors } from '../utils/colors'
 import MapLegend from './MapLegend.vue'
-import type { MapTooltipData } from './MapTooltip.vue'
 import MapTooltip from './MapTooltip.vue'
+import lakes from '../ne_110m_lakes.json'
+import 'maplibre-gl/dist/maplibre-gl.css'
 
 const countriesPbfUrlPromise = import('../countries-simple-geo.pbf?url').then(m => m.default)
 
@@ -88,10 +93,14 @@ const emit = defineEmits<{
 }>()
 
 const { i18n } = composables.useI18n()
+
+const activeColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
+
 const { getColor, legendData } = composables.useLegendScale({
   countryMetrics: toRef(() => countryMetrics),
   metric: toRef(() => metric),
   unit: toRef(() => metricUnit),
+  emptyCountryFill: toRef(() => colors.value.emptyCountryFill),
 })
 const { formatMetric } = composables.useMetricFormat({ unit: toRef(() => metricUnit) })
 const tooltipData = ref<MapTooltipData>()
@@ -100,9 +109,12 @@ const map = ref<Map>()
 const geoJsonData = ref<MapFeatureCollection | null>(null)
 const tooltipPosition = ref({ left: '0px', top: '0px' })
 const showTooltip = ref(false)
+const colors = ref<GeoMapColors>(geoMapColors())
+
 const showNoLocationOverlay = computed(() => {
   return Object.keys(countryMetrics).length === 0 && !fitToCountry
 })
+
 const layerPaint = computed(() => ({
   'fill-color': [
     'match',
@@ -121,10 +133,14 @@ const layerPaint = computed(() => ({
         code,
         getColor(metric),
       ])
-      : [KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER, KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER]),
-    KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER, // default color if no match
+      : [colors.value.emptyCountryFill, colors.value.emptyCountryFill]),
+    colors.value.emptyCountryFill, // default color if no match
   ] as DataDrivenPropertyValueSpecification<ColorSpecification>,
   'fill-opacity': 0.7,
+}))
+
+const lakesPaint = computed(() => ({
+  'fill-color': colors.value.waterFill,
 }))
 
 const showLegend = computed(() => {
@@ -283,9 +299,7 @@ onMounted(async () => {
         id: 'lakes-layer',
         type: 'fill',
         source: 'lakes',
-        paint: {
-          'fill-color': '#FFFFFF',
-        },
+        paint: lakesPaint.value,
       })
 
       map.value?.on('mousemove', 'countries-layer', (e) => {
@@ -335,26 +349,21 @@ onMounted(async () => {
   }
 })
 
-watch(() => countryMetrics, () => {
-  if (map.value && map.value.isStyleLoaded()) {
-    if (map.value.getLayer('countries-layer')) {
-      map.value.removeLayer('countries-layer')
-    }
-    map.value.addLayer({
-      id: 'countries-layer',
-      type: 'fill',
-      source: 'countries',
-      paint: layerPaint.value,
-    })
-    map.value.removeLayer('lakes-layer')
-    map.value?.addLayer({
-      id: 'lakes-layer',
-      type: 'fill',
-      source: 'lakes',
-      paint: {
-        'fill-color': '#FFFFFF',
-      },
-    })
+watch(activeColorMode, () => {
+  colors.value = geoMapColors()
+})
+
+watch([layerPaint, lakesPaint], () => {
+  if (!map.value?.isStyleLoaded()) {
+    return
+  }
+
+  if (map.value.getLayer('countries-layer')) {
+    map.value.setPaintProperty('countries-layer', 'fill-color', layerPaint.value['fill-color'])
+  }
+
+  if (map.value.getLayer('lakes-layer')) {
+    map.value.setPaintProperty('lakes-layer', 'fill-color', lakesPaint.value['fill-color'])
   }
 })
 
@@ -408,7 +417,7 @@ watch(() => bounds, (newVal, oldVal) => {
 
   .no-location-overlay {
     align-items: center;
-    background: rgba(255, 255, 255, 0.7);
+    background: color-mix(in srgb, var(--kui-color-background, $kui-color-background) 70%, transparent);
     bottom: 0;
     display: flex;
     flex-direction: column;

--- a/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
+++ b/packages/analytics/analytics-geo-map/src/components/AnalyticsGeoMap.vue
@@ -23,6 +23,7 @@
     </div>
     <div
       :id="mapContainerId"
+      ref="mapContainer"
       class="analytics-geo-map-container"
     />
     <!-- Legend -->
@@ -105,6 +106,7 @@ const { getColor, legendData } = composables.useLegendScale({
 const { formatMetric } = composables.useMetricFormat({ unit: toRef(() => metricUnit) })
 const tooltipData = ref<MapTooltipData>()
 const mapContainerId = useId()
+const mapContainer = ref<HTMLElement>()
 const map = ref<Map>()
 const geoJsonData = ref<MapFeatureCollection | null>(null)
 const tooltipPosition = ref({ left: '0px', top: '0px' })
@@ -269,6 +271,8 @@ onUnmounted(() => {
 })
 
 onMounted(async () => {
+  colors.value = geoMapColors(mapContainer.value)
+
   try {
     const countriesPbfUrl = await countriesPbfUrlPromise
     const response = await fetch(countriesPbfUrl)
@@ -350,7 +354,7 @@ onMounted(async () => {
 })
 
 watch(activeColorMode, () => {
-  colors.value = geoMapColors()
+  colors.value = geoMapColors(mapContainer.value)
 })
 
 watch([layerPaint, lakesPaint], () => {

--- a/packages/analytics/analytics-geo-map/src/composables/useLegendScale.spec.ts
+++ b/packages/analytics/analytics-geo-map/src/composables/useLegendScale.spec.ts
@@ -6,6 +6,8 @@ import { KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER } from '@kong/design-tokens'
 import { colors } from './useLegendScale'
 import type { MetricUnits } from '../types'
 
+const emptyCountryFill = ref(KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER)
+
 describe('useLegendScale', () => {
   it.each([
     [[10], 1],
@@ -28,6 +30,7 @@ describe('useLegendScale', () => {
       countryMetrics,
       metric,
       unit,
+      emptyCountryFill,
     })
     expect(scale.value.length).toBe(expectedScaleLength)
   })
@@ -43,6 +46,7 @@ describe('useLegendScale', () => {
       countryMetrics,
       metric,
       unit,
+      emptyCountryFill,
     })
 
     const expectedLegendData = [
@@ -71,6 +75,7 @@ describe('useLegendScale', () => {
       countryMetrics,
       metric,
       unit,
+      emptyCountryFill,
     })
 
     const expectedLegendData = [
@@ -105,6 +110,7 @@ describe('useLegendScale', () => {
       countryMetrics,
       metric,
       unit,
+      emptyCountryFill,
     })
 
     // Will generate just one legend item since the other two country codes are invalid and will be ignored

--- a/packages/analytics/analytics-geo-map/src/composables/useLegendScale.ts
+++ b/packages/analytics/analytics-geo-map/src/composables/useLegendScale.ts
@@ -1,6 +1,5 @@
 import { computed, type Ref } from 'vue'
 import { COUNTRIES, type ExploreAggregations } from '@kong-ui-public/analytics-utilities'
-import { KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER } from '@kong/design-tokens'
 import type { MetricUnits } from '../types'
 import composables from '.'
 
@@ -50,10 +49,12 @@ export default function useLegendScale({
   countryMetrics,
   metric,
   unit,
+  emptyCountryFill,
 }: {
   countryMetrics: Readonly<Ref<Record<string, number>>>
   metric: Readonly<Ref<ExploreAggregations>>
   unit: Readonly<Ref<MetricUnits>>
+  emptyCountryFill: Readonly<Ref<string>>
 }) {
 
   const { formatMetric, formatMetricRange } = composables.useMetricFormat({ unit })
@@ -137,14 +138,14 @@ export default function useLegendScale({
 
   const getColor = (value: number) => {
     if (value === 0) {
-      return KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER
+      return emptyCountryFill.value
     }
 
     const idx = scale.value.findIndex((interval) => value >= interval)
     if (idx === -1) {
       return colors[colors.length - 1]
     }
-    return colors[idx] ?? KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER
+    return colors[idx] ?? emptyCountryFill.value
   }
 
   return {

--- a/packages/analytics/analytics-geo-map/src/utils/colors.ts
+++ b/packages/analytics/analytics-geo-map/src/utils/colors.ts
@@ -6,17 +6,19 @@ export interface GeoMapColors {
 }
 
 /**
- * Determine the map colors based on the theme applied to the `<html>` element.
+ * Determine the map colors from the `element` and falls back to `<html>`.
  */
-export const geoMapColors = (): GeoMapColors => {
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
+export const geoMapColors = (element?: Element | null): GeoMapColors => {
+  const target = element ?? (typeof document === 'undefined' ? null : document.documentElement)
+
+  if (typeof window === 'undefined' || !target) {
     return {
       emptyCountryFill: KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER,
       waterFill: KUI_COLOR_BACKGROUND,
     }
   }
 
-  const styles = window.getComputedStyle(document.documentElement)
+  const styles = window.getComputedStyle(target)
 
   const getColor = (customProperty: string, fallback: string): string => (
     styles.getPropertyValue(customProperty).trim() || fallback

--- a/packages/analytics/analytics-geo-map/src/utils/colors.ts
+++ b/packages/analytics/analytics-geo-map/src/utils/colors.ts
@@ -1,0 +1,29 @@
+import { KUI_COLOR_BACKGROUND, KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER } from '@kong/design-tokens'
+
+export interface GeoMapColors {
+  emptyCountryFill: string
+  waterFill: string
+}
+
+/**
+ * Determine the map colors based on the theme applied to the `<html>` element.
+ */
+export const geoMapColors = (): GeoMapColors => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return {
+      emptyCountryFill: KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER,
+      waterFill: KUI_COLOR_BACKGROUND,
+    }
+  }
+
+  const styles = window.getComputedStyle(document.documentElement)
+
+  const getColor = (customProperty: string, fallback: string): string => (
+    styles.getPropertyValue(customProperty).trim() || fallback
+  )
+
+  return {
+    emptyCountryFill: getColor('--kui-color-background-neutral-weaker', KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER),
+    waterFill: getColor('--kui-color-background', KUI_COLOR_BACKGROUND),
+  }
+}


### PR DESCRIPTION
# Summary

Fix [MA-5263](https://konghq.atlassian.net/browse/MA-5263)

This will add color theme functionality to the AnalyticsGeoMap package. Before it was hard coding the color values on the map, but in order to choose colors appropriate to the theme, these need to be computed.

Maplibre unfortunately cannot use `var(...)` props for the map colors. Following the way we provide a 'light' or 'dark' color mode in kongponents (...and elsewhere), the geo map component will now inject the `konnectColorMode` prop and watch for any changes. In order to properly determine the colors, this will read the `--kui-*` token values off of the main document and update the map's colors accordingly for the empty countries and water fills.


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

<details closed>
<summary>Before</summary>

<img width="1183" height="887" alt="before" src="https://github.com/user-attachments/assets/6603184d-3a6c-475a-ae96-bf5f3f51b76b" />



</details>


<details closed>
<summary>After</summary>

<img width="1183" height="887" alt="after" src="https://github.com/user-attachments/assets/24cb8c59-d4be-43ec-b076-9293d5310d2c" />



</details>



<details closed>
<summary>Sandbox</summary>

[sandbox.webm](https://github.com/user-attachments/assets/3b524f90-e70e-45ed-b075-c8c5a761b1df)



</details>


<!--
## Test Coverage Exemption (Optional)
If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.

[TEST_COVERAGE_EXEMPT_REASON] give it a reason
-->


[MA-5263]: https://konghq.atlassian.net/browse/MA-5263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ