### PR TITLE
fix(entities-plugins): linkify learn more in custom plugin schema help [KM-3187]

### DIFF
--- a/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
+++ b/packages/entities/entities-plugins/src/components/CustomPluginForm.vue
@@ -241,7 +241,6 @@
             :accept="['.lua']"
             :button-text="t('custom_plugin_form.step2_files.schema_file.button_text')"
             data-testid="custom-plugin-schema-upload"
-            :help="t('custom_plugin_form.step2_files.schema_file.help')"
             :label="t('custom_plugin_form.step2_files.schema_file.label')"
             :placeholder="editMode && state.fields.schemaContent
               ? t('custom_plugin_form.step2_files.schema_file.placeholder_edit')
@@ -250,6 +249,18 @@
             @file-added="(files: FileList) => handleFileAdded('schema', files)"
             @file-removed="handleFileRemoved('schema')"
           />
+          <p class="schema-file-help">
+            <i18nT keypath="custom_plugin_form.step2_files.schema_file.help.text">
+              <template #link>
+                <KExternalLink
+                  hide-icon
+                  :href="externalLinks.customPluginInstalled"
+                >
+                  {{ t('custom_plugin_form.step2_files.schema_file.help.link') }}
+                </KExternalLink>
+              </template>
+            </i18nT>
+          </p>
           <div class="plugin-modules-section">
             <KLabel>{{ t('custom_plugin_form.step2_files.plugin_modules.label') }}</KLabel>
             <KAlert
@@ -270,7 +281,6 @@
             :accept="['.lua']"
             :button-text="t('custom_plugin_form.step2_files.schema_file.button_text')"
             data-testid="custom-plugin-schema-upload"
-            :help="t('custom_plugin_form.step2_files.schema_file.help')"
             :label="t('custom_plugin_form.step2_files.schema_file.label')"
             :placeholder="editMode && state.fields.schemaContent
               ? t('custom_plugin_form.step2_files.schema_file.placeholder_edit')
@@ -279,6 +289,18 @@
             @file-added="(files: FileList) => handleFileAdded('schema', files)"
             @file-removed="handleFileRemoved('schema')"
           />
+          <p class="schema-file-help">
+            <i18nT keypath="custom_plugin_form.step2_files.schema_file.help.text">
+              <template #link>
+                <KExternalLink
+                  hide-icon
+                  :href="externalLinks.customPluginStreamed"
+                >
+                  {{ t('custom_plugin_form.step2_files.schema_file.help.link') }}
+                </KExternalLink>
+              </template>
+            </i18nT>
+          </p>
           <KFileUpload
             :accept="['.lua']"
             :button-text="t('custom_plugin_form.step2_files.handler_file.button_text')"
@@ -1006,6 +1028,14 @@ const submitData = async (): Promise<void> => {
   display: flex;
   flex-direction: column;
   gap: var(--kui-space-40, $kui-space-40);
+}
+
+.schema-file-help {
+  color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+  font-size: var(--kui-font-size-20, $kui-font-size-20);
+  line-height: var(--kui-line-height-20, $kui-line-height-20);
+  margin: 0;
+  margin-top: calc(-1 * var(--kui-space-40, $kui-space-40));
 }
 
 .custom-plugin-form-steps {

--- a/packages/entities/entities-plugins/src/external-links.ts
+++ b/packages/entities/entities-plugins/src/external-links.ts
@@ -3,4 +3,6 @@ export default {
   condition: 'https://developer.konghq.com/gateway/plugins/expressions/',
   customPluginSandboxing: 'https://developer.konghq.com/gateway/sandboxing/',
   pluginPriority: 'https://developer.konghq.com/gateway/entities/plugin/#plugin-priority',
+  customPluginInstalled: 'https://developer.konghq.com/custom-plugins/konnect-hybrid-mode/',
+  customPluginStreamed: 'https://developer.konghq.com/custom-plugins/streaming-plugins/',
 }

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -1794,7 +1794,10 @@
         "placeholder": "No file selected",
         "placeholder_edit": "File not changed",
         "button_text": "Select File",
-        "help": "Only Lua based schemas are supported by Konnect. Other plugin modules can be in any language as desired. Learn more"
+        "help": {
+          "text": "Only Lua based schemas are supported by Konnect. Other plugin modules can be in any language as desired. {link}",
+          "link": "Learn more"
+        }
       },
       "handler_file": {
         "label": "Upload handler file",


### PR DESCRIPTION
## Summary
- Turn the "Learn more" text in the custom plugin schema file help into an actual link
- Point to the installed custom plugin docs or the streamed custom plugin docs depending on the selected plugin type

Jira ticket: [KM-3187](https://konghq.atlassian.net/browse/KM-3187)

[TEST_COVERAGE_EXEMPT_REASON] This change only updates help text/links and locale strings in an existing form; no new logic or behavior is introduced that requires test coverage.

## Test plan
- [x] Open the custom plugin form, select "Installed" plugin type, verify the schema file help text renders "Learn more" as a link to https://developer.konghq.com/custom-plugins/konnect-hybrid-mode/
- [x] Select "Streamed" plugin type, verify the schema file help text renders "Learn more" as a link to https://developer.konghq.com/custom-plugins/streaming-plugins/

[KM-3187]: https://konghq.atlassian.net/browse/KM-3187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ