### PR TITLE
fix(entities-plugins, forms): pre-fill OIDC principal_claim with sub in free-form

### DIFF
--- a/packages/core/forms/src/components/forms/OIDCPrincipals.vue
+++ b/packages/core/forms/src/components/forms/OIDCPrincipals.vue
@@ -242,6 +242,7 @@
       <PrincipalLookupSettings
         :data-plane-incompatible="hasIncompatibleDataPlane"
         :form-model="formModel"
+        :is-editing="isEditing"
         :on-enabled-change="handleUsePrincipalLookupChange"
         :on-model-updated="onModelUpdated"
         show-enable-toggle
@@ -352,6 +353,7 @@
       <PrincipalLookupSettings
         :data-plane-incompatible="hasIncompatibleDataPlane"
         :form-model="formModel"
+        :is-editing="isEditing"
         :on-enabled-change="handleUsePrincipalLookupChange"
         :on-model-updated="onModelUpdated"
         show-enable-toggle

--- a/packages/core/forms/src/components/forms/PrincipalLookupSettings.vue
+++ b/packages/core/forms/src/components/forms/PrincipalLookupSettings.vue
@@ -234,6 +234,12 @@ export default {
       type: Boolean,
       default: true,
     },
+    // Whether the form is editing an existing plugin. Suppresses the one-time
+    // principal_claim prefill so a saved record isn't modified on load.
+    isEditing: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -261,10 +267,12 @@ export default {
     },
   },
   created() {
-    // One-time prefill: if principal_claim has never been set, write the gateway
-    // default `sub` into the model so users see it explicitly rather than an
+    // One-time prefill on create: if principal_claim has never been set, write the
+    // gateway default `sub` into the model so users see it explicitly rather than an
     // implicit default. Only fires once, on creation — later clears stay cleared.
-    if (!hasValue(this.formModel['config-principals-principal_claim'])) {
+    // Skipped on edit: an absent claim on a saved record already resolves to `sub`, so
+    // writing it would dirty the form on load for no change in behavior.
+    if (!this.isEditing && !hasValue(this.formModel['config-principals-principal_claim'])) {
       this.updateField('config-principals-principal_claim', ['sub'])
     }
   },

--- a/packages/core/forms/src/components/forms/__tests__/PrincipalLookupSettings.spec.ts
+++ b/packages/core/forms/src/components/forms/__tests__/PrincipalLookupSettings.spec.ts
@@ -170,6 +170,18 @@ describe('PrincipalLookupSettings', () => {
       expect((emptyWrapper.vm as any).getTokenClaimInputValue()).toBe('sub')
     })
 
+    it('does not pre-fill the claim when editing a record that has none', () => {
+      const onModelUpdated = vi.fn()
+      const wrapper = mountComponent(
+        { 'config-principals-principal_claim': null },
+        { isEditing: true, onModelUpdated },
+      )
+
+      expect(wrapper.props('formModel')['config-principals-principal_claim']).toBeNull()
+      expect((wrapper.vm as any).getTokenClaimInputValue()).toBe('')
+      expect(onModelUpdated).not.toHaveBeenCalled()
+    })
+
     it('does not re-prefill after the user explicitly clears the field', () => {
       const wrapper = mountComponent({ 'config-principals-principal_claim': null })
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/OpenidConnectForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/OpenidConnectForm.cy.ts
@@ -951,6 +951,56 @@ describe('OpenidConnectForm', () => {
       })
     })
 
+    it('pre-fills the default `sub` token claim into the model when none is set', () => {
+      mountPrincipalsForm()
+
+      expandSettings()
+      cy.getTestId('principals-token-claim').should('have.value', 'sub')
+
+      lastFormChange().then((payload) => {
+        expect(payload.config.principals.principal_claim).to.deep.equal(['sub'])
+      })
+    })
+
+    it('keeps a saved token claim instead of pre-filling it', () => {
+      mountPrincipalsForm({
+        isEditing: true,
+        model: createPrincipalsModel({
+          principals: { ...DEFAULT_PRINCIPALS_MODEL, principal_claim: ['user', 'employee_id'] },
+        }),
+      })
+
+      expandSettings()
+      cy.getTestId('principals-token-claim').should('have.value', 'user.employee_id')
+    })
+
+    it('does not pre-fill the token claim when editing a record that has none', () => {
+      mountPrincipalsForm({ isEditing: true })
+
+      expandSettings()
+      cy.getTestId('principals-token-claim').should('have.value', '')
+
+      // Edit-load must leave the saved (unset) claim alone rather than dirtying the form
+      cy.get('@onFormChange').should((spy: any) => {
+        for (const args of spy.args) {
+          expect(args[0]?.config?.principals?.principal_claim ?? null).to.equal(null)
+        }
+      })
+    })
+
+    it('does not re-prefill the token claim after the user clears it', () => {
+      mountPrincipalsForm()
+
+      expandSettings()
+      cy.getTestId('use-principal-lookup').click({ force: true })
+      cy.getTestId('principals-token-claim').clear()
+      cy.getTestId('principals-token-claim').should('have.value', '')
+
+      lastFormChange().then((payload) => {
+        expect(payload.config.principals.principal_claim).to.equal(null)
+      })
+    })
+
     it('writes the token claim as a dot-notation path array', () => {
       mountPrincipalsForm()
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalLookupSettings.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalLookupSettings.vue
@@ -153,12 +153,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, inject, ref, watch } from 'vue'
 import { isEqual } from 'lodash-es'
 import { KAlert, KCheckbox, KCollapse, KInput, KInputSwitch, KLabel, KRadio, KSelect } from '@kong/kongponents'
 import useI18n from '../../../../composables/useI18n'
 import { useFormShared } from '../../shared/composables'
+import { FORM_EDITING } from '../../shared/const'
 
+import type { ComputedRef } from 'vue'
 import type { FreeFormPluginData } from '../../../../types/plugins/free-form'
 import type { OidcConfigSubset, OidcPrincipals } from './types'
 
@@ -177,6 +179,8 @@ const { showPrincipalsFields = true, ...props } = defineProps<{
 }>()
 
 const { i18n: { t } } = useI18n()
+
+const isEditingRef = inject<ComputedRef<boolean> | undefined>(FORM_EDITING, undefined)
 
 // Read/write formData directly instead of useFormData(): the latter provides its own
 // field path to descendants, which would corrupt relative path resolution for the
@@ -247,9 +251,7 @@ function encodeTokenClaim(claim: string[] | string | null | undefined): string {
   if (typeof claim === 'string' && claim) {
     return claim
   }
-  // Pre-fill the gateway default so users recognize `sub` is used when left unset.
-  // The model stays empty until edited; an empty principal_claim already resolves to `sub`.
-  return 'sub'
+  return ''
 }
 
 // Split on unescaped dots; `\.` and `\\` are escapes for literal dots/backslashes,
@@ -275,6 +277,15 @@ function parseTokenClaim(value: string): string[] | null {
   // Unset rather than `[]`: the schema requires len_min 1 when the claim is present,
   // and an absent principal_claim already resolves to the gateway default (`sub`).
   return result.length > 0 ? result : null
+}
+
+// One-time prefill on create: if principal_claim has never been set, write the gateway
+// default `sub` into the model so users see it explicitly rather than an implicit default
+// (and the shown value is the submitted one). Only fires once, on setup — later clears stay
+// cleared. Skipped on edit: an absent claim on a saved record already resolves to `sub`, so
+// writing it would dirty the form on load for no change in behavior.
+if (!isEditingRef?.value && !hasValue(principalClaim.value)) {
+  principalClaim.value = ['sub']
 }
 
 // The input binds to the raw string and the model derives from it one-way: re-encoding


### PR DESCRIPTION
# Summary

The free-form OIDC principal lookup only faked the gateway default: the token claim input displayed `sub` while config.principals.principal_claim stayed null, so the shown value was not the submitted one. VueFormGenerator was fixed in #3555 but the free-form component was never patched.

Write ['sub'] into the model instead of faking it in the display, and skip the prefill when editing (an absent claim on a saved record already resolves to `sub`, so writing it would only dirty the form on load). The same edit guard is added to the VueFormGenerator component so the two stay in sync.
