### PR TITLE
fix(entities-plugins): use search endpoint for workspace filtering regardless of feature flag

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -592,8 +592,11 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
   } as FuzzyMatchFilterConfig
 })
 
-// Only hit the new search endpoint once the user is actually searching
-const isSearchActive = computed((): boolean => isPluginFilterEnhanced.value && !!filterQuery.value)
+// Only hit the new search endpoint once the user is actually searching.
+// Workspace-scoped Konnect lists always use search, regardless of the `pluginTableImprovements.filtering` flag.
+const isSearchActive = computed((): boolean =>
+  (isPluginFilterEnhanced.value || (props.config.app === 'konnect' && !!props.config.workspace)) && !!filterQuery.value,
+)
 
 const activeFetcherUrl = computed<string>(() => {
   if (isSearchActive.value) {


### PR DESCRIPTION
[KM-3215]

## Summary
- Plugin list filtering under a Konnect workspace now always uses the search endpoint, even when the `pluginTableImprovements.filtering` feature flag is disabled.

[TEST_COVERAGE_EXEMPT_REASON] will be tested in consumer app

[KM-3215]: https://konghq.atlassian.net/browse/KM-3215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ