### PR TITLE
feat(entities-plugins): gate plugin config scope name behind a prop

### DIFF
--- a/packages/entities/entities-plugins/docs/plugin-config-card.md
+++ b/packages/entities/entities-plugins/docs/plugin-config-card.md
@@ -7,6 +7,7 @@ A config card component for plugins. Configuration section properties will be or
   - [Install](#install)
   - [Props](#props)
   - [Events](#events)
+  - [Adopting `showScopeName`](#adopting-showscopename)
   - [Usage example](#usage-example)
 - [TypeScript interfaces](#typescript-interfaces)
 
@@ -73,7 +74,35 @@ A config card component for plugins. Configuration section properties will be or
     - default: `''`
     - The type of Plugin to display the config for.
 
+  - `showScopeName`:
+    - type: `boolean`
+    - required: `false`
+    - default: `false`
+    - **KM-2996 rollout gate.** When `true`, each scoped entity row resolves and shows the entity's
+      name as a link to its detail page with the id as a subtitle, and the row labels drop their
+      "ID" suffix. When `false`, the row shows the bare id as a button that emits
+      `navigation-click`. Only takes effect alongside the `showNameAsLink` prop.
+      See [Adopting `showScopeName`](#adopting-showscopename).
+
+  - `getServiceViewRoute` / `getRouteViewRoute` / `getConsumerViewRoute` / `getConsumerGroupViewRoute`:
+    - type: `(id: string) => RouteLocationRaw`
+    - required: `false`
+    - default: `undefined`
+    - The route for the scoped entity's detail page. Used as the link target when `showScopeName`
+      is enabled. When omitted, the row falls back to emitting `navigation-click` instead of
+      linking, even with `showScopeName` on.
+
 The base konnect or kongManger config.
+
+#### `showNameAsLink`
+
+- type: `Boolean`
+- required: `false`
+- default: `false`
+
+Set this value to `true` to render scoped entity rows (service, route, consumer, consumer group,
+partials) as interactive links instead of a copyable UUID. Nothing about `showScopeName` takes
+effect unless this is also `true`.
 
 #### `configCardDoc`
 
@@ -124,6 +153,74 @@ A `@fetch:success` event is emitted when the Plugin is successfully fetched. The
 #### loading
 
 A `@loading` event is emitted when loading state changes. The event payload is a boolean.
+
+#### navigation-click
+
+A `@navigation-click` event is emitted when a scoped entity row is clicked and no route was
+supplied for it via the config (`getServiceViewRoute` and friends). The payload is
+`(id: string, direction: 'route' | 'consumer' | 'consumer_group' | 'service' | 'partial')`.
+Hosts that supply the route getters get a real `<router-link>` instead and this event does not
+fire for that row.
+
+### Adopting `showScopeName`
+
+`showScopeName` is a temporary rollout gate for KM-2996 and should be wired to your feature flag
+service. It lives on the `config` prop rather than an injection, so a value that resolves after
+mount still takes effect.
+
+Both apps need three things: the flag, the `showNameAsLink` prop, and the four route getters.
+
+```vue
+<template>
+  <PluginConfigCard
+    :config="config"
+    show-name-as-link
+  />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { PluginConfigCard } from '@kong-ui-public/entities-plugins'
+import type { KonnectPluginEntityConfig } from '@kong-ui-public/entities-plugins'
+
+// Konnect: your LaunchDarkly wrapper. Kong Manager: whatever gates features there.
+const showScopeName = useFeatureFlag('KM-2996-plugin-config-scope-name')
+
+// Keep the config a computed so the card re-renders when the flag resolves.
+const config = computed<KonnectPluginEntityConfig>(() => ({
+  app: 'konnect',
+  apiBaseUrl,
+  controlPlaneId,
+  entityId: pluginId,
+  pluginType,
+  showScopeName: showScopeName.value,
+  getServiceViewRoute: (id) => ({ name: 'service-detail', params: { id } }),
+  getRouteViewRoute: (id) => ({ name: 'route-detail', params: { id } }),
+  getConsumerViewRoute: (id) => ({ name: 'consumer-detail', params: { id } }),
+  getConsumerGroupViewRoute: (id) => ({ name: 'consumer-group-detail', params: { id } }),
+}))
+</script>
+```
+
+Notes:
+
+- **Build the config as a `computed`, not a plain object.** A static object captures the flag's
+  initial (usually `false`) value and never updates.
+- **Prefer a flag value that is already resolved when the card mounts.** The name lookups fire once,
+  on the plugin fetch. If the flag flips to `true` after that, the rows relabel and render links but
+  show ids until the card refetches.
+- **`showNameAsLink` is independent and not flagged.** It predates KM-2996 (it was `showIdAsLink`)
+  and still controls whether these rows are links at all. With `showScopeName` off, hosts already
+  passing it keep the exact previous behavior.
+- **Extra API calls when enabled.** With the flag on, the card issues one `GET` per populated scope
+  (up to four: `services/{id}`, `routes/{id}`, `consumers/{id}`, `consumer_groups/{id}`). Failures
+  surface via `@fetch:error` and the row falls back to showing the id, so a missing read permission
+  degrades rather than breaks.
+- **Omitting a route getter is a supported half-state.** That row keeps emitting `navigation-click`,
+  so you can roll the flag out before every detail route exists.
+- **Removing the flag later:** delete `showScopeName` from `BasePluginConfigCardConfig`, drop the
+  `scopeNameEnabled` computed in `PluginConfigCard.vue`, and delete the four `*_id` label keys from
+  `src/locales/en.json`.
 
 ### Usage example
 

--- a/packages/entities/entities-plugins/sandbox/pages/PluginConfigCardPage.vue
+++ b/packages/entities/entities-plugins/sandbox/pages/PluginConfigCardPage.vue
@@ -1,9 +1,22 @@
 <template>
   <SandboxPage title="Plugin Config Card">
+    <template #controls>
+      <KInputSwitch
+        v-model="showNameAsLink"
+        label="Show scoped entities as links"
+      />
+
+      <KInputSwitch
+        v-model="showScopeName"
+        label="KM-2996: resolve scope names"
+      />
+    </template>
+
     <h2>Konnect API</h2>
     <PluginConfigCard
       :config="konnectConfig"
       enable-terraform
+      :show-name-as-link="showNameAsLink"
       @fetch:error="onError"
       @fetch:success="onSuccess"
     />
@@ -11,6 +24,7 @@
     <h2>Kong Manager API</h2>
     <PluginConfigCard
       :config="kongManagerConfig"
+      :show-name-as-link="showNameAsLink"
       @fetch:error="onError"
       @fetch:success="onSuccess"
     />
@@ -18,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import type { AxiosError } from 'axios'
 import SandboxPage from '../SandboxPage.vue'
 import type { KonnectPluginEntityConfig, KongManagerPluginEntityConfig } from '../../src'
@@ -45,24 +59,30 @@ const viewRoutes = {
   getConsumerGroupViewRoute: (id: string) => ({ name: 'view-consumer_group', params: { id } }),
 }
 
+const showNameAsLink = ref(true)
+// KM-2996 rollout gate, lives on the config so flipping it re-renders the cards in place.
+const showScopeName = ref(false)
+
 const controlPlaneId = import.meta.env.VITE_KONNECT_CONTROL_PLANE_ID || ''
-const konnectConfig = ref<KonnectPluginEntityConfig>({
+const konnectConfig = computed<KonnectPluginEntityConfig>(() => ({
   app: 'konnect',
   apiBaseUrl: '/us/kong-api', // `/{geo}/kong-api`, with leading slash and no trailing slash; Consuming app would pass in something like `https://us.api.konghq.com`
   // Set the root `.env.development.local` variable to a control plane your PAT can access
   controlPlaneId,
   entityId: props.id,
   pluginType: props.plugin,
+  showScopeName: showScopeName.value,
   ...viewRoutes,
-})
-const kongManagerConfig = ref<KongManagerPluginEntityConfig>({
+}))
+const kongManagerConfig = computed<KongManagerPluginEntityConfig>(() => ({
   app: 'kongManager',
   workspace: 'default',
   apiBaseUrl: '/kong-manager', // For local dev server proxy
   entityId: props.id,
   pluginType: props.plugin,
+  showScopeName: showScopeName.value,
   ...viewRoutes,
-})
+}))
 
 const onError = (error: AxiosError) => {
   console.log(`Error: ${error}`)

--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.cy.ts
@@ -1,0 +1,346 @@
+import schemaCors from '../../fixtures/schemas/cors'
+import PluginConfigCard from './PluginConfigCard.vue'
+import type { KongManagerPluginEntityConfig, KonnectPluginEntityConfig } from '../types'
+
+const pluginId = '0132e113-3d1a-413b-8d15-e62cbe2cf106'
+const pluginType = 'cors'
+
+// One id per scope so each row's link/subtitle can be asserted independently.
+const scopedIds = {
+  service: 'a2b3c4d5-0000-0000-0000-000000000001',
+  route: 'a2b3c4d5-0000-0000-0000-000000000002',
+  consumer: 'a2b3c4d5-0000-0000-0000-000000000003',
+  consumer_group: 'a2b3c4d5-0000-0000-0000-000000000004',
+}
+
+const scopedNames = {
+  service: 'my-service',
+  route: 'my-route',
+  consumer: 'my-consumer',
+  consumer_group: 'my-consumer-group',
+}
+
+const pluginRecord = {
+  config: { origins: null },
+  created_at: 1680888086,
+  enabled: true,
+  id: pluginId,
+  instance_name: 'my_instance',
+  name: pluginType,
+  protocols: ['http', 'https'],
+  updated_at: 1701713573,
+  consumer: { id: scopedIds.consumer },
+  consumer_group: { id: scopedIds.consumer_group },
+  route: { id: scopedIds.route },
+  service: { id: scopedIds.service },
+}
+
+const viewRoutes = {
+  getServiceViewRoute: (id: string) => ({ name: 'view-service', params: { id } }),
+  getRouteViewRoute: (id: string) => ({ name: 'view-route', params: { id } }),
+  getConsumerViewRoute: (id: string) => ({ name: 'view-consumer', params: { id } }),
+  getConsumerGroupViewRoute: (id: string) => ({ name: 'view-consumer_group', params: { id } }),
+}
+
+const baseConfigKonnect: KonnectPluginEntityConfig = {
+  app: 'konnect',
+  apiBaseUrl: '/us/kong-api',
+  controlPlaneId: 'f0acb165-ff05-4788-aa06-6909b8d1694e',
+  entityId: pluginId,
+  pluginType,
+  ...viewRoutes,
+}
+
+const baseConfigKM: KongManagerPluginEntityConfig = {
+  app: 'kongManager',
+  workspace: 'default',
+  apiBaseUrl: '/kong-manager',
+  entityId: pluginId,
+  pluginType,
+  ...viewRoutes,
+}
+
+describe('<PluginConfigCard />', () => {
+  describe('Konnect', () => {
+    const konnectBase = `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities`
+
+    const interceptSchema = (): void => {
+      cy.intercept(
+        { method: 'GET', url: `${konnectBase}/schemas/plugins/${pluginType}` },
+        { statusCode: 200, body: schemaCors },
+      ).as('getPluginSchema')
+    }
+
+    const interceptPlugin = (): void => {
+      cy.intercept(
+        { method: 'GET', url: `${konnectBase}/plugins/${pluginId}*` },
+        { statusCode: 200, body: pluginRecord },
+      ).as('getPlugin')
+    }
+
+    /** Each scoped entity's own lookup, so a missing name can be simulated per scope. */
+    const interceptScopedEntities = (overrides: Record<string, any> = {}): void => {
+      cy.intercept(
+        { method: 'GET', url: `${konnectBase}/services/${scopedIds.service}` },
+        { statusCode: 200, body: { id: scopedIds.service, name: scopedNames.service, ...overrides.service } },
+      ).as('getService')
+      cy.intercept(
+        { method: 'GET', url: `${konnectBase}/routes/${scopedIds.route}` },
+        { statusCode: 200, body: { id: scopedIds.route, name: scopedNames.route, ...overrides.route } },
+      ).as('getRoute')
+      cy.intercept(
+        { method: 'GET', url: `${konnectBase}/consumers/${scopedIds.consumer}` },
+        { statusCode: 200, body: { id: scopedIds.consumer, username: scopedNames.consumer, ...overrides.consumer } },
+      ).as('getConsumer')
+      cy.intercept(
+        { method: 'GET', url: `${konnectBase}/consumer_groups/${scopedIds.consumer_group}` },
+        { statusCode: 200, body: { id: scopedIds.consumer_group, name: scopedNames.consumer_group, ...overrides.consumer_group } },
+      ).as('getConsumerGroup')
+    }
+
+    const mountCard = (showScopeName: boolean, props: Record<string, any> = {}) => {
+      return cy.mount(PluginConfigCard, {
+        props: {
+          config: { ...baseConfigKonnect, showScopeName },
+          showNameAsLink: true,
+          ...props,
+        },
+      })
+    }
+
+    describe('with config.showScopeName enabled', () => {
+      it('labels the scope rows without the "ID" suffix', () => {
+        interceptSchema()
+        interceptPlugin()
+        interceptScopedEntities()
+
+        mountCard(true)
+        cy.wait(['@getPluginSchema', '@getPlugin'])
+
+        cy.getTestId('service-label').should('contain.text', 'Service')
+        cy.getTestId('service-label').should('not.contain.text', 'Service ID')
+        cy.getTestId('route-label').should('contain.text', 'Route')
+        cy.getTestId('route-label').should('not.contain.text', 'Route ID')
+        cy.getTestId('consumer-label').should('contain.text', 'Consumer')
+        cy.getTestId('consumer-label').should('not.contain.text', 'Consumer ID')
+        cy.getTestId('consumer_group-label').should('contain.text', 'Consumer group')
+        cy.getTestId('consumer_group-label').should('not.contain.text', 'Consumer group ID')
+      })
+
+      it('renders the resolved name as a link with the id as its subtitle', () => {
+        interceptSchema()
+        interceptPlugin()
+        interceptScopedEntities()
+
+        mountCard(true)
+        cy.wait(['@getPluginSchema', '@getPlugin'])
+        cy.wait(['@getService', '@getRoute', '@getConsumer', '@getConsumerGroup'])
+
+        // The consumer's display name comes from `username`, not `name`.
+        for (const scope of ['service', 'route', 'consumer', 'consumer_group'] as const) {
+          cy.getTestId(`${scope}-property-value`).within(() => {
+            cy.get('.navigation-link').should('contain.text', scopedNames[scope])
+            cy.get('.navigation-subtitle').should('have.text', scopedIds[scope])
+            // The pre-flag emit-only button is replaced by a real link.
+            cy.get('.navigation-button').should('not.exist')
+          })
+        }
+      })
+
+      it('falls back to the bare id when the lookup returns no name', () => {
+        interceptSchema()
+        interceptPlugin()
+        interceptScopedEntities({ service: { name: null } })
+
+        mountCard(true)
+        cy.wait(['@getPluginSchema', '@getPlugin', '@getService'])
+
+        cy.getTestId('service-property-value').within(() => {
+          cy.get('.navigation-link').should('contain.text', scopedIds.service)
+          // No name resolved means no id to repeat underneath.
+          cy.get('.navigation-subtitle').should('not.exist')
+        })
+      })
+
+      it('skips the name lookups when showNameAsLink is off', () => {
+        interceptSchema()
+        interceptPlugin()
+        interceptScopedEntities()
+
+        mountCard(true, { showNameAsLink: false })
+        cy.wait(['@getPluginSchema', '@getPlugin'])
+
+        cy.getTestId('service-copy-uuid').should('be.visible')
+        cy.get('@getService.all').should('have.length', 0)
+      })
+    })
+
+    describe('with config.showScopeName disabled', () => {
+      it('labels the scope rows with the "ID" suffix', () => {
+        interceptSchema()
+        interceptPlugin()
+        interceptScopedEntities()
+
+        mountCard(false)
+        cy.wait(['@getPluginSchema', '@getPlugin'])
+
+        cy.getTestId('service-label').should('contain.text', 'Service ID')
+        cy.getTestId('route-label').should('contain.text', 'Route ID')
+        cy.getTestId('consumer-label').should('contain.text', 'Consumer ID')
+        cy.getTestId('consumer_group-label').should('contain.text', 'Consumer group ID')
+      })
+
+      it('renders the bare id as an emit-only button, with no subtitle', () => {
+        interceptSchema()
+        interceptPlugin()
+        interceptScopedEntities()
+
+        mountCard(false)
+        cy.wait(['@getPluginSchema', '@getPlugin'])
+
+        for (const scope of ['service', 'route', 'consumer', 'consumer_group'] as const) {
+          cy.getTestId(`${scope}-property-value`).within(() => {
+            cy.get('.navigation-button').should('contain.text', scopedIds[scope])
+            cy.get('.navigation-link').should('not.exist')
+            cy.get('.navigation-subtitle').should('not.exist')
+          })
+        }
+      })
+
+      it('emits navigation-click instead of navigating', () => {
+        interceptSchema()
+        interceptPlugin()
+        interceptScopedEntities()
+
+        mountCard(false, { 'onNavigation-click': cy.spy().as('onNavigationClick') })
+        cy.wait(['@getPluginSchema', '@getPlugin'])
+
+        cy.getTestId('service-property-value').find('.navigation-button').click()
+
+        cy.get('@onNavigationClick').should('have.been.calledWith', scopedIds.service, 'service')
+      })
+
+      it('never looks up the scoped entity names', () => {
+        interceptSchema()
+        interceptPlugin()
+        interceptScopedEntities()
+
+        mountCard(false)
+        cy.wait(['@getPluginSchema', '@getPlugin'])
+
+        // Give any stray request a chance to fire before asserting none did.
+        cy.getTestId('service-property-value').find('.navigation-button').should('be.visible')
+
+        cy.get('@getService.all').should('have.length', 0)
+        cy.get('@getRoute.all').should('have.length', 0)
+        cy.get('@getConsumer.all').should('have.length', 0)
+        cy.get('@getConsumerGroup.all').should('have.length', 0)
+      })
+    })
+
+    // Hosts resolve their flag service asynchronously, so the value can land after mount.
+    // Living on the config prop (rather than an injection read once in setup) is what makes
+    // this work at all — see the caveat asserted at the end.
+    it('re-renders when the host flips showScopeName after mount', () => {
+      interceptSchema()
+      interceptPlugin()
+      interceptScopedEntities()
+
+      mountCard(false).then(({ wrapper }) => wrapper).as('vueWrapper')
+      cy.wait(['@getPluginSchema', '@getPlugin'])
+
+      cy.getTestId('service-label').should('contain.text', 'Service ID')
+
+      cy.get('@vueWrapper').then((wrapper: any) => wrapper.setProps({
+        config: { ...baseConfigKonnect, showScopeName: true },
+      }))
+
+      cy.getTestId('service-label').should('contain.text', 'Service')
+      cy.getTestId('service-label').should('not.contain.text', 'Service ID')
+      cy.getTestId('service-property-value').find('.navigation-link').should('exist')
+
+      // Documented caveat: the name lookups fire on fetch:success, which already happened, so
+      // the link shows the id until the card refetches. Pass a resolved flag to avoid this.
+      cy.getTestId('service-property-value').find('.navigation-link').should('contain.text', scopedIds.service)
+      cy.get('@getService.all').should('have.length', 0)
+    })
+  })
+
+  describe('Kong Manager', () => {
+    const kmBase = `${baseConfigKM.apiBaseUrl}/${baseConfigKM.workspace}`
+
+    const interceptAll = (): void => {
+      cy.intercept(
+        { method: 'GET', url: `${kmBase}/schemas/plugins/${pluginType}` },
+        { statusCode: 200, body: schemaCors },
+      ).as('getPluginSchema')
+      cy.intercept(
+        { method: 'GET', url: `${kmBase}/plugins/${pluginId}*` },
+        { statusCode: 200, body: pluginRecord },
+      ).as('getPlugin')
+      cy.intercept(
+        { method: 'GET', url: `${kmBase}/services/${scopedIds.service}` },
+        { statusCode: 200, body: { id: scopedIds.service, name: scopedNames.service } },
+      ).as('getService')
+    }
+
+    it('resolves the scope name when the flag is enabled', () => {
+      interceptAll()
+
+      cy.mount(PluginConfigCard, {
+        props: { config: { ...baseConfigKM, showScopeName: true }, showNameAsLink: true },
+      })
+
+      cy.wait(['@getPluginSchema', '@getPlugin', '@getService'])
+
+      cy.getTestId('service-property-value').within(() => {
+        cy.get('.navigation-link').should('contain.text', scopedNames.service)
+        cy.get('.navigation-subtitle').should('have.text', scopedIds.service)
+      })
+    })
+
+    it('falls back to the id when the flag is disabled', () => {
+      interceptAll()
+
+      cy.mount(PluginConfigCard, {
+        props: { config: { ...baseConfigKM, showScopeName: false }, showNameAsLink: true },
+      })
+
+      cy.wait(['@getPluginSchema', '@getPlugin'])
+
+      cy.getTestId('service-label').should('contain.text', 'Service ID')
+      cy.getTestId('service-property-value').within(() => {
+        cy.get('.navigation-button').should('contain.text', scopedIds.service)
+        cy.get('.navigation-subtitle').should('not.exist')
+      })
+      cy.get('@getService.all').should('have.length', 0)
+    })
+  })
+
+  it('defaults to the pre-flag view when showScopeName is omitted', () => {
+    const konnectBase = `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities`
+
+    cy.intercept(
+      { method: 'GET', url: `${konnectBase}/schemas/plugins/${pluginType}` },
+      { statusCode: 200, body: schemaCors },
+    ).as('getPluginSchema')
+    cy.intercept(
+      { method: 'GET', url: `${konnectBase}/plugins/${pluginId}*` },
+      { statusCode: 200, body: pluginRecord },
+    ).as('getPlugin')
+    cy.intercept(
+      { method: 'GET', url: `${konnectBase}/services/${scopedIds.service}` },
+      { statusCode: 200, body: { id: scopedIds.service, name: scopedNames.service } },
+    ).as('getService')
+
+    cy.mount(PluginConfigCard, {
+      props: { config: baseConfigKonnect, showNameAsLink: true },
+    })
+
+    cy.wait(['@getPluginSchema', '@getPlugin'])
+
+    cy.getTestId('service-label').should('contain.text', 'Service ID')
+    cy.getTestId('service-property-value').find('.navigation-button').should('contain.text', scopedIds.service)
+    cy.get('@getService.all').should('have.length', 0)
+  })
+})

--- a/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
+++ b/packages/entities/entities-plugins/src/components/PluginConfigCard.vue
@@ -53,14 +53,7 @@
         <span v-if="!getPropValue('rowValue', slotProps)">–</span>
         <InternalLinkItem
           v-else-if="showNameAsLink"
-          :item="{
-            key: getPropValue('rowValue', slotProps).id,
-            value: linkValue('consumer', getPropValue('rowValue', slotProps).id),
-            to: config.getConsumerViewRoute?.(getPropValue('rowValue', slotProps).id),
-            subtitle: linkSubtitle('consumer', getPropValue('rowValue', slotProps).id),
-            subtitleLoading: isReferenceNameLoading('consumer'),
-            type: ConfigurationSchemaType.LinkInternal,
-          }"
+          :item="referenceLinkItem('consumer', getPropValue('rowValue', slotProps).id, config.getConsumerViewRoute)"
           @navigation-click="() => $emit('navigation-click', getPropValue('rowValue', slotProps).id, 'consumer')"
         />
         <KCopy
@@ -75,14 +68,7 @@
         <span v-if="!getPropValue('rowValue', slotProps)">–</span>
         <InternalLinkItem
           v-else-if="showNameAsLink"
-          :item="{
-            key: getPropValue('rowValue', slotProps).id,
-            value: linkValue('route', getPropValue('rowValue', slotProps).id),
-            to: config.getRouteViewRoute?.(getPropValue('rowValue', slotProps).id),
-            subtitle: linkSubtitle('route', getPropValue('rowValue', slotProps).id),
-            subtitleLoading: isReferenceNameLoading('route'),
-            type: ConfigurationSchemaType.LinkInternal,
-          }"
+          :item="referenceLinkItem('route', getPropValue('rowValue', slotProps).id, config.getRouteViewRoute)"
           @navigation-click="() => $emit('navigation-click', getPropValue('rowValue', slotProps).id, 'route')"
         />
         <KCopy
@@ -96,14 +82,7 @@
         <span v-if="!getPropValue('rowValue', slotProps)">–</span>
         <InternalLinkItem
           v-else-if="showNameAsLink"
-          :item="{
-            key: getPropValue('rowValue', slotProps).id,
-            value: linkValue('service', getPropValue('rowValue', slotProps).id),
-            to: config.getServiceViewRoute?.(getPropValue('rowValue', slotProps).id),
-            subtitle: linkSubtitle('service', getPropValue('rowValue', slotProps).id),
-            subtitleLoading: isReferenceNameLoading('service'),
-            type: ConfigurationSchemaType.LinkInternal,
-          }"
+          :item="referenceLinkItem('service', getPropValue('rowValue', slotProps).id, config.getServiceViewRoute)"
           @navigation-click="() => $emit('navigation-click', getPropValue('rowValue', slotProps).id, 'service')"
         />
         <KCopy
@@ -117,14 +96,7 @@
         <span v-if="!getPropValue('rowValue', slotProps)">–</span>
         <InternalLinkItem
           v-else-if="showNameAsLink"
-          :item="{
-            key: getPropValue('rowValue', slotProps).id,
-            value: linkValue('consumer_group', getPropValue('rowValue', slotProps).id),
-            to: config.getConsumerGroupViewRoute?.(getPropValue('rowValue', slotProps).id),
-            subtitle: linkSubtitle('consumer_group', getPropValue('rowValue', slotProps).id),
-            subtitleLoading: isReferenceNameLoading('consumer_group'),
-            type: ConfigurationSchemaType.LinkInternal,
-          }"
+          :item="referenceLinkItem('consumer_group', getPropValue('rowValue', slotProps).id, config.getConsumerGroupViewRoute)"
           @navigation-click="() => $emit('navigation-click', getPropValue('rowValue', slotProps).id, 'consumer_group')"
         />
         <KCopy
@@ -193,9 +165,11 @@ import type { ReferenceField } from '../composables/useReferenceEntityNames'
 import type {
   ConfigurationSchema,
   PluginConfigurationSchema,
+  RecordItem,
 } from '@kong-ui-public/entities-shared'
 import type { AxiosError } from 'axios'
 import type { PropType } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
 
 import type { KongManagerPluginEntityConfig, KonnectPluginEntityConfig } from '../types'
 
@@ -281,6 +255,12 @@ const fetchUrl = computed<string>(() => {
   return url
 })
 
+/**
+ * KM-2996 rollout gate — see `showScopeName` on the config. Read through a computed so a host
+ * that flips it once its flag service resolves re-renders the rows.
+ */
+const scopeNameEnabled = computed<boolean>(() => !!props.config.showScopeName)
+
 // schema for the basic properties
 const configSchema = computed((): ConfigurationSchema => {
   const customSchema: ConfigurationSchema = {}
@@ -300,22 +280,22 @@ const configSchema = computed((): ConfigurationSchema => {
       order: 1.5,
     },
     consumer: {
-      label: t('plugins.fields.consumer'),
+      label: scopeNameEnabled.value ? t('plugins.fields.consumer') : t('plugins.fields.consumer_id'),
       section: ConfigurationSchemaSection.Basic,
       order: 6,
     },
     route: {
-      label: t('plugins.fields.route'),
+      label: scopeNameEnabled.value ? t('plugins.fields.route') : t('plugins.fields.route_id'),
       section: ConfigurationSchemaSection.Basic,
       order: 6,
     },
     service: {
-      label: t('plugins.fields.service'),
+      label: scopeNameEnabled.value ? t('plugins.fields.service') : t('plugins.fields.service_id'),
       section: ConfigurationSchemaSection.Basic,
       order: 6,
     },
     consumer_group: {
-      label: t('plugins.fields.consumer_group'),
+      label: scopeNameEnabled.value ? t('plugins.fields.consumer_group') : t('plugins.fields.consumer_group_id'),
       section: ConfigurationSchemaSection.Basic,
       order: 6,
     },
@@ -408,16 +388,27 @@ const { resolveReferenceNames, getReferenceName, isReferenceNameLoading } = comp
   onError: (err: AxiosError) => emit('fetch:error', err),
 })
 
-// The name surfaces as the link once resolved, with the id underneath for reference;
-// falls back to linking the bare id when no name is available.
-const linkValue = (field: ReferenceField, id: string): string => getReferenceName(field) || id
-const linkSubtitle = (field: ReferenceField, id: string): string | undefined => getReferenceName(field) ? id : undefined
+/**
+ * With `showScopeName` on, the resolved name surfaces as a router-link with the id underneath for
+ * reference, falling back to the bare id until (or unless) a name is available.
+ * With it off, we keep the pre-KM-2996 behavior: the bare id as an emit-only button, no name lookup.
+ */
+const referenceLinkItem = (field: ReferenceField, id: string, getViewRoute?: (id: string) => RouteLocationRaw): RecordItem => ({
+  key: id,
+  value: scopeNameEnabled.value ? getReferenceName(field) || id : id,
+  to: scopeNameEnabled.value ? getViewRoute?.(id) : undefined,
+  subtitle: scopeNameEnabled.value && getReferenceName(field) ? id : undefined,
+  subtitleLoading: scopeNameEnabled.value && isReferenceNameLoading(field),
+  type: ConfigurationSchemaType.LinkInternal,
+})
 
 const handleFetchSuccess = (entity: Record<string, any>) => {
   emit('fetch:success', entity)
 
   // Names are only ever displayed via InternalLinkItem, so skip the lookups entirely otherwise.
-  if (props.showNameAsLink) {
+  // Reads the flag at fetch time: a host that flips `showScopeName` after this point relabels the
+  // rows and renders links, but shows ids until the card refetches.
+  if (scopeNameEnabled.value && props.showNameAsLink) {
     resolveReferenceNames(entity)
   }
 }

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -747,7 +747,11 @@
       "service": "Service",
       "route": "Route",
       "consumer": "Consumer",
-      "consumer_group": "Consumer group"
+      "consumer_group": "Consumer group",
+      "service_id": "Service ID",
+      "route_id": "Route ID",
+      "consumer_id": "Consumer ID",
+      "consumer_group_id": "Consumer group ID"
     },
     "select": {
       "custom_badge_text": "This plugin is data plane node specific",

--- a/packages/entities/entities-plugins/src/types/plugin-config-card.ts
+++ b/packages/entities/entities-plugins/src/types/plugin-config-card.ts
@@ -3,6 +3,15 @@ import type { KonnectBaseEntityConfig, KongManagerBaseEntityConfig } from '@kong
 
 export interface BasePluginConfigCardConfig {
   pluginType: string
+  /**
+   * KM-2996 rollout gate. When true, each scoped entity row (service, route, consumer,
+   * consumer group) resolves and shows the entity's name as a link to its detail page, with
+   * the id as a subtitle, and the row labels drop their "ID" suffix. Defaults to false =
+   * current behavior: the bare id, as a button that emits `navigation-click`.
+   * Only takes effect alongside `showNameAsLink`, which is what renders the links at all.
+   * Remove this flag once the feature is fully rolled out.
+   */
+  showScopeName?: boolean
   /** A function that returns the route for viewing the plugin's scoped service */
   getServiceViewRoute?: (id: string) => RouteLocationRaw
   /** A function that returns the route for viewing the plugin's scoped route */


### PR DESCRIPTION
# Summary
Guard the KM-2996 scope-name view in PluginConfigCard behind `config.showScopeName`, defaulting to off so hosts fall back to the previous view: the bare id as a button that emits `navigation-click`, with the "<Entity> ID" row labels restored.

The flag lives on the config prop rather than an injection, matching `pluginTableImprovements` on PluginList. Props are reactive, so a value that resolves after mount still takes effect - an injected boolean read once in setup would not, and an injected ref would read as truthy even when false.

Also adds PluginConfigCard.cy.ts, which the component was missing entirely, covering both branches of the flag plus the scoped entity name lookups, and documents `showScopeName`, `showNameAsLink`, the scoped route getters and the `navigation-click` event.
