### PR TITLE
fix(analytics-chart): align TopN headers without dimensions [MA-5439]

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
@@ -440,13 +440,21 @@ const metricItems = computed<SelectItem[]>(() => {
 const dimensionItems = computed<SelectItem[]>(() => {
   let out = []
 
-  for (let i = 1; i <= 3; i++) {
-    out.push({
-      label: `${i}`,
-      value: `${i}`,
-      key: `dimension_${i}`,
-      selected: i === 1,
-    })
+  for (let i = 0; i <= 3; i++) {
+    if (i === 0) {
+      out.push({
+        label: `${i}`,
+        value: `${i}`,
+        key: 'no_dimensions',
+      })
+    } else {
+      out.push({
+        label: `${i}`,
+        value: `${i}`,
+        key: `dimension_${i}`,
+        selected: i === 1,
+      })
+    }
   }
 
   return out
@@ -469,6 +477,9 @@ const randomizeData = () => {
 }
 
 const getTopNDisplay = (dimensionCount: number): DisplayBlob => {
+  if (dimensionCount < 1) {
+    return {}
+  }
   const display: DisplayBlob = {
     route: topNRouteDisplay,
   }
@@ -489,6 +500,11 @@ const getTopNDimensionEvent = (
   idx: number,
   dimensionCount: number,
 ): Record<string, string> => {
+
+  if (dimensionCount < 1) {
+    return {}
+  }
+
   const event = {
     route: routeId,
   }
@@ -540,7 +556,7 @@ const getTopNFallbackTableData = (
 
   return {
     meta: getTopNBaseMeta(display, [scenario.metricKey]),
-    data: rows,
+    data: dimensionCount === 0 ? rows.slice(0, 1) : rows,
   } as ExploreResultV4
 }
 
@@ -599,7 +615,7 @@ const getTopNMetricTableData = (
 
   return {
     meta,
-    data: rows,
+    data: dimensionCount === 0 ? rows.slice(0, 1) : rows,
   } as ExploreResultV4
 }
 

--- a/packages/analytics/analytics-chart/src/components/TopNTable.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/TopNTable.cy.ts
@@ -366,6 +366,44 @@ describe('<TopNTable />', () => {
   })
 
   describe('dimensions', () => {
+    it('aligns metric headers and values when no dimensions are selected', () => {
+      cy.mount(TopNTable, {
+        props: {
+          data: {
+            meta: {
+              ...MULTI_METRIC_TABLE_DATA.meta,
+              display: {},
+            },
+            data: [{
+              event: {
+                REQUEST_COUNT: 9483,
+                '4XX': 1,
+                '5XX': 0,
+                response_latency_average: 100,
+              },
+              timestamp: '2023-08-17T17:55:53.000Z',
+            }],
+          },
+        },
+      })
+
+      const expectedHeaders = ['Request count', '4xx', '5xx', 'Response latency (avg)']
+      const expectedValues = ['9.4K', '1', '0', '100 ms']
+
+      cy.getTestId('top-n-table-header-column').should('have.length', expectedHeaders.length)
+      expectedHeaders.forEach((header, index) => {
+        cy.getTestId('top-n-table-header-column').eq(index).should('have.text', header)
+      })
+      cy.get('tbody tr').should('have.length', 1).within(() => {
+        cy.get('td').should('have.length', expectedValues.length)
+        expectedValues.forEach((value, index) => {
+          cy.get('td').eq(index).should(($cell) => {
+            expect($cell.text().trim()).to.equal(value)
+          })
+        })
+      })
+    })
+
     it('keeps the name header for single-dimension responses', () => {
       cy.mount(TopNTable, {
         props: {

--- a/packages/analytics/analytics-chart/src/components/TopNTable.vue
+++ b/packages/analytics/analytics-chart/src/components/TopNTable.vue
@@ -93,6 +93,7 @@
           >
             <!-- Primary dimension column -->
             <td
+              v-if="displayKeys.length"
               class="top-n-table-cell top-n-table-cell--name"
               :class="{ 'top-n-table-cell-dimension-compact': hasMultipleDimensions }"
             >


### PR DESCRIPTION
# Summary

Fixes [MA-5439](https://konghq.atlassian.net/browse/MA-5439).

TopN tables without dimensions rendered an extra Name cell, shifting metric values away from their headers. Render that cell only when dimensions exist.

Add a regression test for four metrics without dimensions. Extend the sandbox dimension selector to include zero and return one aggregate mock row for that selection.

## Verification

- TopN Cypress component spec: 24 passing, including the regression that failed before the fix.
- Analytics-chart typecheck and sandbox build passed.
- Focused ESLint and `git diff --check` passed.

## Rollout

Consume this PR's preview packages in a separate konnect-ui-apps PR to test in Konnect. The stable package bump follows merge and release.


[MA-5439]: https://konghq.atlassian.net/browse/MA-5439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ