### PR TITLE
fix(entities-plugins): fix search query shape for workspace filtering

### DIFF
--- a/packages/entities/entities-plugins/src/components/PluginList.cy.ts
+++ b/packages/entities/entities-plugins/src/components/PluginList.cy.ts
@@ -1118,6 +1118,48 @@ describe('<PluginList />', () => {
       cy.wait('@getNoWorkspace')
       cy.get('.kong-ui-entities-plugins-list').should('be.visible')
     })
+
+    it('switches to /plugins/search once filtering, even without the pluginTableImprovements.filtering flag', () => {
+      const configWithWorkspace = { ...baseConfigKonnect, workspace: 'default' }
+
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/plugins*`,
+        },
+        (req) => {
+          if (!req.url.includes('/plugins/search')) {
+            req.reply({ statusCode: 200, body: plugins })
+          }
+        },
+      ).as('listPlugins')
+
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `${baseConfigKonnect.apiBaseUrl}/v2/control-planes/${baseConfigKonnect.controlPlaneId}/core-entities/default/plugins/search*`,
+        },
+        { statusCode: 200, body: { data: plugins.data, offset: null } },
+      ).as('searchPlugins')
+
+      cy.mount(PluginList, {
+        props: {
+          cacheIdentifier: `plugin-list-${uuidv4()}`,
+          config: configWithWorkspace,
+          canCreate: () => false,
+          canEdit: () => false,
+          canDelete: () => false,
+          canRetrieve: () => false,
+        },
+      })
+
+      cy.wait('@listPlugins')
+      // Legacy EntityFilter (not PluginFilter) is used since the flag is off
+      cy.get('.kong-ui-entity-filter-input').should('exist')
+
+      cy.get('.kong-ui-entity-filter-input input').type('basic')
+      cy.wait('@searchPlugins').its('request.url').should('include', 'filter[name][contains]=basic')
+    })
   })
 
   describe('plugin list redesign (isPluginTableEnhanced)', () => {

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -502,6 +502,12 @@ const isPluginFilterEnhanced = computed<boolean>(() =>
   props.config.app === 'konnect' && !!props.config.pluginTableImprovements?.filtering,
 )
 
+// Workspace-scoped Konnect lists should hit the search endpoint while filtering, regardless of
+// whether `pluginTableImprovements.filtering` is enabled - same as the other entity lists.
+const isKonnectWorkspaceScoped = computed<boolean>(() =>
+  props.config.app === 'konnect' && !!props.config.workspace,
+)
+
 /**
  * Table Headers
  */
@@ -595,7 +601,7 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
 // Only hit the new search endpoint once the user is actually searching.
 // Workspace-scoped Konnect lists always use search, regardless of the `pluginTableImprovements.filtering` flag.
 const isSearchActive = computed((): boolean =>
-  (isPluginFilterEnhanced.value || (props.config.app === 'konnect' && !!props.config.workspace)) && !!filterQuery.value,
+  (isPluginFilterEnhanced.value || isKonnectWorkspaceScoped.value) && !!filterQuery.value,
 )
 
 const activeFetcherUrl = computed<string>(() => {
@@ -613,7 +619,9 @@ const {
 } = useFetcher(computed(() => ({
   ...props.config,
   cacheIdentifier: props.cacheIdentifier,
-  ...(isSearchActive.value ? { isExactMatch: false } : {}),
+  // `PluginFilter` (used when `isPluginFilterEnhanced`) emits an already wire-ready query string,
+  // which the fetcher must forward as-is rather than wrapping into an exact-match path segment.
+  ...(isPluginFilterEnhanced.value && isSearchActive.value ? { isExactMatch: false } : {}),
 })), activeFetcherUrl)
 
 const clearFilter = (): void => {


### PR DESCRIPTION
[KM-3215]

## Summary
- Follow-up to #3792: that fix correctly switched workspace-scoped Konnect plugin lists to `/plugins/search` once filtering, but it unconditionally forced `isExactMatch: false` on the fetcher config.
- That override is only correct for the already wire-formatted query `PluginFilter` builds when `pluginTableImprovements.filtering` is enabled. For the plain `EntityFilter` input used when the flag is off, it caused the raw search text to be forwarded as-is instead of being wrapped into `filter[name][contains]=<query>`.
- Scoped the `isExactMatch` override to the `PluginFilter`/flag-enabled case only, so the flag-off path falls back to the same default behavior `GatewayServiceList` already relies on to produce the `filter[name][contains]` param.

## Test plan
- [x] Added a Cypress test verifying that typing into the plain `EntityFilter` search box on a workspace-scoped Konnect list (flag off) hits `/plugins/search` with `filter[name][contains]=<query>`
- [x] `pnpm --filter @kong-ui-public/entities-plugins exec cypress run --component --spec './src/components/PluginList.cy.ts'` passes (42/42)

[KM-3215]: https://konghq.atlassian.net/browse/KM-3215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ