### PR TITLE
fix(entities-plugins): prevent DataKit Teleport update errors [KM-3174]

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/DatakitForm.vue
@@ -1,7 +1,6 @@
 <template>
-  <Teleport
+  <TeleportWithFallback
     v-if="formConfig.app === 'konnect'"
-    :disabled="!hasTeleportTarget"
     to="#plugin-form-page-actions"
   >
     <KSegmentedControl
@@ -25,7 +24,7 @@
         </KTooltip>
       </template>
     </KSegmentedControl>
-  </Teleport>
+  </TeleportWithFallback>
 
   <DynamicLayout
     v-bind="{ ...attrs, ...props }"
@@ -77,7 +76,7 @@ import type { PluginFormLayoutProps as Props } from '../../shared/layout/provide
 import type { ConfigSection } from '../../shared/types'
 import type { EditorMode, DatakitPluginData } from './types'
 
-import { computed, inject, onMounted, ref, watch, useAttrs } from 'vue'
+import { computed, inject, ref, watch, useAttrs } from 'vue'
 import { escape } from 'lodash-es'
 import { createI18n } from '@kong-ui-public/i18n'
 import { CodeblockIcon, DesignIcon } from '@kong/icons'
@@ -90,6 +89,7 @@ import { FEATURE_FLAGS } from '../../../../constants'
 import DynamicLayout from '../../shared/layout/DynamicLayout.vue'
 import CaCertificatesField from './CaCertificatesField.vue'
 import CodeEditor from './CodeEditor.vue'
+import TeleportWithFallback from './TeleportWithFallback.vue'
 import { usePreferences } from './composables'
 import FlowEditor from './flow-editor/FlowEditor.vue'
 // import { DatakitConfigSchema } from './schema/strict'
@@ -106,12 +106,6 @@ const attrs = useAttrs()
 
 // provided by consumer apps
 const formConfig = inject<KonnectPluginFormConfig | KongManagerPluginFormConfig>(FORMS_CONFIG)!
-
-// Check if the teleport target exists
-const hasTeleportTarget = ref(false)
-onMounted(() => {
-  hasTeleportTarget.value = !!document.querySelector('#plugin-form-page-actions')
-})
 
 // Editor mode selection
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/TeleportWithFallback.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/TeleportWithFallback.spec.ts
@@ -1,0 +1,70 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+
+import TeleportWithFallback from './TeleportWithFallback.vue'
+
+const TARGET_ID = 'plugin-form-page-actions'
+const CONTENT_TEST_ID = 'teleported-content'
+
+function mountHost(withTarget: boolean) {
+  const errors: unknown[] = []
+  const showContent = ref(true)
+
+  const Host = defineComponent({
+    setup() {
+      return () => h('div', [
+        withTarget ? h('div', { id: TARGET_ID }) : null,
+        showContent.value
+          ? h(
+            TeleportWithFallback,
+            { to: `#${TARGET_ID}` },
+            { default: () => h('button', { 'data-testid': CONTENT_TEST_ID }, 'Mode') },
+          )
+          : null,
+      ])
+    },
+  })
+
+  const wrapper = mount(Host, {
+    attachTo: document.body,
+    global: {
+      config: {
+        errorHandler: (error) => errors.push(error),
+      },
+    },
+  })
+
+  return { errors, showContent, wrapper }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('TeleportWithFallback', () => {
+  it('teleports without update errors when the target mounts in the same component tree', async () => {
+    const { errors, showContent, wrapper } = mountHost(true)
+
+    await nextTick()
+
+    expect(errors).toEqual([])
+    const target = wrapper.get(`#${TARGET_ID}`)
+    expect(target.get(`[data-testid="${CONTENT_TEST_ID}"]`).text()).toBe('Mode')
+
+    showContent.value = false
+    await nextTick()
+
+    expect(target.find(`[data-testid="${CONTENT_TEST_ID}"]`).exists()).toBe(false)
+    expect(errors).toEqual([])
+  })
+
+  it('renders the content inline when the target is unavailable', async () => {
+    const { errors, wrapper } = mountHost(false)
+
+    await nextTick()
+
+    expect(wrapper.get(`[data-testid="${CONTENT_TEST_ID}"]`).text()).toBe('Mode')
+    expect(errors).toEqual([])
+  })
+})

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/TeleportWithFallback.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/datakit/TeleportWithFallback.vue
@@ -1,0 +1,24 @@
+<template>
+  <!-- A disabled Teleport can cache a null target when both mount in the same tree. -->
+  <Teleport
+    v-if="hasTarget"
+    :to="to"
+  >
+    <slot />
+  </Teleport>
+  <slot v-else />
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+const { to } = defineProps<{
+  to: string
+}>()
+
+const hasTarget = ref(false)
+
+onMounted(() => {
+  hasTarget.value = !!document.querySelector(to)
+})
+</script>


### PR DESCRIPTION
[KM-3174]

## Summary

- Mount the DataKit editor-mode switcher in a fresh Teleport only after `#plugin-form-page-actions` is connected, avoiding Vue's cached null Teleport target.
- Preserve the inline editor-mode switcher fallback for consumers without the page-actions target.
- Add focused regression coverage for a target created in the same component tree, clean unmounting, and fallback rendering.

## Testing

- `pnpm --filter @kong-ui-public/entities-plugins test:unit src/components/free-form/plugins/datakit/TeleportWithFallback.spec.ts` (2 tests passed)
- `pnpm --filter @kong-ui-public/entities-plugins typecheck`
- `pnpm --filter @kong-ui-public/entities-plugins lint`
- `pnpm --filter @kong-ui-public/entities-plugins stylelint`
- `pnpm --filter @kong-ui-public/entities-plugins build`

[KM-3174]: https://konghq.atlassian.net/browse/KM-3174