### PR TITLE
feat(entities-gateway-services): don't block delete on the force-delete checkbox

### DIFF
--- a/packages/entities/entities-gateway-services/sandbox/pages/GatewayServiceListPage.vue
+++ b/packages/entities/entities-gateway-services/sandbox/pages/GatewayServiceListPage.vue
@@ -16,6 +16,7 @@
     :can-edit="permissions.canEdit"
     :can-retrieve="permissions.canRetrieve"
     :config="konnectConfig"
+    enable-force-delete-confirmation
     use-action-outside
     @copy:error="onCopyIdError"
     @copy:success="onCopyIdSuccess"

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -900,6 +900,7 @@ describe('<GatewayServiceList />', () => {
 
       cy.get(`${modal} .extra`).should('contain.text', 'Force delete')
         .and('contain.text', 'All routes must be deleted before this gateway service can be deleted. To delete the service and all its routes and plugins at once, select Force delete.')
+        .and('contain.text', 'Check this box to force deletion of all routes and plugins on linked service.')
       cy.getTestId('gateway-service-delete-force-checkbox').should('exist')
 
       cy.getTestId('confirmation-input').type(serviceName)

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.cy.ts
@@ -889,7 +889,7 @@ describe('<GatewayServiceList />', () => {
       cy.wait('@deleteService').its('request.url').should('not.include', 'force')
     })
 
-    it('requires the force-delete checkbox and sends force=true when the service has routes', () => {
+    it('shows a force-delete checkbox and only sends force=true once it is checked, when the service has routes', () => {
       interceptRelatedEntities([{ id: 'route-1' }, { id: 'route-2' }], [{ id: 'plugin-1' }])
       cy.intercept(
         { method: 'DELETE', url: `${servicesUrl}/${serviceId}*` },
@@ -899,16 +899,33 @@ describe('<GatewayServiceList />', () => {
       openDeleteModal()
 
       cy.get(`${modal} .extra`).should('contain.text', 'Force delete')
-        .and('contain.text', 'Check this box to force deletion of all routes and plugins on linked service.')
+        .and('contain.text', 'All routes must be deleted before this gateway service can be deleted. To delete the service and all its routes and plugins at once, select Force delete.')
       cy.getTestId('gateway-service-delete-force-checkbox').should('exist')
 
       cy.getTestId('confirmation-input').type(serviceName)
-      cy.get(`${modal} [data-testid="modal-action-button"]`).should('be.disabled')
+      // The delete button is never disabled by the checkbox — the user can still attempt to delete without it
+      cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled')
 
       cy.getTestId('gateway-service-delete-force-checkbox').click()
-      cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled').click()
+      cy.get(`${modal} [data-testid="modal-action-button"]`).click()
 
       cy.wait('@deleteService').its('request.url').should('include', 'force=true')
+    })
+
+    it('shows the backend error when deleting a service with routes without checking force delete', () => {
+      interceptRelatedEntities([{ id: 'route-1' }], [])
+      cy.intercept(
+        { method: 'DELETE', url: `${servicesUrl}/${serviceId}*` },
+        { statusCode: 400, body: { message: 'Service has routes attached' } },
+      ).as('deleteServiceError')
+
+      openDeleteModal()
+
+      cy.getTestId('confirmation-input').type(serviceName)
+      cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled').click()
+
+      cy.wait('@deleteServiceError').its('request.url').should('not.include', 'force')
+      cy.get(`${modal} .kong-ui-entity-delete-error`).should('contain.text', 'Service has routes attached')
     })
 
     it('shows the plugin count without a checkbox and deletes without force when the service only has plugins', () => {
@@ -965,10 +982,8 @@ describe('<GatewayServiceList />', () => {
       cy.getTestId('gateway-service-delete-force-checkbox').should('exist')
 
       cy.getTestId('confirmation-input').type(serviceName)
-      cy.get(`${modal} [data-testid="modal-action-button"]`).should('be.disabled')
-
       cy.getTestId('gateway-service-delete-force-checkbox').click()
-      cy.get(`${modal} [data-testid="modal-action-button"]`).should('not.be.disabled').click()
+      cy.get(`${modal} [data-testid="modal-action-button"]`).click()
 
       cy.wait('@deleteService').its('request.url').should('include', 'force=true')
     })

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -231,7 +231,6 @@
 
     <EntityDeleteModal
       :action-pending="isDeletePending"
-      :confirm-disabled="requiresForceDelete && !forceDeleteConfirmed"
       :description="deleteDescription"
       :entity-name="gatewayServiceToBeDeleted && (gatewayServiceToBeDeleted.name || gatewayServiceToBeDeleted.id)"
       :entity-type="EntityTypes.GatewayService"
@@ -248,11 +247,13 @@
         <p v-if="relatedEntitiesCheckFailed || !requiresForceDelete">
           {{ relatedEntitiesMessage }}
         </p>
+        <p v-else>
+          {{ t('actions.delete.related_entities.force_delete_notice') }}
+        </p>
         <KCheckbox
           v-if="requiresForceDelete"
           v-model="forceDeleteConfirmed"
           data-testid="gateway-service-delete-force-checkbox"
-          :description="t('actions.delete.related_entities.force_delete_help')"
           :label="t('actions.delete.related_entities.force_delete_checkbox')"
         />
       </template>

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -827,6 +827,7 @@ onBeforeMount(async () => {
 }
 
 .force-delete-notice {
-  margin-bottom: var(--kui-space-50, $kui-space-50);
+  // Override KModal's own `.modal-content p` margin reset
+  margin-bottom: var(--kui-space-50, $kui-space-50) !important;
 }
 </style>

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -247,13 +247,17 @@
         <p v-if="relatedEntitiesCheckFailed || !requiresForceDelete">
           {{ relatedEntitiesMessage }}
         </p>
-        <p v-else>
+        <p
+          v-else
+          class="force-delete-notice"
+        >
           {{ t('actions.delete.related_entities.force_delete_notice') }}
         </p>
         <KCheckbox
           v-if="requiresForceDelete"
           v-model="forceDeleteConfirmed"
           data-testid="gateway-service-delete-force-checkbox"
+          :description="t('actions.delete.related_entities.force_delete_help')"
           :label="t('actions.delete.related_entities.force_delete_checkbox')"
         />
       </template>
@@ -820,5 +824,9 @@ onBeforeMount(async () => {
   .kong-ui-entity-filter-input {
     margin-right: var(--kui-space-50, $kui-space-50);
   }
+}
+
+.force-delete-notice {
+  margin-bottom: var(--kui-space-50, $kui-space-50);
 }
 </style>

--- a/packages/entities/entities-gateway-services/src/locales/en.json
+++ b/packages/entities/entities-gateway-services/src/locales/en.json
@@ -17,6 +17,7 @@
         "check_failed": "We couldn't verify whether this gateway service has routes or plugins attached. Check the box below to force delete it anyway.",
         "plugin": "{count, plural, one {plugin} other {plugins}}",
         "force_delete_checkbox": "Force delete",
+        "force_delete_help": "Check this box to force deletion of all routes and plugins on linked service.",
         "force_delete_notice": "All routes must be deleted before this gateway service can be deleted. To delete the service and all its routes and plugins at once, select Force delete."
       }
     }

--- a/packages/entities/entities-gateway-services/src/locales/en.json
+++ b/packages/entities/entities-gateway-services/src/locales/en.json
@@ -17,7 +17,7 @@
         "check_failed": "We couldn't verify whether this gateway service has routes or plugins attached. Check the box below to force delete it anyway.",
         "plugin": "{count, plural, one {plugin} other {plugins}}",
         "force_delete_checkbox": "Force delete",
-        "force_delete_help": "Check this box to force deletion of all routes and plugins on linked service."
+        "force_delete_notice": "All routes must be deleted before this gateway service can be deleted. To delete the service and all its routes and plugins at once, select Force delete."
       }
     }
   },

--- a/packages/entities/entities-shared/src/components/entity-delete-modal/EntityDeleteModal.vue
+++ b/packages/entities/entities-shared/src/components/entity-delete-modal/EntityDeleteModal.vue
@@ -165,7 +165,7 @@ const proceed = () => {
   }
 
   .extra {
-    margin-top: var(--kui-space-90, $kui-space-90);
+    margin-top: var(--kui-space-60, $kui-space-60);
   }
 
   .body-stacked-copy .description {


### PR DESCRIPTION
## Summary
- Adds an explanatory notice above the "Force delete" checkbox when a Konnect gateway service has routes attached: "All routes must be deleted before this gateway service can be deleted. To delete the service and all its routes and plugins at once, select Force delete."
- The delete button is **no longer disabled** when "Force delete" is unchecked. The user can still click delete without checking it — the request is sent without `force=true`, and if the backend rejects it (e.g. because routes are still attached), the error surfaces in the modal's existing error alert, same as any other delete failure.
- Removes the now-redundant checkbox help text (the new notice paragraph covers it).

Ref: KM-3028



https://github.com/user-attachments/assets/a518c6d2-e778-4c4a-beb4-efa4200d17e8


## Test plan
- [x] Updated/added Cypress tests: delete button is enabled regardless of checkbox state, `force=true` is only sent when checked, and a backend error (mocked 400) renders in the modal when deleting without checking the box
- [x] `pnpm typecheck` and `pnpm lint` pass
- [x] Full `GatewayServiceList.cy.ts` suite passes (39/39)