### PR TITLE
feat(analytics-chart): add OIDC credential label [MA-5281]

### DIFF
--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -100,6 +100,7 @@
     "control_plane": "Control plane",
     "control_plane_group": "Control plane group",
     "consumer": "Consumer",
+    "oidc_credential": "OIDC credential",
     "country_code": "Country",
     "country": "Country",
     "data_plane_node": "Data plane node",


### PR DESCRIPTION
# Summary

[MA-5281](https://konghq.atlassian.net/browse/MA-5281).

Add the `oidc_credential` label "OIDC credential" to analytics-chart.

[MA-5281]: https://konghq.atlassian.net/browse/MA-5281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ