### PR TITLE
fix(analytics): remove splitting of outliers and add percentile plugin [MA-5465]

### DIFF
--- a/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
+++ b/packages/analytics/analytics-chart/src/components/AnalyticsChart.vue
@@ -105,7 +105,6 @@
         data-testid="scatter-chart-container"
         :dimension-axes-title="timestampAxisTitle"
         :granularity="scatterGranularity"
-        :legend-values="legendValues"
         :metric-axes-title="metricAxesTitle"
         :metric-unit="computedMetricUnit"
         :shade-outlier-region="chartOptions.scatter?.shadeOutlierRegion"

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartLegend.vue
@@ -5,19 +5,38 @@
     data-testid="legend"
   >
     <li
-      v-for="{ fillStyle, strokeStyle, text, datasetIndex, index, value, isSegmentEmpty } in (items as any[])"
+      v-for="{ fillStyle, strokeStyle, text, datasetIndex, index, value, isSegmentEmpty, isKey, lineDash } in (items as any[])"
       :key="text"
-      @click="handleLegendItemClick(datasetIndex, index)"
+      :class="{ 'legend-key': isKey }"
+      @click="isKey ? undefined : handleLegendItemClick(datasetIndex, index)"
     >
+      <svg
+        v-if="lineDash?.length"
+        aria-hidden="true"
+        class="line-marker"
+        height="2"
+        width="16"
+      >
+        <line
+          :stroke="strokeStyle"
+          :stroke-dasharray="lineDash.join(' ')"
+          stroke-width="2"
+          x1="0"
+          x2="16"
+          y1="1"
+          y2="1"
+        />
+      </svg>
       <div
+        v-else
         class="square-marker"
         :style="{ background: fillStyle, 'border-color': strokeStyle }"
       />
       <KTooltip>
         <div
           class="label-container"
-          :class="{ 'strike-through': !isDatasetVisible(datasetIndex, index) }"
-          :title="value && showValues ? `${text}: ${value.formatted}` : text"
+          :class="{ 'strike-through': !isKey && !isDatasetVisible(datasetIndex, index), 'inline-value': isKey }"
+          :title="value && (showValues || isKey) ? `${text}: ${value.formatted}` : text"
         >
           <div
             class="label truncate-label"
@@ -25,10 +44,10 @@
             {{ text }}
           </div>
           <div
-            v-if="value && showValues"
+            v-if="value && (showValues || isKey)"
             class="sub-label"
           >
-            {{ value.formatted }}
+            <span v-if="isKey">-</span> {{ value.formatted }}
           </div>
         </div>
         <template
@@ -144,6 +163,22 @@ const isDatasetVisible = (datasetIndex: number = 0, segmentIndex: number): boole
     display: flex;
     line-height: 1;
     margin: 0;
+
+    // A key shows a value that is not a dataset, thus it cannot be toggled.
+    &.legend-key {
+      cursor: default;
+    }
+
+    .line-marker {
+      margin-right: var(--kui-space-30, $kui-space-30);
+      overflow: visible;
+    }
+
+    .label-container.inline-value {
+      align-items: center;
+      display: flex;
+      gap: var(--kui-space-20, $kui-space-20);
+    }
 
     // Color bar preceding label
     .square-marker {

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ChartTooltip.vue
@@ -49,11 +49,19 @@
       </div>
       <ul class="tooltip">
         <template
-          v-for="({ backgroundColor, borderColor, label, value, isSegmentEmpty }, index) in (state.tooltipSeries as any)"
+          v-for="({ backgroundColor, borderColor, label, value, isSegmentEmpty, isExtra }, index) in (state.tooltipSeries as any)"
           :key="label + index"
         >
-          <li v-if="state.tooltipSeries.length">
+          <li
+            v-if="state.tooltipSeries.length"
+            :class="{ 'extra-row': isExtra }"
+          >
             <div
+              v-if="isExtra"
+              class="square-marker marker-placeholder"
+            />
+            <div
+              v-else
               class="square-marker"
               :style="{ background: String(backgroundColor), borderColor: String(borderColor) }"
             />
@@ -217,6 +225,16 @@ watch(tooltipEl, value => {
       height: 12px;
       margin-right: var(--kui-space-30, $kui-space-30);
       width: 12px;
+    }
+
+    .marker-placeholder {
+      background: transparent;
+      border: none;
+    }
+
+    .extra-row .display-label,
+    .extra-row .display-value {
+      color: var(--kui-color-text-neutral, $kui-color-text-neutral);
     }
   }
 }

--- a/packages/analytics/analytics-chart/src/components/chart-plugins/ReferenceLinePlugin.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-plugins/ReferenceLinePlugin.ts
@@ -1,0 +1,56 @@
+import type { Chart, Plugin } from 'chart.js'
+import type { ResolvedReferenceLine } from '../../types'
+
+interface ReferenceLineOptions {
+  lines?: ResolvedReferenceLine[]
+}
+
+const LINE_WIDTH = 1.5
+
+/** Draws horizontal reference lines across a chart */
+export class ReferenceLinePlugin implements Plugin {
+  id = 'referenceLinePlugin'
+
+  // `after`, not `before`: a reference line has to read on top of a bunch of points
+  afterDatasetsDraw(chart: Chart, _: any, pluginOptions: ReferenceLineOptions): void {
+    const lines = pluginOptions?.lines
+
+    if (!lines?.length) {
+      return
+    }
+
+    const yScale = chart.scales.y
+
+    if (!yScale || !chart.chartArea) {
+      return
+    }
+
+    const { top, bottom, left, right } = chart.chartArea
+    const context = chart.ctx
+
+    context.save()
+    context.lineWidth = LINE_WIDTH
+
+    for (const { value, color, borderDash } of lines) {
+      if (!Number.isFinite(value)) {
+        continue
+      }
+
+      const y = yScale.getPixelForValue(value)
+
+      // A line outside the plotted range would otherwise be drawn over an axis
+      if (y < top || y > bottom) {
+        continue
+      }
+
+      context.beginPath()
+      context.setLineDash(borderDash)
+      context.strokeStyle = color
+      context.moveTo(left, y)
+      context.lineTo(right, y)
+      context.stroke()
+    }
+
+    context.restore()
+  }
+}

--- a/packages/analytics/analytics-chart/src/components/chart-types/ScatterChart.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-types/ScatterChart.cy.ts
@@ -8,43 +8,41 @@ const HOUR_MS = 60 * 60 * 1000
 const points = (count: number, valueAt: (i: number) => number) =>
   Array.from({ length: count }, (_, i) => ({ x: START + i * HOUR_MS, y: valueAt(i) }))
 
+const SERIES_COLOR = '#6f7787'
+const OUTLIER_COLOR = '#d44324'
+const OUTLIER_VALUE = 18
+
 const mockChartData: KChartData = {
   datasets: [
     {
       type: 'scatter',
       label: 'Turn',
       data: points(20, i => i + 1),
-      backgroundColor: '#6f7787',
-      borderColor: '#6f7787',
+      backgroundColor: SERIES_COLOR,
+      borderColor: SERIES_COLOR,
       showLine: false,
       rawDimension: 'Turn',
     },
   ],
 } as KChartData
 
+const isOutlier = (raw: any): boolean => Number.isFinite(raw?.y) && raw.y > OUTLIER_VALUE
+
 const withOutliersAndLines: KChartData = {
-  outlierValue: 18,
+  outlier: { value: OUTLIER_VALUE, label: 'Outlier (> p95)', color: OUTLIER_COLOR },
+  referenceLines: [
+    { percentile: 50, label: 'Median', value: 10, color: '#000000', borderDash: [6, 4] },
+    { percentile: 95, label: 'p95', value: OUTLIER_VALUE, color: OUTLIER_COLOR, borderDash: [2, 3] },
+  ],
   datasets: [
-    ...mockChartData.datasets,
     {
       type: 'scatter',
-      label: 'Outlier (> p95)',
-      data: points(2, i => 19 + i).map(point => ({ ...point, tooltipLabel: 'Turn (outlier > p95)' })),
-      backgroundColor: '#d44324',
-      borderColor: '#d44324',
+      label: 'Turn',
+      data: points(20, i => i + 1),
+      backgroundColor: (ctx: any) => isOutlier(ctx.raw) ? OUTLIER_COLOR : SERIES_COLOR,
+      borderColor: (ctx: any) => isOutlier(ctx.raw) ? OUTLIER_COLOR : SERIES_COLOR,
       showLine: false,
-      rawDimension: 'outlier',
-    },
-    {
-      type: 'line',
-      label: 'Median',
-      data: [{ x: START, y: 10 }, { x: START + 20 * HOUR_MS, y: 10 }],
-      borderColor: '#000000',
-      backgroundColor: '#000000',
-      borderDash: [6, 4],
-      pointRadius: 0,
-      total: 10,
-      rawDimension: 'percentile-50',
+      rawDimension: 'Turn',
     },
   ],
 } as KChartData
@@ -81,16 +79,25 @@ describe('<ScatterChart />', () => {
     cy.get('[data-testid="scatter-chart"]').should('be.visible')
   })
 
-  it('renders a legend entry per dataset', () => {
+  it('renders a legend entry per dataset, then a key per annotation', () => {
     mountScatterChart({ chartData: withOutliersAndLines })
-    cy.get('[data-testid="legend"] li').should('have.length', 3)
+    cy.get('[data-testid="legend"] li').should('have.length', 4)
+    cy.get('[data-testid="legend"] li').eq(0).should('contain.text', 'Turn')
+    cy.get('[data-testid="legend"] li').eq(1).should('contain.text', 'Outlier (> p95)')
+    cy.get('[data-testid="legend"] li').eq(2).should('contain.text', 'Median')
+    cy.get('[data-testid="legend"] li').eq(3).should('contain.text', 'p95')
   })
 
-  it('keeps dataset order in the legend rather than sorting by value', () => {
+  it('shows the value each reference line sits at', () => {
+    mountScatterChart({ chartData: withOutliersAndLines, metricUnit: 'usd' })
+    cy.get('[data-testid="legend"] li').eq(2).should('contain.text', '$10.00')
+    cy.get('[data-testid="legend"] li').eq(3).should('contain.text', '$18.00')
+  })
+
+  it('marks a reference line in the legend with the dash pattern it is drawn in', () => {
     mountScatterChart({ chartData: withOutliersAndLines })
-    cy.get('[data-testid="legend"] li').eq(0).should('contain.text', 'Turn')
-    cy.get('[data-testid="legend"] li').eq(1).should('contain.text', 'Outlier')
-    cy.get('[data-testid="legend"] li').eq(2).should('contain.text', 'Median')
+    cy.get('[data-testid="legend"] li').eq(2).find('line').should('have.attr', 'stroke-dasharray', '6 4')
+    cy.get('[data-testid="legend"] li').eq(3).find('line').should('have.attr', 'stroke-dasharray', '2 3')
   })
 
   it('hides the legend when the position is hidden', () => {
@@ -109,8 +116,15 @@ describe('<ScatterChart />', () => {
 
   it('toggles a dataset when its legend entry is clicked', () => {
     mountScatterChart({ chartData: withOutliersAndLines })
+    cy.get('[data-testid="legend"] li').eq(0).click()
+    cy.get('[data-testid="legend"] li').eq(0).find('.label-container').should('have.class', 'strike-through')
+  })
+
+  it('does not toggle anything when a key is clicked', () => {
+    mountScatterChart({ chartData: withOutliersAndLines })
     cy.get('[data-testid="legend"] li').eq(1).click()
-    cy.get('[data-testid="legend"] li').eq(1).find('.label-container').should('have.class', 'strike-through')
+    cy.get('[data-testid="legend"] li').eq(1).find('.label-container').should('not.have.class', 'strike-through')
+    cy.get('[data-testid="legend"] li').eq(0).find('.label-container').should('not.have.class', 'strike-through')
   })
 
   it('renders with no data without erroring', () => {
@@ -133,10 +147,18 @@ describe('<ScatterChart />', () => {
     cy.get('.tooltip-container .display-label').should('have.length', 1)
   })
 
-  it('names the source series in the tooltip for an outlier point', () => {
+  it('names the series an outlier belongs to, and marks it in the outlier color', () => {
     mountScatterChart({ chartData: withOutliersAndLines })
-    sweepOverChart(60, 20, 80, 30)
-    cy.get('.tooltip-container .display-label').should('have.text', 'Turn (outlier > p95)')
+    // The highest values sit at the right of this fixture, above the outlier threshold
+    sweepOverChart(540, 20, 580, 40)
+    cy.get('.tooltip-container .display-label').should('have.text', 'Turn')
+    cy.get('.tooltip-container .square-marker').should('have.css', 'background-color', 'rgb(212, 67, 36)')
+  })
+
+  it('marks a point below the threshold in its series color', () => {
+    mountScatterChart({ chartData: withOutliersAndLines })
+    sweepOverChart(200, 40, 300, 90)
+    cy.get('.tooltip-container .square-marker').should('have.css', 'background-color', 'rgb(111, 119, 135)')
   })
 
   it('hides the tooltip when the cursor leaves the chart', () => {

--- a/packages/analytics/analytics-chart/src/components/chart-types/ScatterChart.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/ScatterChart.vue
@@ -29,7 +29,7 @@
       :id="legendID"
       :chart-instance="chartInstance"
       data-testid="legend"
-      :items="legendItems"
+      :items="allLegendItems"
     />
   </div>
 </template>
@@ -38,11 +38,12 @@
 import type { Chart, Plugin } from 'chart.js'
 import type { ComputedRef } from 'vue'
 import type { GranularityValues } from '@kong-ui-public/analytics-utilities'
-import type { ChartLegendSortFn, ChartTooltipSortFn, EnhancedLegendItem, KChartData, LegendValues, TooltipState } from '../../types'
+import type { ChartLegendSortFn, ChartTooltipSortFn, EnhancedLegendItem, KChartData, TooltipState } from '../../types'
 import type { ScatterChartColors } from '../../utils'
 
 import { computed, inject, onMounted, reactive, ref, toRef, useTemplateRef, watch } from 'vue'
 import { Scatter } from 'vue-chartjs'
+import { unitFormatter } from '@kong-ui-public/analytics-utilities'
 
 import 'chartjs-adapter-date-fns'
 import 'chart.js/auto'
@@ -51,6 +52,7 @@ import composables from '../../composables'
 import { ChartLegendPosition } from '../../enums'
 import { generateLegendItems, scatterChartColors } from '../../utils'
 import { OutlierBandPlugin } from '../chart-plugins/OutlierBandPlugin'
+import { ReferenceLinePlugin } from '../chart-plugins/ReferenceLinePlugin'
 import ToolTip from '../chart-plugins/ChartTooltip.vue'
 import ChartLegend from '../chart-plugins/ChartLegend.vue'
 
@@ -60,7 +62,6 @@ interface ScatterChartProps {
   metricUnit?: string
   granularity: GranularityValues
   timeRangeMs?: number
-  legendValues?: LegendValues
   metricAxesTitle?: string
   dimensionAxesTitle?: string
   syntheticsDataKey?: string
@@ -76,7 +77,6 @@ const props = withDefaults(
     chartData: undefined,
     metricUnit: '',
     timeRangeMs: undefined,
-    legendValues: undefined,
     metricAxesTitle: undefined,
     dimensionAxesTitle: undefined,
     syntheticsDataKey: '',
@@ -90,17 +90,19 @@ const props = withDefaults(
 const legendPosition = inject('legendPosition', ChartLegendPosition.Bottom)
 const activeColorMode = inject<ComputedRef<'light' | 'dark'>>('app:konnectColorMode', computed(() => 'light'))
 
+const { i18n } = composables.useI18n()
+const { formatUnit } = unitFormatter({ i18n })
 const { translateUnit } = composables.useTranslatedUnits()
 
 const chartParentRef = useTemplateRef<HTMLDivElement>('chartParent')
 
 const outlierBandPlugin = new OutlierBandPlugin()
+const referenceLinePlugin = new ReferenceLinePlugin()
 const legendID = crypto.randomUUID()
 const chartID = crypto.randomUUID()
 
 const themeColors = ref<ScatterChartColors>(scatterChartColors())
 const chartInstance = ref<{ chart: Chart }>()
-const legendItems = ref<EnhancedLegendItem[]>([])
 
 const tooltipData: TooltipState = reactive({
   showTooltip: false,
@@ -136,39 +138,61 @@ watch(activeColorMode, () => {
   themeColors.value = scatterChartColors(chartParentRef.value)
 })
 
-const referenceLineValues = computed<LegendValues | undefined>(() => {
-  const legendValues = props.legendValues
+const outlier = computed(() => props.chartData?.outlier)
+const referenceLines = computed(() => props.chartData?.referenceLines ?? [])
 
-  if (!legendValues) {
-    return undefined
-  }
-
-  const values: LegendValues = {}
-
-  for (const { label, total } of props.chartData?.datasets || []) {
-    if (total !== undefined && label && label in legendValues) {
-      values[label] = legendValues[label]
-    }
-  }
-
-  return values
-})
+const datasetLegendItems = ref<EnhancedLegendItem[]>([])
 
 const htmlLegendPlugin: Plugin = {
   id: legendID,
   afterUpdate(chart: Chart) {
-    legendItems.value = generateLegendItems(chart, referenceLineValues.value, props.chartLegendSortFn)
+    datasetLegendItems.value = generateLegendItems(chart, undefined, props.chartLegendSortFn)
   },
 }
 
-const outlierValue = computed(() => (
-  props.shadeOutlierRegion ? props.chartData?.outlierValue : undefined
-))
+/**
+ * These are not associated with a dataset and are not toggle'able, they are simply
+ * key entries for the chart, e.g. percentile lines, outliers, etc.
+ */
+const keyLegendItems = computed<EnhancedLegendItem[]>(() => {
+  const items: EnhancedLegendItem[] = []
 
+  if (outlier.value) {
+    items.push({
+      text: outlier.value.label,
+      fillStyle: outlier.value.color,
+      strokeStyle: outlier.value.color,
+      isKey: true,
+    } as EnhancedLegendItem)
+  }
+
+  for (const line of referenceLines.value) {
+    items.push({
+      text: line.label,
+      fillStyle: line.color,
+      strokeStyle: line.color,
+      lineDash: line.borderDash,
+      isKey: true,
+      value: {
+        raw: line.value,
+        formatted: formatUnit(line.value, props.metricUnit, { translateUnit }),
+      },
+    } as EnhancedLegendItem)
+  }
+
+  return items
+})
+
+const allLegendItems = computed(() => [...datasetLegendItems.value, ...keyLegendItems.value])
+
+const outlierBandValue = computed(() => (
+  props.shadeOutlierRegion ? outlier.value?.value : undefined
+))
 
 const plugins = computed(() => [
   htmlLegendPlugin,
-  ...(outlierValue.value !== undefined ? [outlierBandPlugin] : []),
+  ...(outlierBandValue.value !== undefined ? [outlierBandPlugin] : []),
+  ...(referenceLines.value.length ? [referenceLinePlugin] : []),
 ])
 
 const remountKey = computed(() => `scatter-${plugins.value.map(p => p.id).join('-')}`)
@@ -180,7 +204,9 @@ const { options } = composables.useScatterChartOptions({
   timeRangeMs: toRef(props, 'timeRangeMs'),
   metricAxesTitle: toRef(props, 'metricAxesTitle'),
   dimensionAxesTitle: toRef(props, 'dimensionAxesTitle'),
-  outlierValue,
+  metricUnit: toRef(props, 'metricUnit'),
+  outlierValue: outlierBandValue,
+  referenceLines,
   themeColors,
 })
 

--- a/packages/analytics/analytics-chart/src/composables/useScatterChartOptions.ts
+++ b/packages/analytics/analytics-chart/src/composables/useScatterChartOptions.ts
@@ -5,6 +5,7 @@ import { computed, onUnmounted } from 'vue'
 import { Tooltip } from 'chart.js'
 import { isNullOrUndef } from 'chart.js/helpers'
 import { millisecondsToHours } from 'date-fns'
+import { unitFormatter } from '@kong-ui-public/analytics-utilities'
 
 import {
   formatChartTicksByGranularity,
@@ -12,8 +13,30 @@ import {
   lineChartTooltipBehavior,
   verticalTooltipPositioning,
 } from '../utils'
+import composables from '../composables'
+
+// TODO: update this to be region specific (if possible)
+const AXIS_FORMATTED_UNITS = ['usd', 'bytes']
+const CURRENCY_UNIT = 'usd'
 
 export default function useScatterChartOptions(chartOptions: ScatterChartOptions) {
+  const { i18n } = composables.useI18n()
+  const { formatUnit } = unitFormatter({ i18n })
+
+  const formatMetricTick = (value: number): string | number => {
+    const unit = chartOptions.metricUnit?.value
+
+    if (!unit || !AXIS_FORMATTED_UNITS.includes(unit)) {
+      return value
+    }
+
+    if (value === 0 && unit === CURRENCY_UNIT) {
+      return i18n.formatNumber(0, { style: 'currency', currency: 'USD' })
+    }
+
+    return formatUnit(value, unit)
+  }
+
   const dayBoundaryCrossed = computed(() => {
     const timeRange = Number(chartOptions.timeRangeMs.value)
     const now = new Date()
@@ -68,6 +91,7 @@ export default function useScatterChartOptions(chartOptions: ScatterChartOptions
     },
     ticks: {
       maxTicksLimit: 5,
+      callback: (value: number) => formatMetricTick(value),
     },
     grid: {
       drawBorder: false,
@@ -151,6 +175,9 @@ export default function useScatterChartOptions(chartOptions: ScatterChartOptions
       outlierBandPlugin: {
         value: chartOptions.outlierValue?.value,
         color: chartOptions.themeColors.value.outlierBand,
+      },
+      referenceLinePlugin: {
+        lines: chartOptions.referenceLines?.value,
       },
     },
     layout: {

--- a/packages/analytics/analytics-chart/src/composables/useScatterDatasets.spec.ts
+++ b/packages/analytics/analytics-chart/src/composables/useScatterDatasets.spec.ts
@@ -31,6 +31,13 @@ const makeResult = (data: GroupByResult[], display: DisplayBlob = {} as DisplayB
     } as unknown as QueryResponseMeta,
   } as ExploreResultV4))
 
+/**
+ * Chart.js calls a scriptable option once per point, with the point on `raw`, and once
+ * per dataset — to build the legend swatch — with nothing on it.
+ */
+const resolve = (option: unknown, raw?: unknown): unknown =>
+  typeof option === 'function' ? option({ raw }) : option
+
 describe('jitter', () => {
   it('returns 0 when jitter is disabled', () => {
     expect(jitter(0)).toBe(0)
@@ -94,42 +101,59 @@ describe('useScatterDatasets', () => {
     expect(datasets[0].label).toBe('cp:route-a')
   })
 
-  it('adds percentile line datasets spanning the query time range', () => {
-    const { datasets } = useScatterDatasets(
+  it('resolves percentile lines without plotting them', () => {
+    const { datasets, referenceLines } = useScatterDatasets(
       { scatter: { percentileLines: [{ percentile: 50 }, { percentile: 95 }] } },
       makeResult(costRecords()),
     ).value
 
-    const median = datasets.find(d => d.label === 'Median')
-    const p95 = datasets.find(d => d.label === 'p95')
-
-    expect(median).toBeDefined()
-    expect(p95).toBeDefined()
-    // rank = 0.5 * 9 = 4.5, midway between 5 and 6
-    expect(median!.data).toEqual([
-      { x: new Date(START).valueOf(), y: 5.5 },
-      { x: new Date(END).valueOf(), y: 5.5 },
+    // Lines are chart chrome: a dataset of theirs would widen the axes to the query
+    // time range and squash the plotted records into whatever width was left.
+    expect(datasets).toHaveLength(1)
+    expect(datasets[0].type).toBe('scatter')
+    expect(referenceLines).toEqual([
+      // rank = 0.5 * 9 = 4.5, midway between 5 and 6
+      { percentile: 50, label: 'Median', value: 5.5, color: expect.any(String), borderDash: [6, 4] },
+      { percentile: 95, label: 'p95', value: expect.any(Number), color: expect.any(String), borderDash: [2, 3] },
     ])
-    expect(median!.total).toBe(5.5)
   })
 
-  it('splits points above the outlier percentile into their own dataset', () => {
-    const { datasets } = useScatterDatasets(
+  it('honours a custom label and dash pattern on a line', () => {
+    const { referenceLines } = useScatterDatasets(
+      { scatter: { percentileLines: [{ percentile: 95, label: 'Ceiling', borderDash: [1, 1] }] } },
+      makeResult(costRecords()),
+    ).value
+
+    expect(referenceLines![0]).toMatchObject({ label: 'Ceiling', borderDash: [1, 1] })
+  })
+
+  it('paints points above the outlier percentile in place', () => {
+    const { datasets, outlier } = useScatterDatasets(
       { scatter: { outlierPercentile: 80 } },
       makeResult(costRecords()),
     ).value
 
-    const outliers = datasets.find(d => d.label === 'Outlier (> p80)')
+    // rank = 0.8 * 9 = 7.2, so 9 and 10 sit above the threshold
+    expect(outlier).toEqual({ value: 8.2, label: 'Outlier (> p80)', color: expect.any(String) })
 
-    expect(outliers).toBeDefined()
-    expect(outliers!.data).toEqual([
-      { x: expect.any(Number), y: 9, tooltipLabel: 'Costs (outlier > p80)' },
-      { x: expect.any(Number), y: 10, tooltipLabel: 'Costs (outlier > p80)' },
-    ])
-    expect(datasets[0].data).toHaveLength(8)
+    // Every point stays in the series it belongs to, so the series keeps its legend toggle
+    expect(datasets).toHaveLength(1)
+    expect(datasets[0].data).toHaveLength(10)
+    expect(resolve(datasets[0].backgroundColor, { y: 9 })).toBe(outlier!.color)
+    expect(resolve(datasets[0].backgroundColor, { y: 1 })).toBe('rgba(168, 108, 213, 0.6)')
   })
 
-  it('collects outliers from every series into a single dataset', () => {
+  it('draws an outlier slightly larger than the cloud around it', () => {
+    const { datasets } = useScatterDatasets(
+      { scatter: { outlierPercentile: 80, pointRadius: 3 } },
+      makeResult(costRecords()),
+    ).value
+
+    expect(resolve(datasets[0].pointRadius, { y: 10 })).toBe(4)
+    expect(resolve(datasets[0].pointRadius, { y: 1 })).toBe(3)
+  })
+
+  it('keeps every dimension in its own series when outliers span several', () => {
     const data: GroupByResult[] = [
       { timestamp: START, event: { cost: 1, route: 'a' } },
       { timestamp: START, event: { cost: 100, route: 'a' } },
@@ -137,26 +161,32 @@ describe('useScatterDatasets', () => {
       { timestamp: START, event: { cost: 200, route: 'b' } },
     ]
     const display = { route: { a: { name: 'A' }, b: { name: 'B' } } } as DisplayBlob
-    const { datasets } = useScatterDatasets(
+    const { datasets, outlier } = useScatterDatasets(
       { scatter: { outlierPercentile: 50 } },
       makeResult(data, display),
     ).value
 
-    const outliers = datasets.filter(d => d.rawDimension === 'outlier')
+    expect(datasets.map(d => d.label)).toEqual(['A', 'B'])
+    expect(datasets.every(d => d.data.length === 2)).toBe(true)
+    expect(datasets.map(d => resolve(d.backgroundColor, { y: 1000 }))).toEqual([outlier!.color, outlier!.color])
+  })
 
-    expect(outliers).toHaveLength(1)
-    expect(outliers[0].data).toHaveLength(2)
-    expect(outliers[0].data.map((point: any) => point.tooltipLabel)).toEqual([
-      'A (outlier > Median)',
-      'B (outlier > Median)',
-    ])
+  it('leaves the legend swatch in the series color', () => {
+    const { datasets } = useScatterDatasets(
+      { scatter: { outlierPercentile: 50 } },
+      makeResult(costRecords()),
+    ).value
+
+    // Chart.js resolves a scriptable option with no point on it to build the legend swatch
+    expect(resolve(datasets[0].backgroundColor)).toBe('rgba(168, 108, 213, 0.6)')
+    expect(resolve(datasets[0].borderColor)).toBe('#a86cd5')
   })
 
   it('draws points translucent so a dense cloud shows density', () => {
     const { datasets } = useScatterDatasets({}, makeResult(costRecords())).value
 
-    expect(datasets[0].backgroundColor).toBe('rgba(168, 108, 213, 0.6)')
-    expect(datasets[0].borderColor).toBe('#a86cd5')
+    expect(resolve(datasets[0].backgroundColor, { y: 1 })).toBe('rgba(168, 108, 213, 0.6)')
+    expect(resolve(datasets[0].borderColor, { y: 1 })).toBe('#a86cd5')
   })
 
   it('honours an explicit point opacity', () => {
@@ -166,7 +196,7 @@ describe('useScatterDatasets', () => {
     ).value
 
     // A fully opaque color serializes as rgb() rather than rgba(..., 1).
-    expect(datasets[0].backgroundColor).toBe('rgb(168, 108, 213)')
+    expect(resolve(datasets[0].backgroundColor, { y: 1 })).toBe('rgb(168, 108, 213)')
   })
 
   it('keeps outlier points opaque so they stay vivid over the cloud', () => {
@@ -175,16 +205,15 @@ describe('useScatterDatasets', () => {
       makeResult(costRecords()),
     ).value
 
-    const outliers = datasets.find(d => d.rawDimension === 'outlier')
-
-    expect(outliers?.backgroundColor).not.toContain('rgba')
+    expect(resolve(datasets[0].backgroundColor, { y: 10 })).not.toContain('rgba')
   })
 
-  it('omits percentile lines when none are requested', () => {
-    const { datasets } = useScatterDatasets({}, makeResult(costRecords())).value
+  it('omits percentile lines and the outlier threshold when neither is requested', () => {
+    const chartData = useScatterDatasets({}, makeResult(costRecords())).value
 
-    expect(datasets).toHaveLength(1)
-    expect(datasets[0].type).toBe('scatter')
+    expect(chartData.datasets).toHaveLength(1)
+    expect(chartData.referenceLines).toBeUndefined()
+    expect(chartData.outlier).toBeUndefined()
   })
 
   it('applies jitter to the x value only', () => {
@@ -207,12 +236,12 @@ describe('useScatterDatasets theming', () => {
     document.documentElement.style.setProperty(name, value)
 
   const medianColor = () => {
-    const { datasets } = useScatterDatasets(
+    const { referenceLines } = useScatterDatasets(
       { scatter: { percentileLines: [{ percentile: 50 }] } },
       makeResult(costRecords()),
     ).value
 
-    return datasets.find(d => d.label === 'Median')?.borderColor
+    return referenceLines?.[0].color
   }
 
   afterEach(() => {
@@ -229,23 +258,24 @@ describe('useScatterDatasets theming', () => {
   it('draws outliers in the theme\'s resolved danger color', () => {
     setToken('--kui-color-background-danger', '#d78392')
 
-    const { datasets } = useScatterDatasets(
+    const { datasets, outlier } = useScatterDatasets(
       { scatter: { outlierPercentile: 80 } },
       makeResult(costRecords()),
     ).value
 
-    expect(datasets.find(d => d.rawDimension === 'outlier')?.borderColor).toBe('#d78392')
+    expect(outlier?.color).toBe('#d78392')
+    expect(resolve(datasets[0].borderColor, { y: 10 })).toBe('#d78392')
   })
 
   it('honours an explicit color over the theme token', () => {
     setToken('--kui-color-text', '#d2d7d2')
 
-    const { datasets } = useScatterDatasets(
+    const { referenceLines } = useScatterDatasets(
       { scatter: { percentileLines: [{ percentile: 50, color: '#ff00ff' }] } },
       makeResult(costRecords()),
     ).value
 
-    expect(datasets.find(d => d.label === 'Median')?.borderColor).toBe('#ff00ff')
+    expect(referenceLines?.[0].color).toBe('#ff00ff')
   })
 
   it('repaints when the owning component re-resolves the theme colors', () => {
@@ -259,11 +289,51 @@ describe('useScatterDatasets theming', () => {
       makeResult(costRecords()),
     )
 
-    expect(chartData.value.datasets.find(d => d.label === 'Median')?.borderColor).toBe('#000000')
+    expect(chartData.value.referenceLines?.[0].color).toBe('#000000')
 
     setToken('--kui-color-text', '#ffffff')
     themeColors.value = scatterChartColors()
 
-    expect(chartData.value.datasets.find(d => d.label === 'Median')?.borderColor).toBe('#ffffff')
+    expect(chartData.value.referenceLines?.[0].color).toBe('#ffffff')
+  })
+})
+
+describe('useScatterDatasets extras', () => {
+  const withExtras = (values: number[]): ComputedRef<ScatterChartData> => computed(() => ({
+    points: values.map((value, i) => ({
+      timestamp: new Date(START).valueOf() + i * 1000,
+      value,
+      extras: [{ label: 'Tokens', value: value * 100, unit: 'token count' }],
+    })),
+    metric: 'cost',
+    start: START,
+    end: END,
+  }))
+
+  it('carries extras onto the plotted points', () => {
+    const { datasets } = useScatterDatasets({}, withExtras([1, 2, 3])).value
+
+    expect(datasets[0].data).toEqual([
+      expect.objectContaining({ y: 1, extras: [{ label: 'Tokens', value: 100, unit: 'token count' }] }),
+      expect.objectContaining({ y: 2, extras: [{ label: 'Tokens', value: 200, unit: 'token count' }] }),
+      expect.objectContaining({ y: 3, extras: [{ label: 'Tokens', value: 300, unit: 'token count' }] }),
+    ])
+  })
+
+  it('keeps extras on outlier points', () => {
+    const { datasets } = useScatterDatasets(
+      { scatter: { outlierPercentile: 50 } },
+      withExtras([1, 2, 3, 4, 100]),
+    ).value
+
+    for (const point of datasets[0].data as Array<{ extras?: unknown[] }>) {
+      expect(point.extras).toHaveLength(1)
+    }
+  })
+
+  it('omits the key entirely when a point has no extras', () => {
+    const { datasets } = useScatterDatasets({}, makeResult(costRecords())).value
+
+    expect(datasets[0].data.every(point => !('extras' in (point as object)))).toBe(true)
   })
 })

--- a/packages/analytics/analytics-chart/src/composables/useScatterDatasets.ts
+++ b/packages/analytics/analytics-chart/src/composables/useScatterDatasets.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import type { Dataset, ExploreToDatasetDeps, KChartData, ScatterChartData, ScatterOptions } from '../types'
+import type { Dataset, ExploreToDatasetDeps, KChartData, ScatterChartData, ScatterOptions, ScatterPointExtra } from '../types'
 import type { ScatterChartColors } from '../utils'
 
 import { computed } from 'vue'
@@ -23,6 +23,7 @@ export interface ScatterDatasetDeps extends ExploreToDatasetDeps {
 interface ScatterPoint {
   x: number
   y: number
+  extras?: ScatterPointExtra[]
   // This should only be set for outliers as they all behave as one dataset, without
   // it each point in that dataset will just appear as `Outlier > 95`
   tooltipLabel?: string
@@ -84,7 +85,11 @@ export default function useScatterDatasets(
         const groupId = point.group ?? metric
         const points = grouped.get(groupId) || []
 
-        points.push({ x: point.timestamp + jitter(jitterMs), y: point.value })
+        points.push({
+          x: point.timestamp + jitter(jitterMs),
+          y: point.value,
+          ...(point.extras?.length ? { extras: point.extras } : {}),
+        })
         grouped.set(groupId, points)
         allValues.push(point.value)
       })

--- a/packages/analytics/analytics-chart/src/composables/useScatterDatasets.ts
+++ b/packages/analytics/analytics-chart/src/composables/useScatterDatasets.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'vue'
-import type { Dataset, ExploreToDatasetDeps, KChartData, ScatterChartData, ScatterOptions, ScatterPointExtra } from '../types'
+import type { ScriptableContext } from 'chart.js'
+import type { Dataset, ExploreToDatasetDeps, KChartData, ResolvedReferenceLine, ScatterChartData, ScatterOptions, ScatterPointExtra } from '../types'
 import type { ScatterChartColors } from '../utils'
 
 import { computed } from 'vue'
@@ -10,7 +11,8 @@ import composables from '../composables'
 
 export const DEFAULT_POINT_RADIUS = 2
 export const DEFAULT_POINT_OPACITY = 0.6
-const PERCENTILE_LINE_WIDTH = 1.5
+const OUTLIER_RADIUS_BOOST = 1
+const HOVER_RADIUS_BOOST = 2
 const MEDIAN_PERCENTILE = 50
 const MEDIAN_BORDER_DASH = [6, 4]
 const OUTLIER_BORDER_DASH = [2, 3]
@@ -24,9 +26,6 @@ interface ScatterPoint {
   x: number
   y: number
   extras?: ScatterPointExtra[]
-  // This should only be set for outliers as they all behave as one dataset, without
-  // it each point in that dataset will just appear as `Outlier > 95`
-  tooltipLabel?: string
 }
 
 export const jitter = (jitterMs: number): number => {
@@ -38,8 +37,7 @@ export const jitter = (jitterMs: number): number => {
 }
 
 /**
- * Builds the dataset for scatter plots as one point per record, grouped into a series per dimension
- * with optional percentile reference lines and outliers
+ * Builds the dataset for scatter plots as one point per record, grouped into a series per dimension.
  *
  * Percentiles are computed over the points actually supplied, so they are only really
  * meaningful when the input is not truncated.
@@ -70,7 +68,7 @@ export default function useScatterDatasets(
         return { datasets: [] }
       }
 
-      const { metric, dimension, display, start, end } = data
+      const { metric, dimension, display } = data
 
       const scatter = deps.scatter || {}
       const jitterMs = scatter.jitterMs ?? 0
@@ -102,95 +100,48 @@ export default function useScatterDatasets(
       const percentileValues = requestedPercentiles.length ? computePercentiles(allValues, requestedPercentiles) : new Map<number, number>()
 
       const outlierValue = scatter.outlierPercentile !== undefined ? percentileValues.get(scatter.outlierPercentile) : undefined
-      const splitOutliers = outlierValue !== undefined && Number.isFinite(outlierValue)
-
-      const outlierThresholdLabel = splitOutliers ? labelFor(scatter.outlierPercentile as number) : ''
+      const hasOutliers = outlierValue !== undefined && Number.isFinite(outlierValue)
 
       const colorPalette = isNullOrUndef(deps.colorPalette) ? datavisPalette : deps.colorPalette
       const themeColors = deps.themeColors?.value ?? scatterChartColors()
       const datasets: Dataset[] = []
-      // Outliers from every series collect into one dataset so that the legend gains a
-      // single toggleable "Outlier" entry rather than one per series. We may want
-      // to rethink how this works, but good enough for now...
-      const outliers: ScatterPoint[] = []
 
-      /**
-       * Splits the points of a series, returning the ones that aren't outliers and moving the rest into the
-       * shared `outliers` dataset above
-       */
-      const withoutOutliers = (points: ScatterPoint[], seriesLabel: string): ScatterPoint[] => {
-        if (!splitOutliers) {
-          return points
-        }
 
-        const kept: ScatterPoint[] = []
 
-        for (const point of points) {
-          if (point.y <= (outlierValue as number)) {
-            kept.push(point)
-            continue
-          }
+      const isOutlier = (raw: unknown): boolean => {
+        const y = (raw as ScatterPoint | undefined)?.y
 
-          outliers.push({
-            ...point,
-            tooltipLabel: i18n.t('scatter.outlierTooltip', { series: seriesLabel, label: outlierThresholdLabel }),
-          })
-        }
-
-        return kept
+        return hasOutliers && Number.isFinite(y) && (y as number) > (outlierValue as number)
       }
 
       Array.from(grouped.entries()).forEach(([groupId, points], i) => {
         const name = (dimension && display?.[groupId]?.name) || groupId
         const isSegmentEmpty = groupId === 'empty'
         const baseColor = determineBaseColor(i, name, isSegmentEmpty, colorPalette)
+        // Translucent fill so overlapping points darken where the cloud is dense
+        const fillColor = withAlpha(baseColor, pointOpacity)
 
         // @ts-ignore - dynamic i18n key
         const label: string = (i18n.te(`chartLabels.${name}`) && i18n.t(`chartLabels.${name}`)) || name
-        const kept = withoutOutliers(points, label)
 
         datasets.push({
           type: 'scatter',
           rawDimension: name,
           rawMetric: metric,
           label,
-          // Translucent fill so overlapping points darken where the cloud is dense
-          borderColor: baseColor,
-          backgroundColor: withAlpha(baseColor, pointOpacity),
-          data: kept,
-          pointRadius,
-          pointHoverRadius: pointRadius + 2,
+          // Outliers are recolored where they sit instead of being moved into a separate series
+          borderColor: (ctx: ScriptableContext<'line'>) => isOutlier(ctx.raw) ? themeColors.outlier : baseColor,
+          backgroundColor: (ctx: ScriptableContext<'line'>) => isOutlier(ctx.raw) ? themeColors.outlier : fillColor,
+          pointRadius: (ctx: ScriptableContext<'line'>) => isOutlier(ctx.raw) ? pointRadius + OUTLIER_RADIUS_BOOST : pointRadius,
+          pointHoverRadius: (ctx: ScriptableContext<'line'>) => (isOutlier(ctx.raw) ? pointRadius + OUTLIER_RADIUS_BOOST : pointRadius) + HOVER_RADIUS_BOOST,
+          data: points,
           pointBorderWidth: 0,
           showLine: false,
           isSegmentEmpty,
         } as Dataset)
       })
 
-      if (splitOutliers && outliers.length) {
-        const outlierColor = themeColors.outlier
-
-        datasets.push({
-          type: 'scatter',
-          rawDimension: 'outlier',
-          rawMetric: metric,
-          label: i18n.t('scatter.outlier', { label: outlierThresholdLabel }),
-          borderColor: outlierColor,
-          backgroundColor: outlierColor,
-          data: outliers,
-          pointRadius,
-          pointHoverRadius: pointRadius + 2,
-          pointBorderWidth: 0,
-          showLine: false,
-        } as Dataset)
-      }
-
-      // Reference lines are just two points which gives them legend entries. We may also
-      // want to revisit this.
-      const pointXValues = Array.from(grouped.values()).flat().map(point => point.x)
-      const startMs = new Date(start).valueOf()
-      const endMs = new Date(end).valueOf()
-      const xMin = Number.isFinite(startMs) ? startMs : Math.min(...pointXValues)
-      const xMax = Number.isFinite(endMs) ? endMs : Math.max(...pointXValues)
+      const referenceLines: ResolvedReferenceLine[] = []
 
       percentileLines.forEach(line => {
         const value = percentileValues.get(line.percentile)
@@ -200,28 +151,28 @@ export default function useScatterDatasets(
         }
 
         const isMedian = line.percentile === MEDIAN_PERCENTILE
-        const color = line.color || (isMedian ? themeColors.medianLine : themeColors.outlier)
 
-        datasets.push({
-          type: 'line',
-          rawDimension: `percentile-${line.percentile}`,
-          rawMetric: metric,
+        referenceLines.push({
+          percentile: line.percentile,
           label: labelFor(line.percentile, line.label),
-          data: [{ x: xMin, y: value }, { x: xMax, y: value }],
-          borderColor: color,
-          backgroundColor: color,
+          value,
+          color: line.color || (isMedian ? themeColors.medianLine : themeColors.outlier),
           borderDash: line.borderDash || (isMedian ? MEDIAN_BORDER_DASH : OUTLIER_BORDER_DASH),
-          borderWidth: PERCENTILE_LINE_WIDTH,
-          pointRadius: 0,
-          pointHitRadius: 0,
-          fill: false,
-          total: value,
-        } as Dataset)
+        })
       })
 
       return {
         datasets,
-        ...(splitOutliers ? { outlierValue: outlierValue as number } : {}),
+        ...(hasOutliers
+          ? {
+            outlier: {
+              value: outlierValue as number,
+              label: i18n.t('scatter.outlier', { label: labelFor(scatter.outlierPercentile as number) }),
+              color: themeColors.outlier,
+            },
+          }
+          : {}),
+        ...(referenceLines.length ? { referenceLines } : {}),
       }
     } catch (err) {
       console.warn(err)

--- a/packages/analytics/analytics-chart/src/locales/en.json
+++ b/packages/analytics/analytics-chart/src/locales/en.json
@@ -11,8 +11,7 @@
   "scatter": {
     "median": "Median",
     "percentile": "p{value}",
-    "outlier": "Outlier (> {label})",
-    "outlierTooltip": "{series} (outlier > {label})"
+    "outlier": "Outlier (> {label})"
   },
   "chartUnits": {
     "ms": "ms",

--- a/packages/analytics/analytics-chart/src/types/chart-data.ts
+++ b/packages/analytics/analytics-chart/src/types/chart-data.ts
@@ -2,6 +2,7 @@ import type { ChartData, ChartDataset, LegendItem } from 'chart.js'
 import type { ChartTooltipSortFn } from './chartjs-options'
 import type { ChartType, SimpleChartType } from './chart-types'
 import type { ExploreAggregations } from '@kong-ui-public/analytics-utilities'
+import type { ScatterPointExtra } from './scatter-data'
 
 // Chart.js extended interfaces
 export type Dataset = ChartDataset & {
@@ -33,6 +34,7 @@ export interface AnalyticsDataPoint {
  */
 export interface LabeledDataPoint extends AnalyticsDataPoint {
   tooltipLabel?: string
+  extras?: ScatterPointExtra[]
 }
 
 /**

--- a/packages/analytics/analytics-chart/src/types/chart-data.ts
+++ b/packages/analytics/analytics-chart/src/types/chart-data.ts
@@ -20,7 +20,8 @@ export interface KChartData extends ChartData {
   labels?: string[]
   isLabelEmpty?: boolean[]
   isMultiDimension?: boolean
-  outlierValue?: number
+  outlier?: ScatterOutlier
+  referenceLines?: ResolvedReferenceLine[]
 }
 
 export interface AnalyticsDataPoint {
@@ -62,6 +63,11 @@ export interface EnhancedLegendItem extends LegendItem {
   value: LegendValueEntry
   text: string
   isSegmentEmpty?: boolean
+  /**
+   * A key is not tied to a specific dataset, only used for extra things in a chart like
+   * outliers, thresholds, etc. They also don't toggle anything and always show their value.
+   */
+  isKey?: boolean
 }
 
 /**
@@ -91,7 +97,8 @@ export interface ScatterPercentileLine {
    */
   label?: string
   /**
-   * Dash pattern for the line, defaults to a dashed [5, 5].
+   * Dash pattern for the line, defaults to a dashed [6, 4] for the median and a
+   * dotted [2, 3] for anything else.
    */
   borderDash?: number[]
   /**
@@ -100,23 +107,30 @@ export interface ScatterPercentileLine {
   color?: string
 }
 
-/**
- * TODO: The percentile math for median and outliers are not perfect, these need to be updated
- *       to actually display/inform the user of what is happening. So for now, the percentiles and
- *       median lines will default to none.
- *
- *       e.g. Fix the splitting of the outliers datasets from the original datasets, labels in
- *            the legend that explain what they are doing (or removed completely), better
- *            styling to differentiate the median/outliers
- */
+export interface ResolvedReferenceLine {
+  percentile: number
+  label: string
+  value: number
+  color: string
+  borderDash: number[]
+}
+
+export interface ScatterOutlier {
+  value: number
+  /**
+   * Legend key text, e.g. "Outlier (> p95)".
+   */
+  label: string
+  color: string
+}
+
 export interface ScatterOptions {
   /**
    * Reference lines derived from the plotted y-values, defaults to none.
    */
   percentileLines?: ScatterPercentileLine[]
   /**
-   * Percentile above which points are split into a separate "outlier" dataset,
-   * defaults to undefined (every point stays in its own series).
+   * Percentile above which points are colored as outliers, defaults to undefined
    */
   outlierPercentile?: number
   /**

--- a/packages/analytics/analytics-chart/src/types/chartjs-options.ts
+++ b/packages/analytics/analytics-chart/src/types/chartjs-options.ts
@@ -2,7 +2,7 @@ import type { Ref, ComputedRef } from 'vue'
 import type { Chart, ChartType as ChartJsChartType, TooltipModel, Color } from 'chart.js'
 import type { ChartType } from './chart-types'
 import type { ExploreAggregations, GranularityValues } from '@kong-ui-public/analytics-utilities'
-import type { Threshold } from './chart-data'
+import type { ResolvedReferenceLine, Threshold } from './chart-data'
 import type { ScatterChartColors } from '../utils/theme-colors'
 
 export interface TooltipEntry {
@@ -65,7 +65,9 @@ export interface ScatterChartOptions {
   timeRangeMs: Ref<number | undefined>
   metricAxesTitle?: Ref<string | undefined>
   dimensionAxesTitle?: Ref<string | undefined>
+  metricUnit?: Ref<string | undefined>
   outlierValue?: Ref<number | undefined>
+  referenceLines?: Ref<ResolvedReferenceLine[]>
   themeColors: Ref<ScatterChartColors>
 }
 

--- a/packages/analytics/analytics-chart/src/types/chartjs-options.ts
+++ b/packages/analytics/analytics-chart/src/types/chartjs-options.ts
@@ -12,6 +12,7 @@ export interface TooltipEntry {
   value: string | number
   rawValue: number
   isSegmentEmpty?: boolean
+  isExtra?: boolean
 }
 
 export type ChartTooltipSortFn = (a: TooltipEntry, b: TooltipEntry) => number

--- a/packages/analytics/analytics-chart/src/types/scatter-data.ts
+++ b/packages/analytics/analytics-chart/src/types/scatter-data.ts
@@ -1,5 +1,11 @@
 import type { Display, ResultMetaBase } from '@kong-ui-public/analytics-utilities'
 
+export interface ScatterPointExtra {
+  label: string
+  value: number | string
+  unit?: string
+}
+
 export interface ScatterDataPoint {
   /**
    * Epoch milliseconds.
@@ -14,6 +20,8 @@ export interface ScatterDataPoint {
    * named after the metric.
    */
   group?: string
+  /** Extra values to be placed in the tooltip */
+  extras?: ScatterPointExtra[]
 }
 
 export interface ScatterChartData extends ResultMetaBase {

--- a/packages/analytics/analytics-chart/src/utils/commonOptions.ts
+++ b/packages/analytics/analytics-chart/src/utils/commonOptions.ts
@@ -56,6 +56,17 @@ export const lineChartTooltipBehavior = (
       } as TooltipEntry
     }).sort(sortFn)
 
+    const extras = (tooltip.dataPoints[0]?.raw as LabeledDataPoint)?.extras ?? []
+
+    for (const extra of extras) {
+      tooltipData.tooltipSeries.push({
+        label: extra.label,
+        value: extra.unit ? formatUnit(Number(extra.value) || 0, extra.unit, { translateUnit: tooltipData.translateUnit }) : String(extra.value),
+        rawValue: Number(extra.value) || 0,
+        isExtra: true,
+      } as TooltipEntry)
+    }
+
     tooltipData.left = `${tooltip.x}px`
     tooltipData.top = `${tooltip.y}px`
 

--- a/packages/analytics/analytics-chart/src/utils/scatter-adapters.spec.ts
+++ b/packages/analytics/analytics-chart/src/utils/scatter-adapters.spec.ts
@@ -192,3 +192,83 @@ describe('requestsToScatterData', () => {
     })
   })
 })
+
+describe('requestsToScatterData extras', () => {
+  const result = (results: RequestRecord[]): FetchAllRequestsResult => ({
+    results,
+    meta: { query_id: '', time_range: { start: START, end: END }, size: results.length },
+    truncated: false,
+    limit: 10_000,
+  })
+
+  const records: RequestRecord[] = [{
+    request_start: START,
+    route: 'checkout',
+    ai: [{ cost: 0.1, totalTokens: 2426, providerName: 'openai' }],
+  }]
+
+  it('annotates a point with the requested fields', () => {
+    const data = requestsToScatterData(result(records), {
+      metric: 'cost',
+      unroll: 'ai',
+      extraFields: [
+        { field: 'totalTokens', label: 'Tokens', unit: 'token count' },
+        { field: 'providerName', label: 'Provider' },
+      ],
+    })!
+
+    expect(data.points[0].extras).toEqual([
+      { label: 'Tokens', value: 2426, unit: 'token count' },
+      { label: 'Provider', value: 'openai' },
+    ])
+  })
+
+  it('falls back to the parent record for a field the entry lacks', () => {
+    const data = requestsToScatterData(result(records), {
+      metric: 'cost',
+      unroll: 'ai',
+      extraFields: [{ field: 'route', label: 'Route' }],
+    })!
+
+    expect(data.points[0].extras).toEqual([{ label: 'Route', value: 'checkout' }])
+  })
+
+  it('defaults the label to the field name', () => {
+    const data = requestsToScatterData(result(records), {
+      metric: 'cost',
+      unroll: 'ai',
+      extraFields: [{ field: 'providerName' }],
+    })!
+
+    expect(data.points[0].extras).toEqual([{ label: 'providerName', value: 'openai' }])
+  })
+
+  it('skips fields the record does not carry rather than showing them blank', () => {
+    const data = requestsToScatterData(result(records), {
+      metric: 'cost',
+      unroll: 'ai',
+      extraFields: [
+        { field: 'nope', label: 'Missing' },
+        { field: 'providerName', label: 'Provider' },
+      ],
+    })!
+
+    expect(data.points[0].extras).toEqual([{ label: 'Provider', value: 'openai' }])
+  })
+
+  it('leaves extras undefined when every field is missing', () => {
+    const data = requestsToScatterData(result(records), {
+      metric: 'cost',
+      unroll: 'ai',
+      extraFields: [{ field: 'nope' }],
+    })!
+
+    expect(data.points[0].extras).toBeUndefined()
+  })
+
+  it('leaves extras undefined when none are requested', () => {
+    const data = requestsToScatterData(result(records), { metric: 'cost', unroll: 'ai' })!
+
+    expect(data.points[0].extras).toBeUndefined()
+  })
+})

--- a/packages/analytics/analytics-chart/src/utils/scatter-adapters.ts
+++ b/packages/analytics/analytics-chart/src/utils/scatter-adapters.ts
@@ -5,7 +5,7 @@ import type {
   FetchAllRequestsResult,
   RequestRecord,
 } from '@kong-ui-public/analytics-utilities'
-import type { ScatterChartData, ScatterDataPoint } from '../types'
+import type { ScatterChartData, ScatterDataPoint, ScatterPointExtra } from '../types'
 
 const EMPTY_GROUP = 'empty'
 
@@ -70,7 +70,12 @@ export const exploreResultToScatterData = (result: ExploreResultV4 | undefined):
  * Since `null` would read as 0, this would cause a `0` point on the axis bringing
  * down the percentile with it, so these are just dropped entirely.
  */
-const toPoint = (rawTimestamp: unknown, rawValue: unknown, rawGroup: unknown): ScatterDataPoint | undefined => {
+const toPoint = (
+  rawTimestamp: unknown,
+  rawValue: unknown,
+  rawGroup: unknown,
+  extras?: ScatterPointExtra[],
+): ScatterDataPoint | undefined => {
   if (rawValue === null || rawValue === undefined || rawValue === '') {
     return undefined
   }
@@ -82,8 +87,10 @@ const toPoint = (rawTimestamp: unknown, rawValue: unknown, rawGroup: unknown): S
     return undefined
   }
 
+  const withExtras = extras?.length ? { extras } : {}
+
   if (rawGroup === undefined) {
-    return { timestamp, value }
+    return { timestamp, value, ...withExtras }
   }
 
   // A dimension that has no value is part of the "empty" group
@@ -93,7 +100,42 @@ const toPoint = (rawTimestamp: unknown, rawValue: unknown, rawGroup: unknown): S
     timestamp,
     value,
     group: hasGroupValue ? String(rawGroup) : EMPTY_GROUP,
+    ...withExtras,
   }
+}
+
+const readExtras = (
+  source: unknown,
+  record: RequestRecord,
+  extraFields?: ScatterExtraField[],
+): ScatterPointExtra[] | undefined => {
+  if (!extraFields?.length) {
+    return undefined
+  }
+
+  const extras: ScatterPointExtra[] = []
+
+  for (const { field, label, unit } of extraFields) {
+    const value = readPath(source, field) ?? readPath(record, field)
+
+    if (value === null || value === undefined || value === '') {
+      continue
+    }
+
+    extras.push({
+      label: label ?? field,
+      value: value as string | number,
+      ...(unit ? { unit } : {}),
+    })
+  }
+
+  return extras.length ? extras : undefined
+}
+
+export interface ScatterExtraField {
+  field: string
+  label?: string
+  unit?: string
 }
 
 export interface RequestsToScatterDataOptions {
@@ -103,6 +145,7 @@ export interface RequestsToScatterDataOptions {
   unroll?: string
   timestamp?: string
   display?: Display
+  extraFields?: ScatterExtraField[]
   metricUnit?: string
 }
 
@@ -114,7 +157,7 @@ export const requestsToScatterData = (
     return undefined
   }
 
-  const { metric, dimension, unroll, display, metricUnit } = options
+  const { metric, dimension, unroll, display, extraFields, metricUnit } = options
   const timestampField = options.timestamp ?? 'request_start'
 
   if (!metric) {
@@ -132,7 +175,12 @@ export const requestsToScatterData = (
       const rawValue = readPath(source, metric) ?? readPath(record, metric)
       const rawGroup = dimension ? readPath(source, dimension) ?? readPath(record, dimension) : undefined
 
-      const point = toPoint(timestamp, rawValue, dimension ? rawGroup ?? null : undefined)
+      const point = toPoint(
+        timestamp,
+        rawValue,
+        dimension ? rawGroup ?? null : undefined,
+        readExtras(source, record, extraFields),
+      )
 
       if (point) {
         points.push(point)

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -460,6 +460,69 @@ describe('dashboardSchema.v2', () => {
     expect(validate({ datasource: 'explore', metric: 'ai.cost' })).toBe(false)
   })
 
+  it('accepts an unrolled query annotating its points', () => {
+    const validate = new Ajv({ strict: false }).compile(apiRequestsQuerySchema)
+
+    expect(validate({
+      datasource: 'requests',
+      metric: 'cost',
+      unroll: 'ai',
+      extra_fields: [
+        { field: 'totalTokens', label: 'Tokens', unit: 'token count' },
+        { field: 'responseModel' },
+      ],
+    })).toBe(true)
+
+    // `field` is the one thing an annotation can't do without
+    expect(validate({ datasource: 'requests', metric: 'cost', extra_fields: [{ label: 'Tokens' }] })).toBe(false)
+    expect(validate({ datasource: 'requests', metric: 'cost', unroll: ['ai'] })).toBe(false)
+  })
+
+  describe('scatter tiles', () => {
+    const scatterTile = (query: Record<string, unknown>) => ({
+      tiles: [{
+        type: 'chart',
+        id: 'request-cost-distribution',
+        layout: { position: { col: 0, row: 0 }, size: { cols: 2, rows: 2 } },
+        definition: {
+          query,
+          chart: {
+            type: 'scatter',
+            percentile_lines: [{ percentile: 50 }, { percentile: 95 }],
+            outlier_percentile: 95,
+          },
+        },
+      }],
+      tile_height: 400,
+      columns: 2,
+    })
+
+    it('persists a scatter tile backed by raw request records', () => {
+      expect(validateDashboardConfigSchema(scatterTile({
+        datasource: 'requests',
+        metric: 'cost',
+        dimension: 'providerName',
+        max_records: 5000,
+      }))).toBe(true)
+    })
+
+    it('persists an unrolled scatter tile with annotated points', () => {
+      expect(validateDashboardConfigSchema(scatterTile({
+        datasource: 'requests',
+        metric: 'cost',
+        unroll: 'ai',
+        extra_fields: [{ field: 'totalTokens', label: 'Tokens', unit: 'token count' }],
+      }))).toBe(true)
+    })
+
+    it('keeps the api-requests query away from other chart types', () => {
+      const tile = scatterTile({ datasource: 'requests', metric: 'cost' })
+      tile.tiles[0].definition.chart = { type: 'donut' } as never
+
+      expect(validateDashboardConfigSchema(tile)).toBe(false)
+    })
+  })
+
   it('loosens only the platform branch', () => {
     expect(platformQuerySchema.properties.datasource.oneOf).toHaveLength(2)
     expect(platformQuerySchema.properties.datasource.oneOf?.[0]).toMatchObject({ const: 'platform_usage' })

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -216,7 +216,7 @@ export const scatterChartSchema = {
     },
     outlier_percentile: {
       type: 'number',
-      description: 'Percentile above which points are split into a highlighted outlier series.',
+      description: 'Percentile above which points are colored in the outlier color, in place.',
       minimum: 0,
       maximum: 100,
     },
@@ -778,6 +778,28 @@ export const platformTabularQuerySchema = {
   additionalProperties: false,
 } as const satisfies JSONSchema
 
+export const apiRequestsExtraFieldSchema = {
+  type: 'object',
+  properties: {
+    field: {
+      type: 'string',
+      description: 'Field to read, dotted for a nested one.',
+    },
+    label: {
+      type: 'string',
+      description: 'Tooltip label, defaults to the field name.',
+    },
+    unit: {
+      type: 'string',
+      description: 'Unit to format the value with, e.g. `ms` or `token count`.',
+    },
+  },
+  required: ['field'],
+  additionalProperties: false,
+} as const satisfies JSONSchema
+
+export type ApiRequestsExtraField = FromSchemaWithOptions<typeof apiRequestsExtraFieldSchema>
+
 export const apiRequestsQuerySchema = {
   type: 'object',
   description: 'A query for the api-requests endpoint.',
@@ -806,6 +828,15 @@ export const apiRequestsQuerySchema = {
       type: 'number',
       description: 'Ceiling on records gathered across pages. The endpoint serves at most 1000 per page. Defaults to 10000.',
       minimum: 1,
+    },
+    unroll: {
+      type: 'string',
+      description: 'A nested collection on a request record (`ai`, `mcp_info.rpc`) to expand into one point per entry rather than one per request.',
+    },
+    extra_fields: {
+      type: 'array',
+      description: 'Values to annotate each point with in the tooltip. Read from the unrolled entry first, then the request record.',
+      items: apiRequestsExtraFieldSchema,
     },
   },
   required: ['datasource', 'metric'],
@@ -889,7 +920,11 @@ const tableChartTileDefinitionSchema = {
 
 export type TableChartTileDefinition = FromSchemaWithOptions<typeof tableChartTileDefinitionSchema>
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * A scatter tile fed by raw request records. Kept as its own arm so the api-requests
+ * query, whose field names aren't enumerable, can only pair with the scatter chart.
+ * A scatter tile over an explore query validates through `chartTileDefinitionSchema`.
+ */
 const scatterTileDefinitionSchema = {
   type: 'object',
   properties: {
@@ -907,6 +942,7 @@ export const tileDefinitionSchema = {
   anyOf: [
     chartTileDefinitionSchema,
     tableChartTileDefinitionSchema,
+    scatterTileDefinitionSchema,
   ],
 } as const satisfies JSONSchema
 

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -225,7 +225,7 @@ import GoldenSignalsRenderer from './GoldenSignalsRenderer.vue'
 import TopNTableRenderer from './TopNTableRenderer.vue'
 import TableDataGridRenderer from './TableDataGridRenderer.vue'
 import composables from '../composables'
-import { isTableChartDefinition } from '../utils/tile-definition'
+import { isExploreChartDefinition, isRequestsChartDefinition, isTableChartDefinition } from '../utils/tile-definition'
 import { isTimeRangeUnsupported } from '../utils/time-range-support'
 import { useDatasourceConfigStore } from '@kong-ui-public/analytics-config-store'
 import { storeToRefs } from 'pinia'
@@ -299,7 +299,7 @@ const tileTitle = computed<string | undefined>(() => {
 const tileDescription = computed<string | undefined>(() => definition.header_description)
 const isSlottableTile = computed<boolean>(() => chart.value.type === 'slottable')
 const canExportCsv = computed<boolean>(() => {
-  if (isTableChartDefinition(definition)) {
+  if (isTableChartDefinition(definition) || isRequestsChartDefinition(definition)) {
     return false
   }
 
@@ -507,8 +507,8 @@ const metricOptions = computed<Array<SegmentedControlOption<AllAggregations>>>((
 })))
 
 const isAgedOutQuery = computed(() => {
-  // Check table definitions first so TypeScript narrows before reading query.granularity.
-  if (isTableChartDefinition(definition) || !isTimeSeriesChart.value || !queryReady || loadingChartData.value) {
+  // Check explore type tiles first so TypeScript narrows before reading query.granularity.
+  if (!isExploreChartDefinition(definition) || !isTimeSeriesChart.value || !queryReady || loadingChartData.value) {
     return false
   }
 
@@ -523,8 +523,8 @@ const isAgedOutQuery = computed(() => {
 
 const agedOutWarning = computed(() => {
   const currentGranularity = msToGranularity(chartData.value?.meta.granularity_ms ?? 0) ?? 'unknown'
-  // Check table definitions first so TypeScript narrows before reading query.granularity.
-  const savedGranularity = isTableChartDefinition(definition) ? 'unknown' : definition.query.granularity ?? 'unknown'
+  // Check explore type tiles first so TypeScript narrows before reading query.granularity.
+  const savedGranularity = isExploreChartDefinition(definition) ? definition.query.granularity ?? 'unknown' : 'unknown'
 
   return i18n.t('query_aged_out_warning', {
     currentGranularity: i18n.t(`granularities.${currentGranularity}` as any),
@@ -589,6 +589,10 @@ const hideExportModal = () => {
 }
 
 const getExportData = (): Promise<ExploreResultV4> => {
+  if (isRequestsChartDefinition(definition)) {
+    throw new Error('Cannot export data for a tile backed by the api-requests endpoint')
+  }
+
   // goap datasources don't allow limit increases
   const isGoapDatasource = definition.query.datasource?.startsWith('goap')
 

--- a/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
+++ b/packages/analytics/dashboard-renderer/src/composables/useContextLinks.ts
@@ -3,10 +3,10 @@ import { isPlatformDatasource, msToGranularity } from '@kong-ui-public/analytics
 import { useAnalyticsConfigStore, useDatasourceConfigStore } from '@kong-ui-public/analytics-config-store'
 import { storeToRefs } from 'pinia'
 import type { DeepReadonly, Ref } from 'vue'
-import type { AiExploreAggregations, AiExploreQuery, AllFilters, AnalyticsBridge, ChartTileDefinition, ExploreAggregations, ExploreQuery, ExploreResultV4, QueryableAiExploreDimensions, QueryableExploreDimensions, TableChartTileDefinition, TimeRangeV4, ValidDashboardTableQuery } from '@kong-ui-public/analytics-utilities'
+import type { AiExploreAggregations, AiExploreQuery, AllFilters, AnalyticsBridge, ExploreAggregations, ExploreQuery, ExploreResultV4, QueryableAiExploreDimensions, QueryableExploreDimensions, TileDefinition, TimeRangeV4, ValidDashboardTableQuery } from '@kong-ui-public/analytics-utilities'
 import type { DashboardRendererContext } from '../types'
 import type { ExternalLink } from '@kong-ui-public/analytics-chart'
-import { isTableChartDefinition } from '../utils/tile-definition'
+import { isExploreChartDefinition, isTableChartDefinition } from '../utils/tile-definition'
 
 const EXPLORE_DATASOURCES = [
   'basic',
@@ -34,7 +34,7 @@ export default function useContextLinks(
   }: {
     queryBridge: AnalyticsBridge | undefined
     context: Readonly<Ref<DeepReadonly<DashboardRendererContext>>>
-    definition: Readonly<Ref<ChartTileDefinition | TableChartTileDefinition>>
+    definition: Readonly<Ref<TileDefinition>>
     chartData: Readonly<Ref<DeepReadonly<ExploreResultV4 | undefined>>>
   },
 ) {
@@ -163,8 +163,8 @@ export default function useContextLinks(
 
   const buildExploreQuery = (timeRange: TimeRangeV4, filters: AllFilters[]): ExploreQuery | AiExploreQuery => {
     const currentDefinition = definition.value
-    if (isTableChartDefinition(currentDefinition)) {
-      throw new Error('Cannot build a chart explore query for table chart definitions')
+    if (!isExploreChartDefinition(currentDefinition)) {
+      throw new Error('Cannot build a chart explore query for table or api-requests definitions')
     }
 
     const dimensions = [...(currentDefinition.query.dimensions ?? [])] as QueryableExploreDimensions[] | QueryableAiExploreDimensions[]

--- a/packages/analytics/dashboard-renderer/src/utils/tile-definition.ts
+++ b/packages/analytics/dashboard-renderer/src/utils/tile-definition.ts
@@ -1,4 +1,6 @@
 import type {
+  ChartTileDefinition,
+  ScatterTileDefinition,
   TableChartTileDefinition,
   TileDefinition,
 } from '@kong-ui-public/analytics-utilities'
@@ -8,6 +10,18 @@ export const isTableChartDefinition = (
   definition: TileDefinition | undefined,
 ): definition is TableChartTileDefinition => {
   return definition?.chart.type === 'table'
+}
+
+export const isRequestsChartDefinition = (
+  definition: TileDefinition | undefined,
+): definition is ScatterTileDefinition => {
+  return definition?.query?.datasource === 'requests'
+}
+
+export const isExploreChartDefinition = (
+  definition: TileDefinition | undefined,
+): definition is ChartTileDefinition => {
+  return !!definition && !isTableChartDefinition(definition) && !isRequestsChartDefinition(definition)
 }
 
 export const tileDescription = (


### PR DESCRIPTION
# Summary

Part of MA-5465

This will fix an issue with the percentile drawing and outlier dataset splitting for scatter plots. 


<details>
<summary>Multiple datasets and outliers</summary>

<img width="1236" height="512" alt="Screenshot_20260910_153057" src="https://github.com/user-attachments/assets/dbe269b8-f4bc-4d6b-8da8-5d3d222be7a2" />


</details>


<details>
<summary>One dataset filtered with outliers</summary>

<img width="1236" height="512" alt="Screenshot_20260910_153215" src="https://github.com/user-attachments/assets/e32863ad-9221-482e-9d72-39457cc90c35" />




</details>

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

<!--
## Test Coverage Exemption (Optional)
If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.

[TEST_COVERAGE_EXEMPT_REASON] give it a reason
-->
