### PR TITLE
feat(entities-plugins): add realmsEnabled context to key-auth

### DIFF
--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -133,6 +133,9 @@ const { axiosInstance } = useAxios(appConfig?.axiosRequestConfig)
 const keyAuthContext = usePluginContext('key-auth')
 const identityRealmsEnabled = computed(() => keyAuthContext?.identityRealmsEnabled ?? true)
 
+// Host opt-out: hides the realm field entirely, regardless of whether it's required in the schema.
+const realmsEnabled = computed(() => keyAuthContext?.realmsEnabled ?? true)
+
 const { formData, getSchema } = useFormShared()
 
 const hasPrincipalsErrorOnMiss = computed(() => !!getSchema('$.config.principals.error_on_miss'))
@@ -315,7 +318,7 @@ const realmRequired = computed(() => !!getSchema('$.config.realm')?.required)
 // Top section: omit advanced fields + always-hidden identity fields
 const topOmit = computed(() => {
   const omit = ['anonymous', 'principals', 'identity_realms']
-  if (!realmRequired.value) {
+  if (!realmsEnabled.value || !realmRequired.value) {
     omit.push('realm')
   }
   return omit
@@ -327,7 +330,7 @@ const advancedOmit = computed(() => {
   const allFields: string[] = schema?.fields?.map((f: Record<string, unknown>) => Object.keys(f)[0]) ?? []
 
   const advancedSet = new Set(['anonymous'])
-  if (!realmRequired.value && selectedMode.value !== 'kong-identity') {
+  if (realmsEnabled.value && !realmRequired.value && selectedMode.value !== 'kong-identity') {
     advancedSet.add('realm')
   }
   if (isKonnect.value && identityRealmsInSchema.value && identityRealmsEnabled.value && !hasPrincipals.value) {

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/key-auth/context.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/key-auth/context.ts
@@ -5,4 +5,10 @@ export interface KeyAuthContext {
    * Defaults to `true` when no context is provided.
    */
   identityRealmsEnabled?: boolean
+
+  /**
+   * Enables the `realm` field. When disabled, the field is hidden regardless of whether
+   * it's required in the schema. Defaults to `true` when no context is provided.
+   */
+  realmsEnabled?: boolean
 }


### PR DESCRIPTION
## Summary
- Adds a `realmsEnabled` field to `KeyAuthContext` (defaults to `true`)
- When set to `false`, the key-auth `realm` field is hidden entirely in `ConfigFormContent.vue`, regardless of whether it's required in the schema — mirroring the existing `identityRealmsEnabled` opt-out

[TEST_COVERAGE_EXEMPT_REASON] This change does not require test coverage.

Jira: KM-3177
