### PR TITLE
feat(analytics): show warning for an unsupported timerange [MA-5356]

### DIFF
--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.cy.ts
@@ -607,7 +607,7 @@ describe('<DashboardTile />', () => {
     })
 
     cy.getTestId('time-range-badge').should('exist')
-    cy.getTestId('kui-icon-svg-warning-icon').should('exist')
+    cy.getTestId('time-range-badge').findTestId('kui-icon-svg-warning-icon').should('exist')
   })
 
   it('should not show aged out warning when query granularity matches granularity', () => {
@@ -622,7 +622,7 @@ describe('<DashboardTile />', () => {
     })
 
     cy.getTestId('time-range-badge').should('exist')
-    cy.getTestId('kui-icon-svg-warning-icon').should('not.exist')
+    cy.getTestId('time-range-badge').findTestId('kui-icon-svg-warning-icon').should('not.exist')
   })
 
   it('should not show aged out warning when query is not ready', () => {
@@ -640,7 +640,7 @@ describe('<DashboardTile />', () => {
     })
 
     cy.getTestId('time-range-badge').should('exist')
-    cy.getTestId('kui-icon-svg-warning-icon').should('not.exist')
+    cy.getTestId('time-range-badge').findTestId('kui-icon-svg-warning-icon').should('not.exist')
   })
 
   it('should not show aged out warning when saved granularity is missing', () => {
@@ -659,7 +659,7 @@ describe('<DashboardTile />', () => {
     })
 
     cy.getTestId('time-range-badge').should('exist')
-    cy.getTestId('kui-icon-svg-warning-icon').should('not.exist')
+    cy.getTestId('time-range-badge').findTestId('kui-icon-svg-warning-icon').should('not.exist')
   })
 
   it('jump to requests link should be reactive', () => {

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.spec.ts
@@ -124,7 +124,20 @@ const mockQueryProvider = {
   configFn: () => Promise.resolve({ analytics: { percentiles: true }, requests: null }),
   exploreBaseUrl: async () => 'http://test.com/explore',
   requestsBaseUrl: async () => 'http://test.com/requests',
-  datasourceConfigFn: () => Promise.resolve([]),
+  datasourceConfigFn: () => Promise.resolve([
+    {
+      name: 'api_usage',
+      showInUI: true,
+      fields: [],
+      timeRangeOptions: ['15m', '1h', '24h', '7d', '30d'],
+    },
+    {
+      name: 'managed_cache_usage',
+      showInUI: true,
+      fields: [],
+      timeRangeOptions: ['15m', '1h', '6h', '12h', '24h', '7d'],
+    },
+  ]),
   evaluateFeatureFlagFn: () => true,
 }
 
@@ -285,6 +298,63 @@ describe('<DashboardTile /> zoom requests drilldown', () => {
     await flushPromises()
 
     expect(wrapper.findTestId('time-range-badge').exists()).toBe(false)
+  })
+
+  it('warns when a relative timeframe is unsupported by the datasource', async () => {
+    const wrapper = mountTile('managed_cache_usage')
+    await wrapper.setProps({
+      context: {
+        ...mockContext,
+        timeSpec: {
+          type: 'relative',
+          time_range: '30d',
+        },
+      },
+    })
+    await flushPromises()
+
+    const badge = wrapper.getTestId('unsupported-time-range-badge')
+    const badgeComponent = wrapper.findAllComponents({ name: 'KBadge' })
+      .find(component => component.attributes('data-testid') === 'unsupported-time-range-badge')
+
+    expect(badge.exists()).toBe(true)
+    expect(badgeComponent?.props('tooltip')).toContain('limited to the maximum supported timeframe')
+  })
+
+  it.each([
+    ['managed cache supports the selected timeframe', 'managed_cache_usage', '7d'],
+    ['another datasource supports the selected timeframe', 'api_usage', '30d'],
+  ] as const)('does not show the unsupported timeframe warning when %s', async (_, datasource, timeRange) => {
+    const wrapper = mountTile(datasource)
+    await wrapper.setProps({
+      context: {
+        ...mockContext,
+        timeSpec: {
+          type: 'relative',
+          time_range: timeRange,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.findTestId('unsupported-time-range-badge').exists()).toBe(false)
+  })
+
+  it('warns when an absolute timeframe exceeds the datasource maximum', async () => {
+    const wrapper = mountTile('managed_cache_usage')
+    await wrapper.setProps({
+      context: {
+        ...mockContext,
+        timeSpec: {
+          type: 'absolute',
+          start: new Date('2024-01-01T00:00:00Z'),
+          end: new Date('2024-01-09T00:00:00Z'),
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.findTestId('unsupported-time-range-badge').exists()).toBe(true)
   })
 })
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -27,6 +27,20 @@
 
       <div class="badge-container">
         <KBadge
+          v-if="rangeUnsupported"
+          appearance="warning"
+          data-testid="unsupported-time-range-badge"
+          :tooltip="i18n.t('unsupported_time_range_warning')"
+          :tooltip-attributes="{ maxWidth: '320px' }"
+        >
+          <template #icon>
+            <WarningIcon :size="`var(--kui-icon-size-20, ${KUI_ICON_SIZE_20})`" />
+          </template>
+          <span class="badge-text">
+            {{ i18n.t('unsupported_time_range_badge') }}
+          </span>
+        </KBadge>
+        <KBadge
           v-if="badgeData"
           data-testid="time-range-badge"
           :tooltip="isAgedOutQuery ? agedOutWarning : undefined"
@@ -181,6 +195,7 @@ import type {
   AllFilters,
   TileConfig,
   TileDefinition,
+  TimeRangeV4,
 } from '@kong-ui-public/analytics-utilities'
 
 import { type Component, computed, defineAsyncComponent, inject, nextTick, readonly, ref, toRef, watch } from 'vue'
@@ -197,6 +212,7 @@ import TopNTableRenderer from './TopNTableRenderer.vue'
 import TableDataGridRenderer from './TableDataGridRenderer.vue'
 import composables from '../composables'
 import { isTableChartDefinition } from '../utils/tile-definition'
+import { isTimeRangeUnsupported } from '../utils/time-range-support'
 import { useDatasourceConfigStore } from '@kong-ui-public/analytics-config-store'
 import { storeToRefs } from 'pinia'
 import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_40, KUI_ICON_SIZE_60, KUI_ICON_SIZE_20, KUI_SPACE_70 } from '@kong/design-tokens'
@@ -250,7 +266,7 @@ const emit = defineEmits<{
 const GeoMapRendererAsync = defineAsyncComponent(() => import('./GeoMapRenderer.vue'))
 const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
 const datasourceConfigStore = useDatasourceConfigStore()
-const { stripUnknownFilters } = storeToRefs(datasourceConfigStore)
+const { datasourceConfigMap, stripUnknownFilters } = storeToRefs(datasourceConfigStore)
 const { i18n } = composables.useI18n()
 const chartData = ref<ExploreResultV4>()
 const exportState = ref<ExploreExportState>({ status: 'loading' })
@@ -411,6 +427,16 @@ const badgeData = computed<string | null>(() => {
   return null
 })
 
+const rangeUnsupported = computed(() => {
+  const query = definition.query
+  const datasource = query?.datasource
+  const supportedTimeRanges = datasource ? datasourceConfigMap.value[datasource]?.timeRangeOptions : undefined
+  const tileTimeRange = query && 'time_range' in query ? query.time_range : undefined
+  const timeRange = tileTimeRange ?? context.timeSpec
+
+  return isTimeRangeUnsupported(timeRange as TimeRangeV4 | undefined, supportedTimeRanges)
+})
+
 const hasTileHeader = computed<boolean>(() => {
   if (isSlottableTile.value) {
     return false
@@ -420,6 +446,7 @@ const hasTileHeader = computed<boolean>(() => {
     Boolean(tileTitle.value),
     hasHeaderActions.value,
     Boolean(badgeData.value),
+    rangeUnsupported.value,
     Boolean(tileDescription.value),
     showRefresh,
   ].some(Boolean)
@@ -596,6 +623,7 @@ defineExpose({ getExportData })
   .badge-container {
     display: flex;
     flex-grow: 1;
+    gap: var(--kui-space-30, $kui-space-30);
     justify-content: flex-end;
   }
 

--- a/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/components/QueryDataProvider.spec.ts
@@ -101,6 +101,7 @@ describe('QueryDataProvider', () => {
     resetSwrvState()
     mockedFetcher = undefined
     vi.mocked(useDatasourceConfigStore).mockReturnValue({
+      datasourceConfigMap: ref({}),
       isReady: vi.fn().mockResolvedValue(undefined),
       stripUnknownFilters: ref(({ filters }: { filters: any[] }) => filters),
     } as any)

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.spec.ts
@@ -33,6 +33,11 @@ describe('useIssueQuery', () => {
   })
 
   const mockStore = {
+    datasourceConfigMap: ref({
+      managed_cache_usage: {
+        timeRangeOptions: ['15m', '1h', '6h', '12h', '24h', '7d'],
+      },
+    }),
     isReady: vi.fn().mockResolvedValue(undefined),
     stripUnknownFilters: ref(mockStripUnknownFilters),
   } as any
@@ -103,6 +108,63 @@ describe('useIssueQuery', () => {
     expect(queryFn).toHaveBeenCalledOnce()
     expect(queryFn.mock.calls[0][0]).toMatchObject({
       datasource: 'basic',
+    })
+  })
+
+  it('limits a relative context timeframe to the datasource maximum', async () => {
+    const queryFn = vi.fn().mockResolvedValue({})
+    const wrapper = mountComposable({
+      queryFn,
+    } as any)
+
+    await wrapper.vm.issueQuery({
+      datasource: 'managed_cache_usage',
+      metrics: [],
+      dimensions: [],
+      filters: [],
+    } as any, {
+      ...context,
+      timeSpec: {
+        type: 'relative',
+        time_range: '30d',
+      },
+    })
+
+    expect(queryFn.mock.calls[0][0]).toMatchObject({
+      query: {
+        time_range: {
+          type: 'relative',
+          time_range: '7d',
+          tz: 'UTC',
+        },
+      },
+    })
+  })
+
+  it('limits an absolute tile timeframe while preserving its end', async () => {
+    const queryFn = vi.fn().mockResolvedValue({})
+    const wrapper = mountComposable({
+      queryFn,
+    } as any)
+    const end = new Date('2024-01-30T00:00:00Z')
+
+    await wrapper.vm.issueQuery({
+      datasource: 'managed_cache_usage',
+      metrics: [],
+      dimensions: [],
+      filters: [],
+      time_range: {
+        type: 'absolute',
+        start: new Date('2024-01-01T00:00:00Z'),
+        end,
+      },
+    } as any, context)
+
+    expect(queryFn.mock.calls[0][0].query.time_range).toEqual({
+      type: 'absolute',
+      start: new Date('2024-01-23T00:00:00Z'),
+      end,
+      tz: 'UTC',
     })
   })
 

--- a/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useIssueQuery.ts
@@ -8,11 +8,12 @@ import type { DashboardRendererContext } from '../types'
 import { inject, onUnmounted } from 'vue'
 import { INJECT_QUERY_PROVIDER } from '../constants'
 import { storeToRefs } from 'pinia'
+import { limitTimeRange } from '../utils/time-range-support'
 
 export default function useIssueQuery() {
   const queryBridge: AnalyticsBridge | undefined = inject(INJECT_QUERY_PROVIDER)
   const datasourceConfigStore = useDatasourceConfigStore()
-  const { stripUnknownFilters } = storeToRefs(datasourceConfigStore)
+  const { datasourceConfigMap, stripUnknownFilters } = storeToRefs(datasourceConfigStore)
 
   // Ensure that any pending requests are canceled when superseded or on unmount.
   let abortController: AbortController | null = null
@@ -69,6 +70,8 @@ export default function useIssueQuery() {
         tz: context.tz,
       }
     }
+
+    time_range = limitTimeRange(time_range, datasourceConfigMap.value[datasource]?.timeRangeOptions)
 
     // TODO: similar to other places, consider adding a type guard to ensure the query
     // matches the datasource.  Currently, this block effectively pretends all queries

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -229,6 +229,8 @@
   },
   "jumpToExplore": "Explore",
   "jumpToRequests": "View requests",
+  "unsupported_time_range_badge": "Limited timeframe",
+  "unsupported_time_range_warning": "The selected timeframe exceeds what this datasource supports, so this tile is limited to the maximum supported timeframe.",
   "query_aged_out_warning": "This tile was configured with {savedGranularity} granularity, which is no longer available. It now shows {currentGranularity} data, the closest available granularity.",
   "granularities": {
     "daily": "1 day",

--- a/packages/analytics/dashboard-renderer/src/utils/index.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './configure-definition'
+export * from './time-range-support'

--- a/packages/analytics/dashboard-renderer/src/utils/time-range-support.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/time-range-support.ts
@@ -1,0 +1,65 @@
+import type { TimeRangeV4 } from '@kong-ui-public/analytics-utilities'
+
+import { TimePeriods, TIMEFRAME_LOOKUP } from '@kong-ui-public/analytics-utilities'
+
+interface SupportedTimeRange {
+  durationSeconds: number
+  key: string
+}
+
+const getTimeRangeDurationMs = (timeRange: TimeRangeV4): number | undefined => {
+  if (timeRange.type === 'relative') {
+    return TimePeriods.get(TIMEFRAME_LOOKUP[timeRange.time_range])?.timeframeLengthMs()
+  }
+
+  return new Date(timeRange.end).getTime() - new Date(timeRange.start).getTime()
+}
+
+const getMaximumSupportedTimeRange = (supportedTimeRanges: string[]): SupportedTimeRange | undefined => {
+  return supportedTimeRanges.reduce<SupportedTimeRange | undefined>((maximum, key) => {
+    const durationSeconds = TimePeriods.get(TIMEFRAME_LOOKUP[key])?.maximumTimeframeLength()
+
+    if (durationSeconds === undefined || maximum && durationSeconds <= maximum.durationSeconds) {
+      return maximum
+    }
+
+    return { durationSeconds, key }
+  }, undefined)
+}
+
+export const isTimeRangeUnsupported = (
+  timeRange: TimeRangeV4 | undefined,
+  supportedTimeRanges: string[] | undefined,
+) => {
+  if (!timeRange || !supportedTimeRanges?.length) {
+    return undefined
+  }
+
+  const durationMs = getTimeRangeDurationMs(timeRange)
+  const maximum = getMaximumSupportedTimeRange(supportedTimeRanges)
+
+  return durationMs !== undefined && maximum && durationMs > maximum.durationSeconds * 1000 ? maximum : undefined
+}
+
+export const limitTimeRange = (
+  timeRange: TimeRangeV4 | undefined,
+  supportedTimeRanges: string[] | undefined,
+): TimeRangeV4 | undefined => {
+  const maximum = isTimeRangeUnsupported(timeRange, supportedTimeRanges)
+
+  if (!maximum || !timeRange) {
+    return timeRange
+  }
+
+  if (timeRange.type === 'relative') {
+    return {
+      ...timeRange,
+      time_range: maximum.key,
+    }
+  }
+
+  return {
+    ...timeRange,
+    start: new Date(new Date(timeRange.end).getTime() - maximum.durationSeconds * 1000),
+  }
+}


### PR DESCRIPTION
# Summary

This will add a badge in a DashboardTile header to warn the user when a selected timerange is unsupported based on the datasource selected, as well as changing the query issued for a dashboard tile by limiting the range.

Each datasource provides a supported list of ranges, this is then compared against the selected timeframe to determine if the query should be limited and if the warning should show.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

<!--
## Test Coverage Exemption (Optional)
If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.

[TEST_COVERAGE_EXEMPT_REASON] give it a reason
-->
