### PR TITLE
fix(analytics): time per token translations [MA-5369]

### DIFF
--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -241,7 +241,9 @@
     "cache_items_average": "Cache items (avg)",
     "cache_memory_utilization_max": "Cache memory utilization (max)",
     "cache_status": "Cache status",
-    "cache_hit_rate": "Cache hit rate"
+    "cache_hit_rate": "Cache hit rate",
+    "time_to_first_token_average": "Time to first token (avg)",
+    "time_per_token_average": "Time per token (avg)"
   },
   "metricAxisTitles": {
     "cache_hit_rate": "Cache hit rate {unit}",


### PR DESCRIPTION
# Summary

Satisfy [MA-5369](https://konghq.atlassian.net/browse/MA-5369)

This will add the missing translation strings for `time_per_token_average` and `time_to_first_token_average` chart labels

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

<details open>
<summary>Before</summary>

<img width="491" height="313" alt="before" src="https://github.com/user-attachments/assets/d27813a9-cc34-4df2-b41c-9366bced8be9" />


</details>


<details open>
<summary>After</summary>

<img width="491" height="313" alt="after" src="https://github.com/user-attachments/assets/45090ce2-a4af-48c3-8534-e544a125bd08" />



</details>



## Test Coverage Exemption (Optional)
If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.

[TEST_COVERAGE_EXEMPT_REASON] This will only add missing translation strings, tests are not necessary.


[MA-5369]: https://konghq.atlassian.net/browse/MA-5369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ