### PR TITLE
fix(analytics): improve single value display [MA-5423]

### DIFF
--- a/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
+++ b/packages/analytics/analytics-chart/sandbox/pages/ChartDemoSimple.vue
@@ -206,16 +206,16 @@
               :label="showTrend ? 'Show Trend' : 'Hide Trend'"
             />
           </div>
+          <KSelect
+            v-model="alignX"
+            :items="alignXOptions"
+            label="Align X"
+            placeholder="Select alignment"
+          />
           <div v-if="showTrend">
             <KInputSwitch
               v-model="increaseIsBad"
               :label="increaseIsBad ? 'Increase Is Bad' : 'Increase Is Good'"
-            />
-            <KSelect
-              v-model="alignX"
-              :items="alignXOptions"
-              label="Align X"
-              placeholder="Select alignment"
             />
           </div>
         </div>
@@ -260,6 +260,12 @@
       class="simple-chart-sandbox"
       :class="{ 'single-value-sandbox': isSingleValue }"
     >
+      <div
+        v-if="isSingleValue"
+        class="single-value-preview-header"
+      >
+        Requests
+      </div>
       <SimpleChart
         :chart-data="exploreResult"
         :chart-options="simpleChartOptions"
@@ -321,7 +327,7 @@ import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'
 import type { AlignX, AnalyticsChartColors, SimpleChartType, SimpleChartOptions, SimpleChartMetricDisplay } from '../../src'
 
 import { computed, ref, inject } from 'vue'
-import { generateCrossSectionalData } from '@kong-ui-public/analytics-utilities'
+import { generateCrossSectionalData, generateData } from '@kong-ui-public/analytics-utilities'
 import { SimpleChart, TopNTable } from '../../src'
 
 type TopNMetricKind = 'count' | 'ms' | 'bytes' | 'usd' | 'rpm' | 'fallback'
@@ -415,12 +421,19 @@ const reverseDataset = ref(true)
 const gaugeNumerator = ref(0)
 const showTrend = ref(false)
 const increaseIsBad = ref(false)
-const alignX = ref<AlignX>('evenly')
+const alignX = ref<AlignX>('left')
 
 const statusCodeDimensionValues = ref(new Set(['200', '300']))
 const topNMetric = ref<TopNMetricKind>('count')
 const topNMetricCount = ref(1)
 const topNDimensionCount = ref(1)
+
+const createSingleValueData = (): ExploreResultV4 => generateData({
+  metrics: [{ name: 'request_count', unit: 'count' }],
+  timeSeries: true,
+})
+
+const singleValueData = ref<ExploreResultV4>(createSingleValueData())
 
 const metricItems = computed<SelectItem[]>(() => {
   let out = []
@@ -465,6 +478,17 @@ const exploreResult = computed<ExploreResultV4>(() => {
     return { data: [] as AnalyticsExploreRecord[], meta: {} as QueryResponseMeta }
   }
 
+  if (chartType.value === 'single_value') {
+    const data = singleValueData.value.data
+
+    return {
+      ...singleValueData.value,
+      data: showTrend.value
+        ? [data[0], data[data.length - 1]]
+        : [data[data.length - 1]],
+    }
+  }
+
   return generateCrossSectionalData([{
     name: 'request_count',
     unit: 'count',
@@ -472,7 +496,11 @@ const exploreResult = computed<ExploreResultV4>(() => {
 })
 
 const randomizeData = () => {
-  // Randomize the data
+  if (chartType.value === 'single_value') {
+    singleValueData.value = createSingleValueData()
+    return
+  }
+
   statusCodeDimensionValues.value = new Set([Math.floor(Math.random() * 1000).toString(), Math.floor(Math.random() * 1000).toString()])
 }
 
@@ -656,7 +684,7 @@ const simpleChartOptions = computed<SimpleChartOptions>(() => ({
   numerator: gaugeNumerator.value,
   showTrend: showTrend.value,
   increaseIsBad: showTrend.value ? increaseIsBad.value : false,
-  alignX: showTrend.value ? alignX.value : 'evenly',
+  alignX: alignX.value,
 }))
 
 const dataCode = computed(() => {
@@ -685,9 +713,27 @@ const isSingleValue = computed<boolean>(() => {
 
 .simple-chart-sandbox {
   &.single-value-sandbox {
+    background-color: var(--kui-color-background, #fff);
+    border: 1px solid var(--kui-color-border-neutral, #d9d9d9);
+    border-radius: var(--kui-border-radius-20, 4px);
     max-width: 100%;
-    overflow-x: auto;
-    resize: horizontal;
+    min-height: 160px;
+    min-width: 240px;
+    overflow: auto;
+    resize: both;
+    width: min(100%, 320px);
+
+    .single-value-preview-header {
+      font-size: var(--kui-font-size-40, 16px);
+      font-weight: var(--kui-font-weight-bold, 700);
+      line-height: 24px;
+      padding: var(--kui-space-40, 8px) var(--kui-space-50, 12px) 0;
+    }
+
+    :deep(.simple-chart-shell) {
+      box-sizing: border-box;
+      padding: 0 var(--kui-space-50, 12px) var(--kui-space-50, 12px);
+    }
   }
 }
 

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
@@ -40,6 +40,29 @@ const buildExploreResult = ({
 })
 
 describe('<SingleValue />', () => {
+  it('left-aligns the value and trend by default and responds to alignment changes', () => {
+    cy.mount(SingleValue, {
+      props: {
+        data: buildExploreResult(),
+        showTrend: true,
+      },
+    }).then(({ wrapper }) => {
+      cy.getTestId('single-value-parent').should('have.css', 'justify-content', 'flex-start')
+      cy.get('.single-value-metric').should('have.css', 'align-items', 'flex-start')
+      cy.get('.single-value-trend').should('have.css', 'justify-content', 'flex-start')
+
+      cy.then(() => wrapper.setProps({ alignX: 'right' }))
+      cy.getTestId('single-value-parent').should('have.css', 'justify-content', 'flex-end')
+      cy.get('.single-value-metric').should('have.css', 'align-items', 'flex-end')
+      cy.get('.single-value-trend').should('have.css', 'justify-content', 'flex-end')
+
+      cy.then(() => wrapper.setProps({ alignX: 'center', showTrend: false }))
+      cy.getTestId('single-value-parent').should('have.css', 'justify-content', 'center')
+      cy.get('.single-value-metric').should('have.css', 'align-items', 'center')
+      cy.getTestId('single-value-trend').should('not.exist')
+    })
+  })
+
   it('renders the value from the first bucket when trend is disabled', () => {
     const exploreResult = buildExploreResult({ previous: 100, current: 250 })
 
@@ -173,6 +196,7 @@ describe('<SingleValue />', () => {
       props: {
         data: exploreResult,
         leftAlign: true,
+        alignX: 'right',
       },
     })
 
@@ -191,6 +215,28 @@ describe('<SingleValue />', () => {
     cy.getTestId('single-value-parent')
       .should('have.class', 'align-center')
   })
+
+  for (const width of [240, 480]) {
+    for (const sample of [
+      { metricName: 'request_count', metricUnit: 'count', current: 8412 },
+      { metricName: 'response_latency_p95', metricUnit: 'ms', current: 35.4 },
+      { metricName: 'ai_cost', metricUnit: 'usd', current: 127.25 },
+    ]) {
+      it(`keeps ${sample.metricUnit} values and trends within a ${width}px tile`, () => {
+        cy.mount(SingleValue, {
+          props: { data: buildExploreResult(sample), showTrend: true },
+          attrs: { style: { width: `${width}px` } },
+        })
+
+        cy.getTestId('single-value-parent').should(($parent) => {
+          const parent = $parent[0]
+          expect(parent.scrollWidth).to.be.at.most(parent.clientWidth)
+        })
+        cy.getTestId('single-value-chart').should('be.visible')
+        cy.getTestId('single-value-trend').should('be.visible')
+      })
+    }
+  }
 
   it('applies positive/negative classes based on increaseIsBad', () => {
     const exploreResult = buildExploreResult({ previous: 100, current: 250 })

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.cy.ts
@@ -216,27 +216,30 @@ describe('<SingleValue />', () => {
       .should('have.class', 'align-center')
   })
 
-  for (const width of [240, 480]) {
-    for (const sample of [
-      { metricName: 'request_count', metricUnit: 'count', current: 8412 },
-      { metricName: 'response_latency_p95', metricUnit: 'ms', current: 35.4 },
-      { metricName: 'ai_cost', metricUnit: 'usd', current: 127.25 },
-    ]) {
-      it(`keeps ${sample.metricUnit} values and trends within a ${width}px tile`, () => {
-        cy.mount(SingleValue, {
-          props: { data: buildExploreResult(sample), showTrend: true },
-          attrs: { style: { width: `${width}px` } },
-        })
+  const tileCases = [
+    { width: 240, metricName: 'request_count', metricUnit: 'count', current: 8412 },
+    { width: 240, metricName: 'response_latency_p95', metricUnit: 'ms', current: 35.4 },
+    { width: 240, metricName: 'ai_cost', metricUnit: 'usd', current: 127.25 },
+    { width: 480, metricName: 'request_count', metricUnit: 'count', current: 8412 },
+    { width: 480, metricName: 'response_latency_p95', metricUnit: 'ms', current: 35.4 },
+    { width: 480, metricName: 'ai_cost', metricUnit: 'usd', current: 127.25 },
+  ]
 
-        cy.getTestId('single-value-parent').should(($parent) => {
-          const parent = $parent[0]
-          expect(parent.scrollWidth).to.be.at.most(parent.clientWidth)
-        })
-        cy.getTestId('single-value-chart').should('be.visible')
-        cy.getTestId('single-value-trend').should('be.visible')
+  tileCases.forEach(({ width, ...sample }) => {
+    it(`keeps ${sample.metricUnit} values and trends within a ${width}px tile`, () => {
+      cy.mount(SingleValue, {
+        props: { data: buildExploreResult(sample), showTrend: true },
+        attrs: { style: { width: `${width}px` } },
       })
-    }
-  }
+
+      cy.getTestId('single-value-parent').should(($parent) => {
+        const parent = $parent[0]
+        expect(parent.scrollWidth).to.be.at.most(parent.clientWidth)
+      })
+      cy.getTestId('single-value-chart').should('be.visible')
+      cy.getTestId('single-value-trend').should('be.visible')
+    })
+  })
 
   it('applies positive/negative classes based on increaseIsBad', () => {
     const exploreResult = buildExploreResult({ previous: 100, current: 250 })

--- a/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
+++ b/packages/analytics/analytics-chart/src/components/chart-types/SingleValue.vue
@@ -84,6 +84,7 @@ import {
 } from '@kong/design-tokens'
 
 import { SINGLE_VALUE_DEFAULT_DECIMAL_POINTS } from '../../constants'
+import type { AlignX } from '../../types'
 import composables from '../../composables'
 
 const { i18n } = composables.useI18n()
@@ -114,8 +115,8 @@ const props = defineProps({
     default: false,
   },
   alignX: {
-    type: String as PropType<'left' | 'center' | 'right' | 'between' | 'around' | 'evenly'>,
-    default: 'space-evenly',
+    type: String as PropType<AlignX>,
+    default: 'left',
   },
 })
 
@@ -323,6 +324,27 @@ onMounted(() => {
     justify-content: space-evenly;
   }
 
+  &.align-left,
+  &.align-between {
+    .single-value-wrapper .single-value-metric {
+      align-items: flex-start;
+    }
+
+    .single-value-wrapper .single-value-trend {
+      justify-content: flex-start;
+    }
+  }
+
+  &.align-right {
+    .single-value-wrapper .single-value-metric {
+      align-items: flex-end;
+    }
+
+    .single-value-wrapper .single-value-trend {
+      justify-content: flex-end;
+    }
+  }
+
   .single-value-error {
     &:deep(.empty-state-title) {
       font-size: var(--kui-font-size-20, $kui-font-size-20);
@@ -334,8 +356,8 @@ onMounted(() => {
   .single-value-wrapper {
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    margin-top: -4px; // to account for .tile-content top padding :(
+    gap: var(--kui-space-40, $kui-space-40);
+    max-width: 100%;
 
     .single-value-metric {
       align-items: center;
@@ -351,22 +373,25 @@ onMounted(() => {
 
     .single-value {
       color: var(--kui-color-text, $kui-color-text);
-      font-size: var(--kui-font-size-70, $kui-font-size-70);
+      font-size: var(--kui-font-size-80, $kui-font-size-80);
       font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
-      line-height: var(--kui-line-height-70, $kui-line-height-70);
+      line-height: var(--kui-line-height-80, $kui-line-height-80);
     }
 
     .single-value-unit {
       color: var(--kui-color-text, $kui-color-text);
-      font-size: var(--kui-font-size-60, $kui-font-size-60);
+      font-size: var(--kui-font-size-70, $kui-font-size-70);
       font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
-      line-height: var(--kui-line-height-60, $kui-line-height-60);
+      line-height: var(--kui-line-height-70, $kui-line-height-70);
     }
 
     .single-value-trend {
       align-items: center;
       column-gap: var(--kui-space-40, $kui-space-40);
       display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      row-gap: var(--kui-space-20, $kui-space-20);
 
       .trend-change {
         align-items: center;

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.spec.ts
@@ -15,6 +15,7 @@ import {
   filterablePlatformPresetFilterDimensions,
   slottableSchema,
   slottableTileConfigSchema,
+  singleValueSchema,
   topNTableSchema,
 } from './dashboardSchema.v2'
 import {
@@ -46,6 +47,7 @@ const validateBasicQuerySchema = ajv.compile(basicQuerySchema)
 const validateLlmUsageQuerySchema = ajv.compile(llmUsageSchema)
 const validateAgenticUsageQuerySchema = ajv.compile(agenticUsageSchema)
 const validateSlottableTileSchema = ajv.compile(slottableTileConfigSchema)
+const validateSingleValueSchema = ajv.compile(singleValueSchema)
 
 describe('dashboardSchema.v2', () => {
   const sharedPresetFilterableDimensions = [
@@ -508,6 +510,18 @@ describe('dashboardSchema.v2', () => {
       ...invalidStrictQuery,
       datasource: 'agentic_usage',
     })).toBe(false)
+  })
+
+  it.each(['left', 'center', 'right'])('accepts %s single value alignment', align_x => {
+    expect(validateSingleValueSchema({ type: 'single_value', align_x })).toBe(true)
+  })
+
+  it('accepts a single value without optional alignment', () => {
+    expect(validateSingleValueSchema({ type: 'single_value' })).toBe(true)
+  })
+
+  it.each(['between', 'LEFT', 1, null])('rejects %s single value alignment', align_x => {
+    expect(validateSingleValueSchema({ type: 'single_value', align_x })).toBe(false)
   })
 })
 

--- a/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
+++ b/packages/analytics/analytics-utilities/src/dashboardSchema.v2.ts
@@ -363,6 +363,10 @@ export const singleValueSchema = {
     decimal_points: {
       type: 'number',
     },
+    align_x: {
+      type: 'string',
+      enum: ['left', 'center', 'right'],
+    },
     chart_title: chartTitle,
   },
   required: ['type'],

--- a/packages/analytics/dashboard-renderer/sandbox/index.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/index.ts
@@ -3,6 +3,7 @@ import App from './App.vue'
 
 import Kongponents from '@kong/kongponents'
 import '@kong/kongponents/dist/style.css'
+import '@kong-ui-public/analytics-chart/dist/style.css'
 
 import sandboxQueryProvider from './sandbox-query-provider'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'

--- a/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
+++ b/packages/analytics/dashboard-renderer/sandbox/pages/RendererDemo.vue
@@ -396,20 +396,22 @@ const dashboardConfig = ref<DashboardConfig>({
       definition: {
         chart: {
           type: 'single_value',
-          chart_title: 'Single Value chart of mock data',
+          chart_title: 'Requests',
         },
         query: {
           datasource: 'basic',
-          limit: 1,
+          dimensions: ['time'],
+          granularity: 'trend',
+          metrics: ['request_count'],
         },
       },
       layout: {
         position: {
           col: 3,
-          row: 10,
+          row: 11,
         },
         size: {
-          cols: 3,
+          cols: 2,
           rows: 1,
           fit_to_content: true,
         },

--- a/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
+++ b/packages/analytics/dashboard-renderer/sandbox/sandbox-query-provider.ts
@@ -14,6 +14,29 @@ import type {
 } from '@kong-ui-public/analytics-utilities'
 import { EntityLink } from '@kong-ui-public/entities-shared'
 
+const singleValueTrendExploreResponse: ExploreResultV4 = {
+  data: [
+    {
+      event: { request_count: 7_812 },
+      timestamp: '2024-01-31T18:00:00.000Z',
+    },
+    {
+      event: { request_count: 8_412 },
+      timestamp: '2024-01-31T19:00:00.000Z',
+    },
+  ],
+  meta: {
+    display: {},
+    end: '2024-01-31T20:00:00.000Z',
+    granularity_ms: 60 * 60 * 1000,
+    metric_names: ['request_count'],
+    metric_units: { request_count: 'count' },
+    query_id: 'single-value-trend',
+    start: '2024-01-31T18:00:00.000Z',
+    truncated: false,
+  },
+}
+
 const delayedResponse = <T>(response: T): Promise<T> => {
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -24,6 +47,16 @@ const delayedResponse = <T>(response: T): Promise<T> => {
 
 const queryFn = async (query: DatasourceAwareQuery): Promise<ExploreResultV4> => {
   console.log('Querying data:', query)
+  if (
+    query.query.granularity === 'trend'
+    && query.query.dimensions?.length === 1
+    && query.query.dimensions[0] === 'time'
+    && query.query.metrics?.length === 1
+    && query.query.metrics[0] === 'request_count'
+  ) {
+    return await delayedResponse(singleValueTrendExploreResponse)
+  }
+
   if (query.query.dimensions && query.query.dimensions.includes('time')) {
     return await delayedResponse(
       generateSingleMetricTimeSeriesData(

--- a/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
+++ b/packages/analytics/dashboard-renderer/src/components/DashboardTile.vue
@@ -707,6 +707,10 @@ defineExpose({ getExportData })
     overflow: hidden;
     padding: var(--kui-space-20, $kui-space-20) var(--kui-space-60, $kui-space-60) 0 var(--kui-space-60, $kui-space-60);
 
+    &.type-chart-single_value {
+      padding: var(--kui-space-40, $kui-space-40) var(--kui-space-70, $kui-space-70) var(--kui-space-50, $kui-space-50);
+    }
+
     &.type-chart-table {
       display: flex;
       flex-direction: column;

--- a/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.cy.ts
@@ -40,6 +40,12 @@ describe('<SimpleChartRenderer />', () => {
       cy.getTestId('single-value-trend').should('contain.text', '25.00%')
       cy.getTestId('single-value-parent').should('have.css', 'justify-content', 'flex-start')
 
+      cy.then(() => wrapper.setProps({ chartOptions: { type: 'single_value', align_x: 'center' } }))
+      cy.getTestId('single-value-parent').should('have.css', 'justify-content', 'center')
+
+      cy.then(() => wrapper.setProps({ chartOptions: { type: 'single_value', align_x: 'right' } }))
+      cy.getTestId('single-value-parent').should('have.css', 'justify-content', 'flex-end')
+
       cy.then(() => wrapper.setProps({ query: { datasource: 'basic', metrics: ['request_count'] } }))
       cy.getTestId('single-value-trend').should('not.exist')
     })

--- a/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.cy.ts
+++ b/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.cy.ts
@@ -1,0 +1,47 @@
+import { defineComponent } from 'vue'
+import type { ExploreResultV4 } from '@kong-ui-public/analytics-utilities'
+import '@kong-ui-public/analytics-chart/dist/style.css'
+import SimpleChartRenderer from './SimpleChartRenderer.vue'
+
+const data: ExploreResultV4 = {
+  data: [
+    { timestamp: '2026-09-01T00:00:00Z', event: { request_count: 100 } },
+    { timestamp: '2026-09-02T00:00:00Z', event: { request_count: 125 } },
+  ],
+  meta: {
+    start: '2026-09-01T00:00:00Z',
+    end: '2026-09-03T00:00:00Z',
+    metric_names: ['request_count'],
+    metric_units: { request_count: 'count' },
+    granularity_ms: 86400000,
+  },
+}
+
+describe('<SimpleChartRenderer />', () => {
+  it('renders the current value and left-aligned trend for trend granularity', () => {
+    cy.mount(SimpleChartRenderer, {
+      props: {
+        chartOptions: { type: 'single_value' },
+        query: { datasource: 'basic', metrics: ['request_count'], dimensions: ['time'], granularity: 'trend' },
+        context: { filters: [] },
+        queryReady: true,
+        height: 160,
+        refreshCounter: 0,
+      },
+      global: {
+        stubs: {
+          QueryDataProvider: defineComponent({
+            setup: (_, { slots }) => () => slots.default?.({ data }),
+          }),
+        },
+      },
+    }).then(({ wrapper }) => {
+      cy.getTestId('single-value-chart').should('have.text', '125')
+      cy.getTestId('single-value-trend').should('contain.text', '25.00%')
+      cy.getTestId('single-value-parent').should('have.css', 'justify-content', 'flex-start')
+
+      cy.then(() => wrapper.setProps({ query: { datasource: 'basic', metrics: ['request_count'] } }))
+      cy.getTestId('single-value-trend').should('not.exist')
+    })
+  })
+})

--- a/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.vue
@@ -32,7 +32,11 @@ const props = defineProps<ChartRendererProps<GaugeChartOptions | SingleValueOpti
 const isSingleValueChart = computed((): boolean => props.chartOptions.type === 'single_value')
 
 const simpleChartOptions = computed(() => props.chartOptions.type === 'single_value'
-  ? { ...props.chartOptions, showTrend: props.query.granularity === 'trend' }
+  ? {
+    ...props.chartOptions,
+    alignX: props.chartOptions.align_x ?? 'left',
+    showTrend: props.query.granularity === 'trend',
+  }
   : props.chartOptions)
 </script>
 

--- a/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.vue
+++ b/packages/analytics/dashboard-renderer/src/components/SimpleChartRenderer.vue
@@ -13,7 +13,7 @@
     >
       <SimpleChart
         :chart-data="data"
-        :chart-options="chartOptions"
+        :chart-options="simpleChartOptions"
         :synthetics-data-key="isSingleValueChart ? undefined : (chartOptions as GaugeChartOptions).synthetics_data_key"
       />
     </div>
@@ -30,6 +30,10 @@ import { computed } from 'vue'
 const props = defineProps<ChartRendererProps<GaugeChartOptions | SingleValueOptions>>()
 
 const isSingleValueChart = computed((): boolean => props.chartOptions.type === 'single_value')
+
+const simpleChartOptions = computed(() => props.chartOptions.type === 'single_value'
+  ? { ...props.chartOptions, showTrend: props.query.granularity === 'trend' }
+  : props.chartOptions)
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
# Summary

[MA-5423](https://konghq.atlassian.net/browse/MA-5423)

Default single-value charts to left alignment, increase compact value and unit sizes, and align the value and trend consistently. Adjust single-value dashboard tile padding and derive trend visibility from the query granularity. Add optional `chart.align_x` (`left`, `center`, or `right`) to tile definitions; explicit alignment overrides the default left alignment.

Update both sandboxes with working alignment, trend, randomization, and resizing controls, including a compact Requests tile. Add component coverage for alignment and trend rendering.

<img width="2117" height="984" alt="image" src="https://github.com/user-attachments/assets/0a2c6ce3-1fa9-4343-9cc5-222709b9ea17" />
<img width="1533" height="661" alt="image" src="https://github.com/user-attachments/assets/21b20c41-68dc-40a6-b1ff-e0eb90bf4521" />
<img width="1603" height="826" alt="image" src="https://github.com/user-attachments/assets/5a847643-0d81-46a8-a695-ffe2a0e33e69" />



[MA-5423]: https://konghq.atlassian.net/browse/MA-5423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ