### PR TITLE
feat(entities-plugins): validate plugin config code editor against its schema

### DIFF
--- a/packages/core/monaco-editor/package.json
+++ b/packages/core/monaco-editor/package.json
@@ -87,7 +87,8 @@
     "reflect-metadata": "^0.2.2",
     "shiki": "^4.3.1",
     "vue": "^3.5.35",
-    "yaml": "^2.9.0"
+    "yaml": "^2.9.0",
+    "zod": "^4.4.3"
   },
   "dependencies": {
     "@shikijs/monaco": "^4.3.1",

--- a/packages/core/monaco-editor/src/features/validation.spec.ts
+++ b/packages/core/monaco-editor/src/features/validation.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { collectValidators } from './validation'
+
+import type { ValidateFn } from './validation'
+
+describe('collectValidators', () => {
+  it('returns no issues when there are no validators', async () => {
+    expect(await collectValidators([])(1)).toEqual([])
+  })
+
+  it('concatenates issues from every validator', async () => {
+    const a: ValidateFn = vi.fn(() => [{ message: 'a', path: [] }])
+    const b: ValidateFn = vi.fn(() => [{ message: 'b', path: ['x'] }])
+
+    const combined = collectValidators([a, b])
+    expect(await combined('value')).toEqual([
+      { message: 'a', path: [] },
+      { message: 'b', path: ['x'] },
+    ])
+    expect(a).toHaveBeenCalledWith('value')
+    expect(b).toHaveBeenCalledWith('value')
+  })
+
+  it('preserves validator order in the output regardless of resolution speed', async () => {
+    const slow: ValidateFn = () => new Promise((resolve) => {
+      setTimeout(() => resolve([{ message: 'slow', path: [] }]), 10)
+    })
+    const fast: ValidateFn = () => [{ message: 'fast', path: [] }]
+
+    const combined = collectValidators([slow, fast])
+    expect(await combined(null)).toEqual([
+      { message: 'slow', path: [] },
+      { message: 'fast', path: [] },
+    ])
+  })
+})

--- a/packages/core/monaco-editor/src/features/validation.ts
+++ b/packages/core/monaco-editor/src/features/validation.ts
@@ -1,0 +1,32 @@
+/** A single validation failure, before it's mapped to any source location. */
+export interface ValidationIssue {
+  message: string
+  path: PropertyKey[]
+  /**
+   * A short machine-readable code for the kind of failure, when the
+   * underlying validator provides one (e.g. Zod's issue `code`, such as
+   * `invalid_type` or `too_big`). Left undefined by validators that don't
+   * have an equivalent concept.
+   */
+  code?: string
+}
+
+/**
+ * Validates an already-parsed value and reports any issues. Knows nothing
+ * about the model it came from, the language it was written in, which
+ * validation library (if any) produced it, or how to turn an issue into a
+ * source location - see `languages/*` for that, and e.g. `zod-validation.ts`
+ * for a validator-specific adapter into this shape.
+ */
+export type ValidateFn = (value: unknown) => ValidationIssue[] | Promise<ValidationIssue[]>
+
+/**
+ * Merges multiple {@link ValidateFn}s into a single one that runs them all
+ * and concatenates their issues.
+ */
+export function collectValidators(validators: ValidateFn[]): ValidateFn {
+  return async (value) => {
+    const results = await Promise.all(validators.map((validate) => validate(value)))
+    return results.flat()
+  }
+}

--- a/packages/core/monaco-editor/src/features/zod-validation.spec.ts
+++ b/packages/core/monaco-editor/src/features/zod-validation.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createZodValidator } from './zod-validation'
+
+describe('createZodValidator', () => {
+  it('returns no issues when the schema reports success', () => {
+    const validate = createZodValidator(z.object({ ok: z.boolean() }))
+
+    expect(validate({ ok: true })).toEqual([])
+  })
+
+  it('maps issues, carrying the path and the Zod issue code', () => {
+    const schema = z.object({
+      config: z.object({
+        redis: z.object({ port: z.number().max(65535) }),
+      }),
+    })
+
+    const issues = validate(schema, { config: { redis: { port: 999999 } } })
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        path: ['config', 'redis', 'port'],
+        code: 'too_big',
+      }),
+    ])
+  })
+
+  it('reports a top-level issue with an empty path', () => {
+    const schema = z.string()
+
+    const issues = validate(schema, 123)
+
+    expect(issues).toEqual([
+      expect.objectContaining({ path: [], code: 'invalid_type' }),
+    ])
+  })
+
+  it('strips the redundant "Invalid input:" prefix from Zod\'s stock messages', () => {
+    const issues = validate(z.string(), 123)
+
+    expect(issues[0]?.message).toBe('expected string, received number')
+  })
+
+  it('leaves a bare "Invalid input" (no colon/suffix) message alone', () => {
+    // A union with no custom `error` reports exactly this, with nothing
+    // after it - stripping the prefix would otherwise leave an empty string.
+    const issues = validate(z.union([z.string(), z.number()]), true)
+
+    expect(issues[0]?.message).toBe('Invalid input')
+  })
+
+  function validate(schema: z.ZodType, value: unknown) {
+    return createZodValidator(schema)(value)
+  }
+})

--- a/packages/core/monaco-editor/src/features/zod-validation.ts
+++ b/packages/core/monaco-editor/src/features/zod-validation.ts
@@ -1,0 +1,33 @@
+import type { z } from 'zod'
+import type { ValidateFn } from './validation'
+
+// Zod's stock `invalid_type` message is e.g. "Invalid input: expected
+// string, received number" - the "Invalid input:" prefix is boilerplate
+// that adds nothing ("expected string, received number" already says it),
+// so it's dropped. Only stripped when something meaningful is left
+// afterward - a bare "Invalid input" (no colon/suffix, e.g. an
+// un-customized union failure) is kept as-is rather than becoming empty.
+const INVALID_INPUT_PREFIX = /^Invalid input:\s*/
+
+function cleanMessage(message: string): string {
+  const stripped = message.replace(INVALID_INPUT_PREFIX, '')
+  return stripped || message
+}
+
+/**
+ * Adapts a Zod schema into a {@link ValidateFn}.
+ */
+export function createZodValidator(schema: z.ZodType): ValidateFn {
+  return (value) => {
+    const result = schema.safeParse(value)
+    if (result.success) {
+      return []
+    }
+
+    return result.error.issues.map((issue) => ({
+      message: cleanMessage(issue.message),
+      path: issue.path,
+      code: issue.code,
+    }))
+  }
+}

--- a/packages/core/monaco-editor/src/index.ts
+++ b/packages/core/monaco-editor/src/index.ts
@@ -8,6 +8,8 @@ export {
 
 // TODO: Add barrel exports if we have more features in the future
 export * from './features/code-lenses'
+export * from './features/validation'
+export * from './features/zod-validation'
 
 export * from './singletons/model-contexts'
 export * from './types'

--- a/packages/core/monaco-editor/src/languages/yaml/code-lenses.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/code-lenses.ts
@@ -26,7 +26,7 @@ interface YAMLNodeWithKeyPath {
   keyPath: JSONPath
 }
 
-function getYAMLNodeRange(node: YAMLNode, model: editor.ITextModel): IRange | undefined {
+export function getYAMLNodeRange(node: YAMLNode, model: editor.ITextModel): IRange | undefined {
   const range = node.range
   if (!range) {
     return undefined
@@ -176,7 +176,7 @@ function forEachYAMLNodeWithKeyPath(root: YAMLNode, fn: (node: YAMLNode, keyPath
   }
 }
 
-function getYAMLNodeAtPath(document: YAMLDocument.Parsed, keyPath: JSONPath): YAMLNode | undefined {
+export function getYAMLNodeAtPath(document: YAMLDocument.Parsed, keyPath: JSONPath): YAMLNode | undefined {
   const node = document.getIn(keyPath, true)
   return isNode(node)
     ? node

--- a/packages/core/monaco-editor/src/languages/yaml/index.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/index.ts
@@ -1,2 +1,3 @@
 export * from './code-lenses'
 export * from './context'
+export * from './validation'

--- a/packages/core/monaco-editor/src/languages/yaml/validation.spec.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/validation.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { runYAMLValidation } from './validation'
+
+import type { editor } from 'monaco-editor'
+import type { ValidateFn } from '../../features/validation'
+
+function createFakeModel(text: string, language = 'yaml'): editor.ITextModel {
+  const lines = text.split('\n')
+
+  const model = {
+    getLanguageId: () => language,
+    getAlternativeVersionId: () => 1,
+    getValue: () => text,
+    getPositionAt: (offset: number) => {
+      const before = text.slice(0, offset).split('\n')
+      return { lineNumber: before.length, column: before[before.length - 1].length + 1 }
+    },
+    getFullModelRange: () => ({
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: lines.length,
+      endColumn: lines[lines.length - 1].length + 1,
+    }),
+    onWillDispose: () => ({ dispose: () => {} }),
+  }
+
+  return model as unknown as editor.ITextModel
+}
+
+describe('runYAMLValidation', () => {
+  it('returns no issues for a model in a different language', async () => {
+    const model = createFakeModel('a: 1', 'json')
+
+    const validate: ValidateFn = () => [{ message: 'should not run', path: [] }]
+    expect(await runYAMLValidation(model, validate)).toEqual([])
+  })
+
+  it('passes the parsed YAML value to the validator', async () => {
+    const model = createFakeModel('config:\n  minute: 100\n')
+    let received: unknown
+
+    const validate: ValidateFn = (value) => {
+      received = value
+      return []
+    }
+
+    await runYAMLValidation(model, validate)
+    expect(received).toEqual({ config: { minute: 100 } })
+  })
+
+  it('returns no issues when validation succeeds', async () => {
+    const model = createFakeModel('config:\n  minute: 100\n')
+    const validate: ValidateFn = () => []
+
+    expect(await runYAMLValidation(model, validate)).toEqual([])
+  })
+
+  it('maps an issue path to the range of its own YAML node', async () => {
+    const text = 'config:\n  minute: 100\n  policy: redis\n'
+    const model = createFakeModel(text)
+
+    const validate: ValidateFn = () => [{ message: 'bad policy', path: ['config', 'policy'] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    expect(issue.message).toBe('bad policy')
+    // Line 3 is `  policy: redis` - the range should point at the `redis` value.
+    expect(issue.range.startLineNumber).toBe(3)
+    expect(issue.rangeKind).toBe('exact')
+  })
+
+  it('reports the document root itself as exact when the path is empty', async () => {
+    const text = 'config:\n  minute: 100\n'
+    const model = createFakeModel(text)
+
+    const validate: ValidateFn = () => [{ message: 'root-level issue', path: [] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    expect(issue.rangeKind).toBe('exact')
+  })
+
+  it('falls back to the nearest existing ancestor when the exact path is missing', async () => {
+    const text = 'config:\n  minute: 100\n'
+    const model = createFakeModel(text)
+
+    // `config.redis.port` doesn't exist at all - falls back to `config`'s own
+    // value node, i.e. the nested mapping starting at `minute: 100` (line 2).
+    const validate: ValidateFn = () => [{ message: 'redis.port required', path: ['config', 'redis', 'port'] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    expect(issue.range.startLineNumber).toBe(2)
+    expect(issue.rangeKind).toBe('ancestor')
+  })
+
+  it('falls back to the document root (an ancestor) when a top-level field is missing', async () => {
+    const text = 'config:\n  minute: 100\n'
+    const model = createFakeModel(text)
+
+    // There's no `protocols` key at all - the nearest existing ancestor is the document root itself.
+    const validate: ValidateFn = () => [{ message: 'top-level missing', path: ['protocols'] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    expect(issue.rangeKind).toBe('ancestor')
+  })
+
+  it('falls back to a compact position at the document start for a genuinely empty document', async () => {
+    const model = createFakeModel('')
+
+    const validate: ValidateFn = () => [{ message: 'nothing to point at', path: ['config'] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    // Not the whole (possibly huge) document - just a small anchor at the start.
+    expect(issue.range).toEqual({ startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 2 })
+    expect(issue.rangeKind).toBe('document')
+  })
+
+  it('ignores path segments that are symbols when locating a range', async () => {
+    const text = 'config:\n  minute: 100\n'
+    const model = createFakeModel(text)
+
+    const validate: ValidateFn = () => [{ message: 'weird path', path: ['config', Symbol('x')] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    // Can't look up the symbol segment itself - falls back to `config` (ancestor), not a crash.
+    expect(issue.range).toBeDefined()
+    expect(issue.rangeKind).toBe('ancestor')
+  })
+})

--- a/packages/core/monaco-editor/src/languages/yaml/validation.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/validation.ts
@@ -1,0 +1,102 @@
+import { getModelContext } from '../../singletons/model-contexts'
+import { getYAMLNodeAtPath, getYAMLNodeRange } from './code-lenses'
+
+import type { editor, IRange } from 'monaco-editor'
+import type { Document as YAMLDocument } from 'yaml'
+
+import type { ValidateFn, ValidationIssue } from '../../features/validation'
+import type { ModelContextGetter } from '../../types'
+
+/**
+ * How precisely {@link YAMLValidationIssue.range} points at the issue:
+ * - `exact`: the node for the issue's own path (its full path resolved, even
+ *   an empty path meaning "the document root itself").
+ * - `ancestor`: the path doesn't exist (e.g. a missing required field) - this
+ *   is the nearest existing parent instead, which can span many lines. Shown
+ *   the same way as `exact` (this is also how VS Code's JSON/YAML schema
+ *   validation handles a missing required property - it underlines the
+ *   containing object, not just a point).
+ * - `document`: nothing in the path resolved at all (e.g. a genuinely empty
+ *   document) - there's truly nothing to point at, so this is a compact
+ *   range at the very start of the document, not the whole thing.
+ */
+export type YAMLIssueRangeKind = 'exact' | 'ancestor' | 'document'
+
+export interface YAMLValidationIssue extends ValidationIssue {
+  range: IRange
+  rangeKind: YAMLIssueRangeKind
+}
+
+/** A compact, always-valid range at the very start of the document. */
+function documentStartRange(): IRange {
+  return { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 2 }
+}
+
+/**
+ * Finds the source range for an issue's path. A missing required field has no
+ * node of its own to point at, so this walks up the path - trying shorter and
+ * shorter prefixes - until it lands on a node that actually exists in the
+ * document, falling back to a position at the start of the document as a last
+ * resort. `rangeKind` tells the caller how precise the result actually is.
+ */
+function findRangeForPath(document: YAMLDocument.Parsed, model: editor.ITextModel, path: PropertyKey[]): { range: IRange, rangeKind: YAMLIssueRangeKind } {
+  for (let length = path.length; length >= 0; length--) {
+    const candidate = path.slice(0, length)
+    if (candidate.some((segment) => typeof segment !== 'string' && typeof segment !== 'number')) {
+      continue // symbol path segments can't be looked up in a YAML document
+    }
+
+    const node = getYAMLNodeAtPath(document, candidate as Array<string | number>)
+    if (node) {
+      const range = getYAMLNodeRange(node, model)
+      if (range) {
+        return { range, rangeKind: length === path.length ? 'exact' : 'ancestor' }
+      }
+    }
+  }
+
+  return { range: documentStartRange(), rangeKind: 'document' }
+}
+
+export interface RunYAMLValidationOptions {
+  contextGetter?: ModelContextGetter
+}
+
+/**
+ * Runs a {@link ValidateFn} (e.g. from {@link createZodValidator}) against a
+ * YAML model: parses the model's current content (reusing the
+ * cached AST from {@link getModelContext}), validates it, and maps every
+ * resulting issue back to a source range in the model.
+ *
+ * Returns an empty array if the model isn't YAML, has no parseable content,
+ * or the value is otherwise not currently checkable - callers deciding when
+ * to run this (on keystroke, debounced, etc.) is left entirely up to them.
+ */
+export async function runYAMLValidation(
+  model: editor.ITextModel,
+  validate: ValidateFn,
+  options?: RunYAMLValidationOptions,
+): Promise<YAMLValidationIssue[]> {
+  const context = await (options?.contextGetter ?? getModelContext)(model)
+  if (context.isDefault || context.language !== 'yaml' || !context.document) {
+    return []
+  }
+
+  const document = context.document
+
+  let value: unknown
+  try {
+    value = document.toJS()
+  } catch {
+    // Not cleanly resolvable (e.g. YAML-level errors) - the syntax checker
+    // already surfaces that; schema validation just backs off here.
+    return []
+  }
+
+  const issues = await validate(value)
+
+  return issues.map((issue) => {
+    const { range, rangeKind } = findRangeForPath(document, model, issue.path)
+    return { ...issue, range, rangeKind }
+  })
+}

--- a/packages/entities/entities-plugins/src/components/free-form/shared/CodeEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/CodeEditor.vue
@@ -18,7 +18,8 @@
 
 <script setup lang="ts">
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
-import { MonacoEditor } from '@kong-ui-public/monaco-editor'
+import { collectValidators, createZodValidator, MonacoEditor } from '@kong-ui-public/monaco-editor'
+import { runYAMLValidation } from '@kong-ui-public/monaco-editor/languages/yaml'
 import { dump, load, JSON_SCHEMA } from 'js-yaml'
 import { omit } from 'lodash-es'
 import * as monaco from 'monaco-editor'
@@ -26,20 +27,33 @@ import { computed, inject, shallowRef, toRaw, type ComputedRef } from 'vue'
 
 import { useFormShared } from '../shared/composables'
 import { useCodeLensProviders } from './composables/code-lens-providers'
+import { luaSchemaToZod } from '../../../utils/lua-schema-to-zod'
 
 import '@kong-ui-public/monaco-editor/dist/runtime/style.css'
 
+import type { FormSchema } from '../../../types/plugins/form-schema'
 import type { KongManagerPluginFormConfig, KonnectPluginFormConfig } from '../../../types'
 
 const activeColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
 const config = inject<KonnectPluginFormConfig | KongManagerPluginFormConfig>(FORMS_CONFIG)!
-const { formData, setValue } = useFormShared()
+const { formData, setValue, schema } = useFormShared()
+
+// `schema` is always the plugin's own record schema in this context (not a
+// bare field schema), so it's safe to compile as-is.
+// `strict` is used to show real validation errors (markers). `compat` is
+// used only to decide whether it's currently safe to switch back to the
+// visual form - see the lua-schema-to-zod README's "Compat mode" section.
+const zodSchema = computed(() => luaSchemaToZod(schema as FormSchema))
+const compatSchema = computed(() => luaSchemaToZod(schema as FormSchema, 'compat'))
+const validateSchema = computed(() => collectValidators([createZodValidator(zodSchema.value)]))
 
 const emit = defineEmits<{
   change: [config: unknown]
   sourceChange: [config: string]
   error: [msg: string]
+  /** Whether the current code is safe to switch back to the visual form. */
+  compatChange: [result: { valid: boolean, message: string }]
 }>()
 
 const editorRef = shallowRef<monaco.editor.IStandaloneCodeEditor | null>(null)
@@ -48,6 +62,14 @@ const { setup: setupCodeLensProviders } = useCodeLensProviders(config, {
 })
 
 const LINT_SOURCE = 'YAML Syntax'
+const SCHEMA_VALIDATION_SOURCE = 'Schema Validation'
+
+// The tooltip that shows this has limited space, so only the first issue is
+// shown; its line/column comes from the same YAML-position-mapping used for
+// markers, so the user can jump straight to the spot.
+function formatCompatMessage(issue: { message: string, range: monaco.IRange }): string {
+  return `${issue.message} :${issue.range.startLineNumber}:${issue.range.startColumn}`
+}
 
 function formDataToCode(): string {
   return dump((omit(toRaw(formData), ['__ui_data'])), {
@@ -74,28 +96,79 @@ function handleEditorReady(editor: monaco.editor.IStandaloneCodeEditor) {
   setupCodeLensProviders(model)
   editorRef.value = editor
 
-  editor.onDidChangeModelContent(() => {
+  // Every issue becomes a marker regardless of `rangeKind` - `ancestor`
+  // ranges can span a whole block (e.g. a missing required field underlines
+  // its containing mapping) and `document` is just a compact anchor at the
+  // start of the file (e.g. an empty editor missing a required top-level
+  // field), same as VS Code's JSON/YAML schema validation. None of them
+  // produce a sprawling, unhelpful range anymore.
+  async function runSchemaValidation() {
     try {
-      const config = load(editor.getValue() || '', {
+      // Non-null: `model` was already checked above; TS just can't narrow a
+      // `const` across this nested function declaration's boundary.
+      const issues = await runYAMLValidation(model!, validateSchema.value)
+      monaco.editor.setModelMarkers(model!, SCHEMA_VALIDATION_SOURCE, issues.map((issue) => ({
+        ...issue.range,
+        message: issue.message,
+        severity: monaco.MarkerSeverity.Error,
+      })))
+    } catch (error: unknown) {
+      console.error('[CodeEditor] schema validation failed:', error)
+    }
+  }
+
+  async function syncFromEditor() {
+    let config: unknown
+    try {
+      config = load(editor.getValue() || '', {
         schema: JSON_SCHEMA,
         json: true,
       })
 
       emit('sourceChange', editor.getValue())
-
-      if (typeof config !== 'object' || config === null) {
-        return
-      }
-
-      monaco.editor.setModelMarkers(model, LINT_SOURCE, [])
-
-      setValue(config)
-      emit('change', config)
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error)
       emit('error', errorMsg)
+      return
     }
+
+    if (typeof config !== 'object' || config === null) {
+      return
+    }
+
+    // Non-null: see the comment on `runSchemaValidation` above.
+    monaco.editor.setModelMarkers(model!, LINT_SOURCE, [])
+
+    // Goes through `runYAMLValidation` (not a plain `compatSchema.safeParse`)
+    // so the issue comes with a line/column, not just a message.
+    const compatIssues = await runYAMLValidation(model!, createZodValidator(compatSchema.value))
+    const [firstCompatIssue] = compatIssues
+    emit('compatChange', {
+      valid: !firstCompatIssue,
+      message: firstCompatIssue ? formatCompatMessage(firstCompatIssue) : '',
+    })
+
+    // Only sync into the shared form state (which the visual form directly
+    // renders from) when it's compat-safe - never let a value that would
+    // break or blank out the visual form reach it. If it's not safe, the
+    // form simply keeps showing its last good state.
+    if (!firstCompatIssue) {
+      setValue(config)
+      emit('change', config)
+    }
+  }
+
+  editor.onDidChangeModelContent(() => {
+    syncFromEditor()
+    runSchemaValidation()
   })
+
+  // Run once immediately against the initial content - `onDidChangeModelContent`
+  // only fires on subsequent edits, so without this a freshly opened editor
+  // would show no schema issues (and no compat status) until the user typed
+  // something.
+  syncFromEditor()
+  runSchemaValidation()
 
   focusEnd()
 }

--- a/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/layout/StandardLayout.vue
@@ -9,7 +9,23 @@
       :model-value="editorMode"
       :options="editorModeOptions"
       @update:model-value="handleEditorModeChange"
-    />
+    >
+      <template #option-label="{ option }">
+        <KTooltip :disabled="option.value !== 'code' || compatValid">
+          <template #content>
+            {{ compatMessage }}
+          </template>
+          <div class="ff-editor-mode-option-label">
+            {{ option.label }}
+            <WarningIcon
+              v-if="option.value === 'code' && !compatValid"
+              :color="`var(--kui-color-text-danger, ${KUI_COLOR_TEXT_DANGER})`"
+              :size="16"
+            />
+          </div>
+        </KTooltip>
+      </template>
+    </KSegmentedControl>
   </Teleport>
 
   <PluginConfigurationForm
@@ -205,7 +221,7 @@
       :title="t('plugins.form.sections.code_mode.title')"
     >
       <slot name="code-editor">
-        <CodeEditor />
+        <CodeEditor @compat-change="handleCompatChange" />
       </slot>
     </EntityFormBlock>
   </PluginConfigurationForm>
@@ -221,11 +237,13 @@ export interface Props<T extends FreeFormPluginData = any> extends PluginFormLay
 </script>
 
 <script setup lang="ts" generic="T extends FreeFormPluginData">
-import { computed, inject, nextTick, ref, useAttrs, useTemplateRef } from 'vue'
+import { computed, inject, nextTick, ref, useAttrs, useTemplateRef, watch } from 'vue'
 import { EntityFormBlock } from '@kong-ui-public/entities-shared'
 import { has, pick } from 'lodash-es'
 import { KCollapse, KRadio, KSegmentedControl, KTooltip } from '@kong/kongponents'
 import type { SegmentedControlOption } from '@kong/kongponents'
+import { WarningIcon } from '@kong/icons'
+import { KUI_COLOR_TEXT_DANGER } from '@kong/design-tokens'
 import { useLocalStorage } from '@vueuse/core'
 import { FEATURE_FLAGS } from '../../../../constants'
 import type { FormSchema } from '../../../../types/plugins/form-schema'
@@ -289,16 +307,38 @@ const editorMode = computed<EditorMode>({
 
 const showEditorModeSwitcher = computed(() => enableCodeMode && !hideEditorModeSwitcher)
 
-const editorModeOptions: Array<SegmentedControlOption<EditorMode>> = [
+// Whether the code editor's current content is safe to switch back to the
+// visual form (compat-mode schema check - see CodeEditor.vue's
+// `compat-change` emit and the lua-schema-to-zod README's "Compat mode").
+const compatValid = ref(true)
+const compatMessage = ref('')
+
+function handleCompatChange(result: { valid: boolean, message: string }) {
+  compatValid.value = result.valid
+  compatMessage.value = result.message
+}
+
+// Defensive: compat only ever changes while the code editor is mounted
+// (i.e. while already in 'code' mode), so this shouldn't normally fire -
+// but if it ever does, don't leave the visual form showing while its
+// "Visual" option is disabled.
+watch(compatValid, (valid) => {
+  if (!valid && editorMode.value === 'form') {
+    editorMode.value = 'code'
+  }
+})
+
+const editorModeOptions = computed<Array<SegmentedControlOption<EditorMode>>>(() => [
   {
     label: t('plugins.free-form.editor_mode.visual'),
     value: 'form',
+    disabled: !compatValid.value,
   },
   {
     label: t('plugins.free-form.editor_mode.code'),
     value: 'code',
   },
-]
+])
 
 function handleEditorModeChange(newMode: EditorMode) {
   editorMode.value = newMode
@@ -604,6 +644,12 @@ const advancedCollapsed = ref(true)
 </script>
 
 <style lang="scss" scoped>
+.ff-editor-mode-option-label {
+  align-items: center;
+  display: flex;
+  gap: var(--kui-space-30, $kui-space-30);
+}
+
 .ff-standard-layout {
   display: flex;
   flex-direction: column;

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/README.md
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/README.md
@@ -1,14 +1,16 @@
-# lua-schema-to-zod (POC)
+# lua-schema-to-zod
 
 Compiles a Kong plugin config schema - the JSON the Admin API dumps for a
 plugin's Lua schema (`GET /schemas/plugins/:name`) - into a [Zod](https://zod.dev)
 schema, so a frontend can validate plugin config at runtime without a round
 trip to the gateway.
 
-**Status: proof of concept.** Not wired into the `free-form` form system, not
-used by any production code path. It exists to answer "is this feasible, and
-how far can it get" - see [Scope](#scope) and [Limitations](#limitations)
-below before reaching for it in real UI.
+Used by the `free-form` plugin config form's code editor
+(`shared/CodeEditor.vue`) to show inline validation markers as you type, and
+to decide whether it's currently safe to switch back to the visual form (see
+[Compat mode](#compat-mode)). It does not replace server-side validation -
+see [Scope](#scope) and [Limitations](#limitations) for exactly what it
+covers and what it deliberately doesn't.
 
 ## Usage
 
@@ -16,7 +18,7 @@ below before reaching for it in real UI.
 import { luaSchemaToZod } from './index'
 
 // `schema` is exactly what the Admin API returns for a plugin's schema
-const zodSchema = luaSchemaToZod(schema)
+const zodSchema = luaSchemaToZod(schema) // same as luaSchemaToZod(schema, 'strict')
 
 const result = zodSchema.safeParse({ config: { minute: 100, policy: 'redis', redis: {} } })
 if (!result.success) {
@@ -26,7 +28,48 @@ if (!result.success) {
 
 `compileField` is also exported if you need to compile a single field
 definition in isolation (e.g. for a one-off input outside a full plugin
-config).
+config); it takes the same optional mode argument as `luaSchemaToZod`.
+
+## Compat mode
+
+`luaSchemaToZod(schema, 'compat')` compiles a second, deliberately relaxed
+schema that answers a different question than `'strict'` does. `'strict'`
+asks "is this config fully valid". `'compat'` asks "would rendering this
+value in the visual form break or show something nonsensically blank" - the
+question that matters when deciding whether it's currently safe to switch
+from the code editor back to the form, without the form crashing or quietly
+showing garbage.
+
+| Kept strict in compat mode (a wrong value here breaks or visibly corrupts rendering) | Relaxed in compat mode (a wrong value here just displays as-is, and the form's own field-level validation can flag it normally) |
+|---|---|
+| `required` / explicit `null` - a missing or null value is completely normal for a form field to show empty, so `required` never applies in compat mode; every field is treated as `.nullable().optional()` | - |
+| Type shape: `record` must be an object, `array`/`set` must be an array, `map` must be an object, `foreign`/`referenceable` must match one of their allowed shapes | `uuid: true` (a non-UUID string still renders fine in a text input) |
+| `one_of` (string/number/boolean/set) - Field.vue renders these as a `<select>`; a value outside the option list renders that select empty, a visible broken state, not just an invalid one | `not_one_of`, `len_min`/`len_max`, `between`, `gt`, `match`/`match_all`/`match_none`/`match_any`, `starts_with` - all pure content/business-rule checks that don't affect whether the value can be displayed |
+| - | `integer` (a float in an "integer" field still displays fine in a number input) |
+
+`elements` (array/set), `keys`/`values` (map), and `fields` (record) are all
+recompiled recursively under the *same* mode - a compat-mode array still
+gets compat-mode items, not strict ones.
+
+### File layout
+
+Unlike the table above might suggest, this isn't one compiler with
+`mode === 'strict'` checks sprinkled through it. `strict` and `compat` are
+two independent, self-contained compilers, in their own files:
+
+- [`compile-strict.ts`](./compile-strict.ts) - the full DSL
+- [`compile-compat.ts`](./compile-compat.ts) - the relaxed rules above
+- [`types.ts`](./types.ts) - the `LuaField`/`LuaFormSchema`/`CompileMode`
+  types shared by both (no behavior, just shapes)
+- [`index.ts`](./index.ts) - the public `luaSchemaToZod`/`compileField`,
+  which just pick one of the two compilers by `mode`
+
+This is the same shape as the `datakit` plugin's `schema/compat.ts` +
+`schema/strict.ts` pair, for the same reason: reading either file top to
+bottom tells the whole story for that mode, with no branching on mode mixed
+into shared logic. The two files necessarily duplicate some structure (type
+dispatch, the recursion shape) - that's an intentional trade, not an
+oversight.
 
 ## Scope
 
@@ -53,9 +96,35 @@ Every non-`required: true` field is both nullable and optional, not just
 optional: Kong's own stored/returned plugin config represents "not set" as an
 explicit `null` about as often as by omitting the key, so a schema that only
 accepted `undefined` would reject a lot of real, valid config payloads. A
-field with a `default` still accepts an explicit `null` as-is - the default
-only fills in for a genuinely missing key, matching Kong's own behavior of
-not overriding an explicit null with the field's default.
+non-required field with a `default` still accepts an explicit `null` as-is -
+the default only fills in for a genuinely missing key, matching Kong's own
+behavior of not overriding an explicit null with the field's default.
+
+A `required: true` field is the opposite on both counts, and says so
+explicitly - by name - rather than falling through to whatever generic
+message its compiled type happens to produce. Every message quotes the
+actual field name (the object key at that nesting level; an array's elements
+are labeled `"<field> item"`, a map's `"<field> key"` / `"<field> value"`)
+rather than a generic "this field":
+
+- missing (`undefined`) -> `"redis" is required`, even if the field also has
+  a `default` (a default only fills in a missing value - it doesn't change
+  whether the field is required)
+- explicit `null` -> `"redis" cannot be null`
+- present and non-null, but the wrong shape -> the type's own message (or the
+  compiler's custom one - see `foreign`/`referenceable` below)
+
+This matters most for `foreign` and `referenceable` fields, both of which
+compile to a `z.union(...)`: Zod reports a bare `"Invalid input"` at the top
+level whenever every branch of a union fails, with the real reason buried
+inside `issue.errors` (which nothing here unpacks). Left alone, a missing or
+`null` required `foreign`/`referenceable` field would say nothing more than
+`"Invalid input"`. The required/null check above runs *before* the union is
+ever evaluated, so those two common cases get a real, named message
+regardless of what the field's own type is; the union is also given its own
+custom `error` message naming the field (e.g. `"consumer" must be a string
+ID, or an object with an "id" property`) for the remaining case - a value
+that's present, non-null, and still the wrong shape.
 
 Anything with an unrecognized `type` or an unhandled keyword falls back to
 `z.unknown()` (or is silently ignored) with a `console.warn`, on purpose -
@@ -70,7 +139,7 @@ less," never "throws and breaks the form."
   `at_least_one_of`, `conditional`, `conditional_at_least_one_of`,
   `only_one_of`, ...) - cross-field rules. These are declarative and *could*
   be compiled into a generic `superRefine` executor (that was the original
-  "Layer 2" proposal), but it's out of scope for this POC.
+  "Layer 2" proposal), but it's out of scope here.
 - **`custom_entity_check`** and field-level **`custom_validator`** - Kong's
   Admin API strips Lua functions before serializing a schema to JSON
   (`kong/api/api_helpers.lua`: any table value of Lua type `"function"` is
@@ -111,7 +180,7 @@ it deliberately bails on:
 - any other unrecognized `%`-escape
 
 Validated against all 231 real Admin-API JSON dumps in
-`kong-konnect/gateway-schema-watcher` at the time this POC was written: every
+`kong-konnect/gateway-schema-watcher` at the time this was written: every
 schema compiled without throwing, and exactly 2 patterns (across all
 plugins) hit the bail-out path - both correctly, on constructs in the list
 above. This isn't a guarantee it'll always be that clean as Kong ships new
@@ -150,7 +219,15 @@ cd packages/entities/entities-plugins
 npx vitest run src/utils/lua-schema-to-zod/
 ```
 
-`index.spec.ts` covers specific behaviors (defaults, `between`, `one_of`,
-`starts_with` + `match_none`, vault references, graceful fallback on unknown
-types) against this package's existing `fixtures/schemas/*`. `smoke.spec.ts`
-just asserts every one of those fixtures compiles without throwing.
+Tests are split to match the file layout:
+
+- `compile-strict.spec.ts` - the full DSL (defaults, `between`, `one_of`,
+  `starts_with` + `match_none`, vault references, required/null messages,
+  graceful fallback on unknown types) against this package's existing
+  `fixtures/schemas/*`
+- `compile-compat.spec.ts` - the relaxed rules from the table above
+- `lua-pattern.spec.ts` - the Lua-pattern-to-JS-regex translator
+- `index.spec.ts` - just checks the public `luaSchemaToZod`/`compileField`
+  route to the right one of the two compilers by `mode`
+- `smoke.spec.ts` - asserts every fixture in `fixtures/schemas/*` compiles
+  without throwing (via the public API, strict mode)

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/README.md
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/README.md
@@ -1,23 +1,20 @@
 # lua-schema-to-zod
 
-Compiles a Kong plugin config schema - the JSON the Admin API dumps for a
-plugin's Lua schema (`GET /schemas/plugins/:name`) - into a [Zod](https://zod.dev)
-schema, so a frontend can validate plugin config at runtime without a round
-trip to the gateway.
+Compiles a Kong plugin config schema (the Admin API's JSON dump of a
+plugin's Lua schema, `GET /schemas/plugins/:name`) into a
+[Zod](https://zod.dev) schema, for runtime validation without a round trip
+to the gateway.
 
-Used by the `free-form` plugin config form's code editor
-(`shared/CodeEditor.vue`) to show inline validation markers as you type, and
-to decide whether it's currently safe to switch back to the visual form (see
-[Compat mode](#compat-mode)). It does not replace server-side validation -
-see [Scope](#scope) and [Limitations](#limitations) for exactly what it
-covers and what it deliberately doesn't.
+Used by the `free-form` code editor (`shared/CodeEditor.vue`) to show inline
+markers as you type, and to decide when it's safe to switch back to the
+visual form (see [Compat mode](#compat-mode)). It's not a replacement for
+server-side validation - see [Limitations](#limitations).
 
 ## Usage
 
 ```ts
 import { luaSchemaToZod } from './index'
 
-// `schema` is exactly what the Admin API returns for a plugin's schema
 const zodSchema = luaSchemaToZod(schema) // same as luaSchemaToZod(schema, 'strict')
 
 const result = zodSchema.safeParse({ config: { minute: 100, policy: 'redis', redis: {} } })
@@ -26,61 +23,41 @@ if (!result.success) {
 }
 ```
 
-`compileField` is also exported if you need to compile a single field
-definition in isolation (e.g. for a one-off input outside a full plugin
-config); it takes the same optional mode argument as `luaSchemaToZod`.
+`compileField` compiles a single field definition in isolation; both
+functions take the same optional `mode` argument.
 
 ## Compat mode
 
-`luaSchemaToZod(schema, 'compat')` compiles a second, deliberately relaxed
-schema that answers a different question than `'strict'` does. `'strict'`
-asks "is this config fully valid". `'compat'` asks "would rendering this
-value in the visual form break or show something nonsensically blank" - the
-question that matters when deciding whether it's currently safe to switch
-from the code editor back to the form, without the form crashing or quietly
-showing garbage.
+`'strict'` asks "is this config valid". `'compat'` asks "would rendering
+this value in the visual form break or show something blank" - the
+question that matters when deciding whether it's safe to switch from the
+code editor back to the form.
 
-| Kept strict in compat mode (a wrong value here breaks or visibly corrupts rendering) | Relaxed in compat mode (a wrong value here just displays as-is, and the form's own field-level validation can flag it normally) |
+| Kept strict (a wrong value breaks or corrupts rendering) | Relaxed (still displays fine - strict mode already flags real problems) |
 |---|---|
-| `required` / explicit `null` - a missing or null value is completely normal for a form field to show empty, so `required` never applies in compat mode; every field is treated as `.nullable().optional()` | - |
-| Type shape: `record` must be an object, `array`/`set` must be an array, `map` must be an object, `foreign`/`referenceable` must match one of their allowed shapes | `uuid: true` (a non-UUID string still renders fine in a text input) |
-| `one_of` (string/number/boolean/set) - Field.vue renders these as a `<select>`; a value outside the option list renders that select empty, a visible broken state, not just an invalid one | `not_one_of`, `len_min`/`len_max`, `between`, `gt`, `match`/`match_all`/`match_none`/`match_any`, `starts_with` - all pure content/business-rule checks that don't affect whether the value can be displayed |
-| - | `integer` (a float in an "integer" field still displays fine in a number input) |
+| Type shape: `record`→object, `array`/`set`→array, `map`→object, `foreign`/`referenceable`→one of their allowed shapes | `required` / explicit `null` - a form field just showing empty is normal |
+| `one_of` (string/number/boolean/set) - Field.vue renders these as a `<select>`; an out-of-list value renders it empty | `not_one_of`, `len_min`/`len_max`, `between`, `gt`, `match*`, `starts_with`, `uuid`, `integer` - content/business-rule checks that don't affect whether the value displays |
 
-`elements` (array/set), `keys`/`values` (map), and `fields` (record) are all
-recompiled recursively under the *same* mode - a compat-mode array still
-gets compat-mode items, not strict ones.
+`elements`/`keys`/`values`/`fields` recurse under the *same* mode - a
+compat-mode array still gets compat-mode items.
 
-### File layout
-
-Unlike the table above might suggest, this isn't one compiler with
-`mode === 'strict'` checks sprinkled through it. `strict` and `compat` are
-two independent, self-contained compilers, in their own files:
-
-- [`compile-strict.ts`](./compile-strict.ts) - the full DSL
-- [`compile-compat.ts`](./compile-compat.ts) - the relaxed rules above
-- [`types.ts`](./types.ts) - the `LuaField`/`LuaFormSchema`/`CompileMode`
-  types shared by both (no behavior, just shapes)
-- [`index.ts`](./index.ts) - the public `luaSchemaToZod`/`compileField`,
-  which just pick one of the two compilers by `mode`
-
-This is the same shape as the `datakit` plugin's `schema/compat.ts` +
-`schema/strict.ts` pair, for the same reason: reading either file top to
-bottom tells the whole story for that mode, with no branching on mode mixed
-into shared logic. The two files necessarily duplicate some structure (type
-dispatch, the recursion shape) - that's an intentional trade, not an
-oversight.
+`strict` and `compat` are two independent, self-contained compilers, not
+one compiler with `mode === '...'` branches: [`compile-strict.ts`](./compile-strict.ts),
+[`compile-compat.ts`](./compile-compat.ts), sharing only the types in
+[`types.ts`](./types.ts). [`index.ts`](./index.ts) picks one by `mode`. Same
+shape as the `datakit` plugin's `schema/strict.ts` + `schema/compat.ts`
+pair, and for the same reason: each file reads top to bottom as the whole
+story for its mode.
 
 ## Scope
 
-This is **Layer 1 only**: field-level type and constraint checks. Given a
-field's JSON definition, it maps:
+This is **Layer 1 only**: field-level type and constraint checks.
 
 | Kong DSL | Zod behavior |
 |---|---|
 | `type` (string/number/integer/boolean/array/set/map/record/foreign/json/function) | corresponding Zod type |
-| `required` / `default` | not `required: true` -> `.nullable().optional()` (also `.default()` on top when a default is present); `required: true` -> neither `null` nor `undefined` accepted |
-| `one_of` (string) | `z.enum(...)` | 
+| `required` / `default` | not `required: true` -> `.nullable().optional()` (also `.default()` when a default is present); `required: true` -> neither `null` nor `undefined` accepted |
+| `one_of` (string) | `z.enum(...)` |
 | `one_of` / `not_one_of` (other types) | refinement |
 | `between` | inclusive min/max |
 | `gt` | exclusive min |
@@ -92,44 +69,23 @@ field's JSON definition, it maps:
 | `referenceable: true` | value may also be a `{vault://...}` reference string |
 | `elements` / `keys` / `values` / `fields` | recursively compiled |
 
-Every non-`required: true` field is both nullable and optional, not just
-optional: Kong's own stored/returned plugin config represents "not set" as an
-explicit `null` about as often as by omitting the key, so a schema that only
-accepted `undefined` would reject a lot of real, valid config payloads. A
-non-required field with a `default` still accepts an explicit `null` as-is -
-the default only fills in for a genuinely missing key, matching Kong's own
-behavior of not overriding an explicit null with the field's default.
+Every non-required field is nullable *and* optional, not just optional -
+Kong represents "not set" as an explicit `null` about as often as by
+omitting the key. A required field is the opposite, and names itself in the
+message instead of a generic one (`"redis" is required` /
+`"redis" cannot be null` / the type's own message for a present-but-wrong
+value).
 
-A `required: true` field is the opposite on both counts, and says so
-explicitly - by name - rather than falling through to whatever generic
-message its compiled type happens to produce. Every message quotes the
-actual field name (the object key at that nesting level; an array's elements
-are labeled `"<field> item"`, a map's `"<field> key"` / `"<field> value"`)
-rather than a generic "this field":
+This matters most for `foreign`/`referenceable` fields, compiled as
+`z.union(...)`: Zod's default union-failure message is a bare
+`"Invalid input"` with the real reason buried in `issue.errors`. The
+required/null check runs *before* the union is evaluated, so those two
+common cases still get a real, named message; the union is also given its
+own custom message for the remaining case (present, non-null, wrong shape).
 
-- missing (`undefined`) -> `"redis" is required`, even if the field also has
-  a `default` (a default only fills in a missing value - it doesn't change
-  whether the field is required)
-- explicit `null` -> `"redis" cannot be null`
-- present and non-null, but the wrong shape -> the type's own message (or the
-  compiler's custom one - see `foreign`/`referenceable` below)
-
-This matters most for `foreign` and `referenceable` fields, both of which
-compile to a `z.union(...)`: Zod reports a bare `"Invalid input"` at the top
-level whenever every branch of a union fails, with the real reason buried
-inside `issue.errors` (which nothing here unpacks). Left alone, a missing or
-`null` required `foreign`/`referenceable` field would say nothing more than
-`"Invalid input"`. The required/null check above runs *before* the union is
-ever evaluated, so those two common cases get a real, named message
-regardless of what the field's own type is; the union is also given its own
-custom `error` message naming the field (e.g. `"consumer" must be a string
-ID, or an object with an "id" property`) for the remaining case - a value
-that's present, non-null, and still the wrong shape.
-
-Anything with an unrecognized `type` or an unhandled keyword falls back to
-`z.unknown()` (or is silently ignored) with a `console.warn`, on purpose -
-a schema this compiler doesn't fully understand should degrade to "checks
-less," never "throws and breaks the form."
+Anything with an unrecognized `type` or keyword falls back to `z.unknown()`
+with a `console.warn`, on purpose - an unfamiliar schema should degrade to
+"checks less," never "throws and breaks the form."
 
 ## Limitations
 
@@ -137,80 +93,52 @@ less," never "throws and breaks the form."
 
 - **`entity_checks`** (`mutually_exclusive`, `mutually_required`,
   `at_least_one_of`, `conditional`, `conditional_at_least_one_of`,
-  `only_one_of`, ...) - cross-field rules. These are declarative and *could*
-  be compiled into a generic `superRefine` executor (that was the original
-  "Layer 2" proposal), but it's out of scope here.
-- **`custom_entity_check`** and field-level **`custom_validator`** - Kong's
-  Admin API strips Lua functions before serializing a schema to JSON
-  (`kong/api/api_helpers.lua`: any table value of Lua type `"function"` is
-  dropped). Only metadata like `field_sources` survives; the actual check
-  logic never reaches the frontend. **There is no way to recover this from
-  the JSON, for any plugin, ever** - it's not a "not implemented yet" gap,
-  it's a hard ceiling on what a JSON-schema-to-Zod compiler can do. Fields
-  guarded by one of these still get their plain type/required checks; the
-  cross-field rule itself is just absent client-side.
-- **`shorthand_fields[].func`** - the rename/transform logic for deprecated
-  aliases (e.g. `redis_host` → `config.redis.host`) is also a Lua closure and
-  is dropped the same way. Shorthand fields are compiled as if they were
-  regular fields (their own inline validator survives), but no
-  forward/backward transform is applied.
+  `only_one_of`, ...) - cross-field rules, out of scope here.
+- **`custom_entity_check`** / field-level **`custom_validator`** - not
+  recoverable, for any plugin, ever: Kong's Admin API strips Lua functions
+  before serializing a schema to JSON (`kong/api/api_helpers.lua`), so the
+  actual check logic never reaches the frontend, only metadata like
+  `field_sources`. Guarded fields still get their plain type/required
+  checks; the cross-field rule itself is just absent client-side.
+- **`shorthand_fields[].func`** - same reason; the rename/transform for
+  deprecated aliases (e.g. `redis_host` → `config.redis.host`) is dropped,
+  and the shorthand is compiled as a regular field with no transform applied.
 
-Because of the above, **this compiler cannot replace server-side
-validation** for any plugin that uses these constructs - which, across the
-231 real plugin schemas checked during the feasibility pass, is roughly 42%
-(`custom_entity_check` alone). Treat client-side validation from this
-compiler as a UX improvement (fail fast, per-field messages) layered in
-front of the Admin API's response, never as the source of truth. A save
-action must still go to the Admin API and its 4xx response is what actually
+Because of this, **this compiler cannot replace server-side validation**
+for any plugin using these constructs - roughly 42% of the 231 real plugin
+schemas checked, for `custom_entity_check` alone. Treat it as a UX
+improvement (fail fast, per-field messages), not the source of truth - a
+save action always goes to the Admin API, and its response is what actually
 gates the write.
 
 ### Lua patterns are not JS regex
 
 `match`/`match_all`/`match_none`/`match_any` use Lua pattern syntax, not
-PCRE/JS regex (`%d` not `\d`, no alternation `|`, no `{n,m}`, a bare `-`
-after an item is a *lazy* quantifier unlike JS's greedy `*`). `lua-pattern.ts`
-translates what it's confident about and returns `null` for the rest, which
-the compiler then skips (with a warning) rather than mistranslate. Patterns
-it deliberately bails on:
-
-- `%b` (balanced match) and `%f` (frontier pattern) - no JS equivalent
-- `%p` / `%c` / `%g` character classes and their complements - not mapped
-  (only `%a %d %l %s %u %w %x` and their uppercase complements are)
-- a `-` used as a quantifier outside `[...]` - too easy to translate wrong
-- any other unrecognized `%`-escape
-
-Validated against all 231 real Admin-API JSON dumps in
-`kong-konnect/gateway-schema-watcher` at the time this was written: every
-schema compiled without throwing, and exactly 2 patterns (across all
-plugins) hit the bail-out path - both correctly, on constructs in the list
-above. This isn't a guarantee it'll always be that clean as Kong ships new
-plugins/patterns, just a data point on how conservative the translator is in
-practice.
+PCRE/JS regex (`%d` not `\d`, no alternation, no `{n,m}`, a bare `-` after
+an item is a *lazy* quantifier). `lua-pattern.ts` translates what it's
+confident about and skips the rest (with a warning) rather than mistranslate
+- notably `%b`/`%f`, unmapped classes (`%p`/`%c`/`%g`), and a bare `-`
+outside `[...]`. Checked against all 231 real plugin schemas: everything
+compiled, and only 2 patterns ever hit the bail-out path, both correctly.
 
 ### Byte length, not character length
 
-`len_min`/`len_max` check `#value` in Lua, which is a **byte** count. This
-compiler uses `TextEncoder().encode(value).length` to match that, not
-`value.length` (a JS string's `.length` is a UTF-16 code unit count). This
-matters for multi-byte input (CJK, emoji): a 3-character Chinese string can
-be 9 bytes and would fail a `len_max: 8` that a naive `.length` check would
-have passed.
+`len_min`/`len_max` check `#value` in Lua, a **byte** count - this compiler
+uses `TextEncoder().encode(value).length`, not `value.length` (a UTF-16
+code unit count). A 3-character Chinese string can be 9 bytes and fail a
+`len_max: 8` that a naive `.length` check would have passed.
 
 ### `foreign` fields
 
-A `foreign` field (e.g. `consumer`, `service`) references another entity by
-ID. This compiler only checks that the value is *shaped* like a reference
-(`null`, a string, or `{ id: string }`) - it cannot check the referenced
-entity actually exists, since that requires a DB round trip. That check, if
-wanted, belongs in the UI layer (e.g. an entity picker), not in this Zod
-schema.
+Only checked for *shape* (`null`, a string, or `{ id: string }`) - whether
+the referenced entity actually exists requires a DB round trip, out of
+scope here. That check belongs in the UI layer (e.g. an entity picker).
 
 ### `record` fields are not `.strict()`
 
-Compiled records use plain `z.object(shape)`, which strips unknown keys
-rather than rejecting them. This is deliberate: shorthand fields, and any
-DSL feature this compiler doesn't model yet, would otherwise make
-otherwise-valid configs fail to parse.
+Unknown keys are stripped, not rejected - otherwise shorthand fields or any
+DSL feature this compiler doesn't model yet would make valid configs fail
+to parse.
 
 ## Running the tests
 
@@ -219,15 +147,7 @@ cd packages/entities/entities-plugins
 npx vitest run src/utils/lua-schema-to-zod/
 ```
 
-Tests are split to match the file layout:
-
-- `compile-strict.spec.ts` - the full DSL (defaults, `between`, `one_of`,
-  `starts_with` + `match_none`, vault references, required/null messages,
-  graceful fallback on unknown types) against this package's existing
-  `fixtures/schemas/*`
-- `compile-compat.spec.ts` - the relaxed rules from the table above
-- `lua-pattern.spec.ts` - the Lua-pattern-to-JS-regex translator
-- `index.spec.ts` - just checks the public `luaSchemaToZod`/`compileField`
-  route to the right one of the two compilers by `mode`
-- `smoke.spec.ts` - asserts every fixture in `fixtures/schemas/*` compiles
-  without throwing (via the public API, strict mode)
+Split to match the file layout: `compile-strict.spec.ts`, `compile-compat.spec.ts`,
+`lua-pattern.spec.ts`, `index.spec.ts` (checks the public API routes to the
+right compiler by `mode`), `smoke.spec.ts` (every fixture in
+`fixtures/schemas/*` compiles without throwing, via the public API).

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/README.md
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/README.md
@@ -1,0 +1,148 @@
+# lua-schema-to-zod (POC)
+
+Compiles a Kong plugin config schema - the JSON the Admin API dumps for a
+plugin's Lua schema (`GET /schemas/plugins/:name`) - into a [Zod](https://zod.dev)
+schema, so a frontend can validate plugin config at runtime without a round
+trip to the gateway.
+
+**Status: proof of concept.** Not wired into the `free-form` form system, not
+used by any production code path. It exists to answer "is this feasible, and
+how far can it get" - see [Scope](#scope) and [Limitations](#limitations)
+below before reaching for it in real UI.
+
+## Usage
+
+```ts
+import { luaSchemaToZod } from './index'
+
+// `schema` is exactly what the Admin API returns for a plugin's schema
+const zodSchema = luaSchemaToZod(schema)
+
+const result = zodSchema.safeParse({ config: { minute: 100, policy: 'redis', redis: {} } })
+if (!result.success) {
+  // result.error.issues - per-field messages, usable for form errors
+}
+```
+
+`compileField` is also exported if you need to compile a single field
+definition in isolation (e.g. for a one-off input outside a full plugin
+config).
+
+## Scope
+
+This is **Layer 1 only**: field-level type and constraint checks. Given a
+field's JSON definition, it maps:
+
+| Kong DSL | Zod behavior |
+|---|---|
+| `type` (string/number/integer/boolean/array/set/map/record/foreign/json/function) | corresponding Zod type |
+| `required` / `default` | `.optional()` when not `required: true`, `.default()` when a default is present |
+| `one_of` (string) | `z.enum(...)` | 
+| `one_of` / `not_one_of` (other types) | refinement |
+| `between` | inclusive min/max |
+| `gt` | exclusive min |
+| `len_min` / `len_max` (string) | **byte length**, not JS `.length` - see [Limitations](#limitations) |
+| `len_min` / `len_max` (array/set/map) | element/entry count |
+| `starts_with` | prefix check |
+| `uuid: true` | `.uuid()` |
+| `match` / `match_all` / `match_none` / `match_any` | translated regex checks, see [Lua patterns](#lua-patterns-are-not-js-regex) |
+| `referenceable: true` | value may also be a `{vault://...}` reference string |
+| `elements` / `keys` / `values` / `fields` | recursively compiled |
+
+Anything with an unrecognized `type` or an unhandled keyword falls back to
+`z.unknown()` (or is silently ignored) with a `console.warn`, on purpose -
+a schema this compiler doesn't fully understand should degrade to "checks
+less," never "throws and breaks the form."
+
+## Limitations
+
+### Not implemented at all (by explicit descope, not by accident)
+
+- **`entity_checks`** (`mutually_exclusive`, `mutually_required`,
+  `at_least_one_of`, `conditional`, `conditional_at_least_one_of`,
+  `only_one_of`, ...) - cross-field rules. These are declarative and *could*
+  be compiled into a generic `superRefine` executor (that was the original
+  "Layer 2" proposal), but it's out of scope for this POC.
+- **`custom_entity_check`** and field-level **`custom_validator`** - Kong's
+  Admin API strips Lua functions before serializing a schema to JSON
+  (`kong/api/api_helpers.lua`: any table value of Lua type `"function"` is
+  dropped). Only metadata like `field_sources` survives; the actual check
+  logic never reaches the frontend. **There is no way to recover this from
+  the JSON, for any plugin, ever** - it's not a "not implemented yet" gap,
+  it's a hard ceiling on what a JSON-schema-to-Zod compiler can do. Fields
+  guarded by one of these still get their plain type/required checks; the
+  cross-field rule itself is just absent client-side.
+- **`shorthand_fields[].func`** - the rename/transform logic for deprecated
+  aliases (e.g. `redis_host` → `config.redis.host`) is also a Lua closure and
+  is dropped the same way. Shorthand fields are compiled as if they were
+  regular fields (their own inline validator survives), but no
+  forward/backward transform is applied.
+
+Because of the above, **this compiler cannot replace server-side
+validation** for any plugin that uses these constructs - which, across the
+231 real plugin schemas checked during the feasibility pass, is roughly 42%
+(`custom_entity_check` alone). Treat client-side validation from this
+compiler as a UX improvement (fail fast, per-field messages) layered in
+front of the Admin API's response, never as the source of truth. A save
+action must still go to the Admin API and its 4xx response is what actually
+gates the write.
+
+### Lua patterns are not JS regex
+
+`match`/`match_all`/`match_none`/`match_any` use Lua pattern syntax, not
+PCRE/JS regex (`%d` not `\d`, no alternation `|`, no `{n,m}`, a bare `-`
+after an item is a *lazy* quantifier unlike JS's greedy `*`). `lua-pattern.ts`
+translates what it's confident about and returns `null` for the rest, which
+the compiler then skips (with a warning) rather than mistranslate. Patterns
+it deliberately bails on:
+
+- `%b` (balanced match) and `%f` (frontier pattern) - no JS equivalent
+- `%p` / `%c` / `%g` character classes and their complements - not mapped
+  (only `%a %d %l %s %u %w %x` and their uppercase complements are)
+- a `-` used as a quantifier outside `[...]` - too easy to translate wrong
+- any other unrecognized `%`-escape
+
+Validated against all 231 real Admin-API JSON dumps in
+`kong-konnect/gateway-schema-watcher` at the time this POC was written: every
+schema compiled without throwing, and exactly 2 patterns (across all
+plugins) hit the bail-out path - both correctly, on constructs in the list
+above. This isn't a guarantee it'll always be that clean as Kong ships new
+plugins/patterns, just a data point on how conservative the translator is in
+practice.
+
+### Byte length, not character length
+
+`len_min`/`len_max` check `#value` in Lua, which is a **byte** count. This
+compiler uses `TextEncoder().encode(value).length` to match that, not
+`value.length` (a JS string's `.length` is a UTF-16 code unit count). This
+matters for multi-byte input (CJK, emoji): a 3-character Chinese string can
+be 9 bytes and would fail a `len_max: 8` that a naive `.length` check would
+have passed.
+
+### `foreign` fields
+
+A `foreign` field (e.g. `consumer`, `service`) references another entity by
+ID. This compiler only checks that the value is *shaped* like a reference
+(`null`, a string, or `{ id: string }`) - it cannot check the referenced
+entity actually exists, since that requires a DB round trip. That check, if
+wanted, belongs in the UI layer (e.g. an entity picker), not in this Zod
+schema.
+
+### `record` fields are not `.strict()`
+
+Compiled records use plain `z.object(shape)`, which strips unknown keys
+rather than rejecting them. This is deliberate: shorthand fields, and any
+DSL feature this compiler doesn't model yet, would otherwise make
+otherwise-valid configs fail to parse.
+
+## Running the tests
+
+```bash
+cd packages/entities/entities-plugins
+npx vitest run src/utils/lua-schema-to-zod/
+```
+
+`index.spec.ts` covers specific behaviors (defaults, `between`, `one_of`,
+`starts_with` + `match_none`, vault references, graceful fallback on unknown
+types) against this package's existing `fixtures/schemas/*`. `smoke.spec.ts`
+just asserts every one of those fixtures compiles without throwing.

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/README.md
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/README.md
@@ -36,7 +36,7 @@ field's JSON definition, it maps:
 | Kong DSL | Zod behavior |
 |---|---|
 | `type` (string/number/integer/boolean/array/set/map/record/foreign/json/function) | corresponding Zod type |
-| `required` / `default` | `.optional()` when not `required: true`, `.default()` when a default is present |
+| `required` / `default` | not `required: true` -> `.nullable().optional()` (also `.default()` on top when a default is present); `required: true` -> neither `null` nor `undefined` accepted |
 | `one_of` (string) | `z.enum(...)` | 
 | `one_of` / `not_one_of` (other types) | refinement |
 | `between` | inclusive min/max |
@@ -48,6 +48,14 @@ field's JSON definition, it maps:
 | `match` / `match_all` / `match_none` / `match_any` | translated regex checks, see [Lua patterns](#lua-patterns-are-not-js-regex) |
 | `referenceable: true` | value may also be a `{vault://...}` reference string |
 | `elements` / `keys` / `values` / `fields` | recursively compiled |
+
+Every non-`required: true` field is both nullable and optional, not just
+optional: Kong's own stored/returned plugin config represents "not set" as an
+explicit `null` about as often as by omitting the key, so a schema that only
+accepted `undefined` would reject a lot of real, valid config payloads. A
+field with a `default` still accepts an explicit `null` as-is - the default
+only fills in for a genuinely missing key, matching Kong's own behavior of
+not overriding an explicit null with the field's default.
 
 Anything with an unrecognized `type` or an unhandled keyword falls back to
 `z.unknown()` (or is silently ignored) with a `console.warn`, on purpose -

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/compile-compat.spec.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/compile-compat.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { compileSchemaCompat } from './compile-compat'
+
+// `compat` mode answers a different question than `strict`: not "is this
+// config fully valid" but "would rendering this value in the visual form
+// break or show something nonsensically blank". See the README.
+describe('compileSchemaCompat', () => {
+  it('accepts a missing/null value on a required field', () => {
+    const zodSchema = compileSchemaCompat({
+      fields: [{ name: { type: 'string', required: true } }],
+    })
+
+    expect(zodSchema.safeParse({}).success).toBe(true)
+    expect(zodSchema.safeParse({ name: null }).success).toBe(true)
+  })
+
+  it('still rejects a value outside `one_of` (would render an empty <select>)', () => {
+    const zodSchema = compileSchemaCompat({
+      fields: [{ policy: { type: 'string', one_of: ['local', 'redis'] } }],
+    })
+
+    expect(zodSchema.safeParse({ policy: 'not-an-option' }).success).toBe(false)
+    expect(zodSchema.safeParse({ policy: 'redis' }).success).toBe(true)
+  })
+
+  it('still rejects the wrong JS type for a field (would break the matching Field component)', () => {
+    const zodSchema = compileSchemaCompat({
+      fields: [{ redis: { type: 'record', fields: [{ host: { type: 'string' } }] } }],
+    })
+
+    expect(zodSchema.safeParse({ redis: 'not-an-object' }).success).toBe(false)
+    expect(zodSchema.safeParse({ redis: { host: 'ok' } }).success).toBe(true)
+  })
+
+  it('relaxes content-level checks: length, pattern, range, integer-ness, not_one_of', () => {
+    const zodSchema = compileSchemaCompat({
+      fields: [
+        { name: { type: 'string', len_min: 5, match: '^[a-z]+$' } },
+        { port: { type: 'integer', between: [0, 100] } },
+        { excluded: { type: 'string', not_one_of: ['banned'] } },
+      ],
+    })
+
+    const result = zodSchema.safeParse({ name: 'AB', port: 999.5, excluded: 'banned' })
+    expect(result.success).toBe(true)
+  })
+
+  it('still rejects a `foreign`/`referenceable` value that matches none of the allowed shapes', () => {
+    const zodSchema = compileSchemaCompat({
+      fields: [{ consumer: { type: 'foreign', reference: 'consumers' } }],
+    })
+
+    expect(zodSchema.safeParse({ consumer: 42 }).success).toBe(false)
+    expect(zodSchema.safeParse({ consumer: null }).success).toBe(true)
+    expect(zodSchema.safeParse({ consumer: 'some-id' }).success).toBe(true)
+  })
+
+  it('applies compat rules recursively to array items and map values', () => {
+    const zodSchema = compileSchemaCompat({
+      fields: [
+        {
+          tags: {
+            type: 'array',
+            elements: { type: 'string', len_min: 10 },
+          },
+        },
+        {
+          headers: {
+            type: 'map',
+            values: { type: 'string', one_of: ['a', 'b'] },
+          },
+        },
+      ],
+    })
+
+    // array item content check (len_min) relaxed
+    expect(zodSchema.safeParse({ tags: ['x'] }).success).toBe(true)
+    // map value one_of still enforced
+    expect(zodSchema.safeParse({ headers: { x: 'not-allowed' } }).success).toBe(false)
+    expect(zodSchema.safeParse({ headers: { x: 'a' } }).success).toBe(true)
+  })
+
+  it('does not throw on an unrecognized field type, falls back to unknown()', () => {
+    const weirdSchema = { fields: [{ mystery: { type: 'brand-new-type' as any } }] }
+    const zodSchema = compileSchemaCompat(weirdSchema)
+
+    expect(() => zodSchema.safeParse({ mystery: 'anything' })).not.toThrow()
+  })
+})

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/compile-compat.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/compile-compat.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod'
+
+import type { LuaField, LuaFormSchema, LuaNamedField } from './types'
+
+/**
+ * `compat` mode: compiles a deliberately relaxed schema that only checks
+ * whether a value would break or visibly corrupt rendering in the visual
+ * form - not whether it's fully valid (that's `compile-strict.ts`'s job).
+ * See the README's "Compat mode" section for the full rule table; in short:
+ *
+ * - `required` never applies - a missing/null value is a completely normal
+ *   thing for a form field to show empty.
+ * - Type shape (`record` -> object, `array`/`set` -> array, `map` -> object,
+ *   `foreign`/`referenceable` -> one of their allowed shapes) is still
+ *   enforced - the wrong shape breaks the matching Field component.
+ * - `one_of` is still enforced - Field.vue renders these as a `<select>`,
+ *   and a value outside the option list renders that select empty.
+ * - Everything else (`len_min`/`len_max`, `between`, `gt`, `not_one_of`,
+ *   `match*`, `starts_with`, `uuid`, `integer`) is dropped entirely - none
+ *   of it affects whether the value can be displayed.
+ */
+
+const VAULT_REFERENCE_PATTERN = /^\{vault:\/\/[^}]+\}$/
+
+function withVaultReference(schema: z.ZodTypeAny, label: string): z.ZodTypeAny {
+  return z.union([schema, z.string().regex(VAULT_REFERENCE_PATTERN)], {
+    error: `"${label}" must be a valid value, or a "{vault://...}" reference`,
+  })
+}
+
+function compileStringField(field: Record<string, any>): z.ZodTypeAny {
+  // `one_of` is the one content-adjacent check kept in compat mode - see the
+  // module doc comment.
+  return Array.isArray(field.one_of) && field.one_of.length > 0
+    ? z.enum(field.one_of as [string, ...string[]])
+    : z.string()
+}
+
+function compileNumberField(field: Record<string, any>): z.ZodTypeAny {
+  let schema = z.number()
+
+  if (Array.isArray(field.one_of) && field.one_of.length > 0) {
+    const options = field.one_of as number[]
+    schema = schema.superRefine((value, ctx) => {
+      if (!options.includes(value)) {
+        ctx.addIssue({ code: 'custom', message: 'value is not an allowed option' })
+      }
+    })
+  }
+
+  return schema
+}
+
+function compileBooleanField(field: Record<string, any>): z.ZodTypeAny {
+  if (Array.isArray(field.one_of) && field.one_of.length > 0) {
+    return z.boolean().refine((value) => field.one_of.includes(value), 'value is not an allowed option')
+  }
+  return z.boolean()
+}
+
+function compileArrayField(field: Record<string, any>, label: string): z.ZodTypeAny {
+  const element = field.elements ? compileFieldCompat(field.elements, `${label} item`) : z.unknown()
+  return z.array(element)
+}
+
+function compileMapField(field: Record<string, any>, label: string): z.ZodTypeAny {
+  const keySchema = (field.keys ? compileFieldCompat(field.keys, `${label} key`) : z.string()) as z.ZodString
+  const valueSchema = field.values ? compileFieldCompat(field.values, `${label} value`) : z.unknown()
+  return z.record(keySchema, valueSchema)
+}
+
+function compileForeignField(label: string): z.ZodTypeAny {
+  return z.union([z.string(), z.object({ id: z.string() }).passthrough()], {
+    error: `"${label}" must be a string ID, or an object with an "id" property`,
+  })
+}
+
+function compileRecordField(field: LuaField): z.ZodTypeAny {
+  return buildObjectSchema(field.fields ?? [])
+}
+
+function buildObjectSchema(fields: LuaNamedField[]): z.ZodObject<any> {
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (const namedField of fields) {
+    const [name, definition] = Object.entries(namedField)[0]
+    shape[name] = compileFieldCompat(definition as LuaField, name)
+  }
+  return z.object(shape)
+}
+
+function wrapCommon(schema: z.ZodTypeAny, field: Record<string, any>): z.ZodTypeAny {
+  // `required` never applies in compat mode - always nullable. A `default`
+  // still fills in a missing value (doesn't hurt, and mirrors what the
+  // visual form would actually show), it just doesn't make the field required.
+  let result: z.ZodTypeAny = schema.nullable()
+  result = field.default !== undefined ? result.default(field.default) : result.optional()
+  return result
+}
+
+export function compileFieldCompat(field: LuaField, label: string): z.ZodTypeAny {
+  let schema: z.ZodTypeAny
+
+  switch (field.type) {
+    case 'string':
+      schema = compileStringField(field)
+      break
+    case 'number':
+    case 'integer':
+      schema = compileNumberField(field)
+      break
+    case 'boolean':
+      schema = compileBooleanField(field)
+      break
+    case 'array':
+    case 'set':
+      schema = compileArrayField(field, label)
+      break
+    case 'map':
+      schema = compileMapField(field, label)
+      break
+    case 'record':
+      schema = compileRecordField(field)
+      break
+    case 'foreign':
+      schema = compileForeignField(label)
+      break
+    case 'json':
+      schema = z.unknown()
+      break
+    case 'function':
+      schema = z.string()
+      break
+    default:
+      // No console.warn here (unlike compile-strict.ts) - it already warns
+      // once per compile; compat compiles the same schema again right after.
+      schema = z.unknown()
+  }
+
+  if (field.referenceable) {
+    schema = withVaultReference(schema, label)
+  }
+
+  return wrapCommon(schema, field)
+}
+
+export function compileSchemaCompat(schema: LuaFormSchema): z.ZodObject<any> {
+  return buildObjectSchema(schema.fields)
+}

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/compile-strict.spec.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/compile-strict.spec.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest'
+import type { z } from 'zod'
+import rateLimitingSchema from '../../../fixtures/schemas/rate-limiting'
+import corsSchema from '../../../fixtures/schemas/cors'
+import { compileSchemaStrict } from './compile-strict'
+
+describe('compileSchemaStrict', () => {
+  // The Admin API always nests actual plugin options under `config`; the
+  // fixtures mirror that, so every payload below is `{ config: {...} }`.
+
+  it('compiles the rate-limiting schema and accepts a valid config', () => {
+    const zodSchema = compileSchemaStrict(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        minute: 100,
+        policy: 'redis',
+        redis: {
+          host: 'redis.internal',
+          port: 6379,
+          timeout: 2000,
+        },
+        fault_tolerant: true,
+        sync_rate: -1,
+        hide_client_headers: false,
+        error_code: 429,
+        error_message: 'slow down',
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a number field outside its `between` range', () => {
+    const zodSchema = compileSchemaStrict(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        fault_tolerant: true,
+        sync_rate: -1,
+        hide_client_headers: false,
+        redis: { host: 'x', port: 999999, timeout: 2000 }, // port out of [0, 65535]
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a string not in `one_of`', () => {
+    const zodSchema = compileSchemaStrict(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        fault_tolerant: true,
+        sync_rate: -1,
+        hide_client_headers: false,
+        limit_by: 'not-a-real-option',
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('enforces `starts_with` + `match_none` on config.path', () => {
+    const zodSchema = compileSchemaStrict(rateLimitingSchema)
+    // `redis` is a `required: true` record (Kong still requires the record
+    // itself, even though every one of its own sub-fields is optional/defaulted).
+    const base = { fault_tolerant: true, sync_rate: -1, hide_client_headers: false, redis: {} }
+
+    expect(zodSchema.safeParse({ config: { ...base, path: '/ok/path' } }).success).toBe(true)
+    expect(zodSchema.safeParse({ config: { ...base, path: 'missing-leading-slash' } }).success).toBe(false)
+    expect(zodSchema.safeParse({ config: { ...base, path: '/has//empty//segment' } }).success).toBe(false)
+  })
+
+  it('accepts a `{vault://...}` reference on a `referenceable` field', () => {
+    const zodSchema = compileSchemaStrict(rateLimitingSchema)
+    const base = { fault_tolerant: true, sync_rate: -1, hide_client_headers: false }
+
+    const result = zodSchema.safeParse({
+      config: {
+        ...base,
+        redis: { host: '{vault://env/redis-host}', port: 6379, timeout: 2000 },
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('fills in defaults for optional fields, mirroring Kong config defaults', () => {
+    const zodSchema = compileSchemaStrict(corsSchema)
+
+    const result = zodSchema.parse({ config: {} })
+    // `protocols` (a set) carries a `default` in the real schema.
+    expect(result.protocols).toBeDefined()
+  })
+
+  it('accepts explicit `null` on non-required fields, not just an omitted key', () => {
+    // Kong itself represents "not set" as `null` in stored/returned config
+    // about as often as by omitting the key.
+    const zodSchema = compileSchemaStrict(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        fault_tolerant: true,
+        sync_rate: -1,
+        hide_client_headers: false,
+        redis: {},
+        minute: null, // no `required`, no `default` -> should accept null
+        limit_by: null, // has a `default` -> should still accept an explicit null (not be overridden)
+      },
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const data = result.data as any
+      expect(data.config.minute).toBeNull()
+      expect(data.config.limit_by).toBeNull()
+    }
+  })
+
+  it('still rejects `null` on a `required: true` field', () => {
+    const zodSchema = compileSchemaStrict(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        fault_tolerant: null, // required: true -> null is not acceptable
+        sync_rate: -1,
+        hide_client_headers: false,
+        redis: {},
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('does not throw on an unrecognized field type, falls back to unknown()', () => {
+    const weirdSchema = { type: 'record' as const, fields: [{ mystery: { type: 'brand-new-type' as any } }] }
+    const zodSchema = compileSchemaStrict(weirdSchema)
+
+    expect(() => zodSchema.safeParse({ mystery: 'anything' })).not.toThrow()
+  })
+
+  // `foreign` and `referenceable` fields compile to `z.union(...)`, which
+  // Zod always reports as a bare "Invalid input" at the top level unless it's
+  // given a custom message - the real reason ends up nested and unused.
+  // Required fields additionally get a dedicated message for "missing" vs.
+  // "explicitly null", ahead of whatever the underlying type would've said.
+  describe('meaningful error messages on union-backed fields', () => {
+    function messageFor(result: ReturnType<z.ZodTypeAny['safeParse']>, path: string) {
+      if (result.success) return undefined
+      return result.error.issues.find((issue) => issue.path.join('.') === path)?.message
+    }
+
+    it('reports a required `foreign` field as missing, not "Invalid input"', () => {
+      const zodSchema = compileSchemaStrict({
+        fields: [{ consumer: { type: 'foreign', reference: 'consumers', required: true } }],
+      })
+
+      expect(messageFor(zodSchema.safeParse({}), 'consumer')).toBe('"consumer" is required')
+    })
+
+    it('rejects an explicit `null` on a required `foreign` field', () => {
+      const zodSchema = compileSchemaStrict({
+        fields: [{ consumer: { type: 'foreign', reference: 'consumers', required: true } }],
+      })
+
+      expect(messageFor(zodSchema.safeParse({ consumer: null }), 'consumer')).toBe('"consumer" cannot be null')
+    })
+
+    it('still gives a real message for a wrong-shaped (but present) `foreign` value', () => {
+      const zodSchema = compileSchemaStrict({
+        fields: [{ consumer: { type: 'foreign', reference: 'consumers', required: true } }],
+      })
+
+      const message = messageFor(zodSchema.safeParse({ consumer: 42 }), 'consumer')
+      expect(message).not.toBe('Invalid input')
+      expect(message).toMatch(/id/i)
+    })
+
+    it('reports a required `referenceable` field as missing, not "Invalid input"', () => {
+      const zodSchema = compileSchemaStrict({
+        fields: [{ host: { type: 'string', referenceable: true, required: true } }],
+      })
+
+      expect(messageFor(zodSchema.safeParse({}), 'host')).toBe('"host" is required')
+    })
+
+    it('rejects an explicit `null` on a required `referenceable` field', () => {
+      const zodSchema = compileSchemaStrict({
+        fields: [{ host: { type: 'string', referenceable: true, required: true } }],
+      })
+
+      expect(messageFor(zodSchema.safeParse({ host: null }), 'host')).toBe('"host" cannot be null')
+    })
+
+    it('still gives a real message for a wrong-shaped (but present) `referenceable` value', () => {
+      const zodSchema = compileSchemaStrict({
+        fields: [{ host: { type: 'string', referenceable: true, required: true } }],
+      })
+
+      const message = messageFor(zodSchema.safeParse({ host: 42 }), 'host')
+      expect(message).not.toBe('Invalid input')
+      expect(message).toMatch(/vault/i)
+    })
+
+    it('still allows an explicit `null` on a non-required `foreign` field', () => {
+      const zodSchema = compileSchemaStrict({
+        fields: [{ consumer: { type: 'foreign', reference: 'consumers', eq: null } }],
+      })
+
+      expect(zodSchema.safeParse({ consumer: null }).success).toBe(true)
+    })
+  })
+
+  describe('required-field messages use the actual field name, at every nesting level', () => {
+    it('uses the immediate key name for a required field nested in a record', () => {
+      const zodSchema = compileSchemaStrict({
+        fields: [{
+          redis: {
+            type: 'record',
+            required: true,
+            fields: [{ host: { type: 'string', required: true } }],
+          },
+        }],
+      })
+
+      const result = zodSchema.safeParse({ redis: {} })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const issue = result.error.issues.find((i) => i.path.join('.') === 'redis.host')
+        expect(issue?.message).toBe('"host" is required')
+      }
+    })
+
+    it('labels a required array item field relative to the array', () => {
+      const zodSchema = compileSchemaStrict({
+        fields: [{
+          tags: {
+            type: 'array',
+            required: true,
+            elements: { type: 'foreign', reference: 'consumers', required: true },
+          },
+        }],
+      })
+
+      const result = zodSchema.safeParse({ tags: [null] })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe('"tags item" cannot be null')
+      }
+    })
+  })
+})

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/compile-strict.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/compile-strict.ts
@@ -1,0 +1,330 @@
+import { z } from 'zod'
+import { translateLuaPattern } from './lua-pattern'
+
+import type { LuaField, LuaFormSchema, LuaNamedField } from './types'
+
+/**
+ * `strict` mode: compiles the full DSL (type, required, default, one_of,
+ * between, gt, len_min/len_max, match*, starts_with, uuid, referenceable) -
+ * see the README's "Scope" section. Used to show real validation errors.
+ *
+ * Scope, on purpose (see feasibility discussion):
+ * - `entity_checks` (mutually_exclusive, conditional, at_least_one_of, ...)
+ *   are intentionally NOT compiled here - cross-field rules are a separate
+ *   layer and are explicitly out of scope here.
+ * - `custom_entity_check` / `custom_validator` / `shorthand_fields[].func`
+ *   can never be recovered from the JSON at all (Kong strips Lua functions
+ *   before serializing), so there is nothing to compile for them - the
+ *   fields they touch just fall back to their plain type/required checks.
+ * - Anything this compiler doesn't recognize falls back to `z.unknown()`
+ *   with a console.warn, rather than throwing - an unknown or new DSL
+ *   keyword should never make the config form unusable.
+ */
+
+// Kong's `len_min`/`len_max` operate on Lua's `#value`, which is a BYTE
+// length, not a JS character count - matters for multi-byte (e.g. CJK) input.
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).length
+}
+
+const VAULT_REFERENCE_PATTERN = /^\{vault:\/\/[^}]+\}$/
+
+function withVaultReference(schema: z.ZodTypeAny, label: string): z.ZodTypeAny {
+  // `referenceable: true` means the field may also hold a `{vault://...}`
+  // reference string instead of a real value of its own type.
+  //
+  // Zod's `z.union` always reports a bare "Invalid input" at the top level
+  // when every branch fails - the real reason (e.g. "expected number,
+  // received undefined") is only nested inside `issue.errors`, which
+  // `createZodValidator` doesn't unpack. Without a custom message here, a
+  // missing/invalid value on any referenceable field would say nothing more
+  // than "Invalid input".
+  return z.union([schema, z.string().regex(VAULT_REFERENCE_PATTERN)], {
+    error: `"${label}" must be a valid value, or a "{vault://...}" reference`,
+  })
+}
+
+function warnUnsupportedPattern(pattern: string, context: string): void {
+  console.warn(
+    `[lua-schema-to-zod] could not safely translate Lua pattern "${pattern}" (${context}); skipping this check client-side, the server remains the source of truth`,
+  )
+}
+
+function translateOrWarn(pattern: string, context: string): RegExp | null {
+  const regex = translateLuaPattern(pattern)
+  if (!regex) warnUnsupportedPattern(pattern, context)
+  return regex
+}
+
+interface PatternCheck {
+  err?: string
+  regex: RegExp | null
+}
+
+function collectPatternChecks(field: Record<string, any>): {
+  matchAll: PatternCheck[]
+  matchNone: PatternCheck[]
+  matchAny: { err?: string, regexes: RegExp[] } | null
+} {
+  const matchAll: PatternCheck[] = []
+
+  if (typeof field.match === 'string') {
+    matchAll.push({ err: field.err, regex: translateOrWarn(field.match, 'match') })
+  }
+  if (Array.isArray(field.match_all)) {
+    for (const check of field.match_all) {
+      matchAll.push({ err: check.err, regex: translateOrWarn(check.pattern, 'match_all') })
+    }
+  }
+
+  const matchNone: PatternCheck[] = Array.isArray(field.match_none)
+    ? field.match_none.map((check: any) => ({ err: check.err, regex: translateOrWarn(check.pattern, 'match_none') }))
+    : []
+
+  const matchAny = field.match_any
+    ? {
+      err: field.match_any.err as string | undefined,
+      regexes: (field.match_any.patterns ?? [])
+        .map((pattern: string) => translateOrWarn(pattern, 'match_any'))
+        .filter((regex: RegExp | null): regex is RegExp => regex !== null),
+    }
+    : null
+
+  return { matchAll, matchNone, matchAny }
+}
+
+function compileStringField(field: Record<string, any>): z.ZodTypeAny {
+  let schema: z.ZodTypeAny = Array.isArray(field.one_of) && field.one_of.length > 0
+    ? z.enum(field.one_of as [string, ...string[]])
+    : z.string()
+
+  if (field.uuid && schema instanceof z.ZodString) {
+    schema = schema.uuid()
+  }
+
+  const { matchAll, matchNone, matchAny } = collectPatternChecks(field)
+  // Kong implicitly requires `len_min = 1` (a non-empty string) unless the
+  // schema explicitly sets `len_min` (commonly to 0 to allow empty strings).
+  const minLen = typeof field.len_min === 'number' ? field.len_min : 1
+  const maxLen = typeof field.len_max === 'number' ? field.len_max : undefined
+
+  return schema.superRefine((value, ctx) => {
+    if (typeof value !== 'string') return
+
+    const len = byteLength(value)
+    if (len < minLen) {
+      ctx.addIssue({ code: 'custom', message: `length (in bytes) must be at least ${minLen}` })
+    }
+    if (maxLen !== undefined && len > maxLen) {
+      ctx.addIssue({ code: 'custom', message: `length (in bytes) must be at most ${maxLen}` })
+    }
+
+    if (typeof field.starts_with === 'string' && !value.startsWith(field.starts_with)) {
+      ctx.addIssue({ code: 'custom', message: `must start with "${field.starts_with}"` })
+    }
+
+    if (Array.isArray(field.not_one_of) && field.not_one_of.includes(value)) {
+      ctx.addIssue({ code: 'custom', message: 'this value is not allowed' })
+    }
+
+    for (const check of matchAll) {
+      if (check.regex && !check.regex.test(value)) {
+        ctx.addIssue({ code: 'custom', message: check.err ?? 'does not match the required pattern' })
+      }
+    }
+    for (const check of matchNone) {
+      if (check.regex?.test(value)) {
+        ctx.addIssue({ code: 'custom', message: check.err ?? 'matches a forbidden pattern' })
+      }
+    }
+    if (matchAny && matchAny.regexes.length > 0 && !matchAny.regexes.some((regex) => regex.test(value))) {
+      ctx.addIssue({ code: 'custom', message: matchAny.err ?? 'does not match any of the allowed patterns' })
+    }
+  })
+}
+
+function compileNumberField(field: Record<string, any>): z.ZodTypeAny {
+  let schema = z.number()
+  if (field.type === 'integer') schema = schema.int()
+
+  return schema.superRefine((value, ctx) => {
+    if (Array.isArray(field.between)) {
+      const [min, max] = field.between
+      if (value < min || value > max) {
+        ctx.addIssue({ code: 'custom', message: `must be between ${min} and ${max} (inclusive)` })
+      }
+    }
+    if (typeof field.gt === 'number' && value <= field.gt) {
+      ctx.addIssue({ code: 'custom', message: `must be greater than ${field.gt}` })
+    }
+    if (Array.isArray(field.one_of) && field.one_of.length > 0 && !field.one_of.includes(value)) {
+      ctx.addIssue({ code: 'custom', message: 'value is not an allowed option' })
+    }
+    if (Array.isArray(field.not_one_of) && field.not_one_of.includes(value)) {
+      ctx.addIssue({ code: 'custom', message: 'this value is not allowed' })
+    }
+  })
+}
+
+function compileBooleanField(field: Record<string, any>): z.ZodTypeAny {
+  if (Array.isArray(field.one_of) && field.one_of.length > 0) {
+    return z.boolean().refine((value) => field.one_of.includes(value), 'value is not an allowed option')
+  }
+  return z.boolean()
+}
+
+function compileArrayField(field: Record<string, any>, label: string): z.ZodTypeAny {
+  const element = field.elements ? compileFieldStrict(field.elements, `${label} item`) : z.unknown()
+  let schema = z.array(element)
+  if (typeof field.len_min === 'number') schema = schema.min(field.len_min)
+  if (typeof field.len_max === 'number') schema = schema.max(field.len_max)
+  return schema
+}
+
+function compileMapField(field: Record<string, any>, label: string): z.ZodTypeAny {
+  const keySchema = (field.keys ? compileFieldStrict(field.keys, `${label} key`) : z.string()) as z.ZodString
+  const valueSchema = field.values ? compileFieldStrict(field.values, `${label} value`) : z.unknown()
+  let schema: z.ZodTypeAny = z.record(keySchema, valueSchema)
+
+  if (typeof field.len_min === 'number' || typeof field.len_max === 'number') {
+    schema = schema.superRefine((value, ctx) => {
+      const count = Object.keys(value as object).length
+      if (typeof field.len_min === 'number' && count < field.len_min) {
+        ctx.addIssue({ code: 'custom', message: `must have at least ${field.len_min} entries` })
+      }
+      if (typeof field.len_max === 'number' && count > field.len_max) {
+        ctx.addIssue({ code: 'custom', message: `must have at most ${field.len_max} entries` })
+      }
+    })
+  }
+
+  return schema
+}
+
+// A foreign field's real "does this entity exist" check requires a DB
+// lookup - out of scope client-side. All we can validate is that the value
+// is shaped like a primary key reference. Whether `null` is also acceptable
+// is decided uniformly by `wrapCommon` (via `required`), not here - see
+// `requireDefined`.
+function compileForeignField(label: string): z.ZodTypeAny {
+  return z.union([z.string(), z.object({ id: z.string() }).passthrough()], {
+    error: `"${label}" must be a string ID, or an object with an "id" property`,
+  })
+}
+
+function compileRecordField(field: LuaField): z.ZodTypeAny {
+  return buildObjectSchema(field.fields ?? [])
+}
+
+function buildObjectSchema(fields: LuaNamedField[]): z.ZodObject<any> {
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (const namedField of fields) {
+    const [name, definition] = Object.entries(namedField)[0]
+    shape[name] = compileFieldStrict(definition as LuaField, name)
+  }
+  // Not `.strict()`: shorthand fields, subschema-only fields, and anything
+  // else this compiler doesn't model yet should not make parsing fail.
+  return z.object(shape)
+}
+
+// Wraps a required field so that a missing value and an explicit `null` each
+// get their own clear message - instead of, say, a `foreign`/`referenceable`
+// field's underlying `z.union` reporting a bare "Invalid input" for either.
+// Built on `z.any().superRefine` rather than the schema's own `required`/
+// `invalid_type` customization hooks so this applies uniformly regardless of
+// the field's compiled shape (plain type, union, or otherwise) - one place
+// decides what "required" means, instead of every compile*Field function
+// having to opt in individually.
+function requireDefined(schema: z.ZodTypeAny, label: string): z.ZodTypeAny {
+  return z.any().superRefine((value, ctx) => {
+    if (value === undefined) {
+      ctx.addIssue({ code: 'custom', message: `"${label}" is required` })
+      return
+    }
+    if (value === null) {
+      ctx.addIssue({ code: 'custom', message: `"${label}" cannot be null` })
+      return
+    }
+
+    const result = schema.safeParse(value)
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        // Forwarding an already-well-formed issue of one of `addIssue`'s
+        // several code-specific variants - TS can't narrow which one.
+        ctx.addIssue(issue as any)
+      }
+    }
+  })
+}
+
+function wrapCommon(schema: z.ZodTypeAny, field: Record<string, any>, label: string): z.ZodTypeAny {
+  const isRequired = field.required === true
+
+  // Kong represents "not set" as an explicit `null` in stored/returned config
+  // about as often as by omitting the key entirely - `.optional()` alone
+  // would reject the former, so every non-required field accepts both.
+  let result = isRequired ? requireDefined(schema, label) : schema.nullable()
+
+  if (field.default !== undefined) {
+    // `required: true` + a `default` is a common, valid combination (the
+    // field is "always present" precisely because Kong fills the default
+    // in) - the default applies regardless of `required`, but an explicit
+    // `null` still isn't - `requireDefined` above still rejects it.
+    result = result.default(field.default)
+  } else if (!isRequired) {
+    result = result.optional()
+  }
+
+  return result
+}
+
+export function compileFieldStrict(field: LuaField, label: string): z.ZodTypeAny {
+  let schema: z.ZodTypeAny
+
+  switch (field.type) {
+    case 'string':
+      schema = compileStringField(field)
+      break
+    case 'number':
+    case 'integer':
+      schema = compileNumberField(field)
+      break
+    case 'boolean':
+      schema = compileBooleanField(field)
+      break
+    case 'array':
+    case 'set':
+      schema = compileArrayField(field, label)
+      break
+    case 'map':
+      schema = compileMapField(field, label)
+      break
+    case 'record':
+      schema = compileRecordField(field)
+      break
+    case 'foreign':
+      schema = compileForeignField(label)
+      break
+    case 'json':
+      schema = z.unknown()
+      break
+    case 'function':
+      // Holds Lua/JS source as a string in JSON form; we don't attempt to
+      // validate the source itself.
+      schema = z.string()
+      break
+    default:
+      console.warn(`[lua-schema-to-zod] unsupported field type "${field.type}", falling back to unknown()`)
+      schema = z.unknown()
+  }
+
+  if (field.referenceable) {
+    schema = withVaultReference(schema, label)
+  }
+
+  return wrapCommon(schema, field, label)
+}
+
+export function compileSchemaStrict(schema: LuaFormSchema): z.ZodObject<any> {
+  return buildObjectSchema(schema.fields)
+}

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.spec.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.spec.ts
@@ -94,6 +94,45 @@ describe('luaSchemaToZod (POC)', () => {
     expect(result.protocols).toBeDefined()
   })
 
+  it('accepts explicit `null` on non-required fields, not just an omitted key', () => {
+    // Kong itself represents "not set" as `null` in stored/returned config
+    // about as often as by omitting the key.
+    const zodSchema = luaSchemaToZod(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        fault_tolerant: true,
+        sync_rate: -1,
+        hide_client_headers: false,
+        redis: {},
+        minute: null, // no `required`, no `default` -> should accept null
+        limit_by: null, // has a `default` -> should still accept an explicit null (not be overridden)
+      },
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const data = result.data as any
+      expect(data.config.minute).toBeNull()
+      expect(data.config.limit_by).toBeNull()
+    }
+  })
+
+  it('still rejects `null` on a `required: true` field', () => {
+    const zodSchema = luaSchemaToZod(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        fault_tolerant: null, // required: true -> null is not acceptable
+        sync_rate: -1,
+        hide_client_headers: false,
+        redis: {},
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
   it('does not throw on an unrecognized field type, falls back to unknown()', () => {
     const weirdSchema = { type: 'record' as const, fields: [{ mystery: { type: 'brand-new-type' as any } }] }
     const zodSchema = luaSchemaToZod(weirdSchema)

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.spec.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import rateLimitingSchema from '../../../fixtures/schemas/rate-limiting'
+import corsSchema from '../../../fixtures/schemas/cors'
+import { luaSchemaToZod } from './index'
+import { translateLuaPattern } from './lua-pattern'
+
+describe('luaSchemaToZod (POC)', () => {
+  // The Admin API always nests actual plugin options under `config`; the
+  // fixtures mirror that, so every payload below is `{ config: {...} }`.
+
+  it('compiles the rate-limiting schema and accepts a valid config', () => {
+    const zodSchema = luaSchemaToZod(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        minute: 100,
+        policy: 'redis',
+        redis: {
+          host: 'redis.internal',
+          port: 6379,
+          timeout: 2000,
+        },
+        fault_tolerant: true,
+        sync_rate: -1,
+        hide_client_headers: false,
+        error_code: 429,
+        error_message: 'slow down',
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a number field outside its `between` range', () => {
+    const zodSchema = luaSchemaToZod(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        fault_tolerant: true,
+        sync_rate: -1,
+        hide_client_headers: false,
+        redis: { host: 'x', port: 999999, timeout: 2000 }, // port out of [0, 65535]
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a string not in `one_of`', () => {
+    const zodSchema = luaSchemaToZod(rateLimitingSchema)
+
+    const result = zodSchema.safeParse({
+      config: {
+        fault_tolerant: true,
+        sync_rate: -1,
+        hide_client_headers: false,
+        limit_by: 'not-a-real-option',
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('enforces `starts_with` + `match_none` on config.path', () => {
+    const zodSchema = luaSchemaToZod(rateLimitingSchema)
+    // `redis` is a `required: true` record (Kong still requires the record
+    // itself, even though every one of its own sub-fields is optional/defaulted).
+    const base = { fault_tolerant: true, sync_rate: -1, hide_client_headers: false, redis: {} }
+
+    expect(zodSchema.safeParse({ config: { ...base, path: '/ok/path' } }).success).toBe(true)
+    expect(zodSchema.safeParse({ config: { ...base, path: 'missing-leading-slash' } }).success).toBe(false)
+    expect(zodSchema.safeParse({ config: { ...base, path: '/has//empty//segment' } }).success).toBe(false)
+  })
+
+  it('accepts a `{vault://...}` reference on a `referenceable` field', () => {
+    const zodSchema = luaSchemaToZod(rateLimitingSchema)
+    const base = { fault_tolerant: true, sync_rate: -1, hide_client_headers: false }
+
+    const result = zodSchema.safeParse({
+      config: {
+        ...base,
+        redis: { host: '{vault://env/redis-host}', port: 6379, timeout: 2000 },
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('fills in defaults for optional fields, mirroring Kong config defaults', () => {
+    const zodSchema = luaSchemaToZod(corsSchema)
+
+    const result = zodSchema.parse({ config: {} })
+    // `protocols` (a set) carries a `default` in the real schema.
+    expect(result.protocols).toBeDefined()
+  })
+
+  it('does not throw on an unrecognized field type, falls back to unknown()', () => {
+    const weirdSchema = { type: 'record' as const, fields: [{ mystery: { type: 'brand-new-type' as any } }] }
+    const zodSchema = luaSchemaToZod(weirdSchema)
+
+    expect(() => zodSchema.safeParse({ mystery: 'anything' })).not.toThrow()
+  })
+})
+
+describe('translateLuaPattern (POC)', () => {
+  it('translates simple literal/anchor/char-class patterns', () => {
+    const regex = translateLuaPattern('^[a-zA-Z0-9_-]+$')
+    expect(regex).not.toBeNull()
+    expect(regex!.test('valid_name-1')).toBe(true)
+    expect(regex!.test('has a space')).toBe(false)
+  })
+
+  it('translates %d / %a Lua character classes', () => {
+    const regex = translateLuaPattern('^%d+$')
+    expect(regex).not.toBeNull()
+    expect(regex!.test('12345')).toBe(true)
+    expect(regex!.test('12a45')).toBe(false)
+  })
+
+  it('bails out on a bare `-` quantifier outside a character set', () => {
+    // In Lua, `a-` means "zero or more `a`, lazily" - not a JS-safe rewrite.
+    expect(translateLuaPattern('a-b')).toBeNull()
+  })
+
+  it('bails out on %b balanced-match patterns', () => {
+    expect(translateLuaPattern('%b()')).toBeNull()
+  })
+
+  it('escapes JS-only special chars that are literal in Lua patterns', () => {
+    const regex = translateLuaPattern('a|b{c}')
+    expect(regex).not.toBeNull()
+    expect(regex!.test('a|b{c}')).toBe(true)
+    expect(regex!.test('a')).toBe(false)
+  })
+})

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.spec.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.spec.ts
@@ -1,174 +1,38 @@
 import { describe, expect, it } from 'vitest'
-import rateLimitingSchema from '../../../fixtures/schemas/rate-limiting'
-import corsSchema from '../../../fixtures/schemas/cors'
-import { luaSchemaToZod } from './index'
-import { translateLuaPattern } from './lua-pattern'
+import { compileFieldCompat, compileSchemaCompat } from './compile-compat'
+import { compileFieldStrict, compileSchemaStrict } from './compile-strict'
+import { compileField, luaSchemaToZod } from './index'
 
-describe('luaSchemaToZod (POC)', () => {
-  // The Admin API always nests actual plugin options under `config`; the
-  // fixtures mirror that, so every payload below is `{ config: {...} }`.
+// `strict`/`compat` themselves are tested in compile-strict.spec.ts and
+// compile-compat.spec.ts. This just checks that the public API (what any
+// real caller actually imports) routes to the right one of the two.
+describe('luaSchemaToZod / compileField (public API dispatch)', () => {
+  const schema = { fields: [{ name: { type: 'string' as const, required: true } }] }
 
-  it('compiles the rate-limiting schema and accepts a valid config', () => {
-    const zodSchema = luaSchemaToZod(rateLimitingSchema)
-
-    const result = zodSchema.safeParse({
-      config: {
-        minute: 100,
-        policy: 'redis',
-        redis: {
-          host: 'redis.internal',
-          port: 6379,
-          timeout: 2000,
-        },
-        fault_tolerant: true,
-        sync_rate: -1,
-        hide_client_headers: false,
-        error_code: 429,
-        error_message: 'slow down',
-      },
-    })
-
-    expect(result.success).toBe(true)
+  it('defaults to strict mode', () => {
+    expect(luaSchemaToZod(schema).safeParse({}).success)
+      .toBe(compileSchemaStrict(schema).safeParse({}).success)
   })
 
-  it('rejects a number field outside its `between` range', () => {
-    const zodSchema = luaSchemaToZod(rateLimitingSchema)
-
-    const result = zodSchema.safeParse({
-      config: {
-        fault_tolerant: true,
-        sync_rate: -1,
-        hide_client_headers: false,
-        redis: { host: 'x', port: 999999, timeout: 2000 }, // port out of [0, 65535]
-      },
-    })
-
-    expect(result.success).toBe(false)
+  it('routes to the strict compiler when asked explicitly', () => {
+    expect(luaSchemaToZod(schema, 'strict').safeParse({}).success)
+      .toBe(compileSchemaStrict(schema).safeParse({}).success)
   })
 
-  it('rejects a string not in `one_of`', () => {
-    const zodSchema = luaSchemaToZod(rateLimitingSchema)
-
-    const result = zodSchema.safeParse({
-      config: {
-        fault_tolerant: true,
-        sync_rate: -1,
-        hide_client_headers: false,
-        limit_by: 'not-a-real-option',
-      },
-    })
-
-    expect(result.success).toBe(false)
+  it('routes to the compat compiler', () => {
+    expect(luaSchemaToZod(schema, 'compat').safeParse({}).success)
+      .toBe(compileSchemaCompat(schema).safeParse({}).success)
   })
 
-  it('enforces `starts_with` + `match_none` on config.path', () => {
-    const zodSchema = luaSchemaToZod(rateLimitingSchema)
-    // `redis` is a `required: true` record (Kong still requires the record
-    // itself, even though every one of its own sub-fields is optional/defaulted).
-    const base = { fault_tolerant: true, sync_rate: -1, hide_client_headers: false, redis: {} }
-
-    expect(zodSchema.safeParse({ config: { ...base, path: '/ok/path' } }).success).toBe(true)
-    expect(zodSchema.safeParse({ config: { ...base, path: 'missing-leading-slash' } }).success).toBe(false)
-    expect(zodSchema.safeParse({ config: { ...base, path: '/has//empty//segment' } }).success).toBe(false)
+  it('compileField defaults to strict mode', () => {
+    const field = schema.fields[0].name
+    expect(compileField(field, 'name').safeParse(undefined).success)
+      .toBe(compileFieldStrict(field, 'name').safeParse(undefined).success)
   })
 
-  it('accepts a `{vault://...}` reference on a `referenceable` field', () => {
-    const zodSchema = luaSchemaToZod(rateLimitingSchema)
-    const base = { fault_tolerant: true, sync_rate: -1, hide_client_headers: false }
-
-    const result = zodSchema.safeParse({
-      config: {
-        ...base,
-        redis: { host: '{vault://env/redis-host}', port: 6379, timeout: 2000 },
-      },
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('fills in defaults for optional fields, mirroring Kong config defaults', () => {
-    const zodSchema = luaSchemaToZod(corsSchema)
-
-    const result = zodSchema.parse({ config: {} })
-    // `protocols` (a set) carries a `default` in the real schema.
-    expect(result.protocols).toBeDefined()
-  })
-
-  it('accepts explicit `null` on non-required fields, not just an omitted key', () => {
-    // Kong itself represents "not set" as `null` in stored/returned config
-    // about as often as by omitting the key.
-    const zodSchema = luaSchemaToZod(rateLimitingSchema)
-
-    const result = zodSchema.safeParse({
-      config: {
-        fault_tolerant: true,
-        sync_rate: -1,
-        hide_client_headers: false,
-        redis: {},
-        minute: null, // no `required`, no `default` -> should accept null
-        limit_by: null, // has a `default` -> should still accept an explicit null (not be overridden)
-      },
-    })
-
-    expect(result.success).toBe(true)
-    if (result.success) {
-      const data = result.data as any
-      expect(data.config.minute).toBeNull()
-      expect(data.config.limit_by).toBeNull()
-    }
-  })
-
-  it('still rejects `null` on a `required: true` field', () => {
-    const zodSchema = luaSchemaToZod(rateLimitingSchema)
-
-    const result = zodSchema.safeParse({
-      config: {
-        fault_tolerant: null, // required: true -> null is not acceptable
-        sync_rate: -1,
-        hide_client_headers: false,
-        redis: {},
-      },
-    })
-
-    expect(result.success).toBe(false)
-  })
-
-  it('does not throw on an unrecognized field type, falls back to unknown()', () => {
-    const weirdSchema = { type: 'record' as const, fields: [{ mystery: { type: 'brand-new-type' as any } }] }
-    const zodSchema = luaSchemaToZod(weirdSchema)
-
-    expect(() => zodSchema.safeParse({ mystery: 'anything' })).not.toThrow()
-  })
-})
-
-describe('translateLuaPattern (POC)', () => {
-  it('translates simple literal/anchor/char-class patterns', () => {
-    const regex = translateLuaPattern('^[a-zA-Z0-9_-]+$')
-    expect(regex).not.toBeNull()
-    expect(regex!.test('valid_name-1')).toBe(true)
-    expect(regex!.test('has a space')).toBe(false)
-  })
-
-  it('translates %d / %a Lua character classes', () => {
-    const regex = translateLuaPattern('^%d+$')
-    expect(regex).not.toBeNull()
-    expect(regex!.test('12345')).toBe(true)
-    expect(regex!.test('12a45')).toBe(false)
-  })
-
-  it('bails out on a bare `-` quantifier outside a character set', () => {
-    // In Lua, `a-` means "zero or more `a`, lazily" - not a JS-safe rewrite.
-    expect(translateLuaPattern('a-b')).toBeNull()
-  })
-
-  it('bails out on %b balanced-match patterns', () => {
-    expect(translateLuaPattern('%b()')).toBeNull()
-  })
-
-  it('escapes JS-only special chars that are literal in Lua patterns', () => {
-    const regex = translateLuaPattern('a|b{c}')
-    expect(regex).not.toBeNull()
-    expect(regex!.test('a|b{c}')).toBe(true)
-    expect(regex!.test('a')).toBe(false)
+  it('compileField routes to the compat compiler', () => {
+    const field = schema.fields[0].name
+    expect(compileField(field, 'name', 'compat').safeParse(undefined).success)
+      .toBe(compileFieldCompat(field, 'name').safeParse(undefined).success)
   })
 })

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.ts
@@ -230,13 +230,23 @@ function buildObjectSchema(fields: LuaNamedField[]): z.ZodObject<any> {
 }
 
 function wrapCommon(schema: z.ZodTypeAny, field: Record<string, any>): z.ZodTypeAny {
+  const isRequired = field.required === true
+
+  // Kong represents "not set" as an explicit `null` in stored/returned config
+  // about as often as by omitting the key entirely - `.optional()` alone
+  // would reject the former, so every non-required field accepts both.
+  let result = isRequired ? schema : schema.nullable()
+
   if (field.default !== undefined) {
-    return schema.default(field.default)
+    // `required: true` + a `default` is a common, valid combination (the
+    // field is "always present" precisely because Kong fills the default
+    // in) - the default applies regardless of `required`.
+    result = result.default(field.default)
+  } else if (!isRequired) {
+    result = result.optional()
   }
-  if (field.required !== true) {
-    return schema.optional()
-  }
-  return schema
+
+  return result
 }
 
 export function compileField(field: LuaField): z.ZodTypeAny {

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.ts
@@ -1,0 +1,292 @@
+import { z } from 'zod'
+import { translateLuaPattern } from './lua-pattern'
+
+/**
+ * A Kong plugin config field, as dumped by the Admin API. Deliberately typed
+ * loosely (not as the stricter `FormSchema`/`UnionFieldSchema` in
+ * `../../types/plugins/form-schema`): this compiler consumes live
+ * `JSON.parse()`'d Admin API output, which was never going to satisfy a
+ * hand-maintained literal-union type at the TS level anyway, and the DSL has
+ * more optional keys (e.g. `uuid`, `gt`, `starts_with`) than that type
+ * currently models.
+ */
+type LuaField = Record<string, any> & { type: string }
+// `| undefined`: TS infers sibling keys as `?: undefined` when it widens a
+// heterogeneous array of `{ fieldName: LuaField }` objects into a union.
+type LuaNamedField = Record<string, LuaField | undefined>
+type LuaFormSchema = { fields: LuaNamedField[] }
+
+/**
+ * POC: compile a Kong plugin config JSON schema (as dumped by the Admin API)
+ * into a Zod schema for frontend runtime validation.
+ *
+ * Scope, on purpose (see feasibility discussion):
+ * - Only field-level constraints are compiled (type, required, default,
+ *   one_of/not_one_of, between, gt, len_min/len_max, match*, starts_with,
+ *   uuid, referenceable).
+ * - `entity_checks` (mutually_exclusive, conditional, at_least_one_of, ...)
+ *   are intentionally NOT compiled here - cross-field rules are a separate
+ *   layer and were explicitly descoped for this POC.
+ * - `custom_entity_check` / `custom_validator` / `shorthand_fields[].func`
+ *   can never be recovered from the JSON at all (Kong strips Lua functions
+ *   before serializing), so there is nothing to compile for them - the
+ *   fields they touch just fall back to their plain type/required checks.
+ * - Anything this compiler doesn't recognize falls back to `z.unknown()`
+ *   with a console.warn, rather than throwing - an unknown or new DSL
+ *   keyword should never make the config form unusable.
+ */
+
+// Kong's `len_min`/`len_max` operate on Lua's `#value`, which is a BYTE
+// length, not a JS character count - matters for multi-byte (e.g. CJK) input.
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).length
+}
+
+const VAULT_REFERENCE_PATTERN = /^\{vault:\/\/[^}]+\}$/
+
+function withVaultReference(schema: z.ZodTypeAny): z.ZodTypeAny {
+  // `referenceable: true` means the field may also hold a `{vault://...}`
+  // reference string instead of a real value of its own type.
+  return z.union([schema, z.string().regex(VAULT_REFERENCE_PATTERN)])
+}
+
+function warnUnsupportedPattern(pattern: string, context: string): void {
+  console.warn(
+    `[lua-schema-to-zod] could not safely translate Lua pattern "${pattern}" (${context}); skipping this check client-side, the server remains the source of truth`,
+  )
+}
+
+function translateOrWarn(pattern: string, context: string): RegExp | null {
+  const regex = translateLuaPattern(pattern)
+  if (!regex) warnUnsupportedPattern(pattern, context)
+  return regex
+}
+
+interface PatternCheck {
+  err?: string
+  regex: RegExp | null
+}
+
+function collectPatternChecks(field: Record<string, any>): {
+  matchAll: PatternCheck[]
+  matchNone: PatternCheck[]
+  matchAny: { err?: string, regexes: RegExp[] } | null
+} {
+  const matchAll: PatternCheck[] = []
+
+  if (typeof field.match === 'string') {
+    matchAll.push({ err: field.err, regex: translateOrWarn(field.match, 'match') })
+  }
+  if (Array.isArray(field.match_all)) {
+    for (const check of field.match_all) {
+      matchAll.push({ err: check.err, regex: translateOrWarn(check.pattern, 'match_all') })
+    }
+  }
+
+  const matchNone: PatternCheck[] = Array.isArray(field.match_none)
+    ? field.match_none.map((check: any) => ({ err: check.err, regex: translateOrWarn(check.pattern, 'match_none') }))
+    : []
+
+  const matchAny = field.match_any
+    ? {
+      err: field.match_any.err as string | undefined,
+      regexes: (field.match_any.patterns ?? [])
+        .map((pattern: string) => translateOrWarn(pattern, 'match_any'))
+        .filter((regex: RegExp | null): regex is RegExp => regex !== null),
+    }
+    : null
+
+  return { matchAll, matchNone, matchAny }
+}
+
+function compileStringField(field: Record<string, any>): z.ZodTypeAny {
+  let schema: z.ZodTypeAny = Array.isArray(field.one_of) && field.one_of.length > 0
+    ? z.enum(field.one_of as [string, ...string[]])
+    : z.string()
+
+  if (field.uuid && schema instanceof z.ZodString) {
+    schema = schema.uuid()
+  }
+
+  const { matchAll, matchNone, matchAny } = collectPatternChecks(field)
+  // Kong implicitly requires `len_min = 1` (a non-empty string) unless the
+  // schema explicitly sets `len_min` (commonly to 0 to allow empty strings).
+  const minLen = typeof field.len_min === 'number' ? field.len_min : 1
+  const maxLen = typeof field.len_max === 'number' ? field.len_max : undefined
+
+  return schema.superRefine((value, ctx) => {
+    if (typeof value !== 'string') return
+
+    const len = byteLength(value)
+    if (len < minLen) {
+      ctx.addIssue({ code: 'custom', message: `length (in bytes) must be at least ${minLen}` })
+    }
+    if (maxLen !== undefined && len > maxLen) {
+      ctx.addIssue({ code: 'custom', message: `length (in bytes) must be at most ${maxLen}` })
+    }
+
+    if (typeof field.starts_with === 'string' && !value.startsWith(field.starts_with)) {
+      ctx.addIssue({ code: 'custom', message: `must start with "${field.starts_with}"` })
+    }
+
+    if (Array.isArray(field.not_one_of) && field.not_one_of.includes(value)) {
+      ctx.addIssue({ code: 'custom', message: 'this value is not allowed' })
+    }
+
+    for (const check of matchAll) {
+      if (check.regex && !check.regex.test(value)) {
+        ctx.addIssue({ code: 'custom', message: check.err ?? 'does not match the required pattern' })
+      }
+    }
+    for (const check of matchNone) {
+      if (check.regex?.test(value)) {
+        ctx.addIssue({ code: 'custom', message: check.err ?? 'matches a forbidden pattern' })
+      }
+    }
+    if (matchAny && matchAny.regexes.length > 0 && !matchAny.regexes.some((regex) => regex.test(value))) {
+      ctx.addIssue({ code: 'custom', message: matchAny.err ?? 'does not match any of the allowed patterns' })
+    }
+  })
+}
+
+function compileNumberField(field: Record<string, any>): z.ZodTypeAny {
+  let schema = z.number()
+  if (field.type === 'integer') schema = schema.int()
+
+  return schema.superRefine((value, ctx) => {
+    if (Array.isArray(field.between)) {
+      const [min, max] = field.between
+      if (value < min || value > max) {
+        ctx.addIssue({ code: 'custom', message: `must be between ${min} and ${max} (inclusive)` })
+      }
+    }
+    if (typeof field.gt === 'number' && value <= field.gt) {
+      ctx.addIssue({ code: 'custom', message: `must be greater than ${field.gt}` })
+    }
+    if (Array.isArray(field.one_of) && field.one_of.length > 0 && !field.one_of.includes(value)) {
+      ctx.addIssue({ code: 'custom', message: 'value is not an allowed option' })
+    }
+    if (Array.isArray(field.not_one_of) && field.not_one_of.includes(value)) {
+      ctx.addIssue({ code: 'custom', message: 'this value is not allowed' })
+    }
+  })
+}
+
+function compileBooleanField(field: Record<string, any>): z.ZodTypeAny {
+  if (Array.isArray(field.one_of) && field.one_of.length > 0) {
+    return z.boolean().refine((value) => field.one_of.includes(value), 'value is not an allowed option')
+  }
+  return z.boolean()
+}
+
+function compileArrayField(field: Record<string, any>): z.ZodTypeAny {
+  const element = field.elements ? compileField(field.elements) : z.unknown()
+  let schema = z.array(element)
+  if (typeof field.len_min === 'number') schema = schema.min(field.len_min)
+  if (typeof field.len_max === 'number') schema = schema.max(field.len_max)
+  return schema
+}
+
+function compileMapField(field: Record<string, any>): z.ZodTypeAny {
+  const keySchema = (field.keys ? compileField(field.keys) : z.string()) as z.ZodString
+  const valueSchema = field.values ? compileField(field.values) : z.unknown()
+  let schema: z.ZodTypeAny = z.record(keySchema, valueSchema)
+
+  if (typeof field.len_min === 'number' || typeof field.len_max === 'number') {
+    schema = schema.superRefine((value, ctx) => {
+      const count = Object.keys(value as object).length
+      if (typeof field.len_min === 'number' && count < field.len_min) {
+        ctx.addIssue({ code: 'custom', message: `must have at least ${field.len_min} entries` })
+      }
+      if (typeof field.len_max === 'number' && count > field.len_max) {
+        ctx.addIssue({ code: 'custom', message: `must have at most ${field.len_max} entries` })
+      }
+    })
+  }
+
+  return schema
+}
+
+// A foreign field's real "does this entity exist" check requires a DB
+// lookup - out of scope client-side. All we can validate is that the value
+// is shaped like a primary key reference (or null, commonly allowed).
+function compileForeignField(): z.ZodTypeAny {
+  return z.union([z.null(), z.string(), z.object({ id: z.string() }).passthrough()])
+}
+
+function compileRecordField(field: LuaField): z.ZodTypeAny {
+  return buildObjectSchema(field.fields ?? [])
+}
+
+function buildObjectSchema(fields: LuaNamedField[]): z.ZodObject<any> {
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (const namedField of fields) {
+    const [name, definition] = Object.entries(namedField)[0]
+    shape[name] = compileField(definition as LuaField)
+  }
+  // Not `.strict()`: shorthand fields, subschema-only fields, and anything
+  // else this compiler doesn't model yet should not make parsing fail.
+  return z.object(shape)
+}
+
+function wrapCommon(schema: z.ZodTypeAny, field: Record<string, any>): z.ZodTypeAny {
+  if (field.default !== undefined) {
+    return schema.default(field.default)
+  }
+  if (field.required !== true) {
+    return schema.optional()
+  }
+  return schema
+}
+
+export function compileField(field: LuaField): z.ZodTypeAny {
+  let schema: z.ZodTypeAny
+
+  switch (field.type) {
+    case 'string':
+      schema = compileStringField(field)
+      break
+    case 'number':
+    case 'integer':
+      schema = compileNumberField(field)
+      break
+    case 'boolean':
+      schema = compileBooleanField(field)
+      break
+    case 'array':
+    case 'set':
+      schema = compileArrayField(field)
+      break
+    case 'map':
+      schema = compileMapField(field)
+      break
+    case 'record':
+      schema = compileRecordField(field)
+      break
+    case 'foreign':
+      schema = compileForeignField()
+      break
+    case 'json':
+      schema = z.unknown()
+      break
+    case 'function':
+      // Holds Lua/JS source as a string in JSON form; we don't attempt to
+      // validate the source itself.
+      schema = z.string()
+      break
+    default:
+      console.warn(`[lua-schema-to-zod] unsupported field type "${field.type}", falling back to unknown()`)
+      schema = z.unknown()
+  }
+
+  if (field.referenceable) {
+    schema = withVaultReference(schema)
+  }
+
+  return wrapCommon(schema, field)
+}
+
+/** Compile a full plugin config schema (the Admin API's root schema shape) into a Zod object schema. */
+export function luaSchemaToZod(schema: LuaFormSchema): z.ZodObject<any> {
+  return buildObjectSchema(schema.fields)
+}

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/index.ts
@@ -1,302 +1,32 @@
-import { z } from 'zod'
-import { translateLuaPattern } from './lua-pattern'
+import { compileFieldCompat, compileSchemaCompat } from './compile-compat'
+import { compileFieldStrict, compileSchemaStrict } from './compile-strict'
+
+import type { z } from 'zod'
+import type { CompileMode, LuaField, LuaFormSchema } from './types'
+
+export type { CompileMode } from './types'
 
 /**
- * A Kong plugin config field, as dumped by the Admin API. Deliberately typed
- * loosely (not as the stricter `FormSchema`/`UnionFieldSchema` in
- * `../../types/plugins/form-schema`): this compiler consumes live
- * `JSON.parse()`'d Admin API output, which was never going to satisfy a
- * hand-maintained literal-union type at the TS level anyway, and the DSL has
- * more optional keys (e.g. `uuid`, `gt`, `starts_with`) than that type
- * currently models.
- */
-type LuaField = Record<string, any> & { type: string }
-// `| undefined`: TS infers sibling keys as `?: undefined` when it widens a
-// heterogeneous array of `{ fieldName: LuaField }` objects into a union.
-type LuaNamedField = Record<string, LuaField | undefined>
-type LuaFormSchema = { fields: LuaNamedField[] }
-
-/**
- * POC: compile a Kong plugin config JSON schema (as dumped by the Admin API)
+ * Compile a Kong plugin config JSON schema (as dumped by the Admin API)
  * into a Zod schema for frontend runtime validation.
  *
- * Scope, on purpose (see feasibility discussion):
- * - Only field-level constraints are compiled (type, required, default,
- *   one_of/not_one_of, between, gt, len_min/len_max, match*, starts_with,
- *   uuid, referenceable).
- * - `entity_checks` (mutually_exclusive, conditional, at_least_one_of, ...)
- *   are intentionally NOT compiled here - cross-field rules are a separate
- *   layer and were explicitly descoped for this POC.
- * - `custom_entity_check` / `custom_validator` / `shorthand_fields[].func`
- *   can never be recovered from the JSON at all (Kong strips Lua functions
- *   before serializing), so there is nothing to compile for them - the
- *   fields they touch just fall back to their plain type/required checks.
- * - Anything this compiler doesn't recognize falls back to `z.unknown()`
- *   with a console.warn, rather than throwing - an unknown or new DSL
- *   keyword should never make the config form unusable.
+ * `strict` (default) and `compat` are two independent, self-contained
+ * compilers - see `compile-strict.ts` and `compile-compat.ts` - not one
+ * compiler switched by a flag. This module just picks which one to run.
  */
-
-// Kong's `len_min`/`len_max` operate on Lua's `#value`, which is a BYTE
-// length, not a JS character count - matters for multi-byte (e.g. CJK) input.
-function byteLength(value: string): number {
-  return new TextEncoder().encode(value).length
+export function compileField(field: LuaField, label: string, mode: CompileMode = 'strict'): z.ZodTypeAny {
+  return mode === 'strict' ? compileFieldStrict(field, label) : compileFieldCompat(field, label)
 }
 
-const VAULT_REFERENCE_PATTERN = /^\{vault:\/\/[^}]+\}$/
-
-function withVaultReference(schema: z.ZodTypeAny): z.ZodTypeAny {
-  // `referenceable: true` means the field may also hold a `{vault://...}`
-  // reference string instead of a real value of its own type.
-  return z.union([schema, z.string().regex(VAULT_REFERENCE_PATTERN)])
-}
-
-function warnUnsupportedPattern(pattern: string, context: string): void {
-  console.warn(
-    `[lua-schema-to-zod] could not safely translate Lua pattern "${pattern}" (${context}); skipping this check client-side, the server remains the source of truth`,
-  )
-}
-
-function translateOrWarn(pattern: string, context: string): RegExp | null {
-  const regex = translateLuaPattern(pattern)
-  if (!regex) warnUnsupportedPattern(pattern, context)
-  return regex
-}
-
-interface PatternCheck {
-  err?: string
-  regex: RegExp | null
-}
-
-function collectPatternChecks(field: Record<string, any>): {
-  matchAll: PatternCheck[]
-  matchNone: PatternCheck[]
-  matchAny: { err?: string, regexes: RegExp[] } | null
-} {
-  const matchAll: PatternCheck[] = []
-
-  if (typeof field.match === 'string') {
-    matchAll.push({ err: field.err, regex: translateOrWarn(field.match, 'match') })
-  }
-  if (Array.isArray(field.match_all)) {
-    for (const check of field.match_all) {
-      matchAll.push({ err: check.err, regex: translateOrWarn(check.pattern, 'match_all') })
-    }
-  }
-
-  const matchNone: PatternCheck[] = Array.isArray(field.match_none)
-    ? field.match_none.map((check: any) => ({ err: check.err, regex: translateOrWarn(check.pattern, 'match_none') }))
-    : []
-
-  const matchAny = field.match_any
-    ? {
-      err: field.match_any.err as string | undefined,
-      regexes: (field.match_any.patterns ?? [])
-        .map((pattern: string) => translateOrWarn(pattern, 'match_any'))
-        .filter((regex: RegExp | null): regex is RegExp => regex !== null),
-    }
-    : null
-
-  return { matchAll, matchNone, matchAny }
-}
-
-function compileStringField(field: Record<string, any>): z.ZodTypeAny {
-  let schema: z.ZodTypeAny = Array.isArray(field.one_of) && field.one_of.length > 0
-    ? z.enum(field.one_of as [string, ...string[]])
-    : z.string()
-
-  if (field.uuid && schema instanceof z.ZodString) {
-    schema = schema.uuid()
-  }
-
-  const { matchAll, matchNone, matchAny } = collectPatternChecks(field)
-  // Kong implicitly requires `len_min = 1` (a non-empty string) unless the
-  // schema explicitly sets `len_min` (commonly to 0 to allow empty strings).
-  const minLen = typeof field.len_min === 'number' ? field.len_min : 1
-  const maxLen = typeof field.len_max === 'number' ? field.len_max : undefined
-
-  return schema.superRefine((value, ctx) => {
-    if (typeof value !== 'string') return
-
-    const len = byteLength(value)
-    if (len < minLen) {
-      ctx.addIssue({ code: 'custom', message: `length (in bytes) must be at least ${minLen}` })
-    }
-    if (maxLen !== undefined && len > maxLen) {
-      ctx.addIssue({ code: 'custom', message: `length (in bytes) must be at most ${maxLen}` })
-    }
-
-    if (typeof field.starts_with === 'string' && !value.startsWith(field.starts_with)) {
-      ctx.addIssue({ code: 'custom', message: `must start with "${field.starts_with}"` })
-    }
-
-    if (Array.isArray(field.not_one_of) && field.not_one_of.includes(value)) {
-      ctx.addIssue({ code: 'custom', message: 'this value is not allowed' })
-    }
-
-    for (const check of matchAll) {
-      if (check.regex && !check.regex.test(value)) {
-        ctx.addIssue({ code: 'custom', message: check.err ?? 'does not match the required pattern' })
-      }
-    }
-    for (const check of matchNone) {
-      if (check.regex?.test(value)) {
-        ctx.addIssue({ code: 'custom', message: check.err ?? 'matches a forbidden pattern' })
-      }
-    }
-    if (matchAny && matchAny.regexes.length > 0 && !matchAny.regexes.some((regex) => regex.test(value))) {
-      ctx.addIssue({ code: 'custom', message: matchAny.err ?? 'does not match any of the allowed patterns' })
-    }
-  })
-}
-
-function compileNumberField(field: Record<string, any>): z.ZodTypeAny {
-  let schema = z.number()
-  if (field.type === 'integer') schema = schema.int()
-
-  return schema.superRefine((value, ctx) => {
-    if (Array.isArray(field.between)) {
-      const [min, max] = field.between
-      if (value < min || value > max) {
-        ctx.addIssue({ code: 'custom', message: `must be between ${min} and ${max} (inclusive)` })
-      }
-    }
-    if (typeof field.gt === 'number' && value <= field.gt) {
-      ctx.addIssue({ code: 'custom', message: `must be greater than ${field.gt}` })
-    }
-    if (Array.isArray(field.one_of) && field.one_of.length > 0 && !field.one_of.includes(value)) {
-      ctx.addIssue({ code: 'custom', message: 'value is not an allowed option' })
-    }
-    if (Array.isArray(field.not_one_of) && field.not_one_of.includes(value)) {
-      ctx.addIssue({ code: 'custom', message: 'this value is not allowed' })
-    }
-  })
-}
-
-function compileBooleanField(field: Record<string, any>): z.ZodTypeAny {
-  if (Array.isArray(field.one_of) && field.one_of.length > 0) {
-    return z.boolean().refine((value) => field.one_of.includes(value), 'value is not an allowed option')
-  }
-  return z.boolean()
-}
-
-function compileArrayField(field: Record<string, any>): z.ZodTypeAny {
-  const element = field.elements ? compileField(field.elements) : z.unknown()
-  let schema = z.array(element)
-  if (typeof field.len_min === 'number') schema = schema.min(field.len_min)
-  if (typeof field.len_max === 'number') schema = schema.max(field.len_max)
-  return schema
-}
-
-function compileMapField(field: Record<string, any>): z.ZodTypeAny {
-  const keySchema = (field.keys ? compileField(field.keys) : z.string()) as z.ZodString
-  const valueSchema = field.values ? compileField(field.values) : z.unknown()
-  let schema: z.ZodTypeAny = z.record(keySchema, valueSchema)
-
-  if (typeof field.len_min === 'number' || typeof field.len_max === 'number') {
-    schema = schema.superRefine((value, ctx) => {
-      const count = Object.keys(value as object).length
-      if (typeof field.len_min === 'number' && count < field.len_min) {
-        ctx.addIssue({ code: 'custom', message: `must have at least ${field.len_min} entries` })
-      }
-      if (typeof field.len_max === 'number' && count > field.len_max) {
-        ctx.addIssue({ code: 'custom', message: `must have at most ${field.len_max} entries` })
-      }
-    })
-  }
-
-  return schema
-}
-
-// A foreign field's real "does this entity exist" check requires a DB
-// lookup - out of scope client-side. All we can validate is that the value
-// is shaped like a primary key reference (or null, commonly allowed).
-function compileForeignField(): z.ZodTypeAny {
-  return z.union([z.null(), z.string(), z.object({ id: z.string() }).passthrough()])
-}
-
-function compileRecordField(field: LuaField): z.ZodTypeAny {
-  return buildObjectSchema(field.fields ?? [])
-}
-
-function buildObjectSchema(fields: LuaNamedField[]): z.ZodObject<any> {
-  const shape: Record<string, z.ZodTypeAny> = {}
-  for (const namedField of fields) {
-    const [name, definition] = Object.entries(namedField)[0]
-    shape[name] = compileField(definition as LuaField)
-  }
-  // Not `.strict()`: shorthand fields, subschema-only fields, and anything
-  // else this compiler doesn't model yet should not make parsing fail.
-  return z.object(shape)
-}
-
-function wrapCommon(schema: z.ZodTypeAny, field: Record<string, any>): z.ZodTypeAny {
-  const isRequired = field.required === true
-
-  // Kong represents "not set" as an explicit `null` in stored/returned config
-  // about as often as by omitting the key entirely - `.optional()` alone
-  // would reject the former, so every non-required field accepts both.
-  let result = isRequired ? schema : schema.nullable()
-
-  if (field.default !== undefined) {
-    // `required: true` + a `default` is a common, valid combination (the
-    // field is "always present" precisely because Kong fills the default
-    // in) - the default applies regardless of `required`.
-    result = result.default(field.default)
-  } else if (!isRequired) {
-    result = result.optional()
-  }
-
-  return result
-}
-
-export function compileField(field: LuaField): z.ZodTypeAny {
-  let schema: z.ZodTypeAny
-
-  switch (field.type) {
-    case 'string':
-      schema = compileStringField(field)
-      break
-    case 'number':
-    case 'integer':
-      schema = compileNumberField(field)
-      break
-    case 'boolean':
-      schema = compileBooleanField(field)
-      break
-    case 'array':
-    case 'set':
-      schema = compileArrayField(field)
-      break
-    case 'map':
-      schema = compileMapField(field)
-      break
-    case 'record':
-      schema = compileRecordField(field)
-      break
-    case 'foreign':
-      schema = compileForeignField()
-      break
-    case 'json':
-      schema = z.unknown()
-      break
-    case 'function':
-      // Holds Lua/JS source as a string in JSON form; we don't attempt to
-      // validate the source itself.
-      schema = z.string()
-      break
-    default:
-      console.warn(`[lua-schema-to-zod] unsupported field type "${field.type}", falling back to unknown()`)
-      schema = z.unknown()
-  }
-
-  if (field.referenceable) {
-    schema = withVaultReference(schema)
-  }
-
-  return wrapCommon(schema, field)
-}
-
-/** Compile a full plugin config schema (the Admin API's root schema shape) into a Zod object schema. */
-export function luaSchemaToZod(schema: LuaFormSchema): z.ZodObject<any> {
-  return buildObjectSchema(schema.fields)
+/**
+ * Compile a full plugin config schema (the Admin API's root schema shape)
+ * into a Zod object schema.
+ *
+ * @param mode `'strict'` (default) compiles the full DSL, for showing real
+ * validation errors. `'compat'` compiles a deliberately relaxed schema for
+ * deciding whether it's currently safe to switch from the code editor back
+ * to the visual form - see the README's "Compat mode" section.
+ */
+export function luaSchemaToZod(schema: LuaFormSchema, mode: CompileMode = 'strict'): z.ZodObject<any> {
+  return mode === 'strict' ? compileSchemaStrict(schema) : compileSchemaCompat(schema)
 }

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/lua-pattern.spec.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/lua-pattern.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { translateLuaPattern } from './lua-pattern'
+
+describe('translateLuaPattern', () => {
+  it('translates simple literal/anchor/char-class patterns', () => {
+    const regex = translateLuaPattern('^[a-zA-Z0-9_-]+$')
+    expect(regex).not.toBeNull()
+    expect(regex!.test('valid_name-1')).toBe(true)
+    expect(regex!.test('has a space')).toBe(false)
+  })
+
+  it('translates %d / %a Lua character classes', () => {
+    const regex = translateLuaPattern('^%d+$')
+    expect(regex).not.toBeNull()
+    expect(regex!.test('12345')).toBe(true)
+    expect(regex!.test('12a45')).toBe(false)
+  })
+
+  it('bails out on a bare `-` quantifier outside a character set', () => {
+    // In Lua, `a-` means "zero or more `a`, lazily" - not a JS-safe rewrite.
+    expect(translateLuaPattern('a-b')).toBeNull()
+  })
+
+  it('bails out on %b balanced-match patterns', () => {
+    expect(translateLuaPattern('%b()')).toBeNull()
+  })
+
+  it('escapes JS-only special chars that are literal in Lua patterns', () => {
+    const regex = translateLuaPattern('a|b{c}')
+    expect(regex).not.toBeNull()
+    expect(regex!.test('a|b{c}')).toBe(true)
+    expect(regex!.test('a')).toBe(false)
+  })
+})

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/lua-pattern.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/lua-pattern.ts
@@ -1,0 +1,104 @@
+/**
+ * Best-effort translator from Kong's Lua pattern syntax (used in `match` /
+ * `match_all` / `match_none` / `match_any`) to a JS RegExp.
+ *
+ * Lua patterns are NOT PCRE/JS regex: no alternation (`|`), no `{n,m}` bounded
+ * repetition, `-` after an item is a *lazy* "0 or more" quantifier (unlike
+ * JS's greedy `*`), and character classes use `%d %a %s %w ...` instead of
+ * `\d \w \s`. A naive `new RegExp(pattern)` on a Lua pattern can silently
+ * validate the wrong thing, which is worse than not validating at all.
+ *
+ * This translator only handles constructs it can map with confidence and
+ * returns `null` for anything else (bare `-` quantifiers outside `[...]`,
+ * `%b`/`%f`, unknown `%x` escapes). Callers should skip the check client-side
+ * when `null` comes back, and rely on the server's real (Lua) validation.
+ */
+
+const CHAR_CLASSES: Record<string, string> = {
+  a: '[A-Za-z]',
+  A: '[^A-Za-z]',
+  d: '\\d',
+  D: '\\D',
+  l: '[a-z]',
+  L: '[^a-z]',
+  s: '\\s',
+  S: '\\S',
+  u: '[A-Z]',
+  U: '[^A-Z]',
+  w: '[A-Za-z0-9]',
+  W: '[^A-Za-z0-9]',
+  x: '[0-9a-fA-F]',
+  X: '[^0-9a-fA-F]',
+}
+
+// Chars that have no special meaning in Lua patterns but ARE special in JS
+// regex - they must be escaped so JS doesn't misinterpret them.
+const JS_ONLY_SPECIAL_CHARS = new Set(['|', '{', '}'])
+
+export function translateLuaPattern(pattern: string): RegExp | null {
+  if (pattern.includes('%b') || pattern.includes('%f')) {
+    // Balanced-match / frontier patterns have no JS regex equivalent.
+    return null
+  }
+
+  let out = ''
+  let inBracket = false
+
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i]
+
+    if (c === '%') {
+      const next = pattern[i + 1]
+      if (next === undefined) return null // dangling escape, malformed
+
+      if (next >= '1' && next <= '9') {
+        out += `\\${next}` // backreference
+      } else if (CHAR_CLASSES[next]) {
+        out += CHAR_CLASSES[next]
+      } else if (!/[A-Za-z0-9]/.test(next)) {
+        out += `\\${next}` // escaped literal magic char, e.g. %. %+ %-
+      } else {
+        return null // unknown %-escape, don't guess
+      }
+      i++
+      continue
+    }
+
+    if (c === '[') {
+      inBracket = true
+      out += c
+      continue
+    }
+
+    if (c === ']') {
+      inBracket = false
+      out += c
+      continue
+    }
+
+    if (c === '-') {
+      if (inBracket) {
+        out += c // literal range char inside [...]
+      } else {
+        // Lazy "0 or more" quantifier in Lua - too easy to get wrong, bail.
+        return null
+      }
+      continue
+    }
+
+    if (JS_ONLY_SPECIAL_CHARS.has(c)) {
+      out += `\\${c}`
+      continue
+    }
+
+    out += c
+  }
+
+  if (inBracket) return null // unterminated character set
+
+  try {
+    return new RegExp(out)
+  } catch {
+    return null
+  }
+}

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/smoke.spec.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/smoke.spec.ts
@@ -3,7 +3,7 @@ import { luaSchemaToZod } from './index'
 import acl from '../../../fixtures/schemas/acl'
 import aiProxy from '../../../fixtures/schemas/ai-proxy'
 import cors from '../../../fixtures/schemas/cors'
-import governance from '../../../fixtures/schemas/governance'
+import entitlementEnforcement from '../../../fixtures/schemas/entitlement-enforcement'
 import mocking from '../../../fixtures/schemas/mocking'
 import nestedMixed from '../../../fixtures/schemas/nested-mixed'
 import oidc from '../../../fixtures/schemas/oidc'
@@ -12,7 +12,7 @@ import rateLimiting from '../../../fixtures/schemas/rate-limiting'
 
 // `free-form-mocking.ts` exports test-case builder functions, not a
 // `FormSchema` itself, so it's not a fixture for this compiler.
-const all = { acl, aiProxy, cors, governance, mocking, nestedMixed, oidc, opentelemetry, rateLimiting }
+const all = { acl, aiProxy, cors, entitlementEnforcement, mocking, nestedMixed, oidc, opentelemetry, rateLimiting }
 
 describe('smoke: compile every fixture without throwing', () => {
   for (const [name, schema] of Object.entries(all)) {

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/smoke.spec.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/smoke.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { luaSchemaToZod } from './index'
+import acl from '../../../fixtures/schemas/acl'
+import aiProxy from '../../../fixtures/schemas/ai-proxy'
+import cors from '../../../fixtures/schemas/cors'
+import governance from '../../../fixtures/schemas/governance'
+import mocking from '../../../fixtures/schemas/mocking'
+import nestedMixed from '../../../fixtures/schemas/nested-mixed'
+import oidc from '../../../fixtures/schemas/oidc'
+import opentelemetry from '../../../fixtures/schemas/opentelemetry'
+import rateLimiting from '../../../fixtures/schemas/rate-limiting'
+
+// `free-form-mocking.ts` exports test-case builder functions, not a
+// `FormSchema` itself, so it's not a fixture for this compiler.
+const all = { acl, aiProxy, cors, governance, mocking, nestedMixed, oidc, opentelemetry, rateLimiting }
+
+describe('smoke: compile every fixture without throwing', () => {
+  for (const [name, schema] of Object.entries(all)) {
+    it(`compiles ${name}`, () => {
+      expect(() => luaSchemaToZod(schema as any)).not.toThrow()
+    })
+  }
+})

--- a/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/types.ts
+++ b/packages/entities/entities-plugins/src/utils/lua-schema-to-zod/types.ts
@@ -1,0 +1,33 @@
+/**
+ * A Kong plugin config field, as dumped by the Admin API. Deliberately typed
+ * loosely (not as the stricter `FormSchema`/`UnionFieldSchema` in
+ * `../../types/plugins/form-schema`): this compiler consumes live
+ * `JSON.parse()`'d Admin API output, which was never going to satisfy a
+ * hand-maintained literal-union type at the TS level anyway, and the DSL has
+ * more optional keys (e.g. `uuid`, `gt`, `starts_with`) than that type
+ * currently models.
+ */
+export type LuaField = Record<string, any> & { type: string }
+
+// `| undefined`: TS infers sibling keys as `?: undefined` when it widens a
+// heterogeneous array of `{ fieldName: LuaField }` objects into a union.
+export type LuaNamedField = Record<string, LuaField | undefined>
+
+export type LuaFormSchema = { fields: LuaNamedField[] }
+
+/**
+ * `strict` compiles the full DSL - see `compile-strict.ts` - for showing
+ * real validation errors. `compat` - `compile-compat.ts` - compiles a
+ * deliberately looser schema whose only job is "would rendering this value
+ * in the visual form break or show something nonsensically blank", used to
+ * decide whether switching from the code editor back to the visual form is
+ * currently safe, not whether the config is fully valid. See the README's
+ * "Compat mode" section for the exact rules.
+ *
+ * These are two independent, self-contained compilers (not one compiler
+ * parameterized by a flag) - each reads top to bottom as a complete story
+ * for its mode. Some structure (type dispatch, recursion shape) is
+ * necessarily duplicated between them; that's an intentional trade for never
+ * having a `mode === '...'` branch buried inside shared logic.
+ */
+export type CompileMode = 'strict' | 'compat'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/core/page-layout:
     dependencies:


### PR DESCRIPTION
## Summary

Compiles a Kong plugin config schema (the Admin API's dump of a plugin's Lua schema) into [Zod](https://zod.dev) schemas, and wires that into the free-form code editor so YAML edits are checked as you type instead of only at save time.

- **`lua-schema-to-zod`** compiles two independent schemas per plugin, in their own files:
  - `compile-strict.ts` - the full DSL (`type`, `required`, `default`, `one_of`/`not_one_of`, `between`, `gt`, `len_min`/`len_max`, `match*`, `starts_with`, `uuid`, `referenceable`), shown as real editor markers.
  - `compile-compat.ts` - a deliberately relaxed schema (required/null and all content-level checks dropped; type shape and `one_of` kept, since those are what actually break rendering - e.g. a `<select>` bound to an out-of-enum value renders empty). Used only to decide whether the current code is currently safe to switch back to the visual form without breaking or blanking it out.
  - `entity_checks` and `custom_entity_check`/`custom_validator`/`shorthand_fields[].func` remain explicitly out of scope - Kong strips Lua functions before serializing a schema to JSON, so that logic can never be recovered from the JSON for any plugin. Documented in the [README](packages/entities/entities-plugins/src/utils/lua-schema-to-zod/README.md).
- **`monaco-editor`** gains the underlying capability: `createZodValidator`/`collectValidators` adapt Zod schemas into composable, vendor-agnostic validators, and `runYAMLValidation` maps their issues back to source positions (line/column) in a YAML document, classifying how precisely each maps (`exact`/`ancestor`/`document`).
- **`CodeEditor.vue`** shows real-time schema-validation markers (on load and on every edit) and only syncs compat-safe config into the shared form state - a value that would break rendering never reaches it, so the last known-good state is preserved until the code is fixed.
- **`StandardLayout.vue`** disables the "Visual" mode toggle and shows a warning icon with the first compat error (message + `:line:column`) on the "Code" toggle while the code isn't compat-safe, mirroring the `datakit` plugin's existing flow-editor-availability pattern.

This is no longer exploratory - it's wired into the real code editor used across plugin config forms, not a sandbox. It still isn't a replacement for server-side validation (see the README's Limitations section); a save action always goes to the Admin API, whose response remains the source of truth.

## Test plan

- [x] `pnpm --filter @kong-ui-public/monaco-editor test:unit` - 158 tests, including the new `features/validation`, `features/zod-validation`, and `languages/yaml/validation` suites
- [x] `pnpm --filter @kong-ui-public/entities-plugins vitest run src/utils/lua-schema-to-zod/` - 44 tests, split by file: `compile-strict.spec.ts`, `compile-compat.spec.ts`, `lua-pattern.spec.ts`, `index.spec.ts` (public API dispatch), `smoke.spec.ts`
- [x] Typechecked and linted clean across both packages
- [x] Manually validated (ad hoc, not part of this PR) against all 231 real plugin schema JSON dumps in `kong-konnect/gateway-schema-watcher`, in both `strict` and `compat` mode - all compile and safe-parse without throwing
- [ ] Manual click-through in a running app (form ↔ code switching, marker display, disabled-toggle + tooltip) - not yet done in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)