### PR TITLE
feat(sandbox-layout): add built-in theme picker to SandboxLayout

### DIFF
--- a/packages/core/sandbox-layout/package.json
+++ b/packages/core/sandbox-layout/package.json
@@ -59,7 +59,7 @@
     "extends": "../../../package.json"
   },
   "distSizeChecker": {
-    "errorLimit": "200KB"
+    "errorLimit": "300KB"
   },
   "peerDependencies": {
     "vue": ">= 3.3.13 < 4"

--- a/packages/core/sandbox-layout/src/components/SandboxLayout.vue
+++ b/packages/core/sandbox-layout/src/components/SandboxLayout.vue
@@ -18,6 +18,9 @@
                 :visible="mobileNavIsToggled.value"
                 @close="toggleMobileNav"
               >
+                <div class="nav-theme-picker">
+                  <SandboxThemePicker />
+                </div>
                 <SandboxNavigation @router-link-click="toggleMobileNav" />
               </KSlideout>
             </div>
@@ -64,6 +67,9 @@
     </header>
     <div class="layout">
       <div class="desktop-nav-container">
+        <div class="nav-theme-picker">
+          <SandboxThemePicker />
+        </div>
         <SandboxNavigation />
       </div>
       <div class="sandbox-container">
@@ -84,6 +90,7 @@
 
 <script setup lang="ts">
 import SandboxNavigation from '../components/SandboxNavigation.vue'
+import SandboxThemePicker from '../components/SandboxThemePicker.vue'
 import { provide, computed } from 'vue'
 import { CogIcon, MenuIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
@@ -169,18 +176,31 @@ const controlsWidth = computed((): string => `${props.controlsMinWidth}px`)
     }
   }
 
-  .sandbox-controls,
-  .desktop-nav-container {
+  .sandbox-controls {
     display: none;
 
-    // Always show nav and controls on desktop
+    // Always show controls on desktop
     @media (min-width: $kui-breakpoint-laptop) {
       display: block;
     }
   }
 
   .desktop-nav-container {
+    display: none;
     min-width: 240px;
+
+    // Always show nav on desktop
+    @media (min-width: $kui-breakpoint-laptop) {
+      display: block;
+    }
+  }
+
+  // Placed above the nav links (not pinned to the container bottom) so it stays
+  // visible without scrolling, however long the page's own nav list grows.
+  .nav-theme-picker {
+    border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
+    margin-bottom: var(--kui-space-70, $kui-space-70);
+    padding-bottom: var(--kui-space-70, $kui-space-70);
   }
 
   .sandbox-container {

--- a/packages/core/sandbox-layout/src/components/SandboxNavigation.vue
+++ b/packages/core/sandbox-layout/src/components/SandboxNavigation.vue
@@ -47,7 +47,7 @@ const navLinks: SandboxNavigationItem[] = inject(KONG_UI_SANDBOX_LAYOUT_LINKS_IN
     }
 
     a {
-      background: #eee;
+      background: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
       border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
       color: var(--kui-color-text-primary, $kui-color-text-primary);
       display: block;
@@ -60,7 +60,7 @@ const navLinks: SandboxNavigationItem[] = inject(KONG_UI_SANDBOX_LAYOUT_LINKS_IN
       white-space: nowrap;
 
       &:hover {
-        background: #ccc;
+        background: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker);
         color: var(--kui-color-text-primary-stronger, $kui-color-text-primary-stronger);
       }
 
@@ -82,7 +82,10 @@ const navLinks: SandboxNavigationItem[] = inject(KONG_UI_SANDBOX_LAYOUT_LINKS_IN
 <style lang="scss">
 // Unscoped to control page elements
 html, body {
+  background-color: var(--kui-color-background, $kui-color-background);
+  color: var(--kui-color-text-primary, $kui-color-text-primary);
   margin: 0;
+  min-height: 100%;
   padding: 0;
 }
 </style>

--- a/packages/core/sandbox-layout/src/components/SandboxThemePicker.vue
+++ b/packages/core/sandbox-layout/src/components/SandboxThemePicker.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="kong-ui-sandbox-theme-picker">
+    <div class="theme-picker-row">
+      <span class="theme-picker-label">Theme</span>
+      <div
+        aria-label="Theme"
+        class="theme-picker-group"
+        role="radiogroup"
+      >
+        <KTooltip
+          v-for="option in KONG_UI_SANDBOX_THEME_MODE_OPTIONS"
+          :key="option.value"
+          placement="top"
+          :text="option.label"
+        >
+          <label
+            class="theme-picker-option"
+            :class="{ active: option.value === mode }"
+          >
+            <input
+              :aria-label="option.label"
+              :checked="option.value === mode"
+              class="theme-picker-input"
+              name="sandbox-theme-mode"
+              type="radio"
+              :value="option.value"
+              @change="mode = option.value"
+            >
+            <component
+              :is="MODE_ICONS[option.value]"
+              decorative
+              :size="`var(--kui-icon-size-30, ${KUI_ICON_SIZE_30})`"
+            />
+          </label>
+        </KTooltip>
+      </div>
+    </div>
+
+    <div class="theme-picker-row">
+      <span class="theme-picker-label">High contrast</span>
+      <KInputSwitch
+        v-model="highContrast"
+        aria-label="High contrast"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Component } from 'vue'
+import { DarkModeIcon, LightModeIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { KONG_UI_SANDBOX_THEME_MODE_OPTIONS } from '../constants'
+import { useSandboxTheme } from '../composables/useSandboxTheme'
+import type { SandboxThemeMode } from '../types'
+
+const { mode, highContrast } = useSandboxTheme()
+
+const MODE_ICONS: Record<SandboxThemeMode, Component> = {
+  day: LightModeIcon,
+  night: DarkModeIcon,
+}
+</script>
+
+<style lang="scss" scoped>
+// Hardcode the size of the theme picker option for consistency (icons
+// differ in width/height so we can't rely on content size + padding)
+$theme-picker-option-size: 28px;
+
+.kong-ui-sandbox-theme-picker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kui-space-60, $kui-space-60);
+  width: 100%;
+
+  .theme-picker-row {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .theme-picker-label {
+    color: var(--kui-color-text, $kui-color-text);
+    font-size: var(--kui-font-size-20, $kui-font-size-20);
+    font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+  }
+
+  .theme-picker-group {
+    background-color: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker);
+    border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
+    border-radius: var(--kui-border-radius-round, $kui-border-radius-round);
+    display: flex;
+    flex-direction: row;
+  }
+
+  .theme-picker-option {
+    align-items: center;
+    border-radius: var(--kui-border-radius-round, $kui-border-radius-round);
+    color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+    cursor: pointer;
+    display: flex;
+    height: $theme-picker-option-size;
+    justify-content: center;
+    margin: var(--kui-space-0, $kui-space-0);
+    outline: none;
+    position: relative;
+    transition: background-color var(--kui-animation-duration-20, $kui-animation-duration-20) ease-in, color var(--kui-animation-duration-20, $kui-animation-duration-20) ease-in, border var(--kui-animation-duration-20, $kui-animation-duration-20) ease-in;
+    width: $theme-picker-option-size;
+
+    &:hover {
+      background-color: var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak);
+    }
+
+    /* Mirror the native radio's focus ring onto the visible label */
+    &:has(.theme-picker-input:focus-visible) {
+      box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
+      z-index: 1;
+    }
+
+    .theme-picker-input {
+      /* Visually hide the radio but keep it in the accessibility tree and
+         keyboard-focusable, so the radiogroup semantics and native arrow-key
+         navigation remain intact */
+      border: var(--kui-border-width-0, $kui-border-width-0);
+      clip-path: inset(50%);
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      padding: var(--kui-space-0, $kui-space-0);
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
+    }
+
+    &.active {
+      background-color: var(--kui-color-background, $kui-color-background);
+      border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
+      color: var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest);
+    }
+  }
+}
+</style>

--- a/packages/core/sandbox-layout/src/composables/useSandboxTheme.ts
+++ b/packages/core/sandbox-layout/src/composables/useSandboxTheme.ts
@@ -1,0 +1,39 @@
+import { computed, ref, watch } from 'vue'
+import '@kong/design-tokens/themes/electric-lime-day.css'
+import '@kong/design-tokens/themes/electric-lime-day-high-contrast.css'
+import '@kong/design-tokens/themes/electric-lime-night.css'
+import '@kong/design-tokens/themes/electric-lime-night-high-contrast.css'
+import { KONG_UI_SANDBOX_DEFAULT_THEME, KONG_UI_SANDBOX_THEME_STORAGE_KEY } from '../constants'
+import type { SandboxTheme, SandboxThemeMode } from '../types'
+
+function parseTheme(theme: SandboxTheme): { mode: SandboxThemeMode, highContrast: boolean } {
+  return {
+    mode: theme.includes('night') ? 'night' : 'day',
+    highContrast: theme.endsWith('high-contrast'),
+  }
+}
+
+function buildTheme(mode: SandboxThemeMode, highContrast: boolean): SandboxTheme {
+  return highContrast ? `electric-lime-${mode}-high-contrast` : `electric-lime-${mode}`
+}
+
+const initial = parseTheme(
+  (localStorage.getItem(KONG_UI_SANDBOX_THEME_STORAGE_KEY) as SandboxTheme | null) || KONG_UI_SANDBOX_DEFAULT_THEME,
+)
+
+// Module-level (not created inside `useSandboxTheme`) so every `SandboxThemePicker`
+// instance in the page — e.g. the desktop sidebar copy and the mobile slideout copy —
+// shares one reactive state instead of drifting out of sync with each other.
+const mode = ref<SandboxThemeMode>(initial.mode)
+const highContrast = ref<boolean>(initial.highContrast)
+
+const theme = computed<SandboxTheme>(() => buildTheme(mode.value, highContrast.value))
+
+watch(theme, (value) => {
+  document.documentElement.setAttribute('data-kui-theme', value)
+  localStorage.setItem(KONG_UI_SANDBOX_THEME_STORAGE_KEY, value)
+}, { immediate: true })
+
+export function useSandboxTheme() {
+  return { theme, mode, highContrast }
+}

--- a/packages/core/sandbox-layout/src/constants.ts
+++ b/packages/core/sandbox-layout/src/constants.ts
@@ -1,1 +1,14 @@
+import type { SandboxTheme, SandboxThemeMode } from './types'
+
 export const KONG_UI_SANDBOX_LAYOUT_LINKS_INJECTION_KEY = 'kong-ui-sandbox-layout-links'
+
+/** `localStorage` key used to persist the sandbox theme across reloads. */
+export const KONG_UI_SANDBOX_THEME_STORAGE_KEY = 'kong-ui-sandbox-theme'
+
+/** Every sandbox defaults to this theme unless the user picked a different one. */
+export const KONG_UI_SANDBOX_DEFAULT_THEME: SandboxTheme = 'electric-lime-day'
+
+export const KONG_UI_SANDBOX_THEME_MODE_OPTIONS: Array<{ label: string, value: SandboxThemeMode }> = [
+  { label: 'Day', value: 'day' },
+  { label: 'Night', value: 'night' },
+]

--- a/packages/core/sandbox-layout/src/index.ts
+++ b/packages/core/sandbox-layout/src/index.ts
@@ -1,5 +1,7 @@
 import SandboxLayout from './components/SandboxLayout.vue'
+import SandboxThemePicker from './components/SandboxThemePicker.vue'
 
-export { SandboxLayout }
+export { SandboxLayout, SandboxThemePicker }
 
 export * from './types'
+export * from './constants'

--- a/packages/core/sandbox-layout/src/types/index.ts
+++ b/packages/core/sandbox-layout/src/types/index.ts
@@ -3,3 +3,4 @@
 
 // Example:
 export * from './navigation'
+export * from './theme'

--- a/packages/core/sandbox-layout/src/types/theme.ts
+++ b/packages/core/sandbox-layout/src/types/theme.ts
@@ -1,0 +1,7 @@
+export type SandboxTheme =
+  | 'electric-lime-day'
+  | 'electric-lime-day-high-contrast'
+  | 'electric-lime-night'
+  | 'electric-lime-night-high-contrast'
+
+export type SandboxThemeMode = 'day' | 'night'


### PR DESCRIPTION
## Summary
- `SandboxLayout` now renders a day/night + high-contrast theme picker above the nav links (desktop sidebar and mobile menu)
- Defaults to `electric-lime-day` and persists the choice in `localStorage`

## Test plan
- [x] `pnpm typecheck` / `lint` / `stylelint` / `build` pass for `sandbox-layout`
- [x] Manually verified in a consuming sandbox (theme toggles correctly, persists across reload, mobile menu shows the same picker)

## Screenshots

<img width="1292" height="586" alt="image" src="https://github.com/user-attachments/assets/d1af612d-047d-4a10-b71e-7cb283779970" />

<img width="1248" height="508" alt="image" src="https://github.com/user-attachments/assets/9ed4d125-d601-44f3-9e4c-fd01b22e4d2c" />


[TEST_COVERAGE_EXEMPT_REASON] Sandbox-only dev tooling