### PR TITLE
fix(entities-plugins): decouple OIDC linked consumer groups from linked consumers

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/OpenidConnectForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/OpenidConnectForm.cy.ts
@@ -1056,12 +1056,22 @@ describe('OpenidConnectForm', () => {
       cy.getTestId('principals-custom-identity-name').should('exist')
     })
 
-    it('unchecking "Use linked consumers" also unchecks consumer groups', () => {
+    it('toggles linked consumers and consumer groups independently', () => {
       mountPrincipalsForm()
 
       expandSettings()
       cy.getTestId('use-principal-lookup').click({ force: true })
       cy.getTestId('principals-match-consumer').uncheck({ force: true })
+
+      // Consumer groups stays enabled and keeps its own value
+      cy.getTestId('principals-match-consumer-groups').should('not.be.disabled').should('be.checked')
+
+      lastFormChange().then((payload) => {
+        expect(payload.config.principals.match_consumer).to.equal(false)
+        expect(payload.config.principals.match_consumer_groups).to.equal(true)
+      })
+
+      cy.getTestId('principals-match-consumer-groups').uncheck({ force: true })
 
       lastFormChange().then((payload) => {
         expect(payload.config.principals.match_consumer).to.equal(false)

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalLookupSettings.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalLookupSettings.vue
@@ -108,7 +108,7 @@
           data-testid="principals-match-consumer"
           :disabled="fieldsDisabled"
           :model-value="matchConsumer ?? false"
-          @update:model-value="handleMatchConsumerChange"
+          @update:model-value="matchConsumer = $event"
         >
           {{ t('plugins.free-form.openid-connect.lookup.match_consumer.label') }}
           <template #description>
@@ -126,7 +126,7 @@
       <div class="principals-field-group">
         <KCheckbox
           data-testid="principals-match-consumer-groups"
-          :disabled="fieldsDisabled || !matchConsumer"
+          :disabled="fieldsDisabled"
           :model-value="matchConsumerGroups ?? false"
           @update:model-value="matchConsumerGroups = $event"
         >
@@ -310,13 +310,6 @@ watch(principalClaim, (claim) => {
     tokenClaimInput.value = encodeTokenClaim(claim)
   }
 })
-
-function handleMatchConsumerChange(checked: boolean) {
-  matchConsumer.value = checked
-  if (!checked) {
-    matchConsumerGroups.value = false
-  }
-}
 
 function handleLookupMethodChange(value: string | null) {
   selectedLookupMethod.value = value ?? 'kong-identity'


### PR DESCRIPTION
# Summary

KM-3152
The "Use linked consumer groups" checkbox was disabled while "Use linked consumers" was off, and unchecking consumers forced consumer groups off. The two principal lookup settings are independent, so gate both only on whether principal lookup itself is enabled.
