### PR TITLE
fix(entities-plugins): prevent OIDC credential autofill

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/OpenidConnectForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/OpenidConnectForm.cy.ts
@@ -783,8 +783,8 @@ describe('OpenidConnectForm', () => {
 
       cy.getTestId('oidc-auth-mode-external').click({ force: true })
 
-      cy.getTestId('external-client-id').should('exist')
-      cy.getTestId('external-client-secret').should('exist')
+      cy.getTestId('external-client-id').should('have.attr', 'autocomplete', 'new-password')
+      cy.getTestId('external-client-secret').should('have.attr', 'autocomplete', 'new-password')
       cy.getTestId('ff-config.issuer').should('exist')
 
       lastFormChange().then((payload) => {
@@ -857,7 +857,8 @@ describe('OpenidConnectForm', () => {
 
       cy.getTestId('kong-identity-issuer-input').should('exist')
       cy.getTestId('principals-directory-select').should('not.exist')
-      cy.getTestId('principals-client-id-input').should('exist')
+      cy.getTestId('principals-client-id-input').should('have.attr', 'autocomplete', 'new-password')
+      cy.getTestId('principals-client-secret').should('have.attr', 'autocomplete', 'new-password')
     })
 
     it('infers External mode from a non-Kong-Identity issuer on edit', () => {

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalsSection.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalsSection.vue
@@ -156,6 +156,7 @@
       >
         <KInput
           v-if="!hasAuthServersAccess"
+          autocomplete="new-password"
           class="principals-client-select"
           data-testid="principals-client-id-input"
           :label="index === 0 ? t('plugins.free-form.openid-connect.principals.client.label') : undefined"
@@ -198,6 +199,7 @@
         </KSelect>
         <div class="principals-client-secret-wrapper">
           <KInput
+            autocomplete="new-password"
             class="principals-client-secret"
             data-testid="principals-client-secret"
             :disabled="hasAuthServersAccess && !selectedServer"
@@ -260,6 +262,7 @@
       >
         <div class="external-client-field">
           <KInput
+            autocomplete="new-password"
             class="external-client-input"
             data-testid="external-client-id"
             :label="index === 0 ? t('plugins.free-form.openid-connect.principals.client.id_label') : undefined"
@@ -287,6 +290,7 @@
         </div>
         <div class="external-client-field">
           <KInput
+            autocomplete="new-password"
             class="external-client-input"
             data-testid="external-client-secret"
             :label="index === 0 ? t('plugins.free-form.openid-connect.principals.client.secret_label') : undefined"


### PR DESCRIPTION
## Summary

Prevent Chrome from automatically prefilling OIDC client credentials in the FreeForm principals flow.

- Mark client ID and client secret fields as `autocomplete="new-password"` in both Kong Identity fallback and External auth server modes.
- Add component assertions for all four credential inputs.

## Testing

- OpenID Connect component tests: 79 passing
- Entities plugins typecheck
- ESLint and Stylelint