### PR TITLE
feat(entities): add tags multi-select filter to Kong Manager entity lists

### DIFF
--- a/packages/entities/entities-certificates/src/components/CACertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CACertificateList.vue
@@ -221,6 +221,7 @@ import {
   useTableState,
   useFetcher,
   useDeleteUrlBuilder,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
 import type {
@@ -233,9 +234,11 @@ import type {
   BaseTableHeaders,
   EmptyStateOptions,
   ExactMatchFilterConfig,
+  FilterFields,
   FuzzyMatchFilterConfig,
   TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
 const emit = defineEmits<{
@@ -339,6 +342,11 @@ const fetcherBaseUrl = computed((): string => {
   return url
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -350,9 +358,24 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
+  const filterFields: FilterFields = {
+    ...props.config.app === 'kongManager' && { tags: { ...fields.tags, searchable: true } },
+  }
+
   return {
     isExactMatch,
-    schema: props.config.filterSchema,
+    fields: filterFields,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-certificates/src/components/CertificateList.vue
+++ b/packages/entities/entities-certificates/src/components/CertificateList.vue
@@ -245,6 +245,7 @@ import {
   useFetcher,
   useDeleteUrlBuilder,
   useTableState,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
 import type {
@@ -257,9 +258,11 @@ import type {
   BaseTableHeaders,
   EmptyStateOptions,
   ExactMatchFilterConfig,
+  FilterFields,
   FuzzyMatchFilterConfig,
   TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
 const emit = defineEmits<{
@@ -368,6 +371,11 @@ const fetcherBaseUrl = computed((): string => {
     .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -379,9 +387,24 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
+  const filterFields: FilterFields = {
+    ...props.config.app === 'kongManager' && { tags: { ...fields.tags, searchable: true } },
+  }
+
   return {
     isExactMatch,
-    schema: props.config.filterSchema,
+    fields: filterFields,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
+++ b/packages/entities/entities-consumer-groups/src/components/ConsumerGroupList.vue
@@ -237,6 +237,7 @@ import {
   useAxios,
   useFetcher,
   useDeleteUrlBuilder,
+  useTagsFilter,
   TableTags,
   useTableState,
 } from '@kong-ui-public/entities-shared'
@@ -253,6 +254,7 @@ import type {
   FuzzyMatchFilterConfig,
   TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 import '@kong-ui-public/entities-shared/dist/style.css'
 import AddToGroupModal from './AddToGroupModal.vue'
 
@@ -369,6 +371,11 @@ const fetcherBaseUrl = computed<string>(() => {
     .replace(/{consumerId}/gi, props.config?.consumerId || '')
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -388,8 +395,19 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     isExactMatch,
     fields: {
       name: fields.name,
+      ...props.config.app === 'kongManager' && { tags: { ...fields.tags, searchable: true } },
     },
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-consumers/src/components/ConsumerList.vue
+++ b/packages/entities/entities-consumers/src/components/ConsumerList.vue
@@ -243,6 +243,7 @@ import {
   useAxios,
   useFetcher,
   useDeleteUrlBuilder,
+  useTagsFilter,
   TableTags,
   useTableState,
 } from '@kong-ui-public/entities-shared'
@@ -259,6 +260,7 @@ import type {
   FuzzyMatchFilterConfig,
   TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 import '@kong-ui-public/entities-shared/dist/style.css'
 import AddConsumerModal from './AddConsumerModal.vue'
 
@@ -379,6 +381,11 @@ const activeFetcherUrl = computed<string>(() => {
   return fetcherBaseUrl.value
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -395,8 +402,19 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     fields: {
       username: fields.username,
       custom_id: fields.custom_id,
+      ...props.config.app === 'kongManager' && { tags: { ...fields.tags, searchable: true } },
     },
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
+++ b/packages/entities/entities-gateway-services/src/components/GatewayServiceList.vue
@@ -299,8 +299,10 @@ import {
   useTableState,
   useFetcher,
   useDeleteUrlBuilder,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
 const emit = defineEmits<{
@@ -447,6 +449,11 @@ const baseRequestUrl = computed((): URL => {
     : new URL(fetcherBaseUrl.value)
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -458,13 +465,26 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
-  const { name, enabled, protocol, host, port, path } = fields
-  const filterFields: FilterFields = { name, enabled, protocol, host, port, path }
+  const { name, enabled, protocol, host, port, path, tags } = fields
+  const filterFields: FilterFields = {
+    name, enabled, protocol, host, port, path,
+    ...props.config.app === 'kongManager' && { tags: { ...tags, searchable: true } },
+  }
 
   return {
     isExactMatch,
     fields: filterFields,
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-key-sets/src/components/KeySetList.vue
+++ b/packages/entities/entities-key-sets/src/components/KeySetList.vue
@@ -191,6 +191,7 @@ import {
   useTableState,
   useFetcher,
   useDeleteUrlBuilder,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
 import type {
@@ -207,6 +208,7 @@ import type {
   FuzzyMatchFilterConfig,
   TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
 const emit = defineEmits<{
@@ -302,6 +304,11 @@ const fetcherBaseUrl = computed<string>(() => {
     .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -313,12 +320,25 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
-  const filterFields: FilterFields = { name: fields.name }
+  const filterFields: FilterFields = {
+    name: fields.name,
+    ...props.config.app === 'kongManager' && { tags: { ...fields.tags, searchable: true } },
+  }
 
   return {
     isExactMatch,
     fields: filterFields,
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-keys/src/components/KeyList.vue
+++ b/packages/entities/entities-keys/src/components/KeyList.vue
@@ -194,6 +194,7 @@ import {
   useFetcher,
   useDeleteUrlBuilder,
   useTableState,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
 import type {
@@ -210,6 +211,7 @@ import type {
   FuzzyMatchFilterConfig,
   TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 import '@kong-ui-public/entities-shared/dist/style.css'
 
 const emit = defineEmits<{
@@ -309,6 +311,11 @@ const fetcherBaseUrl = computed<string>(() => {
     .replace(/{keySetId}/gi, props.config?.keySetId || '')
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -320,12 +327,25 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
-  const filterFields: FilterFields = { name: fields.name }
+  const filterFields: FilterFields = {
+    name: fields.name,
+    ...props.config.app === 'kongManager' && { tags: { ...fields.tags, searchable: true } },
+  }
 
   return {
     isExactMatch,
     fields: filterFields,
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-plugins/src/components/PluginList.vue
+++ b/packages/entities/entities-plugins/src/components/PluginList.vue
@@ -350,9 +350,11 @@ import {
   useDeleteUrlBuilder,
   useTableState,
   useGatewayFeatureSupported,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
 import '@kong-ui-public/entities-shared/dist/style.css'
+import type { SelectItem } from '@kong/kongponents'
 
 import type {
   BaseTableHeaders,
@@ -569,6 +571,12 @@ const fetcherBaseUrl = computed<string>(() => buildFetcherUrl(
     : endpoints.list[props.config.app].all,
 ))
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope
+// (Konnect's enhanced plugin filtering uses `PluginFilter`/KFilterGroup, which is untouched here).
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -589,12 +597,23 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     enabled: { ...fields.enabled, label: t('search.filter.field.enabled') },
     name: fields.name,
     instance_name: { label: t('plugins.list.table_headers.instance_name'), searchable: true },
+    ...props.config.app === 'kongManager' && { tags: { ...fields.tags, searchable: true } },
   }
 
   return {
     isExactMatch: false,
     fields: filterFields,
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.vue
+++ b/packages/entities/entities-redis-configurations/src/components/RedisConfigurationList.vue
@@ -255,6 +255,7 @@ import {
   EntityTypes,
   useAxios,
   useDeleteUrlBuilder,
+  useTagsFilter,
   EntityDeleteModal,
   FetcherStatus,
   TableTags,
@@ -263,6 +264,7 @@ import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { AddIcon, RefreshIcon, DeployIcon, ClipboardIcon, DatabaseIcon } from '@kong/icons'
 import { KAlert, KExternalLink } from '@kong/kongponents'
+import type { SelectItem } from '@kong/kongponents'
 
 import { getCpgRedisAlertMessageKey, shouldShowCpgRedisAlert } from '../cpgRedisAlert'
 import { MANAGED_CACHE_FOR_REDIS_DOC_URL } from '../constants'
@@ -919,6 +921,11 @@ const emptyStateFeatures = computed(() => {
   return features
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
 
@@ -929,15 +936,29 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
-  const { name } = tableHeaders.value
+  // Konnect-managed Redis configurations don't support tags.
+  const showTagsFilter = props.config.app === 'kongManager' && !isKonnectManagedRedisEnabled.value
+
+  const { name, tags } = tableHeaders.value
   const filterFields: FilterFields = {
     name,
+    ...showTagsFilter && { tags: { ...tags, searchable: true } },
   }
 
   return {
     isExactMatch,
     fields: filterFields,
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...showTagsFilter && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-routes/src/components/RouteList.vue
+++ b/packages/entities/entities-routes/src/components/RouteList.vue
@@ -257,7 +257,7 @@ import type { AxiosError } from 'axios'
 import { useRouter } from 'vue-router'
 
 import { BadgeMethodAppearances } from '@kong/kongponents'
-import type { BadgeMethodAppearance, HeaderTag } from '@kong/kongponents'
+import type { BadgeMethodAppearance, HeaderTag, SelectItem } from '@kong/kongponents'
 import { AddIcon, ForwardIcon, BookIcon } from '@kong/icons'
 import {
   EntityBaseTable,
@@ -270,6 +270,7 @@ import {
   useFetcher,
   useTableState,
   useDeleteUrlBuilder,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
 import type {
@@ -443,6 +444,11 @@ const activeFetcherUrl = computed<string>(() => {
   return fetcherBaseUrl.value
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -455,15 +461,26 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
-  const { name, protocols, hosts, methods, paths, expression } = fields
+  const { name, protocols, hosts, methods, paths, expression, tags } = fields
   const filterFields: FilterFields = {
     name, protocols, hosts, methods, paths, ...props.hasExpressionColumn && { expression },
+    ...props.config.app === 'kongManager' && { tags: { ...tags, searchable: true } },
   }
 
   return {
     isExactMatch,
     fields: filterFields,
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-shared/fixtures/mockData.ts
+++ b/packages/entities/entities-shared/fixtures/mockData.ts
@@ -77,10 +77,9 @@ export const mockFuzzyMatchFilterConfig = {
       label: 'Paths',
       searchable: true,
     },
-    // To hide certain fields in the filter, set their `searchable` to `false
     tags: {
       label: 'Tags',
-      searchable: false,
+      searchable: true,
     },
   },
   schema: {
@@ -90,6 +89,12 @@ export const mockFuzzyMatchFilterConfig = {
     },
     port: {
       type: 'number',
+    },
+    tags: {
+      type: 'select',
+      multiple: true,
+      enableItemCreation: true,
+      values: ['tag1', 'tag2', 'tag3'],
     },
   },
 } satisfies FuzzyMatchFilterConfig

--- a/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.cy.ts
+++ b/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.cy.ts
@@ -113,5 +113,80 @@ describe('<EntityFilter />', () => {
         })
       })
     })
+
+    it('should render a multiselect for a field with schema.multiple and emit its value when applied', () => {
+      // The multiselect popover's positioning logic can trigger a benign, well-known browser warning
+      // ("ResizeObserver loop completed with undelivered notifications") that Cypress otherwise treats as a test failure.
+      cy.on('uncaught:exception', (err) => !err.message.includes('ResizeObserver loop'))
+
+      cy.mount(EntityFilter, {
+        props: {
+          modelValue: '',
+          config: mockFuzzyMatchFilterConfig,
+        },
+      })
+
+      cy.get('.kong-ui-entity-filter [data-testid="filter-button"]').click()
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"]').click()
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"] .k-multiselect').should('exist').click()
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"] .k-multiselect').contains('tag1').click()
+      // eslint-disable-next-line cypress/unsafe-to-chain-command
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"] [data-testid="apply-filter"]').click().then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'update:modelValue').then((evt) => {
+          cy.wrap(evt[0][0]).should('be.equal', 'tags=tag1')
+        })
+      })
+    })
+
+    it('should re-emit an unchanged comma-joined value when a multi-value tags filter is re-applied', () => {
+      cy.mount(EntityFilter, {
+        props: {
+          modelValue: 'tags=tag1,tag2',
+          config: mockFuzzyMatchFilterConfig,
+        },
+      })
+
+      cy.get('.kong-ui-entity-filter [data-testid="filter-button"]').click()
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"]').click()
+      // eslint-disable-next-line cypress/unsafe-to-chain-command
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"] [data-testid="apply-filter"]').click().then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'update:modelValue').then((evt) => {
+          // URLSearchParams percent-encodes ',' as %2C; the server decodes it back to the literal comma
+          cy.wrap(evt[0][0]).should('be.equal', 'tags=tag1%2Ctag2')
+        })
+      })
+    })
+
+    it('should restore selected tags from an existing comma-joined modelValue', () => {
+      cy.mount(EntityFilter, {
+        props: {
+          modelValue: 'tags=tag1,tag2',
+          config: mockFuzzyMatchFilterConfig,
+        },
+      })
+
+      cy.get('.kong-ui-entity-filter [data-testid="filter-button"]').click()
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"]').click()
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"] .k-multiselect').contains('tag1').should('be.visible')
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"] .k-multiselect').contains('tag2').should('be.visible')
+    })
+
+    it('should remove the tags param entirely when cleared', () => {
+      cy.mount(EntityFilter, {
+        props: {
+          modelValue: 'tags=tag1,tag2',
+          config: mockFuzzyMatchFilterConfig,
+        },
+      })
+
+      cy.get('.kong-ui-entity-filter [data-testid="filter-button"]').click()
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"]').click()
+      // eslint-disable-next-line cypress/unsafe-to-chain-command
+      cy.get('.kong-ui-entity-filter-menu [data-testid="tags"] [data-testid="clear-filter"]').click().then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'update:modelValue').then((evt) => {
+          cy.wrap(evt[0][0]).should('be.equal', '')
+        })
+      })
+    })
   })
 })

--- a/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
+++ b/packages/entities/entities-shared/src/components/entity-filter/EntityFilter.vue
@@ -76,24 +76,34 @@
             >
               {{ t('filter.fieldLabel') }}
             </label>
+            <KMultiselect
+              v-if="config.schema?.[field.value]?.type === 'select' && config.schema?.[field.value]?.multiple"
+              :id="getFieldId(field.value)"
+              :enable-item-creation="config.schema?.[field.value]?.enableItemCreation"
+              :items="getMultiselectOptions(field.value)"
+              :model-value="getMultiselectValue(field.value)"
+              :placeholder="t('filter.selectPlaceholder')"
+              @update:model-value="(items) => handleMultiselectChange(field.value, items)"
+            />
             <KSelect
-              v-if="config.schema?.[field.value]?.type === 'select'"
+              v-else-if="config.schema?.[field.value]?.type === 'select'"
               :id="getFieldId(field.value)"
               :enable-filtering="enableFiltering(field.value)"
               :enable-item-creation="config.schema?.[field.value]?.enableItemCreation"
               :filter-function="(params: SelectFilterFunctionParams<string | number>) => handleFilter(field.value, params)"
               :items="getFieldOptions(field.value)"
-              :model-value="searchParams[field.value]"
+              :model-value="getSingleSelectValue(field.value)"
               :placeholder="t('filter.selectPlaceholder')"
               @change="(item) => handleSelectChange(field.value, item)"
             />
             <KInput
               v-else
               :id="getFieldId(field.value)"
-              v-model="searchParams[field.value]"
               autocomplete="off"
+              :model-value="getSingleSelectValue(field.value)"
               :placeholder="t('filter.inputPlaceholder')"
               :type="getFieldInputType(field.value)"
+              @update:model-value="(value) => { searchParams[field.value] = String(value ?? '') }"
             />
           </div>
           <div
@@ -166,8 +176,11 @@ const emit = defineEmits<{
 }>()
 
 const showMenu = ref(false)
-const searchParams = ref<{ [key: string]: string }>({})
+const searchParams = ref<{ [key: string]: string | string[] }>({})
 const expandedFields = ref<Set<string>>(new Set())
+
+const isMultiField = (field: string): boolean =>
+  !!(props.config as FuzzyMatchFilterConfig).schema?.[field]?.multiple
 
 const filteredFields = computed<string[]>(() => {
   const fields: string[] = []
@@ -194,9 +207,9 @@ const searchableFields = computed<Array<{ label: string, value: string, expanded
 watch(() => props.modelValue, (val) => {
   searchParams.value = {}
   new URLSearchParams(val).forEach((value, key) => {
-    searchParams.value[key] = value
+    searchParams.value[key] = isMultiField(key) ? value.split(',').filter(Boolean) : value
   })
-})
+}, { immediate: true })
 
 const toggleMenu = () => {
   showMenu.value = !showMenu.value
@@ -226,6 +239,14 @@ const getFieldOptions = (field: string) =>
   ((props.config as FuzzyMatchFilterConfig).schema?.[field]?.values ?? [])
     .map(o => typeof o === 'string' ? { value: o, label: o } : o)
 
+const getMultiselectOptions = (field: string) =>
+  getFieldOptions(field).map(o => ({ ...o, value: String(o.value) }))
+
+const getSingleSelectValue = (field: string): string | undefined => {
+  const value = searchParams.value[field]
+  return Array.isArray(value) ? undefined : value
+}
+
 const getFieldInputType = (field: string) => {
   return (props.config as FuzzyMatchFilterConfig).schema?.[field]?.type ?? 'text'
 }
@@ -233,7 +254,7 @@ const getFieldInputType = (field: string) => {
 const clearField = (field: string) => {
   searchParams.value = {
     ...searchParams.value,
-    [field]: '',
+    [field]: isMultiField(field) ? [] : '',
   }
   applyFields()
 }
@@ -247,8 +268,13 @@ const applyFields = (hideMenu = false) => {
   const filteredParams = Object
     .keys(searchParams.value)
     .reduce((acc, key) => {
-      if (searchParams.value[key]) {
-        acc[key] = `${searchParams.value[key]}`
+      const value = searchParams.value[key]
+      if (Array.isArray(value)) {
+        if (value.length) {
+          acc[key] = value.join(',')
+        }
+      } else if (value) {
+        acc[key] = `${value}`
       }
       return acc
     }, {} as { [key: string]: string })
@@ -279,6 +305,15 @@ const handleSelectChange = (field: string, item: (SelectItem & { custom?: boolea
   searchParams.value[field] = item
     ? item.custom ? String(item.label) : String(item.value)
     : ''
+}
+
+const getMultiselectValue = (field: string): string[] => {
+  const value = searchParams.value[field]
+  return Array.isArray(value) ? value : []
+}
+
+const handleMultiselectChange = (field: string, items: string[]) => {
+  searchParams.value[field] = items
 }
 </script>
 

--- a/packages/entities/entities-shared/src/composables/index.ts
+++ b/packages/entities/entities-shared/src/composables/index.ts
@@ -14,6 +14,7 @@ import useTruncationDetector from './useTruncationDetector'
 import useValidators from './useValidators'
 import { useSchema, useSchemaProvider, useSubSchema } from './useSchema'
 import useTableState from './useTableState'
+import useTagsFilter from './useTagsFilter'
 
 // All composables must be exported as part of the default object for Cypress test stubs
 export default {
@@ -37,4 +38,5 @@ export default {
   useSchemaProvider,
   useSubSchema,
   useTableState,
+  useTagsFilter,
 }

--- a/packages/entities/entities-shared/src/composables/useTagsFilter.ts
+++ b/packages/entities/entities-shared/src/composables/useTagsFilter.ts
@@ -1,0 +1,54 @@
+import { onMounted, ref } from 'vue'
+import type { SelectItem } from '@kong/kongponents'
+import type { KongManagerConfig } from '../types'
+import useAxios from './useAxios'
+
+interface TagRecord {
+  tag: string
+}
+
+/**
+ * Fetches the first page of tag-to-entity associations from the Admin API `/tags` endpoint
+ * and returns a deduplicated list of tag names to use as select options for the tags filter.
+ *
+ * The `/tags` endpoint returns paginated tag-to-entity association records rather than a
+ * distinct list of tag names, so this only surfaces suggestions from the first page; users can
+ * still type in a tag that isn't part of the initial suggestions via `enableItemCreation`.
+ */
+export default function useTagsFilter(config: KongManagerConfig) {
+  const tagOptions = ref<SelectItem[]>([])
+  const tagsLoading = ref(false)
+
+  const buildTagsUrl = (): string => {
+    const url = `${config.apiBaseUrl}/{workspace}/tags`
+    return url.replace(/\/{workspace}/gi, config.workspace ? `/${config.workspace}` : '')
+  }
+
+  const fetchTags = async (): Promise<void> => {
+    tagsLoading.value = true
+
+    try {
+      const { axiosInstance } = useAxios(config.axiosRequestConfig)
+      const { data } = await axiosInstance.get<{ data: TagRecord[] }>(buildTagsUrl(), {
+        params: { size: 100 },
+      })
+
+      const uniqueTags = Array.from(new Set((data?.data ?? []).map((record) => record.tag).filter(Boolean)))
+      tagOptions.value = uniqueTags.map((tag) => ({ label: tag, value: tag }))
+    } catch (err) {
+      console.error('useTagsFilter', err)
+      tagOptions.value = []
+    } finally {
+      tagsLoading.value = false
+    }
+  }
+
+  onMounted(() => {
+    fetchTags()
+  })
+
+  return {
+    tagOptions,
+    tagsLoading,
+  }
+}

--- a/packages/entities/entities-shared/src/index.ts
+++ b/packages/entities/entities-shared/src/index.ts
@@ -23,13 +23,13 @@ import TableTags from './components/common/TableTags.vue'
 import composables from './composables'
 
 // Extract specific composables to export
-const { useAxios, useDeleteUrlBuilder, useBaseEntityDeckOptions, useBaseFormDeckOptions, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchema, useSchemaProvider, useTableState } = composables
+const { useAxios, useDeleteUrlBuilder, useBaseEntityDeckOptions, useBaseFormDeckOptions, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchema, useSchemaProvider, useTableState, useTagsFilter } = composables
 
 // Components
 export { OnboardingCard, EntityBaseConfigCard, ConfigCardItem, ConfigCardDisplay, InternalLinkItem, EntityBaseForm, EntityBaseTable, EntityDeleteModal, EntityFilter, EntityToggleModal, PermissionsWrapper, EntityFormSection, EntityFormBlock, EntityLink, EntityEmptyState, JsonCodeBlock, TerraformCodeBlock, YamlCodeBlock, DeckCodeBlock, GeneratePatModal, SensitiveInput, TableTags }
 
 // Composables
-export { useAxios, useDeleteUrlBuilder, useBaseEntityDeckOptions, useBaseFormDeckOptions, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchema, useSchemaProvider, useTableState }
+export { useAxios, useDeleteUrlBuilder, useBaseEntityDeckOptions, useBaseFormDeckOptions, useErrors, useExternalLinkCreator, useFetchUrlBuilder, useFetcher, useFetcherCacheKey, useDebouncedFilter, useStringHelpers, useHelpers, useGatewayFeatureSupported, useTruncationDetector, useValidators, useSchema, useSchemaProvider, useTableState, useTagsFilter }
 
 // Types
 export * from './types'

--- a/packages/entities/entities-shared/src/types/entity-filter.ts
+++ b/packages/entities/entities-shared/src/types/entity-filter.ts
@@ -34,6 +34,8 @@ export interface FilterSchema {
     values?: string[] | SelectItem[]
     /** Allow users to create custom items in the select input, only used if type is 'select' */
     enableItemCreation?: boolean
+    /** Render the select input as a multiselect and join selected values with ',' when applied, only used if type is 'select' */
+    multiple?: boolean
   }
 }
 

--- a/packages/entities/entities-snis/src/components/SniList.vue
+++ b/packages/entities/entities-snis/src/components/SniList.vue
@@ -205,6 +205,7 @@ import {
   useFetcher,
   useDeleteUrlBuilder,
   useTableState,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
 import type {
@@ -221,6 +222,7 @@ import type {
   FuzzyMatchFilterConfig,
   TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 import '@kong-ui-public/entities-shared/dist/style.css'
 import { AddIcon, BookIcon, CloudIcon } from '@kong/icons'
 
@@ -336,6 +338,11 @@ const fetcherBaseUrl = computed<string>(() => {
     .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -347,13 +354,25 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
-  const { name } = fields
-  const filterFields: FilterFields = { name }
+  const { name, tags } = fields
+  const filterFields: FilterFields = {
+    name, ...props.config.app === 'kongManager' && { tags: { ...tags, searchable: true } },
+  }
 
   return {
     isExactMatch,
     fields: filterFields,
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
+++ b/packages/entities/entities-upstreams-targets/src/components/UpstreamsList.vue
@@ -182,8 +182,10 @@ import {
   EntityDeleteModal,
   useAxios,
   EntityTypes,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 import type { PropType } from 'vue'
 import { computed, onBeforeMount, ref, watch } from 'vue'
 import type { AxiosError } from 'axios'
@@ -300,6 +302,11 @@ const fetcherBaseUrl = computed((): string => {
     .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -311,13 +318,25 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
-  const { name, slots } = fields
-  const filterFields: FilterFields = { name, slots }
+  const { name, slots, tags } = fields
+  const filterFields: FilterFields = {
+    name, slots, ...props.config.app === 'kongManager' && { tags: { ...tags, searchable: true } },
+  }
 
   return {
     isExactMatch,
     fields: filterFields,
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...props.config.app === 'kongManager' && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 

--- a/packages/entities/entities-vaults/src/components/VaultList.vue
+++ b/packages/entities/entities-vaults/src/components/VaultList.vue
@@ -194,6 +194,7 @@ import {
   useFetcher,
   useDeleteUrlBuilder,
   useTableState,
+  useTagsFilter,
   TableTags,
 } from '@kong-ui-public/entities-shared'
 
@@ -205,6 +206,7 @@ import type {
   FuzzyMatchFilterConfig,
   TableErrorMessage,
 } from '@kong-ui-public/entities-shared'
+import type { SelectItem } from '@kong/kongponents'
 
 import composables from '../composables'
 import endpoints from '../vaults-endpoints'
@@ -331,6 +333,11 @@ const fetcherBaseUrl = computed<string>(() => {
     .replace(/\/{workspace}/gi, props.config?.workspace ? `/${props.config.workspace}` : '')
 })
 
+// Tags filter options are only relevant for Kong Manager's fuzzy-match filter; Konnect is out of scope.
+const { tagOptions } = props.config.app === 'kongManager'
+  ? useTagsFilter(props.config)
+  : { tagOptions: ref<SelectItem[]>([]) }
+
 const filterQuery = ref<string>('')
 const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['config']>(() => {
   const isExactMatch = (props.config.app === 'konnect' || props.config.isExactMatch)
@@ -342,13 +349,26 @@ const filterConfig = computed<InstanceType<typeof EntityFilter>['$props']['confi
     } as ExactMatchFilterConfig
   }
 
-  const { prefix, name } = fields
-  const filterFields: FilterFields = { name, prefix }
+  // AI Gateway uses labels instead of tags, so the tags filter is not applicable there.
+  const showTagsFilter = props.config.app === 'kongManager' && !isAiGateway.value
+
+  const { prefix, name, tags } = fields
+  const filterFields: FilterFields = { name, prefix, ...showTagsFilter && { tags: { ...tags, searchable: true } } }
 
   return {
     isExactMatch: false,
     fields: filterFields,
-    schema: props.config.filterSchema,
+    schema: {
+      ...props.config.filterSchema,
+      ...showTagsFilter && {
+        tags: props.config.filterSchema?.tags ?? {
+          type: 'select',
+          multiple: true,
+          enableItemCreation: true,
+          values: tagOptions.value,
+        },
+      },
+    },
   } as FuzzyMatchFilterConfig
 })
 


### PR DESCRIPTION
## Summary

- Kong Manager's entity list filter (`EntityFilter`) supported single-value `select` fields only; `tags` was shown as a table column on every entity but was never a filter dimension.
- Extends the shared `FilterSchema`/`EntityFilter.vue` with a `multiple` mode rendered as `KMultiselect`; selected values are joined with `,` when applied (Admin API AND semantics) and split back out when restoring from the query string.
- Adds a new `useTagsFilter` composable that fetches the first page of `GET /tags` and surfaces the distinct tag names as select suggestions (`enableItemCreation` lets users type a tag not in that first page, since `/tags` returns paginated tag-to-entity associations rather than a deduplicated tag list).
- Wires a `tags` filter into every Kong Manager entity list still using `EntityFilter`: Routes, Gateway Services, Consumers, Consumer Groups, Plugins, Vaults, Upstreams, SNIs, Keys, Key Sets, Certificates, CA Certificates, Redis Configurations.

## Out of scope

- **Konnect** — gated out everywhere (`config.app === 'kongManager'` only).
- **Plugins' enhanced filter UI** (`PluginFilter.vue` / KFilterGroup, behind `pluginTableImprovements.filtering`) — untouched. That UI already has its own tags filter using `/` (OR) semantics; Plugins' Kong Manager view uses the plain `EntityFilter` path this PR extends, so it gets the new `,` (AND) tags filter without touching the other UI.
- Vaults in AI Gateway mode and Redis Configurations with Konnect-managed Redis enabled don't get the filter, since those already hide the `tags` column.

## Test plan

- [x] `EntityFilter.cy.ts` — new cases for multiselect rendering, comma-joined apply, clear, and restoring selections from an existing query string.
- [x] Existing Cypress component suites for every touched entity list re-run green (Routes, Gateway Services, Consumers, Consumer Groups, Vaults, Upstreams, SNIs, Keys, Key Sets, Certificates, CA Certificates, Redis Configurations, Plugins).
- [x] `vue-tsc` typecheck and `eslint` clean on all touched packages.
- [ ] Manual verification against a live Admin API `/tags` response was not done in this session (no ticket/manual QA pass requested for this draft).