### PR TITLE
feat(entities-plugins): making some fields to textarea

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/ai-prompt-decorator.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/ai-prompt-decorator.ts
@@ -1,5 +1,18 @@
 import { definePluginConfig } from '../shared/define-plugin-config'
+import StringField from '../shared/StringField.vue'
 
 export default definePluginConfig({
   experimental: true,
+  fieldRenderers: [
+    {
+      match: 'config.prompts.prepend.*.content',
+      component: StringField,
+      propsOverrides: { multiline: true, rows: 4 },
+    },
+    {
+      match: 'config.prompts.append.*.content',
+      component: StringField,
+      propsOverrides: { multiline: true, rows: 4 },
+    },
+  ],
 })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/ai-rag-injector.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/ai-rag-injector.ts
@@ -1,8 +1,16 @@
+import StringField from '../shared/StringField.vue'
 import { definePluginConfig } from '../shared/define-plugin-config'
 import { vectordbFieldRenderers, vectordbRenderRules } from './_shared/vectordb'
 
 export default definePluginConfig({
   experimental: true,
-  fieldRenderers: vectordbFieldRenderers,
+  fieldRenderers: [
+    ...vectordbFieldRenderers,
+    {
+      match: 'config.inject_template',
+      component: StringField,
+      propsOverrides: { multiline: true, rows: 8 },
+    },
+  ],
   renderRules: vectordbRenderRules,
 })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/ai-semantic-prompt-guard.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/ai-semantic-prompt-guard.ts
@@ -1,8 +1,21 @@
+import StringField from '../shared/StringField.vue'
 import { definePluginConfig } from '../shared/define-plugin-config'
 import { vectordbFieldRenderers, vectordbRenderRules } from './_shared/vectordb'
 
 export default definePluginConfig({
   experimental: true,
-  fieldRenderers: vectordbFieldRenderers,
+  fieldRenderers: [
+    ...vectordbFieldRenderers,
+    {
+      match: 'config.rules.allow_prompts.*',
+      component: StringField,
+      propsOverrides: { multiline: true, rows: 2 },
+    },
+    {
+      match: 'config.rules.deny_prompts.*',
+      component: StringField,
+      propsOverrides: { multiline: true, rows: 2 },
+    },
+  ],
   renderRules: vectordbRenderRules,
 })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/ai-semantic-response-guard.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/ai-semantic-response-guard.ts
@@ -1,8 +1,21 @@
+import StringField from '../shared/StringField.vue'
 import { definePluginConfig } from '../shared/define-plugin-config'
 import { vectordbFieldRenderers, vectordbRenderRules } from './_shared/vectordb'
 
 export default definePluginConfig({
   experimental: true,
-  fieldRenderers: vectordbFieldRenderers,
+  fieldRenderers: [
+    ...vectordbFieldRenderers,
+    {
+      match: 'config.rules.allow_responses.*',
+      component: StringField,
+      propsOverrides: { multiline: true, rows: 2 },
+    },
+    {
+      match: 'config.rules.deny_responses.*',
+      component: StringField,
+      propsOverrides: { multiline: true, rows: 2 },
+    },
+  ],
   renderRules: vectordbRenderRules,
 })


### PR DESCRIPTION
# Summary

KM-3135

### ai-prompt-decorator
- config.prompts.prepend.*.content
- config.prompts.append.*.content
<img width="1272" height="1656" alt="image" src="https://github.com/user-attachments/assets/9e177794-36ab-426a-acd4-67dcb4d202f2" />

### ai-rag-injector
- config.inject_template
<img width="1114" height="908" alt="image" src="https://github.com/user-attachments/assets/4c5ae448-27f4-4c7f-88bb-9a5fe2c7c68c" />

### ai-semantic-prompt-guard
- config.rules.allow_prompts.*
- config.rules.deny_prompts.*
<img width="1208" height="938" alt="image" src="https://github.com/user-attachments/assets/28834a38-349f-409f-b5c6-62769c252a46" />

### ai-semantic-response-guard
- config.rules.allow_responses.*
- config.rules.deny_responses.*

<img width="1820" height="776" alt="image" src="https://github.com/user-attachments/assets/a5932847-98a6-4d5c-b937-1eed22c5a86d" />

[TEST_COVERAGE_EXEMPT_REASON] This change does not require test coverage


