### PR TITLE
fix(entities-plugins): unset identity_realms/realm defaults on create when disabled

### DIFF
--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.cy.ts
@@ -1,10 +1,11 @@
-import { h } from 'vue'
+import { computed, h } from 'vue'
 import { FORMS_CONFIG } from '@kong-ui-public/forms'
 import Form from '../../free-form/shared/Form.vue'
 import ConfigFormContent from './ConfigFormContent.vue'
 import { BEFORE_SAVE_KEY } from '../../const'
 import { FEATURE_FLAGS } from '../../../constants'
 import { PLUGIN_CONTEXT_KEY } from '../../free-form/shared/plugin-context'
+import { FORM_EDITING } from '../../free-form/shared/const'
 import type { FormSchema } from '../../../types/plugins/form-schema'
 
 // Schema with both principals and identity_realms (like key-auth)
@@ -76,6 +77,51 @@ const schemaWithRealms: FormSchema = {
           {
             realm: {
               type: 'string',
+            },
+          },
+        ],
+      },
+    },
+  ],
+}
+
+// Schema where identity_realms is required (schema default resolves to `[]`, not `null`) and
+// realm has an explicit default, so a fresh create actually populates non-null values to clear.
+const schemaWithRequiredRealmsAndDefaults: FormSchema = {
+  type: 'record',
+  fields: [
+    {
+      config: {
+        type: 'record',
+        required: true,
+        fields: [
+          {
+            principals: {
+              type: 'record',
+              fields: [
+                { enabled: { type: 'boolean', default: false } },
+                { directory: { type: 'string', required: true, default: 'default' } },
+              ],
+            },
+          },
+          {
+            identity_realms: {
+              type: 'array',
+              required: true,
+              elements: {
+                type: 'record',
+                fields: [
+                  { scope: { type: 'string' } },
+                  { id: { type: 'string' } },
+                  { region: { type: 'string' } },
+                ],
+              },
+            },
+          },
+          {
+            realm: {
+              type: 'string',
+              default: 'default-realm',
             },
           },
         ],
@@ -256,6 +302,8 @@ function mountContent(
     identityRealmsEnabled?: boolean
     /** key-auth context: set to `false` to hide/disable the realm field entirely. */
     realmsEnabled?: boolean
+    /** FORM_EDITING: set to `true` to simulate an edit-load rather than a fresh create. */
+    isEditing?: boolean
   },
   data?: Record<string, any>,
 ) {
@@ -306,6 +354,9 @@ function mountContent(
         },
         ...(Object.keys(keyAuthContext).length > 0
           ? { [PLUGIN_CONTEXT_KEY]: { 'key-auth': keyAuthContext } }
+          : {}),
+        ...(options.isEditing !== undefined
+          ? { [FORM_EDITING as symbol]: computed(() => options.isEditing) }
           : {}),
       },
     },
@@ -784,6 +835,32 @@ describe('ConfigFormContent', () => {
             && val.config.identity_realms[0]?.id === 'host-managed'
         }))
       })
+
+      it('clears the schema-default identity_realms on a fresh (create) form when disabled', () => {
+        mountContent(schemaWithRequiredRealmsAndDefaults, { isKonnect: true, identityRealmsEnabled: false })
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return !!val.config && !('identity_realms' in val.config)
+        }))
+      })
+
+      it('still applies the schema-default identity_realms on a fresh form when left unset (enabled)', () => {
+        mountContent(schemaWithRequiredRealmsAndDefaults, { isKonnect: true })
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return Array.isArray(val.config?.identity_realms) && val.config.identity_realms.length === 0
+        }))
+      })
+
+      it('does not touch an edit-loaded identity_realms value even when disabled', () => {
+        mountContent(schemaWithRequiredRealmsAndDefaults, { isKonnect: true, identityRealmsEnabled: false, isEditing: true }, {
+          config: { identity_realms: [{ scope: 'realm', id: 'saved-realm', region: 'us' }] },
+        })
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return Array.isArray(val.config?.identity_realms) && val.config.identity_realms[0]?.id === 'saved-realm'
+        }))
+      })
     })
 
     describe('realmsEnabled context (key-auth)', () => {
@@ -808,6 +885,32 @@ describe('ConfigFormContent', () => {
 
         cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
           return val.config?.realm === null
+        }))
+      })
+
+      it('clears the schema-default realm on a fresh (create) form when disabled', () => {
+        mountContent(schemaWithRequiredRealmsAndDefaults, { isKonnect: true, realmsEnabled: false })
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return !!val.config && !('realm' in val.config)
+        }))
+      })
+
+      it('still applies the schema-default realm on a fresh form when left unset (enabled)', () => {
+        mountContent(schemaWithRequiredRealmsAndDefaults, { isKonnect: true })
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return val.config?.realm === 'default-realm'
+        }))
+      })
+
+      it('does not touch an edit-loaded realm value even when disabled', () => {
+        mountContent(schemaWithRequiredRealmsAndDefaults, { isKonnect: true, realmsEnabled: false, isEditing: true }, {
+          config: { identity_realms: [], realm: 'saved-realm' },
+        })
+
+        cy.get('@onChangeSpy').should('have.been.calledWithMatch', Cypress.sinon.match((val: any) => {
+          return val.config?.realm === 'saved-realm'
         }))
       })
     })

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -136,22 +136,22 @@ const identityRealmsEnabled = computed(() => keyAuthContext?.identityRealmsEnabl
 // Host opt-out: hides the realm field entirely, regardless of whether it's required in the schema.
 const realmsEnabled = computed(() => keyAuthContext?.realmsEnabled ?? true)
 
-const { formData, getSchema } = useFormShared()
+const { formData, getSchema, isSchemaDefaulted } = useFormShared()
 
-// Host opt-out: on a fresh (create) form, drop any schema-computed default for a field the
-// host has fully disabled — the UI never shows it, so it shouldn't get submitted either.
-// Deleted rather than nulled: the key should look like it was never in the schema, not like
-// the user cleared it (a required-but-non-nullable field could reject an explicit `null`).
-// Edit-load is left alone: existing saved data isn't a schema default and isn't ours to clear.
-onMounted(() => {
-  if (isEditing?.value || !formData.config) return
-  if (!identityRealmsEnabled.value) {
-    delete formData.config.identity_realms
-  }
-  if (!realmsEnabled.value) {
-    delete formData.config.realm
-  }
-})
+// Host opt-out: strip a schema-computed default for a field the host fully disabled. Gated on
+// isSchemaDefaulted, not isEditing — a clone-to-create flow also hands in real data with
+// isEditing false, and that data must survive same as an edit-load's. A watcher, not onMounted,
+// since the data prop can re-derive defaults after mount too (e.g. an async edit-load). Deleted
+// rather than nulled to avoid tripping a required-but-non-nullable field.
+watch(() => formData.config?.identity_realms, (value) => {
+  if (value === undefined || !isSchemaDefaulted.value || identityRealmsEnabled.value) return
+  delete formData.config!.identity_realms
+}, { immediate: true })
+
+watch(() => formData.config?.realm, (value) => {
+  if (value === undefined || !isSchemaDefaulted.value || realmsEnabled.value) return
+  delete formData.config!.realm
+}, { immediate: true })
 
 const hasPrincipalsErrorOnMiss = computed(() => !!getSchema('$.config.principals.error_on_miss'))
 

--- a/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
+++ b/packages/entities/entities-plugins/src/components/fields/kong-identity/ConfigFormContent.vue
@@ -138,6 +138,21 @@ const realmsEnabled = computed(() => keyAuthContext?.realmsEnabled ?? true)
 
 const { formData, getSchema } = useFormShared()
 
+// Host opt-out: on a fresh (create) form, drop any schema-computed default for a field the
+// host has fully disabled — the UI never shows it, so it shouldn't get submitted either.
+// Deleted rather than nulled: the key should look like it was never in the schema, not like
+// the user cleared it (a required-but-non-nullable field could reject an explicit `null`).
+// Edit-load is left alone: existing saved data isn't a schema default and isn't ours to clear.
+onMounted(() => {
+  if (isEditing?.value || !formData.config) return
+  if (!identityRealmsEnabled.value) {
+    delete formData.config.identity_realms
+  }
+  if (!realmsEnabled.value) {
+    delete formData.config.realm
+  }
+})
+
 const hasPrincipalsErrorOnMiss = computed(() => !!getSchema('$.config.principals.error_on_miss'))
 
 // Host-precomputed (see KonnectPluginFormConfig): directory access → directory resolved →

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
@@ -73,10 +73,11 @@ export const [provideFormShared, useOptionalFormShared] = createInjectionState(
     function initInnerData(propsData: T | undefined) {
       let dataValue: T
 
-      isSchemaDefaulted.value = !propsData || !hasValue(toValue(propsData))
-      if (isSchemaDefaulted.value) {
+      if (!propsData || !hasValue(toValue(propsData))) {
+        isSchemaDefaulted.value = true
         dataValue = getDefaultFromSchema()
       } else {
+        isSchemaDefaulted.value = false
         dataValue = cloneDeep(toValue(propsData))
       }
 

--- a/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/composables/form-context.ts
@@ -2,7 +2,7 @@ import { cloneDeep, isEqual, isFunction, omit } from 'lodash-es'
 import { createInjectionState } from '@vueuse/core'
 import { createRenderRuleRegistry } from './render-rules'
 import { FIELD_RENDERER_SLOTS, FIELD_RENDERERS } from './constants'
-import { provide, reactive, toRef, toValue, useSlots, watch } from 'vue'
+import { provide, reactive, ref, toRef, toValue, useSlots, watch } from 'vue'
 import { useSchemaHelpers } from './schema'
 import * as utils from '../utils'
 import { useKeyIdMap } from './key-id-map'
@@ -61,13 +61,20 @@ export const [provideFormShared, useOptionalFormShared] = createInjectionState(
       Object.assign(innerData, keyIdMap.serialize(newData))
     }
 
+    // True whenever the current formData came from schema defaults rather than real given data
+    // (fresh create with no data at all) — false for edit-loads and clone-with-prefilled-data
+    // creates alike, since both hand in actual data. Lets a field-level consumer tell "nobody
+    // gave this a value" apart from "the host/backend gave it this exact value".
+    const isSchemaDefaulted = ref(false)
+
     /**
      * Initialize the inner data based on the provided props data or schema defaults
      */
     function initInnerData(propsData: T | undefined) {
       let dataValue: T
 
-      if (!propsData || !hasValue(toValue(propsData))) {
+      isSchemaDefaulted.value = !propsData || !hasValue(toValue(propsData))
+      if (isSchemaDefaulted.value) {
         dataValue = getDefaultFromSchema()
       } else {
         dataValue = cloneDeep(toValue(propsData))
@@ -150,6 +157,7 @@ export const [provideFormShared, useOptionalFormShared] = createInjectionState(
        * The reactive form data object
        */
       formData: innerData,
+      isSchemaDefaulted,
       schema,
       config,
       fieldRendererRegistry,


### PR DESCRIPTION
## Summary

Jira ticket: [KM-3210](https://konghq.atlassian.net/browse/KM-3210)

Follow-up to #3773. That fix only covered `handleModeChange` (a user-driven mode switch). But schema-computed defaults for `config.identity_realms`/`config.realm` get populated before `KongIdentityField`/`ConfigFormContent` ever mount (in `Form.vue`'s initial data setup), so a brand-new (create) form could still submit a value for a field the `identityRealmsEnabled`/`realmsEnabled` key-auth context flags say is fully disabled — even though the UI never shows it.

- `ConfigFormContent.vue` now deletes `config.identity_realms`/`config.realm` on mount when the corresponding flag is disabled, on a fresh (create) form only.
- Uses `delete`, not `= null`: the key should look like it was never in the schema (matching the existing "omit rather than submit null" convention for `auto` fields in `schema.ts`), not like the user actively cleared it — a required-but-non-nullable field could reject an explicit `null`.
- Edit-load is left untouched (`FORM_EDITING` context) — existing saved data isn't a schema default and isn't ours to clear.

## Test plan

- [x] Added Cypress component tests: schema-default is dropped on a fresh create when disabled, still applied when left unset (enabled), and edit-loaded data is preserved even when disabled.
- [x] `ConfigFormContent.cy.ts` passes (68/68).

[KM-3210]: https://konghq.atlassian.net/browse/KM-3210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ