### PR TITLE
refactor(entities-plugins): isolate free-form's i18n from the shared locale file

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ArrayField.vue
@@ -81,7 +81,7 @@
             <StringArrayField
               v-else-if="subSchema.type === 'array' && subSchema.elements.type === 'string'"
               autofocus
-              :help="t('plugins.free-form.tag_helper')"
+              :help="t('tag_helper')"
               :name="String(index)"
             />
             <Field

--- a/packages/entities/entities-plugins/src/components/free-form/shared/EntityChecksAlert.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/EntityChecksAlert.vue
@@ -36,9 +36,9 @@ const checks = computed(() => {
   const checks: string[] = []
 
   const checkTypes = [
-    { key: 'at_least_one_of', i18nKey: 'plugins.form.field_rules.at_least_one_of' },
-    { key: 'mutually_required', i18nKey: 'plugins.form.field_rules.mutually_required' },
-    { key: 'mutually_exclusive', i18nKey: 'plugins.form.field_rules.mutually_exclusive' },
+    { key: 'at_least_one_of', i18nKey: 'field_rules.at_least_one_of' },
+    { key: 'mutually_required', i18nKey: 'field_rules.mutually_required' },
+    { key: 'mutually_exclusive', i18nKey: 'field_rules.mutually_exclusive' },
   ] as const
 
   for (const check of entityChecks) {

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ExpressionEditor.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ExpressionEditor.vue
@@ -23,7 +23,7 @@
       @click="expanded = true"
     >
       <AddIcon />
-      {{ i18n.t('plugins.free-form.expression.add') }}
+      {{ i18n.t('expression.add') }}
     </KButton>
 
     <div
@@ -32,7 +32,7 @@
     >
       <StringField
         class="ff-expression-editor-input"
-        :label="i18n.t('plugins.free-form.expression.label')"
+        :label="i18n.t('expression.label')"
         :label-attributes="labelAttributes"
         multiline
         :name="expressionName"
@@ -42,7 +42,7 @@
       >
         <template #help>
           <slot name="help">
-            <i18nT keypath="plugins.free-form.expression.help.text">
+            <i18nT keypath="expression.help.text">
               <template #type>
                 {{ i18n.t(returnsKey) }}
               </template>
@@ -51,7 +51,7 @@
                   hide-icon
                   :href="externalLinks.condition"
                 >
-                  {{ i18n.t('plugins.free-form.expression.help.learn') }}
+                  {{ i18n.t('expression.help.learn') }}
                 </KExternalLink>
               </template>
             </i18nT>
@@ -61,7 +61,7 @@
 
       <KButton
         appearance="tertiary"
-        :aria-label="i18n.t('plugins.free-form.expression.remove')"
+        :aria-label="i18n.t('expression.remove')"
         class="ff-expression-editor-remove"
         :data-testid="`ff-expression-remove-${path}`"
         icon
@@ -132,10 +132,10 @@ watch(expression.hasExpression, (hasExpression) => {
 })
 
 const RETURNS_KEYS = {
-  string: 'plugins.free-form.expression.returns.string',
-  number: 'plugins.free-form.expression.returns.number',
-  integer: 'plugins.free-form.expression.returns.integer',
-  boolean: 'plugins.free-form.expression.returns.boolean',
+  string: 'expression.returns.string',
+  number: 'expression.returns.number',
+  integer: 'expression.returns.integer',
+  boolean: 'expression.returns.boolean',
 } as const
 
 const returnsKey = computed(() => {
@@ -144,11 +144,11 @@ const returnsKey = computed(() => {
   // phrasing here yet — better a vague sentence than a raw i18n key on screen.
   return type && type in RETURNS_KEYS
     ? RETURNS_KEYS[type as keyof typeof RETURNS_KEYS]
-    : 'plugins.free-form.expression.returns.unknown'
+    : 'expression.returns.unknown'
 })
 
 const labelAttributes = computed(() => ({
-  info: i18n.t('plugins.free-form.expression.info'),
+  info: i18n.t('expression.info'),
   tooltipAttributes: { maxWidth: '300px', placement: 'top' as const },
   'data-testid': `ff-expression-label-${path.value}`,
 }))

--- a/packages/entities/entities-plugins/src/components/free-form/shared/ForeignField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/ForeignField.vue
@@ -71,7 +71,7 @@ const placeholder = computed(() => {
   if (fieldAttrs.value.placeholder) {
     return fieldAttrs.value.placeholder
   }
-  return t('plugins.free-form.foreign_placeholder', { entity: field.schema.value?.reference ?? 'entity' })
+  return t('foreign_placeholder', { entity: field.schema.value?.reference ?? 'entity' })
 })
 
 const rawInputValue = ref(initialValue ?? '')

--- a/packages/entities/entities-plugins/src/components/free-form/shared/NumberField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/NumberField.vue
@@ -46,7 +46,7 @@
       v-if="realShowVaultSecretPicker && !autofillSlot"
       appearance="warning"
       :data-testid="`ff-vault-secret-picker-warning-${field.path.value}`"
-      :message="i18n.t('plugins.free-form.vault_picker.component_error')"
+      :message="i18n.t('vault_picker.component_error')"
     />
   </div>
 </template>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/StringField.vue
@@ -61,7 +61,7 @@
           v-if="realShowVaultSecretPicker && !autofillSlot"
           appearance="warning"
           :data-testid="`ff-vault-secret-picker-warning-${field.path.value}`"
-          :message="i18n.t('plugins.free-form.vault_picker.component_error')"
+          :message="i18n.t('vault_picker.component_error')"
         />
       </template>
     </EnhancedInput>
@@ -79,7 +79,7 @@
         v-if="realShowVaultSecretPicker && !autofillSlot"
         appearance="warning"
         :data-testid="`ff-vault-secret-picker-warning-${field.path.value}`"
-        :message="i18n.t('plugins.free-form.vault_picker.component_error')"
+        :message="i18n.t('vault_picker.component_error')"
       />
     </template>
   </div>

--- a/packages/entities/entities-plugins/src/components/free-form/shared/SwitchField.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/shared/SwitchField.vue
@@ -29,7 +29,7 @@ import { KInputSwitch, type LabelAttributes } from '@kong/kongponents'
 import { useField, useFieldAttrs } from './composables'
 import { toRef } from 'vue'
 import type { BaseFieldProps } from './types'
-import useI18n from '../../../composables/useI18n'
+import useFreeformI18n from '../../../composables/useFreeformI18n'
 
 interface SwitchFieldProps extends BaseFieldProps {
   labelAttributes?: LabelAttributes
@@ -37,7 +37,7 @@ interface SwitchFieldProps extends BaseFieldProps {
   disabledText?: string
 }
 
-const { i18n: { t } } = useI18n()
+const { i18n: { t } } = useFreeformI18n()
 
 const { name, enabledText, disabledText, ...props } = defineProps<SwitchFieldProps>()
 const { value: fieldValue, hide, emptyOrDefaultValue, ...field } = useField<boolean>(toRef(() => name))

--- a/packages/entities/entities-plugins/src/locales/freeform-en.json
+++ b/packages/entities/entities-plugins/src/locales/freeform-en.json
@@ -1,39 +1,35 @@
 {
   "actions": {
     "add_entity": "Add {entity}",
-    "remove_entity": "Remove {entity}"
+    "remove_entity": "Remove {entity}",
+    "enabled": "Enabled",
+    "disabled": "Disabled"
   },
-  "plugins": {
-    "form": {
-      "field_rules": {
-        "at_least_one_of": "At least one of the following values is required: {parameters}.",
-        "mutually_required": "These values must be used together: {parameters}.",
-        "mutually_exclusive": "Only one of these values can be used: {parameters}."
-      }
+  "field_rules": {
+    "at_least_one_of": "At least one of the following values is required: {parameters}.",
+    "mutually_required": "These values must be used together: {parameters}.",
+    "mutually_exclusive": "Only one of these values can be used: {parameters}."
+  },
+  "tag_helper": "Use comma to separate values. eg: value1, value2",
+  "foreign_placeholder": "Enter a UUID of {entity}",
+  "vault_picker": {
+    "component_error": "The vault secret picker is not available"
+  },
+  "expression": {
+    "add": "Add expression",
+    "remove": "Remove expression",
+    "label": "Kong plug-in dynamic expression",
+    "info": "Supply this value as an expression that is evaluated on every request. When set, it takes priority over the value entered above.",
+    "help": {
+      "text": "Define a Kong plug-in dynamic expression to evaluate each request. The expression must return {type}. {link}",
+      "learn": "Learn more"
     },
-    "free-form": {
-      "tag_helper": "Use comma to separate values. eg: value1, value2",
-      "foreign_placeholder": "Enter a UUID of {entity}",
-      "vault_picker": {
-        "component_error": "The vault secret picker is not available"
-      },
-      "expression": {
-        "add": "Add expression",
-        "remove": "Remove expression",
-        "label": "Kong plug-in dynamic expression",
-        "info": "Supply this value as an expression that is evaluated on every request. When set, it takes priority over the value entered above.",
-        "help": {
-          "text": "Define a Kong plug-in dynamic expression to evaluate each request. The expression must return {type}. {link}",
-          "learn": "Learn more"
-        },
-        "returns": {
-          "string": "a string",
-          "number": "a number",
-          "integer": "an integer",
-          "boolean": "a boolean value (true or false)",
-          "unknown": "a value of the type of the field above"
-        }
-      }
+    "returns": {
+      "string": "a string",
+      "number": "a number",
+      "integer": "an integer",
+      "boolean": "a boolean value (true or false)",
+      "unknown": "a value of the type of the field above"
     }
   }
 }


### PR DESCRIPTION
## Summary

[TEST_COVERAGE_EXEMPT_REASON] This change only swaps which i18n composable/locale file a component reads from and restructures locale key paths; string values and rendered output are unchanged, so no test changes are needed.
