### PR TITLE
chore: OIDC principal improvements

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/OpenidConnectForm.cy.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/OpenidConnectForm.cy.ts
@@ -905,6 +905,60 @@ describe('OpenidConnectForm', () => {
         expect(call, 'directory adoption call not found').not.to.equal(undefined)
       })
     })
+
+    it('resets client_id/client_secret to null (not an array) when the auth server changes', () => {
+      mountPrincipalsForm({
+        model: createPrincipalsModel({
+          client_id: ['old-client'],
+          client_secret: ['old-secret'],
+        }),
+      }, [
+        { id: 'server-1', name: 'My Auth Server', issuer: 'https://my-server.us.identity.konghq.com' },
+      ])
+
+      cy.wait('@getAuthServers')
+
+      cy.getTestId('principals-directory-select').click()
+      cy.getTestId('select-item-server-1').click()
+
+      lastFormChange().then((payload) => {
+        expect(payload.config.client_id).to.equal(null)
+        expect(payload.config.client_secret).to.equal(null)
+      })
+    })
+
+    it('caches and restores client_id, client_secret, and issuer when toggling between Kong Identity and External', () => {
+      mountPrincipalsForm({ formsConfig: { isKongIdentityAuthServersAvailable: false } })
+
+      cy.getTestId('kong-identity-issuer-input').type('https://my-issuer.example.com')
+      cy.getTestId('principals-client-id-input').type('kong-client-id')
+      cy.getTestId('principals-client-secret').type('kong-client-secret')
+
+      cy.getTestId('oidc-auth-mode-external').click({ force: true })
+
+      // Entering External mode for the first time starts blank...
+      cy.getTestId('external-client-id').should('have.value', '')
+      cy.getTestId('external-client-secret').should('have.value', '')
+      cy.getTestId('ff-config.issuer').should('have.value', '')
+
+      cy.getTestId('external-client-id').type('external-client-id')
+      cy.getTestId('external-client-secret').type('external-client-secret')
+      cy.getTestId('ff-config.issuer').type('https://external-issuer.example.com')
+
+      cy.getTestId('oidc-auth-mode-kong-identity').click({ force: true })
+
+      // ...and toggling back to Kong Identity restores what was entered there before leaving.
+      cy.getTestId('kong-identity-issuer-input').should('have.value', 'https://my-issuer.example.com')
+      cy.getTestId('principals-client-id-input').should('have.value', 'kong-client-id')
+      cy.getTestId('principals-client-secret').should('have.value', 'kong-client-secret')
+
+      cy.getTestId('oidc-auth-mode-external').click({ force: true })
+
+      // External's own entries are restored too, not cleared a second time.
+      cy.getTestId('external-client-id').should('have.value', 'external-client-id')
+      cy.getTestId('external-client-secret').should('have.value', 'external-client-secret')
+      cy.getTestId('ff-config.issuer').should('have.value', 'https://external-issuer.example.com')
+    })
   })
 
   // ── O: Principal lookup settings ───────────────────────────────────────────

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalLookupSettings.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalLookupSettings.vue
@@ -113,12 +113,13 @@
           {{ t('plugins.free-form.openid-connect.lookup.match_consumer.label') }}
           <template #description>
             {{ t('plugins.free-form.openid-connect.lookup.match_consumer.description') }}
-            <a
+            <KExternalLink
               class="principals-learn-more-link"
               href="https://developer.konghq.com/identity/principals/"
               rel="noopener noreferrer"
+              hide-icon
               target="_blank"
-            >{{ t('plugins.free-form.openid-connect.lookup.match_consumer.link') }}</a>
+            >{{ t('plugins.free-form.openid-connect.lookup.match_consumer.link') }}</KExternalLink>
           </template>
         </KCheckbox>
       </div>
@@ -133,12 +134,13 @@
           {{ t('plugins.free-form.openid-connect.lookup.match_consumer_groups.label') }}
           <template #description>
             {{ t('plugins.free-form.openid-connect.lookup.match_consumer_groups.description') }}
-            <a
+            <KExternalLink
               class="principals-learn-more-link"
               href="https://developer.konghq.com/identity/principals/"
               rel="noopener noreferrer"
+              hide-icon
               target="_blank"
-            >{{ t('plugins.free-form.openid-connect.lookup.match_consumer_groups.link') }}</a>
+            >{{ t('plugins.free-form.openid-connect.lookup.match_consumer_groups.link') }}</KExternalLink>
           </template>
         </KCheckbox>
       </div>
@@ -357,8 +359,6 @@ function handleEnableToggle(enabled: boolean) {
     color: var(--kui-color-text-primary, $kui-color-text-primary);
     font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
     gap: var(--kui-space-20, $kui-space-20);
-    outline: none;
-    text-decoration: none;
 
     &:hover {
       color: var(--kui-color-text-primary-strong, $kui-color-text-primary-strong);

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalLookupSettings.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalLookupSettings.vue
@@ -115,11 +115,13 @@
             {{ t('plugins.free-form.openid-connect.lookup.match_consumer.description') }}
             <KExternalLink
               class="principals-learn-more-link"
+              hide-icon
               href="https://developer.konghq.com/identity/principals/"
               rel="noopener noreferrer"
-              hide-icon
               target="_blank"
-            >{{ t('plugins.free-form.openid-connect.lookup.match_consumer.link') }}</KExternalLink>
+            >
+              {{ t('plugins.free-form.openid-connect.lookup.match_consumer.link') }}
+            </KExternalLink>
           </template>
         </KCheckbox>
       </div>
@@ -136,11 +138,13 @@
             {{ t('plugins.free-form.openid-connect.lookup.match_consumer_groups.description') }}
             <KExternalLink
               class="principals-learn-more-link"
+              hide-icon
               href="https://developer.konghq.com/identity/principals/"
               rel="noopener noreferrer"
-              hide-icon
               target="_blank"
-            >{{ t('plugins.free-form.openid-connect.lookup.match_consumer_groups.link') }}</KExternalLink>
+            >
+              {{ t('plugins.free-form.openid-connect.lookup.match_consumer_groups.link') }}
+            </KExternalLink>
           </template>
         </KCheckbox>
       </div>

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalsSection.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalsSection.vue
@@ -149,7 +149,7 @@
       />
 
       <div
-        v-for="(clientId, index) in clientIdArray"
+        v-for="(clientId, index) in clientIds"
         :key="index"
         class="client-row"
         :class="{ 'client-row-with-label': index === 0 }"
@@ -204,7 +204,7 @@
             data-testid="principals-client-secret"
             :disabled="hasAuthServersAccess && !selectedServer"
             :label="index === 0 ? t('plugins.free-form.openid-connect.principals.client.secret_label') : undefined"
-            :model-value="clientSecretArray[index] ?? undefined"
+            :model-value="clientSecrets[index] ?? undefined"
             :placeholder="t('plugins.free-form.openid-connect.principals.client.secret_placeholder')"
             show-password-mask-toggle
             type="password"
@@ -215,7 +215,7 @@
             v-if="autofillSlot"
             :schema="{ model: 'config-client_secret', referenceable: true }"
             :update="(val: string) => handleClientSecretChange(index, val)"
-            :value="clientSecretArray[index]"
+            :value="clientSecrets[index]"
           />
         </div>
         <button
@@ -255,7 +255,7 @@
 
     <template v-else>
       <div
-        v-for="(clientId, index) in clientIdArray"
+        v-for="(clientId, index) in clientIds"
         :key="index"
         class="client-row"
         :class="{ 'client-row-with-label': index === 0 }"
@@ -294,7 +294,7 @@
             class="external-client-input"
             data-testid="external-client-secret"
             :label="index === 0 ? t('plugins.free-form.openid-connect.principals.client.secret_label') : undefined"
-            :model-value="clientSecretArray[index] ?? undefined"
+            :model-value="clientSecrets[index] ?? undefined"
             :placeholder="t('plugins.free-form.openid-connect.principals.client.secret_placeholder')"
             show-password-mask-toggle
             type="password"
@@ -313,14 +313,14 @@
             v-if="autofillSlot"
             :schema="{ model: 'config-client_secret', referenceable: true }"
             :update="(val: string) => handleClientSecretChange(index, val)"
-            :value="clientSecretArray[index]"
+            :value="clientSecrets[index]"
           />
         </div>
         <button
           :aria-label="t('plugins.free-form.openid-connect.principals.client.remove')"
           class="remove-client-btn"
           data-testid="remove-external-client-action"
-          :disabled="clientIdArray.length <= 1"
+          :disabled="clientIds.length <= 1"
           type="button"
           @click="removeClientRow(index)"
         >
@@ -476,17 +476,31 @@ const issuer = computed<string | null>({
   },
 })
 
-const clientIdValue = computed<Array<string | null> | null>({
-  get: () => formData.config?.client_id ?? null,
+// A cleared field is `null` on the model but still needs one row on screen, so the getter
+// fabricates `[null]`. The setter is that getter's inverse: a lone empty row is the
+// fabrication coming back (the inputs echo it on re-render) and clears the field again,
+// while extra rows are ones the user actually added and pass through. Writing `null` clears.
+const clientIds = computed<Array<string | null>, Array<string | null> | null>({
+  get: () => {
+    const ids = formData.config?.client_id
+    return Array.isArray(ids) && ids.length > 0 ? ids : [null]
+  },
   set: (value) => {
-    if (formData.config) formData.config.client_id = value
+    if (formData.config) {
+      formData.config.client_id = value && (value.length > 1 || value[0]) ? value : getEmptyValue()
+    }
   },
 })
 
-const clientSecretValue = computed<Array<string | null> | null>({
-  get: () => formData.config?.client_secret ?? null,
+const clientSecrets = computed<Array<string | null>, Array<string | null> | null>({
+  get: () => {
+    const secrets = formData.config?.client_secret
+    return Array.isArray(secrets) && secrets.length > 0 ? secrets : [null]
+  },
   set: (value) => {
-    if (formData.config) formData.config.client_secret = value
+    if (formData.config) {
+      formData.config.client_secret = value && (value.length > 1 || value[0]) ? value : getEmptyValue()
+    }
   },
 })
 
@@ -537,20 +551,8 @@ const clientItems = computed(() =>
   clients.value.map(c => ({ label: c.name, value: c.client_id || c.id })),
 )
 
-const clientIdArray = computed<Array<string | null>>(() => {
-  const ids = clientIdValue.value
-  if (Array.isArray(ids) && ids.length > 0) return ids
-  return [null]
-})
-
-const clientSecretArray = computed<Array<string | null>>(() => {
-  const secrets = clientSecretValue.value
-  if (Array.isArray(secrets) && secrets.length > 0) return secrets
-  return [null]
-})
-
 const isRemoveClientDisabled = computed(() =>
-  (hasAuthServersAccess.value && !selectedServer.value) || clientIdArray.value.length <= 1,
+  (hasAuthServersAccess.value && !selectedServer.value) || clientIds.value.length <= 1,
 )
 
 // Without auth-server access, the Kong Identity server/client dropdowns fall back to
@@ -653,8 +655,8 @@ function handleServerChange(serverId: string | null) {
     issuer.value = selectedServer.value.issuer
   }
   // Reset client selection when server changes
-  clientIdValue.value = null
-  clientSecretValue.value = null
+  clientIds.value = null
+  clientSecrets.value = null
   clients.value = []
   clientsLoading.value = !!serverId
   if (serverId) {
@@ -663,38 +665,36 @@ function handleServerChange(serverId: string | null) {
 }
 
 function handleClientChange(index: number, clientId: string | null) {
-  const clientIds = [...clientIdArray.value]
-  clientIds[index] = clientId
-  clientIdValue.value = clientIds
+  const next = [...clientIds.value]
+  next[index] = clientId
+  clientIds.value = next
 }
 
 function handleClientSecretChange(index: number, value: string) {
-  const secrets = [...clientSecretArray.value]
-  secrets[index] = value
-  clientSecretValue.value = secrets
+  const next = [...clientSecrets.value]
+  next[index] = value
+  clientSecrets.value = next
 }
 
 function addClientRow() {
-  // Base off the normalized arrays so the virtualized first row (when the
-  // model is still null) is preserved instead of being dropped.
-  clientIdValue.value = [...clientIdArray.value, null]
-  clientSecretValue.value = [...clientSecretArray.value, null]
+  clientIds.value = [...clientIds.value, null]
+  clientSecrets.value = [...clientSecrets.value, null]
 }
 
 function removeClientRow(index: number) {
-  if (clientIdArray.value.length <= 1) return
+  if (clientIds.value.length <= 1) return
 
-  const clientIds = [...clientIdArray.value]
-  clientIds.splice(index, 1)
-  clientIdValue.value = clientIds
+  const nextIds = [...clientIds.value]
+  nextIds.splice(index, 1)
+  clientIds.value = nextIds
 
-  const secrets = [...clientSecretArray.value]
-  secrets.splice(index, 1)
-  clientSecretValue.value = secrets
+  const nextSecrets = [...clientSecrets.value]
+  nextSecrets.splice(index, 1)
+  clientSecrets.value = nextSecrets
 }
 
 function getClientItemsForRow(index: number) {
-  const selectedIds = clientIdArray.value
+  const selectedIds = clientIds.value
   return clientItems.value.map(item => ({
     ...item,
     disabled: selectedIds.some((id, i) => i !== index && id === item.value),
@@ -755,16 +755,16 @@ function handleModeChange(newMode: PrincipalsMode) {
     if (oldMode === MODE_KONG_IDENTITY) {
       kongIdentityCache.value = {
         issuer: issuer.value,
-        clientId: clientIdValue.value,
-        clientSecret: clientSecretValue.value,
+        clientId: clientIds.value,
+        clientSecret: clientSecrets.value,
         selectedServer: selectedServer.value,
         clients: clients.value,
       }
     } else {
       externalCache.value = {
         issuer: issuer.value,
-        clientId: clientIdValue.value,
-        clientSecret: clientSecretValue.value,
+        clientId: clientIds.value,
+        clientSecret: clientSecrets.value,
       }
     }
 

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalsSection.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalsSection.vue
@@ -506,6 +506,26 @@ const selectedServer = ref<KongIdentityServer | null>(null)
 const leavePromptType = ref<'authServer' | 'client' | 'principal' | null>(null)
 let restoringServer = false
 
+interface KongIdentityModeCache {
+  issuer: string | null
+  clientId: Array<string | null> | null
+  clientSecret: Array<string | null> | null
+  selectedServer: KongIdentityServer | null
+  clients: KongIdentityClient[]
+}
+
+interface ExternalModeCache {
+  issuer: string | null
+  clientId: Array<string | null> | null
+  clientSecret: Array<string | null> | null
+}
+
+// Preserve what the user typed in each mode so toggling back and forth doesn't
+// throw their entries away.
+const kongIdentityCache = ref<KongIdentityModeCache | null>(null)
+const externalCache = ref<ExternalModeCache | null>(null)
+let previousMode: PrincipalsMode = selectedMode.value
+
 const clientIdInfo = computed(() => getLabelAttributes('config.client_id').info)
 const clientSecretInfo = computed(() => getLabelAttributes('config.client_secret').info)
 
@@ -633,8 +653,8 @@ function handleServerChange(serverId: string | null) {
     issuer.value = selectedServer.value.issuer
   }
   // Reset client selection when server changes
-  clientIdValue.value = [null]
-  clientSecretValue.value = [null]
+  clientIdValue.value = null
+  clientSecretValue.value = null
   clients.value = []
   clientsLoading.value = !!serverId
   if (serverId) {
@@ -726,11 +746,51 @@ function applyAuthMethodsForMode(mode: PrincipalsMode) {
 }
 
 function handleModeChange(newMode: PrincipalsMode) {
-  // Clear the mode-specific credential fields either way
-  if (formData.config) {
-    formData.config.client_id = getEmptyValue()
-    formData.config.client_secret = getEmptyValue()
-    formData.config.issuer = getEmptyValue()
+  const oldMode = previousMode
+  previousMode = newMode
+
+  if (oldMode !== newMode) {
+    // Stash what the user entered in the mode being left, so it can be restored if they
+    // toggle back instead of being lost.
+    if (oldMode === MODE_KONG_IDENTITY) {
+      kongIdentityCache.value = {
+        issuer: issuer.value,
+        clientId: clientIdValue.value,
+        clientSecret: clientSecretValue.value,
+        selectedServer: selectedServer.value,
+        clients: clients.value,
+      }
+    } else {
+      externalCache.value = {
+        issuer: issuer.value,
+        clientId: clientIdValue.value,
+        clientSecret: clientSecretValue.value,
+      }
+    }
+
+    // Restore the mode being entered from its cache, or clear if it's never been visited.
+    if (newMode === MODE_KONG_IDENTITY) {
+      const cached = kongIdentityCache.value
+      if (formData.config) {
+        formData.config.issuer = cached?.issuer ?? getEmptyValue()
+        formData.config.client_id = cached?.clientId ?? getEmptyValue()
+        formData.config.client_secret = cached?.clientSecret ?? getEmptyValue()
+      }
+      if (cached?.selectedServer) {
+        restoringServer = true
+      }
+      selectedServer.value = cached?.selectedServer ?? null
+      clients.value = cached?.clients ?? []
+    } else {
+      const cached = externalCache.value
+      if (formData.config) {
+        formData.config.issuer = cached?.issuer ?? getEmptyValue()
+        formData.config.client_id = cached?.clientId ?? getEmptyValue()
+        formData.config.client_secret = cached?.clientSecret ?? getEmptyValue()
+      }
+      selectedServer.value = null
+      clients.value = []
+    }
   }
 
   // Principal lookup is opt-in (the "Use principal lookup" toggle) in both modes, so it
@@ -751,12 +811,6 @@ function handleModeChange(newMode: PrincipalsMode) {
       match_consumer_groups: true,
       directory: dir,
     }
-  }
-
-  if (newMode === MODE_EXTERNAL) {
-    // Reset local state
-    selectedServer.value = null
-    clients.value = []
   }
 
   applyAuthMethodsForMode(newMode)


### PR DESCRIPTION
# Summary

KM-3156
KM-3165
KM-3167

- Fix: selecting a Kong Identity auth server reset client_id/client_secret to [null] instead of null, so newly-created OIDC principals configs persisted an array-wrapped null instead of a plain null.
- Fix: toggling the "Kong Identity" / "External Auth Server" radio wiped issuer, client_id, and client_secret (and the selected auth server/client list) unconditionally on every switch. Each mode's values are now cached and restored when switching back, so users no longer lose what they typed by toggling.
- Fix: the "learn more" links in the principal lookup settings (match consumer / match consumer groups) used a raw <a> tag instead of KExternalLink, leaving them without the standard external-link icon/styling; swapped to KExternalLink (with hide-icon) and dropped the now-redundant manual outline/text-decoration overrides.
# Test Coverage
- Added a Cypress component test asserting client_id/client_secret reset to null (not an array) when the auth server selection changes.
- Added a Cypress component test covering the full toggle round-trip (Kong Identity → External → Kong Identity → External), asserting each mode's issuer/client_id/client_secret are preserved instead of cleared.
