### PR TITLE
fix(entities-plugins): prevent Datakit teleport errors [KM-3174]

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.cy.ts
@@ -1,0 +1,47 @@
+import { h, ref } from 'vue'
+import { FORMS_CONFIG } from '@kong-ui-public/forms'
+
+import { getPluginConfig } from '../../shared/plugin-registry'
+
+const DatakitForm = getPluginConfig('datakit')!.component
+
+describe('<DatakitForm />', () => {
+  it('teleports actions to a target mounted in the same tree and unmounts cleanly', () => {
+    const showForm = ref(true)
+    const Host = () => h('main', [
+      h('div', { id: 'plugin-form-page-actions' }),
+      showForm.value
+        ? h(DatakitForm as any, {
+          schema: { type: 'record', fields: [] },
+          model: { config: {} },
+          pluginName: 'datakit',
+          isEditing: false,
+          onFormChange: () => {},
+        })
+        : h('div', { 'data-testid': 'done-page' }),
+    ])
+
+    cy.mount(Host, {
+      global: {
+        provide: {
+          [FORMS_CONFIG]: { app: 'konnect' },
+        },
+        stubs: {
+          DynamicLayout: true,
+          KSegmentedControl: true,
+        },
+      },
+    })
+
+    cy.get('#plugin-form-page-actions')
+      .find('[data-testid="datakit-editor-mode-switcher"]')
+      .should('exist')
+
+    cy.then(() => {
+      showForm.value = false
+    })
+
+    cy.getTestId('done-page').should('exist')
+    cy.getTestId('datakit-editor-mode-switcher').should('not.exist')
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.vue
@@ -1,6 +1,7 @@
 <template>
   <Teleport
     v-if="formConfig.app === 'konnect'"
+    defer
     :disabled="!hasTeleportTarget"
     to="#plugin-form-page-actions"
   >


### PR DESCRIPTION
# Description

[KM-3174]

Add Vue 3.5 Teleport deferred target resolution to the Datakit editor mode switcher.

AI Manager v2 renders `#plugin-form-page-actions` and `DatakitForm` in the same Vue tree. During the initial mount, the target element has been created inside the PageLayout root, but that root is not connected to `document` yet. Without `defer`, the disabled Teleport resolves its selector immediately and caches a null target. `DatakitForm` then detects the connected target in `onMounted` and enables the Teleport, causing Vue to move its children to the cached null target and throw an `insertBefore` error. The interrupted renderer update leaves the old policy form DOM mounted after navigation.

The `defer` prop postpones target resolution until the end of the same mount tick, after the PageLayout root is connected. The existing `disabled` binding remains unchanged, so the editor switcher still renders inline when the target is absent.

This fix relies on Vue 3.5 deferred Teleport behavior. The affected first-party consumers use Vue 3.5; consumers on the package peer range below 3.5 will ignore `defer` and will not gain deferred target resolution.

## Validation

- Added a focused Datakit Cypress regression covering a target mounted in the same detached tree and clean unmount; 1/1 passing and verified to fail when `defer` is removed
- Reproduced the delayed same-tree target and navigation/unmount flow on Vue 3.5.35 and 3.5.41
- entities-plugins typecheck
- ESLint and Stylelint for `DatakitForm.vue`
- 20 unit-test files / 213 tests
- Full entities-plugins build

[KM-3174]: https://konghq.atlassian.net/browse/KM-3174