### PR TITLE
feat(entities-shared): support configurable autocomplete

### DIFF
--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
@@ -17,6 +17,7 @@ describe('<SensitiveInput />', () => {
       })
 
       cy.getTestId('sensitive-input-rotate').should('not.exist')
+      input().should('have.attr', 'autocomplete', 'new-password')
       input().should('not.have.attr', 'readonly')
       input().type('my-secret')
       cy.then(() => Cypress.vueWrapper.emitted('update:modelValue'))
@@ -133,6 +134,7 @@ describe('<SensitiveInput />', () => {
         })
 
         textarea().should('not.have.attr', 'readonly')
+        textarea().should('have.attr', 'autocomplete', 'new-password')
         cy.getTestId('sensitive-input-toggle').should('not.exist')
         cy.getTestId('sensitive-input-rotate').should('not.exist')
       })

--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.cy.ts
@@ -17,11 +17,19 @@ describe('<SensitiveInput />', () => {
       })
 
       cy.getTestId('sensitive-input-rotate').should('not.exist')
-      input().should('have.attr', 'autocomplete', 'new-password')
+      input().should('have.attr', 'autocomplete', 'off')
       input().should('not.have.attr', 'readonly')
       input().type('my-secret')
       cy.then(() => Cypress.vueWrapper.emitted('update:modelValue'))
         .should('not.be.undefined')
+    })
+
+    it('forwards the autocomplete prop', () => {
+      cy.mount(SensitiveInput, {
+        props: { autocomplete: 'new-password' },
+      })
+
+      input().should('have.attr', 'autocomplete', 'new-password')
     })
 
     it('defaults to an empty value when modelValue is omitted', () => {
@@ -134,9 +142,17 @@ describe('<SensitiveInput />', () => {
         })
 
         textarea().should('not.have.attr', 'readonly')
-        textarea().should('have.attr', 'autocomplete', 'new-password')
+        textarea().should('have.attr', 'autocomplete', 'off')
         cy.getTestId('sensitive-input-toggle').should('not.exist')
         cy.getTestId('sensitive-input-rotate').should('not.exist')
+      })
+
+      it('forwards the autocomplete prop', () => {
+        cy.mount(SensitiveInput, {
+          props: { autocomplete: 'new-password', multiline: true },
+        })
+
+        textarea().should('have.attr', 'autocomplete', 'new-password')
       })
 
       it('emits update:modelValue while typing', () => {

--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
@@ -5,7 +5,7 @@
   >
     <KInput
       v-if="!multiline"
-      autocomplete="off"
+      autocomplete="new-password"
       data-testid="sensitive-input"
       :disabled="disabled"
       :error="error"
@@ -72,7 +72,7 @@
     <!-- Multiline mode: KTextArea + action row below (no visibility toggle; textarea has no type="password") -->
     <template v-else>
       <KTextArea
-        autocomplete="off"
+        autocomplete="new-password"
         :character-limit="false"
         data-testid="sensitive-input"
         :disabled="disabled || undefined"

--- a/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
+++ b/packages/entities/entities-shared/src/components/common/SensitiveInput.vue
@@ -5,7 +5,7 @@
   >
     <KInput
       v-if="!multiline"
-      autocomplete="new-password"
+      :autocomplete="autocomplete"
       data-testid="sensitive-input"
       :disabled="disabled"
       :error="error"
@@ -72,7 +72,7 @@
     <!-- Multiline mode: KTextArea + action row below (no visibility toggle; textarea has no type="password") -->
     <template v-else>
       <KTextArea
-        autocomplete="new-password"
+        :autocomplete="autocomplete"
         :character-limit="false"
         data-testid="sensitive-input"
         :disabled="disabled || undefined"
@@ -191,6 +191,7 @@ const {
   error = false,
   errorMessage,
   multiline = false,
+  autocomplete = 'off',
 } = defineProps<{
   /** The sensitive value, bound via v-model. */
   modelValue?: string
@@ -227,6 +228,7 @@ const {
   errorMessage?: string
   /** When true, renders a KTextArea instead of a KInput. */
   multiline?: boolean
+  autocomplete?: 'off' | 'new-password'
 }>()
 
 const emit = defineEmits<{


### PR DESCRIPTION
## Summary

- add an optional SensitiveInput autocomplete prop limited to "off" and "new-password"
- default autocomplete to "off" to preserve existing behavior
- forward the configured value to single-line and multiline controls
- add component coverage for the default and explicit "new-password" value

An omitted or explicitly undefined prop uses the Vue default of "off".

## Testing

- pnpm --filter @kong-ui-public/entities-shared lint -- src/components/common/SensitiveInput.vue src/components/common/SensitiveInput.cy.ts
- pnpm --filter @kong-ui-public/entities-shared typecheck
- focused SensitiveInput Cypress component spec (22 passing)