### PR TITLE
feat(analytics): add scatter chart renderer [MA-5465]

### DIFF
--- a/packages/analytics/analytics-chart/src/utils/scatter-adapters.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/scatter-adapters.spec.ts
@@ -1,6 +1,6 @@
-import type { DisplayBlob, ExploreResultV4, QueryResponseMeta } from '@kong-ui-public/analytics-utilities'
+import type { DisplayBlob, ExploreResultV4, FetchAllRequestsResult, QueryResponseMeta, RequestRecord } from '@kong-ui-public/analytics-utilities'
 import { describe, it, expect, vi } from 'vitest'
-import { exploreResultToScatterData } from './scatter-adapters'
+import { exploreResultToScatterData, requestsToScatterData } from './scatter-adapters'
 
 const START = '2024-06-16T00:00:00.000Z'
 const END = '2024-06-16T00:00:10.000Z'
@@ -63,5 +63,132 @@ describe('exploreResultToScatterData', () => {
     const data = exploreResultToScatterData(exploreResult())!
 
     expect(data).toMatchObject({ start: START, end: END, truncated: true, limit: 50 })
+  })
+})
+
+describe('requestsToScatterData', () => {
+  const requestsResult = (results: RequestRecord[]): FetchAllRequestsResult => ({
+    results,
+    meta: {
+      query_id: '',
+      time_range: { start: START, end: END },
+      size: results.length,
+    },
+    truncated: true,
+    limit: 10_000,
+  })
+
+  const flatRecords: RequestRecord[] = [
+    { request_start: START, latencies_response_ms: 12, route: 'a' },
+    { request_start: END, latencies_response_ms: 34, route: 'b' },
+  ]
+
+  it('returns undefined for missing input', () => {
+    expect(requestsToScatterData(undefined, { metric: 'latencies_response_ms' })).toBeUndefined()
+  })
+
+  it('returns undefined and logs when the metric is missing', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementationOnce(() => {})
+
+    expect(requestsToScatterData(requestsResult(flatRecords), { metric: '' })).toBeUndefined()
+    expect(errorSpy).toHaveBeenCalledOnce()
+    errorSpy.mockRestore()
+  })
+
+  it('plots one point per record with no dimension', () => {
+    const data = requestsToScatterData(requestsResult(flatRecords), { metric: 'latencies_response_ms' })!
+
+    expect(data.points).toEqual([
+      { timestamp: new Date(START).valueOf(), value: 12 },
+      { timestamp: new Date(END).valueOf(), value: 34 },
+    ])
+    expect(data.dimension).toBeUndefined()
+  })
+
+  it('groups points by a dimension', () => {
+    const records = [...flatRecords, { request_start: END, latencies_response_ms: 56, route: '' }]
+    const data = requestsToScatterData(requestsResult(records), {
+      metric: 'latencies_response_ms',
+      dimension: 'route',
+    })!
+
+    expect(data.points.map(p => p.group)).toEqual(['a', 'b', 'empty'])
+  })
+
+  it('drops records whose metric is null, empty or invalid', () => {
+    const records: RequestRecord[] = [
+      { request_start: START, latencies_response_ms: null },
+      { request_start: START, latencies_response_ms: '' },
+      { request_start: START, latencies_response_ms: 'nope' },
+      { request_start: 'not a date', latencies_response_ms: 12 },
+      { request_start: START },
+      { request_start: START, latencies_response_ms: 12 },
+    ]
+
+    expect(requestsToScatterData(requestsResult(records), { metric: 'latencies_response_ms' })!.points)
+      .toEqual([{ timestamp: new Date(START).valueOf(), value: 12 }])
+  })
+
+  it('reads a dotted path off the record', () => {
+    const records: RequestRecord[] = [{ request_start: START, mcp_info: { rpc: [{ latency: 7 }] } }]
+    const data = requestsToScatterData(requestsResult(records), { metric: 'mcp_info.rpc.0.latency' })!
+
+    expect(data.points).toEqual([{ timestamp: new Date(START).valueOf(), value: 7 }])
+  })
+
+  it('honors a custom timestamp field', () => {
+    const records: RequestRecord[] = [{ started_at: START, latencies_response_ms: 12 }]
+    const data = requestsToScatterData(requestsResult(records), {
+      metric: 'latencies_response_ms',
+      timestamp: 'started_at',
+    })!
+
+    expect(data.points).toEqual([{ timestamp: new Date(START).valueOf(), value: 12 }])
+  })
+
+  describe('unroll', () => {
+    const nestedRecords: RequestRecord[] = [
+      {
+        request_start: START,
+        route: 'a',
+        ai: [{ cost: 1, providerName: 'openai' }, { cost: 2, providerName: 'anthropic' }],
+      },
+      { request_start: END, route: 'b', latencies_response_ms: 34 },
+    ]
+
+    it('plots one point per nested entry, sharing the parent timestamp', () => {
+      const data = requestsToScatterData(requestsResult(nestedRecords), { metric: 'cost', unroll: 'ai' })!
+
+      expect(data.points).toEqual([
+        { timestamp: new Date(START).valueOf(), value: 1 },
+        { timestamp: new Date(START).valueOf(), value: 2 },
+      ])
+    })
+
+    it('groups unrolled points by a field on the entry', () => {
+      const data = requestsToScatterData(requestsResult(nestedRecords), {
+        metric: 'cost',
+        dimension: 'providerName',
+        unroll: 'ai',
+      })!
+
+      expect(data.points.map(p => p.group)).toEqual(['openai', 'anthropic'])
+    })
+
+    it('falls back to the parent record for a dimension the entry lacks', () => {
+      const data = requestsToScatterData(requestsResult(nestedRecords), {
+        metric: 'cost',
+        dimension: 'route',
+        unroll: 'ai',
+      })!
+
+      expect(data.points.map(p => p.group)).toEqual(['a', 'a'])
+    })
+
+    it('ignores a collection that is not an array', () => {
+      const records: RequestRecord[] = [{ request_start: START, ai: { cost: 1 } }]
+
+      expect(requestsToScatterData(requestsResult(records), { metric: 'cost', unroll: 'ai' })!.points).toEqual([])
+    })
   })
 })

--- a/packages/analytics/analytics-chart/src/utils/scatter-adapters.ts
+++ b/packages/analytics/analytics-chart/src/utils/scatter-adapters.ts
@@ -1,4 +1,10 @@
-import type { AnalyticsExploreRecord, ExploreResultV4 } from '@kong-ui-public/analytics-utilities'
+import type {
+  AnalyticsExploreRecord,
+  Display,
+  ExploreResultV4,
+  FetchAllRequestsResult,
+  RequestRecord,
+} from '@kong-ui-public/analytics-utilities'
 import type { ScatterChartData, ScatterDataPoint } from '../types'
 
 const EMPTY_GROUP = 'empty'
@@ -88,4 +94,86 @@ const toPoint = (rawTimestamp: unknown, rawValue: unknown, rawGroup: unknown): S
     value,
     group: hasGroupValue ? String(rawGroup) : EMPTY_GROUP,
   }
+}
+
+export interface RequestsToScatterDataOptions {
+  metric: string
+  dimension?: string
+  /** A nested object to expand into one point per entry. */
+  unroll?: string
+  timestamp?: string
+  display?: Display
+  metricUnit?: string
+}
+
+export const requestsToScatterData = (
+  result: FetchAllRequestsResult | undefined,
+  options: RequestsToScatterDataOptions,
+): ScatterChartData | undefined => {
+  if (!result || !('meta' in result)) {
+    return undefined
+  }
+
+  const { metric, dimension, unroll, display, metricUnit } = options
+  const timestampField = options.timestamp ?? 'request_start'
+
+  if (!metric) {
+    console.error('Cannot build scatter chart data from these request records. Missing metric.')
+
+    return undefined
+  }
+
+  const points: ScatterDataPoint[] = []
+
+  for (const record of result.results ?? []) {
+    const timestamp = readPath(record, timestampField)
+
+    for (const source of unrolledSources(record, unroll)) {
+      const rawValue = readPath(source, metric) ?? readPath(record, metric)
+      const rawGroup = dimension ? readPath(source, dimension) ?? readPath(record, dimension) : undefined
+
+      const point = toPoint(timestamp, rawValue, dimension ? rawGroup ?? null : undefined)
+
+      if (point) {
+        points.push(point)
+      }
+    }
+  }
+
+  return {
+    points,
+    metric,
+    metricUnit,
+    dimension,
+    display,
+    start: result.meta?.time_range?.start,
+    end: result.meta?.time_range?.end,
+    truncated: result.truncated,
+    limit: result.limit,
+    datasource: 'requests',
+  }
+}
+
+const unrolledSources = (record: RequestRecord, unroll?: string): unknown[] => {
+  if (!unroll) {
+    return [record]
+  }
+
+  const entries = readPath(record, unroll)
+
+  return Array.isArray(entries) ? entries : []
+}
+
+const readPath = (source: unknown, path: string): unknown => {
+  let current = source
+
+  for (const key of path.split('.')) {
+    if (current === null || typeof current !== 'object') {
+      return undefined
+    }
+
+    current = (current as Record<string, unknown>)[key]
+  }
+
+  return current
 }

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -203,10 +203,10 @@ import { formatTime, isPlatformDatasource, TimePeriods, msToGranularity, TIMEFRA
 import CsvExportModal from './CsvExportModal.vue'
 import '@kong-ui-public/analytics-chart/dist/style.css'
 import '@kong-ui-public/analytics-metric-provider/dist/style.css'
-import BaseAnalyticsChartRenderer from './BaseAnalyticsChartRenderer.vue'
 import SimpleChartRenderer from './SimpleChartRenderer.vue'
 import BarChartRenderer from './BarChartRenderer.vue'
 import { DEFAULT_TILE_HEIGHT, INJECT_QUERY_PROVIDER } from '../constants'
+import ScatterChartRenderer from './ScatterChartRenderer.vue'
 import TimeseriesChartRenderer from './TimeseriesChartRenderer.vue'
 import GoldenSignalsRenderer from './GoldenSignalsRenderer.vue'
 import TopNTableRenderer from './TopNTableRenderer.vue'
@@ -339,7 +339,7 @@ const hasHeaderActions = computed<boolean>(() => canShowHeaderActions.value && k
 const rendererLookup: Record<DashboardTileType, Component | undefined> = {
   'timeseries_line': TimeseriesChartRenderer,
   'timeseries_bar': TimeseriesChartRenderer,
-  'scatter': BaseAnalyticsChartRenderer,
+  'scatter': ScatterChartRenderer,
   'horizontal_bar': BarChartRenderer,
   'vertical_bar': BarChartRenderer,
   'gauge': SimpleChartRenderer,

--- a/packages/analytics/dashboard-renderer/src/components/ScatterChartRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/ScatterChartRenderer.cy.ts
@@ -1,0 +1,154 @@
+import type { AnalyticsBridge, ApiRequestsQuery, ExploreResultV4, ValidDashboardChartQuery } from '@kong-ui-public/analytics-utilities'
+import type { ScatterChartData } from '@kong-ui-public/analytics-chart'
+import type { DashboardRendererContext } from '../types'
+
+import { createPinia, setActivePinia } from 'pinia'
+import ScatterChartRenderer from './ScatterChartRenderer.vue'
+import { INJECT_QUERY_PROVIDER } from '../constants'
+
+const START = '2024-06-16T00:00:00.000Z'
+const END = '2024-06-16T01:00:00.000Z'
+
+const scatterData = (points = 3): ScatterChartData => ({
+  points: Array.from({ length: points }, (_, i) => ({
+    timestamp: new Date(START).valueOf() + i * 1000,
+    value: i + 1,
+  })),
+  metric: 'latencies_response_ms',
+  start: START,
+  end: END,
+})
+
+const exploreResult = (): ExploreResultV4 => ({
+  data: [{ timestamp: START, event: { request_count: 3, route: 'a' } }],
+  meta: {
+    start: START,
+    end: END,
+    granularity_ms: 3_600_000,
+    display: { route: { a: { name: 'Route A' } } },
+    metric_names: ['request_count'],
+    metric_units: { request_count: 'count' },
+    query_id: '',
+  },
+} as unknown as ExploreResultV4)
+
+const query: ApiRequestsQuery = {
+  datasource: 'requests',
+  metric: 'latencies_response_ms',
+}
+
+describe('<ScatterChartRenderer />', () => {
+  beforeEach(() => {
+    cy.viewport(1200, 800)
+    setActivePinia(createPinia())
+  })
+
+  let refreshCounter = 0
+
+  const render = ({
+    scatterDataFn,
+    queryReady = true,
+    tileQuery = query,
+    queryFn,
+  }: {
+    scatterDataFn?: DashboardRendererContext['scatterDataFn']
+    queryReady?: boolean
+    tileQuery?: ApiRequestsQuery | ValidDashboardChartQuery
+    queryFn?: () => Promise<ExploreResultV4>
+  } = {}) => {
+    refreshCounter++
+
+    cy.mount(ScatterChartRenderer, {
+      props: {
+        query: tileQuery,
+        context: {
+          filters: [],
+          ...(scatterDataFn && { scatterDataFn: cy.spy(scatterDataFn).as('fetcher') }),
+        } as DashboardRendererContext,
+        queryReady,
+        chartOptions: { type: 'scatter' },
+        height: 400,
+        refreshCounter,
+      },
+      global: {
+        provide: {
+          [INJECT_QUERY_PROVIDER]: {
+            queryFn: cy.spy(queryFn ?? (() => Promise.resolve(exploreResult()))).as('queryFn'),
+            datasourceConfigFn: () => Promise.resolve([]),
+          } as unknown as AnalyticsBridge,
+        },
+      },
+    })
+  }
+
+  it('renders the chart from the data the consumer supplies', () => {
+    render({ scatterDataFn: () => Promise.resolve(scatterData()) })
+
+    cy.get('@fetcher').should('have.been.calledOnce')
+    cy.get('[data-testid="scatter-chart-container"]').should('be.visible')
+    cy.get('[data-testid="scatter-chart-empty-state"]').should('not.exist')
+  })
+
+  it('passes the tile query and an abort controller to the consumer', () => {
+    render({ scatterDataFn: () => Promise.resolve(scatterData()) })
+
+    cy.get('@fetcher').then((spy: any) => {
+      const call = spy.getCall(0)
+      expect(call.args[0]).to.deep.equal(query)
+      expect(call.args[2]).to.be.instanceOf(AbortController)
+    })
+  })
+
+  it('shows an empty state when the consumer supplies no scatterDataFn', () => {
+    render()
+
+    cy.get('[data-testid="scatter-chart-empty-state"]').should('be.visible')
+      .and('contain.text', 'No scatter data provider supplied')
+  })
+
+  it('shows an empty state when the fetch rejects', () => {
+    render({ scatterDataFn: () => Promise.reject(new Error('nope')) })
+
+    cy.get('[data-testid="scatter-chart-empty-state"]').should('be.visible')
+    cy.get('[data-testid="scatter-chart-container"]').should('not.exist')
+  })
+
+  it('surfaces a forbidden query error', () => {
+    const forbidden = Object.assign(new Error('forbidden'), { response: { status: 403 } })
+
+    render({ scatterDataFn: () => Promise.reject(forbidden) })
+
+    cy.get('[data-testid="scatter-chart-empty-state"]').should('be.visible')
+  })
+
+  describe('explore-backed tiles', () => {
+    const exploreQuery: ValidDashboardChartQuery = {
+      datasource: 'api_usage',
+      metrics: ['request_count'],
+      dimensions: ['route'],
+      granularity: 'hourly',
+    } as ValidDashboardChartQuery
+
+    it('goes through the query bridge, not the consumer fetch', () => {
+      render({ tileQuery: exploreQuery, scatterDataFn: () => Promise.resolve(scatterData()) })
+
+      cy.get('@queryFn').should('have.been.calledOnce')
+      cy.get('@fetcher').should('not.have.been.called')
+      cy.get('[data-testid="scatter-chart-container"]').should('be.visible')
+    })
+
+    it('renders without a scatterDataFn at all', () => {
+      render({ tileQuery: exploreQuery })
+
+      cy.get('@queryFn').should('have.been.calledOnce')
+      cy.get('[data-testid="scatter-chart-container"]').should('be.visible')
+      cy.get('[data-testid="scatter-chart-empty-state"]').should('not.exist')
+    })
+  })
+
+  it('does not fetch until the query is ready', () => {
+    render({ scatterDataFn: () => Promise.resolve(scatterData()), queryReady: false })
+
+    cy.get('@fetcher').should('not.have.been.called')
+  })
+})

--- a/packages/analytics/dashboard-renderer/src/components/ScatterChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/ScatterChartRenderer.vue
@@ -1,0 +1,188 @@
+<template>
+  <QueryDataProvider
+    v-if="!isRequestsQuery"
+    v-slot="{ data: exploreData }"
+    :context="context"
+    :query="(query as ValidDashboardChartQuery)"
+    :query-ready="queryReady"
+    :refresh-counter="refreshCounter"
+    @chart-data="emit('chart-data', $event)"
+    @query-complete="emit('query-complete')"
+  >
+    <div class="analytics-chart">
+      <AnalyticsChart
+        :chart-data="exploreData"
+        :chart-options="options"
+        legend-position="bottom"
+        :synthetics-data-key="chartOptions.synthetics_data_key"
+        tooltip-title=""
+      />
+    </div>
+  </QueryDataProvider>
+
+  <KSkeleton
+    v-else-if="isLoading"
+    class="chart-skeleton"
+    type="table"
+  />
+
+  <KEmptyState
+    v-else-if="hasError"
+    :action-button-visible="false"
+    data-testid="scatter-chart-empty-state"
+  >
+    <template #icon>
+      <VisibilityOffIcon v-if="queryError?.type === 'forbidden'" />
+      <WarningOutlineIcon v-else />
+    </template>
+    <template #title>
+      <p>{{ errorMessage }}</p>
+    </template>
+    <template
+      v-if="queryError?.details"
+      #default
+    >
+      <p>{{ queryError.details }}</p>
+    </template>
+  </KEmptyState>
+
+  <div
+    v-else-if="displayData"
+    class="analytics-chart"
+  >
+    <AnalyticsChart
+      :chart-data="displayData"
+      :chart-options="options"
+      legend-position="bottom"
+      :synthetics-data-key="chartOptions.synthetics_data_key"
+      tooltip-title=""
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AnalyticsChartOptions, QueryError, ScatterChartData } from '@kong-ui-public/analytics-chart'
+import type { ApiRequestsQuery, ExploreResultV4, ValidDashboardChartQuery } from '@kong-ui-public/analytics-utilities'
+import type { ScatterRendererProps } from '../types'
+
+import { computed, onUnmounted, ref, watch } from 'vue'
+import useSWRV from 'swrv'
+import { useSwrvState } from '@kong-ui-public/core'
+import { AnalyticsChart, handleQueryError } from '@kong-ui-public/analytics-chart'
+import { VisibilityOffIcon, WarningOutlineIcon } from '@kong/icons'
+
+import composables from '../composables'
+import QueryDataProvider from './QueryDataProvider.vue'
+
+const props = defineProps<ScatterRendererProps>()
+
+const emit = defineEmits<{
+  (e: 'chart-data', chartData: ExploreResultV4): void
+  (e: 'query-complete'): void
+}>()
+
+const { i18n } = composables.useI18n()
+
+const isRequestsQuery = computed(() => props.query.datasource === 'requests')
+const scatterDataFn = computed(() => props.context.scatterDataFn)
+
+let abortController: AbortController | null = null
+
+onUnmounted(() => {
+  abortController?.abort()
+})
+
+const queryKey = () => {
+  if (isRequestsQuery.value && props.queryReady && scatterDataFn.value) {
+    return JSON.stringify([props.query, props.context, props.refreshCounter])
+  }
+
+  return null
+}
+
+const queryError = ref<QueryError | null>(null)
+
+const { data, error, isValidating } = useSWRV(queryKey, async () => {
+  const startKey = queryKey()
+
+  abortController?.abort()
+  const controller = new AbortController()
+  abortController = controller
+
+  try {
+    const result = await scatterDataFn.value!(props.query as ApiRequestsQuery, props.context, controller)
+
+    if (queryKey() !== startKey) {
+      // The original fetch has been superseded by a newer query
+      return undefined
+    }
+
+    queryError.value = null
+
+    return result
+  } catch (e: any) {
+    if (queryKey() !== startKey) {
+      // This avoids an empty error state when a fetch has been aborted
+      return undefined
+    }
+
+    queryError.value = handleQueryError(e)
+
+    throw e
+  } finally {
+    if (queryKey() === startKey) {
+      emit('query-complete')
+    }
+  }
+}, {
+  refreshInterval: props.context.refreshInterval,
+  revalidateOnFocus: false,
+  shouldRetryOnError: false,
+})
+
+const { state, swrvState: STATE } = useSwrvState(data, error, isValidating)
+
+const oldData = ref<ScatterChartData | undefined>()
+const displayData = computed(() => data.value ?? oldData.value)
+
+watch(data, newData => {
+  if (newData) {
+    oldData.value = newData
+  }
+})
+
+const hasError = computed(() => !scatterDataFn.value || state.value === STATE.ERROR || !!queryError.value)
+const errorMessage = computed(() => {
+  if (!scatterDataFn.value) {
+    return i18n.t('renderer.noScatterDataFn')
+  }
+
+  return queryError.value?.message || i18n.t('renderer.unexpectedError')
+})
+
+const isLoading = computed(() => !hasError.value && (!props.queryReady || state.value === STATE.PENDING) && !displayData.value)
+
+const options = computed((): AnalyticsChartOptions => ({
+  type: 'scatter',
+  chartDatasetColors: props.chartOptions.chart_dataset_colors,
+  scatter: {
+    percentileLines: props.chartOptions.percentile_lines?.map(line => ({
+      percentile: line.percentile,
+      label: line.label,
+      borderDash: line.border_dash,
+      color: line.color,
+    })),
+    outlierPercentile: props.chartOptions.outlier_percentile,
+    shadeOutlierRegion: props.chartOptions.shade_outlier_region,
+    jitterMs: props.chartOptions.jitter_ms,
+    pointRadius: props.chartOptions.point_radius,
+    pointOpacity: props.chartOptions.point_opacity,
+  },
+}))
+</script>
+
+<style scoped lang="scss">
+.analytics-chart {
+  height: 100%;
+}
+</style>

--- a/packages/analytics/dashboard-renderer/src/locales/en.json
+++ b/packages/analytics/dashboard-renderer/src/locales/en.json
@@ -5,6 +5,7 @@
       "description": "Begin by choosing at least one metric"
     },
     "noQueryBridge": "No query bridge provided.  Unable to render dashboard.",
+    "noScatterDataFn": "No scatter data provider supplied.",
     "unexpectedError": "An unexpected error has occurred.",
     "trendRange": {
       "24h": "Last 24-hour summary",

--- a/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
+++ b/packages/analytics/dashboard-renderer/src/types/renderer-types.ts
@@ -1,10 +1,12 @@
 import type {
   AllFilters,
+  ApiRequestsQuery,
+  ScatterChartOptions,
   TimeRangeV4,
   ValidDashboardChartQuery,
   ValidDashboardTableQuery,
 } from '@kong-ui-public/analytics-utilities'
-import type { ExternalLink } from '@kong-ui-public/analytics-chart'
+import type { ExternalLink, ScatterChartData } from '@kong-ui-public/analytics-chart'
 
 export interface DashboardRendererContext {
   filters: AllFilters[]
@@ -15,6 +17,11 @@ export interface DashboardRendererContext {
   showTileActions?: boolean
   zoomable?: boolean
   showTileZoomActions?: boolean
+  scatterDataFn?: (
+    query: ApiRequestsQuery,
+    context: DashboardRendererContext,
+    abortController: AbortController,
+  ) => Promise<ScatterChartData | undefined>
 }
 
 export interface PdfExportOptions {
@@ -69,6 +76,11 @@ export interface ChartRendererProps<T> {
   headerDescription?: string
   requestsLink?: ExternalLink
   exploreLink?: ExternalLink
+}
+
+export interface ScatterRendererProps extends Omit<ChartRendererProps<ScatterChartOptions>, 'query'> {
+  /** A scatter tile can show either request or explore data */
+  query: ApiRequestsQuery | ValidDashboardChartQuery
 }
 
 export interface TableRendererProps {


### PR DESCRIPTION
# Summary

Part of [MA-5465](https://konghq.atlassian.net/browse/MA-5465)

In order for dashboard tiles to display scatter charts that also consume `api-request` data, it needs a separate renderer as the `QueryDataProvider` only supports explore queries. Extending the data provider seemed unnecessary for this use case and so I made a new renderer.

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

<!--
## Test Coverage Exemption (Optional)
If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.

[TEST_COVERAGE_EXEMPT_REASON] give it a reason
-->


[MA-5465]: https://konghq.atlassian.net/browse/MA-5465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ