### PR TITLE
fix(dashboard-renderer): localize table headers

### DIFF
--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -206,6 +206,8 @@
     "consumer_count": "Consumer count",
     "plugin_count": "Plugin count",
     "node_count": "Data plane node count",
+    "oidc_credential": "OIDC credential",
+    "principal": "Principal",
     "virtual_cluster_id": "Virtual cluster",
     "backend_cluster_id": "Backend cluster",
     "listener_id": "Listener",


### PR DESCRIPTION
## Summary

Add the missing OIDC credential and principal labels for TableDataGrid headers.

## Changes

- Add English `chartLabels` values used by the dashboard table renderer.
- [TEST_COVERAGE_EXEMPT_REASON] This change only adds static locale strings. Existing tests cover the shared header translation behavior.