### PR TITLE
fix(analytics): validate zoom range for time series chart [MA-5288]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.cy.ts
@@ -91,6 +91,32 @@ const selectChartArea = () => {
   })
 }
 
+const DRAG_WAIT = 300
+
+const pressAndHoldChartArea = ({ x, y }: { x: number, y: number }) => {
+  const selector = '.chart-container > canvas'
+
+  cy.get(selector).trigger('mousedown', x, y)
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(DRAG_WAIT)
+  cy.get(selector).trigger('mouseup', x, y)
+}
+
+const dragChartAreaAndReturn = ({ x, y }: { x: number, y: number }) => {
+  const selector = '.chart-container > canvas'
+
+  cy.get(selector).trigger('mousedown', x, y)
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(DRAG_WAIT)
+  cy.get(selector).trigger('mousemove', x + 100, y)
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(100)
+  cy.get(selector).trigger('mousemove', x, y)
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(100)
+  cy.get(selector).trigger('mouseup', x, y)
+}
+
 const mockQueryProvider = {
   evaluateFeatureFlagFn: () => true,
 }
@@ -606,6 +632,81 @@ describe('<AnalyticsChart />', () => {
       cy.get('body').should('have.class', 'no-select')
       cy.get('body').trigger('pointerup', { button: 0 })
       cy.get('body').should('not.have.class', 'no-select')
+    })
+
+    describe('invalid selections', () => {
+      const mountWithAllActions = () => mount({
+        timeseriesZoom: true,
+        exploreLink: { href: '#explore' },
+        requestsLink: { href: '#requests' },
+        onSelectChartRange: cy.spy().as('onSelectChartRange'),
+        onZoomTimeRange: cy.spy().as('onZoomTimeRange'),
+      })
+
+      const expectNoZoomActions = () => {
+        cy.get('.zoom-actions-container').should('not.exist')
+        cy.getTestId('zoom-action-item-zoom-in').should('not.exist')
+        cy.getTestId('zoom-action-item-explore').should('not.exist')
+        cy.getTestId('zoom-action-item-view-requests').should('not.exist')
+        cy.get('@onSelectChartRange').should('not.have.been.called')
+        cy.get('@onZoomTimeRange').should('not.have.been.called')
+      }
+
+      it('offers no zoom actions when pressing and holding on a single point', () => {
+        mountWithAllActions()
+
+        cy.get('.analytics-chart-parent').should('be.visible')
+        cy.get('[data-testid="time-series-line-chart"]').should('be.visible')
+
+        pressAndHoldChartArea({ x: 400, y: 50 })
+
+        expectNoZoomActions()
+      })
+
+      it('offers no zoom actions when a drag returns to its origin', () => {
+        mountWithAllActions()
+
+        cy.get('.analytics-chart-parent').should('be.visible')
+        cy.get('[data-testid="time-series-line-chart"]').should('be.visible')
+
+        dragChartAreaAndReturn({ x: 400, y: 50 })
+
+        expectNoZoomActions()
+      })
+
+      it('does not reuse the previous selection when pressing and holding afterwards', () => {
+        mountWithAllActions()
+
+        cy.get('.analytics-chart-parent').should('be.visible')
+        cy.get('[data-testid="time-series-line-chart"]').should('be.visible')
+
+        selectChartArea()
+        cy.get('@onSelectChartRange').should('have.been.calledOnce')
+        cy.getTestId('zoom-action-item-zoom-in').should('exist')
+
+        cy.get('.zoom-actions-close-icon').click()
+        cy.get('.zoom-actions-container').should('not.exist')
+
+        pressAndHoldChartArea({ x: 400, y: 50 })
+
+        cy.get('.zoom-actions-container').should('not.exist')
+        cy.get('@onSelectChartRange').should('have.been.calledOnce')
+        cy.get('@onZoomTimeRange').should('not.have.been.called')
+      })
+
+      it('still offers zoom actions for a valid selection', () => {
+        mountWithAllActions()
+
+        cy.get('.analytics-chart-parent').should('be.visible')
+        cy.get('[data-testid="time-series-line-chart"]').should('be.visible')
+
+        selectChartArea()
+
+        cy.get('@onSelectChartRange').should('have.been.calledOnce')
+        cy.getTestId('zoom-action-item-zoom-in').should('exist')
+        cy.getTestId('zoom-action-item-explore').should('exist')
+        cy.getTestId('zoom-action-item-view-requests').should('exist')
+      })
     })
   })
 })

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/DragSelectPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/DragSelectPlugin.ts
@@ -107,7 +107,7 @@ export class DragSelectPlugin implements Plugin {
 
         const range = selectionRange(chart, this)
 
-        if (range && range.xEnd > range.xStart) {
+        if (range) {
           dispatchEvent('dragSelect', chart, range)
         } else {
           this.clearSelectionArea()

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/DragSelectPlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/DragSelectPlugin.ts
@@ -1,8 +1,8 @@
 import type { Chart, Plugin } from 'chart.js'
 
 export interface DragSelectEventDetail {
-  xStart: number | undefined
-  xEnd: number | undefined
+  xStart: number
+  xEnd: number
 }
 
 const drawSelectionBorder = (chart: Chart, startX: number, endX: number) => {
@@ -27,18 +27,24 @@ const drawSelectionArea = (chart: Chart, startX: number, endX: number) => {
   ctx.restore()
 }
 
-const dispatchEvent = (eventName: string, chart: Chart, pluginInstance: DragSelectPlugin) => {
+const selectionRange = (chart: Chart, pluginInstance: DragSelectPlugin): DragSelectEventDetail | undefined => {
   const xStartValue = chart.scales.x.getValueForPixel(pluginInstance.startX)
   const xEndValue = chart.scales.x.getValueForPixel(pluginInstance.endX)
 
-  if (xStartValue && xEndValue) {
-    chart.canvas.dispatchEvent(new CustomEvent<DragSelectEventDetail>(eventName, {
-      detail: {
-        xStart: Math.min(xStartValue, xEndValue),
-        xEnd: Math.max(xStartValue, xEndValue),
-      },
-    }))
+  if (xStartValue === undefined || xEndValue === undefined) {
+    return undefined
   }
+
+  return {
+    xStart: Math.min(xStartValue, xEndValue),
+    xEnd: Math.max(xStartValue, xEndValue),
+  }
+}
+
+const dispatchEvent = (eventName: string, chart: Chart, range: DragSelectEventDetail) => {
+  chart.canvas.dispatchEvent(new CustomEvent<DragSelectEventDetail>(eventName, {
+    detail: range,
+  }))
 }
 
 export class DragSelectPlugin implements Plugin {
@@ -75,6 +81,7 @@ export class DragSelectPlugin implements Plugin {
         this._clearSelectionArea = false
         dragInitiated = true
         this._startX = event.clientX - rect.left
+        this._endX = this._startX
       }, 150)
     }
 
@@ -82,7 +89,11 @@ export class DragSelectPlugin implements Plugin {
       const rect = canvas.getBoundingClientRect()
       if (dragInitiated && this._isDragging) {
         this._endX = event.clientX - rect.left
-        dispatchEvent('dragSelectMove', chart, this)
+        const range = selectionRange(chart, this)
+
+        if (range) {
+          dispatchEvent('dragSelectMove', chart, range)
+        }
       }
     }
 
@@ -91,9 +102,16 @@ export class DragSelectPlugin implements Plugin {
       clearTimeout(this._dragTimeout)
       if (dragInitiated && this._isDragging) {
         this._endX = event.clientX - rect.left
-        dispatchEvent('dragSelect', chart, this)
         dragInitiated = false
         this._isDragging = false
+
+        const range = selectionRange(chart, this)
+
+        if (range && range.xEnd > range.xStart) {
+          dispatchEvent('dragSelect', chart, range)
+        } else {
+          this.clearSelectionArea()
+        }
       }
     }
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/TimeSeriesChart.vue
@@ -197,6 +197,14 @@ const { options } = composables.useLineChartOptions({
 
 composables.useReportChartDataForSynthetics(toRef(props, 'chartData'), toRef(props, 'syntheticsDataKey'))
 
+const isValidZoomRange = (range?: { start: Date, end: Date }) => {
+  if (!range) {
+    return false
+  }
+
+  return range.end.getTime() > range.start.getTime()
+}
+
 /**
      * When in Preview mode, Chart and Legend are vertically stacked, and the
      * Legend list items are allowed to spread horizontally.
@@ -265,15 +273,26 @@ const handleDragSelect = (event: Event) => {
   event.preventDefault()
   event.stopPropagation()
   const { xStart, xEnd } = (event as CustomEvent<DragSelectEventDetail>).detail
-  if (xStart && xEnd) {
-    zoomTimeRange.value = {
-      start: new Date(xStart),
-      end: new Date(xEnd),
-      type: 'absolute',
-    }
-    tooltipData.interactionMode = 'zoom-interactive'
 
-    emit('select-chart-range', zoomTimeRange.value)
+  const selectedRange: AbsoluteTimeRangeV4 = {
+    start: new Date(xStart),
+    end: new Date(xEnd),
+    type: 'absolute',
+  }
+
+  // If the range is empty or invalid, this will cancel the event entirely.
+  if (!isValidZoomRange(selectedRange)) {
+    zoomTimeRange.value = undefined
+    resetTooltipState(false)
+
+    return
+  }
+
+  zoomTimeRange.value = selectedRange
+  tooltipData.interactionMode = 'zoom-interactive'
+
+  if (selectedRange) {
+    emit('select-chart-range', selectedRange)
   }
 }
 
@@ -285,12 +304,10 @@ const handleDragMove = (event: Event) => {
 
   const { xStart, xEnd } = (event as CustomEvent<DragSelectEventDetail>).detail
 
-  if (xStart && xEnd) {
-    zoomTimeRange.value = {
-      start: new Date(xStart),
-      end: new Date(xEnd),
-      type: 'absolute',
-    }
+  zoomTimeRange.value = {
+    start: new Date(xStart),
+    end: new Date(xEnd),
+    type: 'absolute',
   }
 }
 


### PR DESCRIPTION
# Summary

Fix [MA-5288](https://konghq.atlassian.net/browse/MA-5288)

This will fix two issues when zooming on a timeseries chart:
1. Selecting a range where the start and end time are the same
2. Selecting a time on the chart without dragging (zooming) would cause the next drag time to jump to the first time that was clicked.

If the user ends up with the same start and end time when zooming, the dispatched action will simply not be emitted, which prevents an invalid time range from being selected.

<details closed>
<summary>Before</summary>

[before.webm](https://github.com/user-attachments/assets/e00dc6c8-8826-43e7-bd17-673c16d1eae3)


</details>


<details closed>
<summary>After</summary>


[after.webm](https://github.com/user-attachments/assets/2727286b-6bd0-416a-9a0b-36f506b202b2)


</details>

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

<!--
## Test Coverage Exemption (Optional)
If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.

[TEST_COVERAGE_EXEMPT_REASON] give it a reason
-->


[MA-5288]: https://konghq.atlassian.net/browse/MA-5288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ