### PR TITLE
feat(monaco-editor): add zod-based YAML schema validation

### DIFF
--- a/packages/core/monaco-editor/package.json
+++ b/packages/core/monaco-editor/package.json
@@ -87,7 +87,8 @@
     "reflect-metadata": "^0.2.2",
     "shiki": "^4.4.3",
     "vue": "^3.5.41",
-    "yaml": "^2.9.0"
+    "yaml": "^2.9.0",
+    "zod": "^4.4.3"
   },
   "dependencies": {
     "@shikijs/monaco": "^4.4.3",

--- a/packages/core/monaco-editor/package.json
+++ b/packages/core/monaco-editor/package.json
@@ -74,7 +74,8 @@
     "@kong/kongponents": ">=9.63.0 <10.0.0",
     "monaco-editor": ">=0.52.0 <1.0.0",
     "shiki": ">=3.0.0 <5.0.0",
-    "vue": "^3.5.35"
+    "vue": "^3.5.35",
+    "zod": ">=4.0.0 <5.0.0"
   },
   "devDependencies": {
     "@kong-ui-public/i18n": "workspace:^",

--- a/packages/core/monaco-editor/src/features/validation.spec.ts
+++ b/packages/core/monaco-editor/src/features/validation.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { collectValidators } from './validation'
+
+import type { ValidateFn } from './validation'
+
+describe('collectValidators', () => {
+  it('returns no issues when there are no validators', async () => {
+    expect(await collectValidators([])(1)).toEqual([])
+  })
+
+  it('concatenates issues from every validator', async () => {
+    const a: ValidateFn = vi.fn(() => [{ message: 'a', path: [] }])
+    const b: ValidateFn = vi.fn(() => [{ message: 'b', path: ['x'] }])
+
+    const combined = collectValidators([a, b])
+    expect(await combined('value')).toEqual([
+      { message: 'a', path: [] },
+      { message: 'b', path: ['x'] },
+    ])
+    expect(a).toHaveBeenCalledWith('value')
+    expect(b).toHaveBeenCalledWith('value')
+  })
+
+  it('preserves validator order in the output regardless of resolution speed', async () => {
+    const slow: ValidateFn = () => new Promise((resolve) => {
+      setTimeout(() => resolve([{ message: 'slow', path: [] }]), 10)
+    })
+    const fast: ValidateFn = () => [{ message: 'fast', path: [] }]
+
+    const combined = collectValidators([slow, fast])
+    expect(await combined(null)).toEqual([
+      { message: 'slow', path: [] },
+      { message: 'fast', path: [] },
+    ])
+  })
+})

--- a/packages/core/monaco-editor/src/features/validation.ts
+++ b/packages/core/monaco-editor/src/features/validation.ts
@@ -1,0 +1,32 @@
+/** A single validation failure, before it's mapped to any source location. */
+export interface ValidationIssue {
+  message: string
+  path: PropertyKey[]
+  /**
+   * A short machine-readable code for the kind of failure, when the
+   * underlying validator provides one (e.g. Zod's issue `code`, such as
+   * `invalid_type` or `too_big`). Left undefined by validators that don't
+   * have an equivalent concept.
+   */
+  code?: string
+}
+
+/**
+ * Validates an already-parsed value and reports any issues. Knows nothing
+ * about the model it came from, the language it was written in, which
+ * validation library (if any) produced it, or how to turn an issue into a
+ * source location - see `languages/*` for that, and e.g. `zod-validation.ts`
+ * for a validator-specific adapter into this shape.
+ */
+export type ValidateFn = (value: unknown) => ValidationIssue[] | Promise<ValidationIssue[]>
+
+/**
+ * Merges multiple {@link ValidateFn}s into a single one that runs them all
+ * and concatenates their issues.
+ */
+export function collectValidators(validators: ValidateFn[]): ValidateFn {
+  return async (value) => {
+    const results = await Promise.all(validators.map((validate) => validate(value)))
+    return results.flat()
+  }
+}

--- a/packages/core/monaco-editor/src/features/zod-validation.spec.ts
+++ b/packages/core/monaco-editor/src/features/zod-validation.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createZodValidator } from './zod-validation'
+
+describe('createZodValidator', () => {
+  it('returns no issues when the schema reports success', () => {
+    const validate = createZodValidator(z.object({ ok: z.boolean() }))
+
+    expect(validate({ ok: true })).toEqual([])
+  })
+
+  it('maps issues, carrying the path and the Zod issue code', () => {
+    const schema = z.object({
+      config: z.object({
+        redis: z.object({ port: z.number().max(65535) }),
+      }),
+    })
+
+    const issues = validate(schema, { config: { redis: { port: 999999 } } })
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        path: ['config', 'redis', 'port'],
+        code: 'too_big',
+      }),
+    ])
+  })
+
+  it('reports a top-level issue with an empty path', () => {
+    const schema = z.string()
+
+    const issues = validate(schema, 123)
+
+    expect(issues).toEqual([
+      expect.objectContaining({ path: [], code: 'invalid_type' }),
+    ])
+  })
+
+  it('strips the redundant "Invalid input:" prefix from Zod\'s stock messages', () => {
+    const issues = validate(z.string(), 123)
+
+    expect(issues[0]?.message).toBe('expected string, received number')
+  })
+
+  it('leaves a bare "Invalid input" (no colon/suffix) message alone', () => {
+    // A union with no custom `error` reports exactly this, with nothing
+    // after it - stripping the prefix would otherwise leave an empty string.
+    const issues = validate(z.union([z.string(), z.number()]), true)
+
+    expect(issues[0]?.message).toBe('Invalid input')
+  })
+
+  function validate(schema: z.ZodType, value: unknown) {
+    return createZodValidator(schema)(value)
+  }
+})

--- a/packages/core/monaco-editor/src/features/zod-validation.ts
+++ b/packages/core/monaco-editor/src/features/zod-validation.ts
@@ -1,0 +1,33 @@
+import type { z } from 'zod'
+import type { ValidateFn } from './validation'
+
+// Zod's stock `invalid_type` message is e.g. "Invalid input: expected
+// string, received number" - the "Invalid input:" prefix is boilerplate
+// that adds nothing ("expected string, received number" already says it),
+// so it's dropped. Only stripped when something meaningful is left
+// afterward - a bare "Invalid input" (no colon/suffix, e.g. an
+// un-customized union failure) is kept as-is rather than becoming empty.
+const INVALID_INPUT_PREFIX = /^Invalid input:\s*/
+
+function cleanMessage(message: string): string {
+  const stripped = message.replace(INVALID_INPUT_PREFIX, '')
+  return stripped || message
+}
+
+/**
+ * Adapts a Zod schema into a {@link ValidateFn}.
+ */
+export function createZodValidator(schema: z.ZodType): ValidateFn {
+  return (value) => {
+    const result = schema.safeParse(value)
+    if (result.success) {
+      return []
+    }
+
+    return result.error.issues.map((issue) => ({
+      message: cleanMessage(issue.message),
+      path: issue.path,
+      code: issue.code,
+    }))
+  }
+}

--- a/packages/core/monaco-editor/src/index.ts
+++ b/packages/core/monaco-editor/src/index.ts
@@ -8,6 +8,8 @@ export {
 
 // TODO: Add barrel exports if we have more features in the future
 export * from './features/code-lenses'
+export * from './features/validation'
+export * from './features/zod-validation'
 
 export * from './singletons/model-contexts'
 export * from './types'

--- a/packages/core/monaco-editor/src/languages/yaml/code-lenses.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/code-lenses.ts
@@ -26,7 +26,7 @@ interface YAMLNodeWithKeyPath {
   keyPath: JSONPath
 }
 
-function getYAMLNodeRange(node: YAMLNode, model: editor.ITextModel): IRange | undefined {
+export function getYAMLNodeRange(node: YAMLNode, model: editor.ITextModel): IRange | undefined {
   const range = node.range
   if (!range) {
     return undefined
@@ -176,7 +176,7 @@ function forEachYAMLNodeWithKeyPath(root: YAMLNode, fn: (node: YAMLNode, keyPath
   }
 }
 
-function getYAMLNodeAtPath(document: YAMLDocument.Parsed, keyPath: JSONPath): YAMLNode | undefined {
+export function getYAMLNodeAtPath(document: YAMLDocument.Parsed, keyPath: JSONPath): YAMLNode | undefined {
   const node = document.getIn(keyPath, true)
   return isNode(node)
     ? node

--- a/packages/core/monaco-editor/src/languages/yaml/index.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/index.ts
@@ -1,2 +1,3 @@
 export * from './code-lenses'
 export * from './context'
+export * from './validation'

--- a/packages/core/monaco-editor/src/languages/yaml/validation.spec.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/validation.spec.ts
@@ -124,4 +124,40 @@ describe('runYAMLValidation', () => {
     expect(issue.range).toBeDefined()
     expect(issue.rangeKind).toBe('ancestor')
   })
+
+  describe('bails out when the document has YAML-level errors', () => {
+    // The `yaml` parser is error-tolerant: `document.toJS()` can still return a
+    // (possibly wrong) value even though `document.errors` is non-empty, so
+    // these all still need an explicit bail-out rather than relying on `toJS()` to throw.
+    it.each([
+      ['duplicate keys', 'foo: 1\nfoo: 2\n'],
+      ['inconsistent indentation', 'foo:\n  bar: 1\n baz: 2\n'],
+      ['tabs used for indentation', 'foo:\n\tbar: 1\n'],
+      ['unclosed flow map', 'foo: {a: 1, b: 2\n'],
+    ])('%s', async (_name, text) => {
+      const model = createFakeModel(text)
+
+      let validateCalled = false
+      const validate: ValidateFn = () => {
+        validateCalled = true
+        return []
+      }
+
+      expect(await runYAMLValidation(model, validate)).toEqual([])
+      expect(validateCalled).toBe(false)
+    })
+
+    it('still runs validation when the document has no errors', async () => {
+      const model = createFakeModel('foo: 1\n')
+
+      let validateCalled = false
+      const validate: ValidateFn = () => {
+        validateCalled = true
+        return []
+      }
+
+      await runYAMLValidation(model, validate)
+      expect(validateCalled).toBe(true)
+    })
+  })
 })

--- a/packages/core/monaco-editor/src/languages/yaml/validation.spec.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/validation.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { runYAMLValidation } from './validation'
+
+import type { editor } from 'monaco-editor'
+import type { ValidateFn } from '../../features/validation'
+
+function createFakeModel(text: string, language = 'yaml'): editor.ITextModel {
+  const lines = text.split('\n')
+
+  const model = {
+    getLanguageId: () => language,
+    getAlternativeVersionId: () => 1,
+    getValue: () => text,
+    getPositionAt: (offset: number) => {
+      const before = text.slice(0, offset).split('\n')
+      return { lineNumber: before.length, column: before[before.length - 1].length + 1 }
+    },
+    getFullModelRange: () => ({
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: lines.length,
+      endColumn: lines[lines.length - 1].length + 1,
+    }),
+    onWillDispose: () => ({ dispose: () => {} }),
+  }
+
+  return model as unknown as editor.ITextModel
+}
+
+describe('runYAMLValidation', () => {
+  it('returns no issues for a model in a different language', async () => {
+    const model = createFakeModel('a: 1', 'json')
+
+    const validate: ValidateFn = () => [{ message: 'should not run', path: [] }]
+    expect(await runYAMLValidation(model, validate)).toEqual([])
+  })
+
+  it('passes the parsed YAML value to the validator', async () => {
+    const model = createFakeModel('config:\n  minute: 100\n')
+    let received: unknown
+
+    const validate: ValidateFn = (value) => {
+      received = value
+      return []
+    }
+
+    await runYAMLValidation(model, validate)
+    expect(received).toEqual({ config: { minute: 100 } })
+  })
+
+  it('returns no issues when validation succeeds', async () => {
+    const model = createFakeModel('config:\n  minute: 100\n')
+    const validate: ValidateFn = () => []
+
+    expect(await runYAMLValidation(model, validate)).toEqual([])
+  })
+
+  it('maps an issue path to the range of its own YAML node', async () => {
+    const text = 'config:\n  minute: 100\n  policy: redis\n'
+    const model = createFakeModel(text)
+
+    const validate: ValidateFn = () => [{ message: 'bad policy', path: ['config', 'policy'] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    expect(issue.message).toBe('bad policy')
+    // Line 3 is `  policy: redis` - the range should point at the `redis` value.
+    expect(issue.range.startLineNumber).toBe(3)
+    expect(issue.rangeKind).toBe('exact')
+  })
+
+  it('reports the document root itself as exact when the path is empty', async () => {
+    const text = 'config:\n  minute: 100\n'
+    const model = createFakeModel(text)
+
+    const validate: ValidateFn = () => [{ message: 'root-level issue', path: [] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    expect(issue.rangeKind).toBe('exact')
+  })
+
+  it('falls back to the nearest existing ancestor when the exact path is missing', async () => {
+    const text = 'config:\n  minute: 100\n'
+    const model = createFakeModel(text)
+
+    // `config.redis.port` doesn't exist at all - falls back to `config`'s own
+    // value node, i.e. the nested mapping starting at `minute: 100` (line 2).
+    const validate: ValidateFn = () => [{ message: 'redis.port required', path: ['config', 'redis', 'port'] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    expect(issue.range.startLineNumber).toBe(2)
+    expect(issue.rangeKind).toBe('ancestor')
+  })
+
+  it('falls back to the document root (an ancestor) when a top-level field is missing', async () => {
+    const text = 'config:\n  minute: 100\n'
+    const model = createFakeModel(text)
+
+    // There's no `protocols` key at all - the nearest existing ancestor is the document root itself.
+    const validate: ValidateFn = () => [{ message: 'top-level missing', path: ['protocols'] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    expect(issue.rangeKind).toBe('ancestor')
+  })
+
+  it('falls back to a compact position at the document start for a genuinely empty document', async () => {
+    const model = createFakeModel('')
+
+    const validate: ValidateFn = () => [{ message: 'nothing to point at', path: ['config'] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    // Not the whole (possibly huge) document - just a small anchor at the start.
+    expect(issue.range).toEqual({ startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 2 })
+    expect(issue.rangeKind).toBe('document')
+  })
+
+  it('ignores path segments that are symbols when locating a range', async () => {
+    const text = 'config:\n  minute: 100\n'
+    const model = createFakeModel(text)
+
+    const validate: ValidateFn = () => [{ message: 'weird path', path: ['config', Symbol('x')] }]
+    const [issue] = await runYAMLValidation(model, validate)
+
+    // Can't look up the symbol segment itself - falls back to `config` (ancestor), not a crash.
+    expect(issue.range).toBeDefined()
+    expect(issue.rangeKind).toBe('ancestor')
+  })
+})

--- a/packages/core/monaco-editor/src/languages/yaml/validation.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/validation.ts
@@ -1,0 +1,102 @@
+import { getModelContext } from '../../singletons/model-contexts'
+import { getYAMLNodeAtPath, getYAMLNodeRange } from './code-lenses'
+
+import type { editor, IRange } from 'monaco-editor'
+import type { Document as YAMLDocument } from 'yaml'
+
+import type { ValidateFn, ValidationIssue } from '../../features/validation'
+import type { ModelContextGetter } from '../../types'
+
+/**
+ * How precisely {@link YAMLValidationIssue.range} points at the issue:
+ * - `exact`: the node for the issue's own path (its full path resolved, even
+ *   an empty path meaning "the document root itself").
+ * - `ancestor`: the path doesn't exist (e.g. a missing required field) - this
+ *   is the nearest existing parent instead, which can span many lines. Shown
+ *   the same way as `exact` (this is also how VS Code's JSON/YAML schema
+ *   validation handles a missing required property - it underlines the
+ *   containing object, not just a point).
+ * - `document`: nothing in the path resolved at all (e.g. a genuinely empty
+ *   document) - there's truly nothing to point at, so this is a compact
+ *   range at the very start of the document, not the whole thing.
+ */
+export type YAMLIssueRangeKind = 'exact' | 'ancestor' | 'document'
+
+export interface YAMLValidationIssue extends ValidationIssue {
+  range: IRange
+  rangeKind: YAMLIssueRangeKind
+}
+
+/** A compact, always-valid range at the very start of the document. */
+function documentStartRange(): IRange {
+  return { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 2 }
+}
+
+/**
+ * Finds the source range for an issue's path. A missing required field has no
+ * node of its own to point at, so this walks up the path - trying shorter and
+ * shorter prefixes - until it lands on a node that actually exists in the
+ * document, falling back to a position at the start of the document as a last
+ * resort. `rangeKind` tells the caller how precise the result actually is.
+ */
+function findRangeForPath(document: YAMLDocument.Parsed, model: editor.ITextModel, path: PropertyKey[]): { range: IRange, rangeKind: YAMLIssueRangeKind } {
+  for (let length = path.length; length >= 0; length--) {
+    const candidate = path.slice(0, length)
+    if (candidate.some((segment) => typeof segment !== 'string' && typeof segment !== 'number')) {
+      continue // symbol path segments can't be looked up in a YAML document
+    }
+
+    const node = getYAMLNodeAtPath(document, candidate as Array<string | number>)
+    if (node) {
+      const range = getYAMLNodeRange(node, model)
+      if (range) {
+        return { range, rangeKind: length === path.length ? 'exact' : 'ancestor' }
+      }
+    }
+  }
+
+  return { range: documentStartRange(), rangeKind: 'document' }
+}
+
+export interface RunYAMLValidationOptions {
+  contextGetter?: ModelContextGetter
+}
+
+/**
+ * Runs a {@link ValidateFn} (e.g. from {@link createZodValidator}) against a
+ * YAML model: parses the model's current content (reusing the
+ * cached AST from {@link getModelContext}), validates it, and maps every
+ * resulting issue back to a source range in the model.
+ *
+ * Returns an empty array if the model isn't YAML, has no parseable content,
+ * or the value is otherwise not currently checkable - callers deciding when
+ * to run this (on keystroke, debounced, etc.) is left entirely up to them.
+ */
+export async function runYAMLValidation(
+  model: editor.ITextModel,
+  validate: ValidateFn,
+  options?: RunYAMLValidationOptions,
+): Promise<YAMLValidationIssue[]> {
+  const context = await (options?.contextGetter ?? getModelContext)(model)
+  if (context.isDefault || context.language !== 'yaml' || !context.document) {
+    return []
+  }
+
+  const document = context.document
+
+  let value: unknown
+  try {
+    value = document.toJS()
+  } catch {
+    // Not cleanly resolvable (e.g. YAML-level errors) - the syntax checker
+    // already surfaces that; schema validation just backs off here.
+    return []
+  }
+
+  const issues = await validate(value)
+
+  return issues.map((issue) => {
+    const { range, rangeKind } = findRangeForPath(document, model, issue.path)
+    return { ...issue, range, rangeKind }
+  })
+}

--- a/packages/core/monaco-editor/src/languages/yaml/validation.ts
+++ b/packages/core/monaco-editor/src/languages/yaml/validation.ts
@@ -83,13 +83,21 @@ export async function runYAMLValidation(
   }
 
   const document = context.document
+  if (document.errors.length > 0) {
+    // The YAML parser is error-tolerant: it recovers *some* value even when
+    // the source has syntax errors, so a successful `toJS()` below can't be
+    // trusted on its own. The syntax checker already surfaces these errors;
+    // schema validation just backs off rather than validating a value that
+    // may not reflect what's actually written in the document.
+    return []
+  }
 
   let value: unknown
   try {
     value = document.toJS()
   } catch {
-    // Not cleanly resolvable (e.g. YAML-level errors) - the syntax checker
-    // already surfaces that; schema validation just backs off here.
+    // Not cleanly resolvable - the syntax checker already surfaces that;
+    // schema validation just backs off here.
     return []
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/core/page-layout:
     dependencies:


### PR DESCRIPTION
## Summary
- `createZodValidator`/`collectValidators` (features) adapt Zod schemas into composable validators.
- `runYAMLValidation` (languages/yaml/validation.ts) runs those validators against a YAML model and maps issues back to source ranges (`ancestor` underlines a whole block, `document` anchors at the file start).
- Exports `getYAMLNodeRange`/`getYAMLNodeAtPath` from code-lenses.ts so validation.ts can reuse them.
