### PR TITLE
fix(entities-plugins): clear rate-limiting-advanced expressions explicitly

### DIFF
--- a/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RateLimitingAdvancedForm.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RateLimitingAdvancedForm.spec.ts
@@ -92,10 +92,10 @@ describe('RateLimitingAdvancedForm — emitted payload', () => {
 
     await wrapper.get('[data-testid="ff-expression-remove-config.limit.0"]').trigger('click')
 
-    // Clearing a row leaves its slot behind, so the array would otherwise be
-    // submitted as nothing but empty strings. Unset says the same thing, and
-    // matches a plugin that never carried an expression at all.
-    expect(lastChange().expressions.limit).toBeUndefined()
+    // Explicitly null, not an omitted key: Kong Manager updates with PATCH,
+    // which keeps whatever the payload leaves out — so an omitted twin leaves
+    // the stored one in place and the clear never reaches the server.
+    expect(lastChange().expressions.limit).toBeNull()
   })
 
   it('keeps a cleared expression cleared once the host echoes the payload back', async () => {
@@ -114,7 +114,7 @@ describe('RateLimitingAdvancedForm — emitted payload', () => {
     await nextTick()
     await nextTick()
 
-    expect(lastChange().expressions.limit).toBeUndefined()
+    expect(lastChange().expressions.limit).toBeNull()
     expect(lastChange().config.limit).toEqual(twoLimits.limit)
   })
 
@@ -169,6 +169,33 @@ describe('RateLimitingAdvancedForm — emitted payload', () => {
 
     expect(wrapper.get('[data-testid="ff-expression-config.custom_key"] textarea').attributes('placeholder'))
       .toBe('e.g. principal.metadata.ff_id ? principal.metadata.ff_id : principal.id')
+  })
+
+  it('unsets the twin array while a sibling twin still holds an expression', async () => {
+    const { wrapper, lastChange } = mountForm({
+      config: twoLimits,
+      expressions: { custom_key: 'principal.metadata.id', limit: ['', 'principal.metadata.limit'] },
+    })
+
+    await wrapper.get('[data-testid="ff-expression-remove-config.limit.1"]').trigger('click')
+
+    // `custom_key` keeps the record alive, so the array has to clear itself
+    // rather than be submitted as a run of empty strings.
+    expect(lastChange().expressions.limit).toBeNull()
+    expect(lastChange().expressions.custom_key).toBe('principal.metadata.id')
+  })
+
+  it('keeps the twin array the same length as the limits it pairs with', async () => {
+    const { wrapper, lastChange } = mountForm({
+      config: twoLimits,
+      expressions: { limit: ['req.size', ''] },
+    })
+
+    await wrapper.get('[data-testid="rla-form-add-limit"]').trigger('click')
+    expect(lastChange().expressions.limit).toHaveLength(lastChange().config.limit.length)
+
+    await wrapper.get('[data-testid="rla-form-remove-limit-1"]').trigger('click')
+    expect(lastChange().expressions.limit).toHaveLength(lastChange().config.limit.length)
   })
 
   it('still deletes a null namespace, which the server generates', async () => {

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RequestLimitsForm.spec.ts
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RequestLimitsForm.spec.ts
@@ -168,7 +168,7 @@ describe('RequestLimitsForm (rate-limiting-advanced)', () => {
       await badge.trigger('click')
 
       expect(lastChange().config.limit).toHaveLength(1)
-      expect(lastChange().expressions.limit).toBeUndefined()
+      expect(lastChange().expressions.limit).toBeNull()
     })
   })
 })

--- a/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RequestLimitsForm.vue
+++ b/packages/entities/entities-plugins/src/components/free-form/plugins/rate-limiting-advanced/RequestLimitsForm.vue
@@ -164,7 +164,7 @@ interface UseCase {
   }
 }
 
-const { formData, getSchema, getEmptyOrDefault } = useFormShared<FormData>()
+const { formData, getSchema, getEmptyOrDefault, getEmptyValue } = useFormShared<FormData>()
 
 const requestLimits = computed<RequestLimit[]>(() => {
   const modelValue = formData.config?.limit?.map((limit, index) => {
@@ -201,10 +201,12 @@ const alignExpressionLimits = (mutate: (limits: Array<string | EmptyValue>) => v
 /**
  * Unsets the twin array once no row holds an expression.
  *
- * Clearing a row leaves an empty slot behind rather than shortening the array,
- * because the Gateway pairs the two arrays by position — so clearing every row
- * would otherwise submit a run of empty strings. Dropping the key says the same
- * thing, and matches a plugin that never carried an expression at all.
+ * `null`, not a dropped key: Kong Manager updates with PATCH, and PATCH keeps
+ * every field the payload omits, so omitting the array leaves the stored one in
+ * place — the user's clear silently does not happen, and if the same edit also
+ * removed a row the stored twins outnumber `config.limit` and the Gateway
+ * rejects the merged entity (`expressions.limit[i] is set but config.limit is
+ * not`). An explicit `null` replaces it.
  *
  * Written into the form's own data, and deliberately NOT by rewriting the value
  * the form emits. The form compares the payload it last emitted against an
@@ -214,10 +216,12 @@ const alignExpressionLimits = (mutate: (limits: Array<string | EmptyValue>) => v
  */
 watch(() => formData.expressions?.limit, (limits) => {
   if (!Array.isArray(limits)) return
-  // Every "no expression" value is falsy: `''` in a slot, null when unset.
+  // Clearing a row leaves its slot behind, so an array whose every slot is
+  // empty means no row has an expression any more. Every "no expression" value
+  // is falsy: `''` in a slot, null when unset.
   if (limits.some(Boolean)) return
 
-  delete formData.expressions!.limit
+  formData.expressions!.limit = getEmptyValue()
 }, { deep: true })
 
 const addRequestLimit = () => {
@@ -365,10 +369,11 @@ const filteredUseCases = computed<UseCase[]>(() => {
 
 const toggleUseCase = (useCase: UseCase, useCaseKey: string) => {
   // A preset replaces every limit, so the expressions attached to the rows it
-  // replaces go with them.
+  // replaces go with them. The watcher above unsets the record if this leaves
+  // nothing behind.
   const clearExpressionLimits = () => {
     if (formData.expressions) {
-      delete formData.expressions.limit
+      formData.expressions.limit = null
     }
   }
 


### PR DESCRIPTION
# Summary

Kong Manager updates plugins with PATCH, which keeps every field the payload omits. When editing an existing plugin with `expression.limit` field, clearing an expression results in `expressions.limit: undefined` key, so the stored expression array will be merged incorrectly.

Unset the whole twin record as an explicit `null` instead.
