### PR TITLE
chore(entities-plugins): add ignored plugins for plugin catalog

### DIFF
--- a/packages/entities/entities-plugins/sandbox/pages/PluginCatalogPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginCatalogPage.vue
@@ -83,6 +83,7 @@
       custom-plugins="disabled"
       :disabled-plugins="{ 'acl': 'ACL is not supported for this entity type' }"
       :highlighted-plugin-ids="highlightedPluginIds"
+      :ignored-plugins="['entitlement-enforcement']"
       @delete-custom:success="handleDeleteSuccess"
     />
   </SandboxPage>

--- a/packages/entities/entities-plugins/src/components/PluginCatalog.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.cy.ts
@@ -179,6 +179,31 @@ describe('<PluginCatalog />', {
 
   })
 
+  it('should correctly hide ignored plugins', () => {
+    const ignoredPlugins = ['basic-auth']
+
+    interceptKonnect()
+
+    cy.mount(PluginCatalog, {
+      props: {
+        config: baseConfigKonnect,
+        ignoredPlugins,
+      },
+      router,
+    })
+
+    cy.wait('@getAvailablePlugins')
+
+    cy.getTestId('plugin-catalog').should('be.visible')
+
+    ignoredPlugins.forEach((pluginName) => {
+      // search for the plugin so it would surface out of its (collapsed) group if it were listed
+      cy.getTestId('plugins-filter-input').clear()
+      cy.getTestId('plugins-filter-input').type(pluginName)
+      cy.getTestId(`${pluginName}-card`).should('not.exist')
+    })
+  })
+
   it('should handle error state - available plugins failed to load', () => {
     cy.intercept(
       {

--- a/packages/entities/entities-plugins/src/components/PluginCatalog.vue
+++ b/packages/entities/entities-plugins/src/components/PluginCatalog.vue
@@ -211,6 +211,8 @@ const { sortAlpha, objectsAreEqual } = useHelpers()
 // Latest version of Plugin Select
 const props = withDefaults(defineProps<{
   config: KonnectPluginSelectConfig | KongManagerPluginSelectConfig
+  /** Plugins that should not be displayed */
+  ignoredPlugins?: string[]
   disabledPlugins?: DisabledPlugin
   highlightedPluginIds?: string[]
   customPluginSupport?: CustomPluginSupportLevel
@@ -222,6 +224,7 @@ const props = withDefaults(defineProps<{
   canReadClonedPlugin?: () => boolean | Promise<boolean>
   canEditClonedPlugin?: () => boolean | Promise<boolean>
 }>(), {
+  ignoredPlugins: () => [],
   availableOnServer: true,
   customPluginSupport: 'none',
   canDeleteCustomPlugin: async () => true,
@@ -418,7 +421,8 @@ const buildPluginList = (): PluginCardList => {
       ...allCustomPluginNames,
     ],
   )]
-    // Used to filter out ignored plugins, seems we don't need it anymore
+    // Filter out ignored plugins
+    .filter((plugin: string) => !props.ignoredPlugins.includes(plugin))
     // Filter plugins by entity type if adding scoped plugin
     .filter((plugin: string) => {
       // For Global Plugins
@@ -534,6 +538,12 @@ const buildPluginList = (): PluginCardList => {
 // rebuild the list
 watch(() => props.disabledPlugins, (val, oldVal) => {
   if (!objectsAreEqual(val || {}, oldVal || {}) && !isLoading.value) {
+    pluginsList.value = buildPluginList()
+  }
+})
+
+watch(() => props.ignoredPlugins, (val, oldVal) => {
+  if (!objectsAreEqual(val, oldVal) && !isLoading.value) {
     pluginsList.value = buildPluginList()
   }
 })


### PR DESCRIPTION
# Summary

- **`PluginCatalog.vue`**
  - New optional prop `ignoredPlugins?: string[]`, defaulting to `[]`.
  - `buildPluginList()` filters the ignored ids out before the entity-scope filter,
    matching `PluginSelect`'s ordering.
  - Added a watcher that rebuilds the plugin list when the prop changes after the
    initial load, mirroring the existing `disabledPlugins` watcher.
- **`PluginCatalog.cy.ts`** — new `should correctly hide ignored plugins` test. It types
  the ignored plugin's name into the search box first so the assertion can't pass merely
  because the card is hidden behind a collapsed group's "show all".
- **`PluginCatalogPage.vue`** (sandbox) — passes `:ignored-plugins="['entitlement-enforcement']"`
  so the behavior is exercisable in the sandbox.
