### PR TITLE
fix(entities-plugins): respect key-auth context flags when resetting identity_realms/realm

### DIFF
--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -254,6 +254,8 @@ function mountContent(
     dataPlaneVersions?: string[]
     /** key-auth context: set to `false` to disable the identity_realms flow entirely. */
     identityRealmsEnabled?: boolean
+    /** key-auth context: set to `false` to hide/disable the realm field entirely. */
+    realmsEnabled?: boolean
   },
   data?: Record<string, any>,
 ) {
@@ -278,6 +280,10 @@ function mountContent(
 
   const beforeSaveCallbacks: Array<() => boolean> = []
 
+  const keyAuthContext: Record<string, boolean> = {}
+  if (options.identityRealmsEnabled !== undefined) keyAuthContext.identityRealmsEnabled = options.identityRealmsEnabled
+  if (options.realmsEnabled !== undefined) keyAuthContext.realmsEnabled = options.realmsEnabled
+
   cy.mount(() =>
     h('div', { style: 'padding: 20px' },
       h(Form, {
@@ -298,8 +304,8 @@ function mountContent(
         [BEFORE_SAVE_KEY as symbol]: (cb: () => boolean) => {
           beforeSaveCallbacks.push(cb); return () => {}
         },
-        ...(options.identityRealmsEnabled !== undefined
-          ? { [PLUGIN_CONTEXT_KEY]: { 'key-auth': { identityRealmsEnabled: options.identityRealmsEnabled } } }
+        ...(Object.keys(keyAuthContext).length > 0
+          ? { [PLUGIN_CONTEXT_KEY]: { 'key-auth': keyAuthContext } }
           : {}),
       },
     },
@@ -751,6 +757,58 @@ describe('ConfigFormContent', () => {
 
         cy.getTestId('kong-identity-mode-centrally-managed').should('exist')
         cy.wait('@fetchRealms')
+      })
+
+      it('does not clear identity_realms when switching to "Kong Identity" while disabled', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, identityRealmsEnabled: false }, {
+          config: { principals: null, identity_realms: [{ scope: 'cp', id: 'host-managed', region: null }] },
+        })
+
+        cy.getTestId('kong-identity-mode-kong-identity').closest('.k-radio').click()
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return Array.isArray(val.config?.identity_realms)
+            && val.config.identity_realms[0]?.id === 'host-managed'
+        }))
+      })
+
+      it('does not clear identity_realms when switching to "Consumers" while disabled', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, identityRealmsEnabled: false }, {
+          config: { principals: { enabled: true, directory: 'default' }, identity_realms: [{ scope: 'cp', id: 'host-managed', region: null }] },
+        })
+
+        cy.getTestId('kong-identity-mode-consumers').closest('.k-radio').click()
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return Array.isArray(val.config?.identity_realms)
+            && val.config.identity_realms[0]?.id === 'host-managed'
+        }))
+      })
+    })
+
+    describe('realmsEnabled context (key-auth)', () => {
+      it('does not clear realm when switching to "Kong Identity" while disabled', () => {
+        mountContent(schemaWithRealms, { isKonnect: true, realmsEnabled: false }, {
+          config: { principals: null, identity_realms: null, realm: 'host-managed-realm' },
+        })
+
+        cy.getTestId('kong-identity-mode-kong-identity').closest('.k-radio').click()
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return val.config?.realm === 'host-managed-realm'
+        }))
+      })
+
+      it('still clears realm when switching to "Kong Identity" when left unset (defaults to enabled)', () => {
+        mountContent(schemaWithRealms, { isKonnect: true }, {
+          config: { principals: null, identity_realms: null, realm: 'my-realm' },
+        })
+
+        cy.getTestId('kong-identity-mode-kong-identity').closest('.k-radio').click()
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return val.config?.realm === null
+        }))
       })
     })
   })

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/KongIdentityField.vue
@@ -102,6 +102,9 @@ const identityRealmsInSchema = computed(() => {
 const keyAuthContext = usePluginContext('key-auth')
 const identityRealmsEnabled = computed(() => keyAuthContext?.identityRealmsEnabled ?? true)
 
+// Host opt-out: the realm field is hidden entirely, regardless of whether it's required in the schema.
+const realmsEnabled = computed(() => keyAuthContext?.realmsEnabled ?? true)
+
 // Launch decision: Centrally Managed is shown unconditionally whenever the schema
 // supports identity_realms — we intentionally do NOT hide it when no realms exist yet.
 // Hiding it (platform-wide) is deferred to a fast-follow.
@@ -140,10 +143,10 @@ function handleModeChange(mode: AuthMode) {
       // `directory` starts as 'default'; ConfigFormContent's selectedMode watcher overwrites it
       // with the host-resolved principalsDirectoryName once this mode change is detected.
       formData.config.principals = { ...getEmptyOrDefault('$.config.principals'), enabled: true, directory: 'default' }
-      if (identityRealmsInSchema.value) {
+      if (identityRealmsInSchema.value && identityRealmsEnabled.value) {
         formData.config.identity_realms = []
       }
-      if (!getSchema('$.config.realm')?.required) {
+      if (realmsEnabled.value && !getSchema('$.config.realm')?.required) {
         formData.config.realm = null
       }
       break
@@ -151,7 +154,7 @@ function handleModeChange(mode: AuthMode) {
     case 'consumers': {
       const principalsRequired = !!getSchema('$.config.principals')?.required
       formData.config.principals = principalsRequired ? getEmptyOrDefault('$.config.principals') : null
-      if (identityRealmsInSchema.value) {
+      if (identityRealmsInSchema.value && identityRealmsEnabled.value) {
         formData.config.identity_realms = [{ scope: 'cp' }]
       }
       break


### PR DESCRIPTION
## Summary

Stacked on top of #3772.

`KongIdentityField`'s `handleModeChange` resets `config.identity_realms` and `config.realm` based only on schema presence, ignoring the `identityRealmsEnabled`/`realmsEnabled` key-auth plugin context flags that gate every other read/render path for these two fields (`showCentrallyManaged`, `fetchRealms`, `topOmit`/`advancedOmit` in `ConfigFormContent.vue`). This let a mode switch clobber a field the host had explicitly opted out of.

- `identity_realms` reset in the `kong-identity`/`consumers` cases now also requires `identityRealmsEnabled.value`.
- `realm` reset in the `kong-identity` case now also requires `realmsEnabled.value` (this flag was not even read in `KongIdentityField.vue` before).

## Test plan

- [x] Added Cypress component tests covering mode switches while `identityRealmsEnabled`/`realmsEnabled` are disabled, and a regression test confirming default (enabled) behavior is unchanged.
- [x] `ConfigFormContent.cy.ts` passes (62/62).