### PR TITLE
feat(entities-plugins): cite the AI Gateway version in AI Manager's OIDC principals card

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalsSection.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/openid-connect/PrincipalsSection.vue
@@ -31,7 +31,7 @@
             {{ t('plugins.free-form.openid-connect.principals.kong_identity_label') }}
           </div>
           <div class="auth-mode-card-description">
-            {{ t('plugins.free-form.openid-connect.principals.kong_identity_description') }}
+            {{ kongIdentityDescription }}
           </div>
         </div>
       </KRadio>
@@ -414,6 +414,7 @@ import { USE_SECRET_INPUT_KEY } from '../../../../constants'
 import Field from '../../shared/Field.vue'
 import { useFormShared } from '../../shared/composables'
 import { FORM_EDITING } from '../../shared/const'
+import { usePluginContext } from '../../shared/plugin-context'
 import PrincipalLookupSettings from './PrincipalLookupSettings.vue'
 import { AUTH_METHODS, KONG_IDENTITY_METHODS, isKongIdentityIssuer } from './AuthMethodsField.vue'
 
@@ -510,6 +511,14 @@ const clientsLoading = ref(false)
 const selectedServer = ref<KongIdentityServer | null>(null)
 const leavePromptType = ref<'authServer' | 'client' | 'principal' | null>(null)
 let restoringServer = false
+
+// AI Manager ships its own gateway, so the Kong Identity card cites the AI Gateway
+// version principals landed in rather than the data plane 3.15 baseline.
+const openidConnectContext = usePluginContext('openid-connect')
+
+const kongIdentityDescription = computed(() => openidConnectContext?.source === 'ai-manager'
+  ? t('plugins.free-form.openid-connect.principals.kong_identity_description_ai_manager')
+  : t('plugins.free-form.openid-connect.principals.kong_identity_description'))
 
 const clientIdInfo = computed(() => getLabelAttributes('config.client_id').info)
 const clientSecretInfo = computed(() => getLabelAttributes('config.client_secret').info)

--- a/packages/entities/entities-plugins/src/locales/en.json
+++ b/packages/entities/entities-plugins/src/locales/en.json
@@ -1052,6 +1052,7 @@
           "learn_more": "Learn more.",
           "kong_identity_label": "Kong Identity",
           "kong_identity_description": "Use Kong Identity to authenticate OpenID Connect tokens. If all data plane nodes are running version 3.15 or later, you can also map requests to Kong Identity principals for advanced policies and integrations.",
+          "kong_identity_description_ai_manager": "Use Kong Identity to authenticate OpenID Connect tokens. If all AI Gateway nodes are running version 2.0 or later, you can also map requests to Kong Identity principals for advanced policies and integrations.",
           "external_label": "External auth server",
           "external_description": "Connect to your existing identity provider to manage authentication outside of Kong.",
           "guide": {


### PR DESCRIPTION
# Summary

KM-3202
The Kong Identity card tells the user which version their nodes need before requests can map to principals. AI Manager ships its own gateway, so the data plane 3.15 baseline means nothing there — it needs AI Gateway 2.0 or later.

Branch on the existing 'openid-connect' plugin context (the same `source === 'ai-manager'` discriminator that already drives cache_tokens_salt) to pick a second locale key. Gateway Manager's copy is unchanged.

## Test Coverage Exemption
[TEST_COVERAGE_EXEMPT_REASON] only copy change

