### PR TITLE
fix: pnpm audit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   immutable@>=5.0.0-beta.1 <5.1.8: '>=5.1.9'
   immutable@<4.3.9: '>=4.3.9 <6.0.0'
   ip-address@<=10.3.0: '>=10.5.0'
+  pacote@>=11.2.7 <21.5.1: '>=21.5.1 <22.0.0'
 
 importers:
 
@@ -8351,6 +8352,11 @@ packages:
   package-manager-detector@1.7.0:
     resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
 
+  pacote@21.5.1:
+    resolution: {integrity: sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   pacote@21.0.1:
     resolution: {integrity: sha512-LHGIUQUrcDIJUej53KJz1BPvUuHrItrR2yrnN0Kl9657cJ0ZT6QJHk9wWPBnQZhYT5KLyZWrk9jaYc2aKDu4yw==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -12676,7 +12682,7 @@ snapshots:
       npm-package-arg: 13.0.1
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.0
-      pacote: 21.5.0
+      pacote: 21.5.1
       parse-conflict-json: 4.0.0
       proc-log: 5.0.0
       proggy: 3.0.0
@@ -12745,7 +12751,7 @@ snapshots:
     dependencies:
       cacache: 20.0.4
       json-parse-even-better-errors: 5.0.0
-      pacote: 21.5.0
+      pacote: 21.5.1
       proc-log: 6.1.0
       semver: 7.8.5
     transitivePeerDependencies:
@@ -17961,7 +17967,7 @@ snapshots:
       nx: 23.1.1
       p-map: 4.0.0
       p-queue: 6.6.2
-      pacote: 21.0.1
+      pacote: 21.5.1
       read-cmd-shim: 4.0.0
       semver: 7.7.2
       signal-exit: 3.0.7
@@ -19227,6 +19233,29 @@ snapshots:
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.7.0: {}
+
+  pacote@21.5.1:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/git': 7.0.2
+      '@npmcli/installed-package-contents': 4.0.0
+      '@npmcli/package-json': 7.0.2
+      '@npmcli/promise-spawn': 9.0.1
+      '@npmcli/run-script': 10.0.3
+      cacache: 20.0.4
+      fs-minipass: 3.0.3
+      minipass: 7.1.3
+      npm-package-arg: 13.0.1
+      npm-packlist: 10.0.3
+      npm-pick-manifest: 11.0.3
+      npm-registry-fetch: 19.1.0
+      proc-log: 6.1.0
+      sigstore: 5.0.0
+      ssri: 13.0.1
+      tar: 7.5.22
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
 
   pacote@21.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,7 @@ overrides:
   immutable@>=5.0.0-beta.1 <5.1.8: '>=5.1.9'
   immutable@<4.3.9: '>=4.3.9 <6.0.0'
   ip-address@<=10.3.0: '>=10.5.0'
+  pacote@>=11.2.7 <21.5.1: '>=21.5.1 <22.0.0'
 
 onlyBuiltDependencies:
   - '@evilmartians/lefthook'


### PR DESCRIPTION
# Summary

- Override vulnerable `pacote` versions with `>=21.5.1 <22.0.0`.