### PR TITLE
fix(analytics-chart): localize OIDC credential headers

### DIFF
--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -213,6 +213,8 @@
     "consumer_count": "Consumer count",
     "plugin_count": "Plugin count",
     "node_count": "Data plane node count",
+    "oidc_credential": "OIDC credential",
+    "principal": "Principal",
     "virtual_cluster_id": "Virtual cluster",
     "backend_cluster_id": "Backend cluster",
     "listener_id": "Listener",


### PR DESCRIPTION
## Summary

Add the missing TopN labels for OIDC credential and principal dimensions.

## Changes

- Add English `chartLabels` values for both dimensions.
- [TEST_COVERAGE_EXEMPT_REASON] This change only adds static English locale strings. Existing TopN header tests cover the shared rendering behavior.