### PR TITLE
feat(core): init package for e-charts [OLLY-1320]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,6 +39,7 @@
 /packages/core/expressions/ @Kong/team-km @Kong/team-core-ui
 /packages/core/table-data-grid @Kong/team-data @Kong/team-core-ui
 /packages/core/freeform/ @Kong/team-km @Kong/team-core-ui
+/packages/core/e-charts/ @Kong/team-core-ui @Kong/team-data
 
 # Portal packages
 /packages/portal/document-viewer/ @Kong/team-devx @Kong/team-core-ui

--- a/packages/core/e-charts/LICENSE
+++ b/packages/core/e-charts/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Kong, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/core/e-charts/README.md
+++ b/packages/core/e-charts/README.md
@@ -1,0 +1,31 @@
+# @kong-ui-public/e-charts
+
+{A description of this package}
+
+- [Features](#features)
+- [Requirements](#requirements)
+- [Usage](#usage)
+  - [Install](#install)
+  - [Props](#props)
+
+## Features
+
+- List of package features
+
+## Requirements
+
+- List of package requirements (e.g. "`vue` and must be initialized in the host application")
+
+## Usage
+
+### Install
+
+{Installation instructions}
+
+### Props
+
+#### `example`
+
+- type: `Boolean`
+- required: `false`
+- default: `false`

--- a/packages/core/e-charts/package.json
+++ b/packages/core/e-charts/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@kong-ui-public/e-charts",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./dist/e-charts.umd.js",
+  "module": "./dist/e-charts.es.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/e-charts.es.js",
+      "require": "./dist/e-charts.umd.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": "./dist/*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "dev": "cross-env USE_SANDBOX=true vite",
+    "build": "run-s typecheck build:package build:types",
+    "build:package": "vite build -m production",
+    "build:analyzer": "BUILD_VISUALIZER='core/e-charts' vite build -m production",
+    "build:types": "vue-tsc -p './tsconfig.build.json' --emitDeclarationOnly",
+    "build:sandbox": "cross-env USE_SANDBOX=true vite build -m production",
+    "preview": "cross-env USE_SANDBOX=true vite preview",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
+    "stylelint": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}'",
+    "stylelint:fix": "stylelint --allow-empty-input './src/**/*.{css,scss,sass,less,styl,vue}' --fix",
+    "typecheck": "vue-tsc -p './tsconfig.build.json' --noEmit",
+    "test:component": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress run --component -b chrome --spec './src/**/*.cy.ts' --project '../../../.'",
+    "test:component:open": "BABEL_ENV=cypress cross-env FORCE_COLOR=1 cypress open --component -b chrome --project '../../../.'",
+    "test:unit": "cross-env FORCE_COLOR=1 vitest run",
+    "test:unit:open": "cross-env FORCE_COLOR=1 vitest --ui"
+  },
+  "devDependencies": {
+    "@kong/design-tokens": "3.3.1",
+    "@kong/kongponents": "9.64.15",
+    "vue": "^3.5.41"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/public-ui-components.git",
+    "directory": "packages/core/e-charts"
+  },
+  "homepage": "https://github.com/Kong/public-ui-components/tree/main/packages/core/e-charts",
+  "bugs": {
+    "url": "https://github.com/Kong/public-ui-components/issues"
+  },
+  "author": "Kong, Inc.",
+  "license": "Apache-2.0",
+  "volta": {
+    "extends": "../../../package.json"
+  },
+  "distSizeChecker": {
+    "errorLimit": "200KB"
+  },
+  "peerDependencies": {
+    "@kong/kongponents": "9.64.15",
+    "vue": "^3.5.41"
+  }
+}

--- a/packages/core/e-charts/sandbox/App.vue
+++ b/packages/core/e-charts/sandbox/App.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="sandbox-container">
+    <main>
+      <p>This is the component sandbox.</p>
+      <ECharts />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ECharts } from '../src'
+</script>

--- a/packages/core/e-charts/sandbox/index.html
+++ b/packages/core/e-charts/sandbox/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ECharts Component Sandbox</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+      html,
+      body {
+        font-family: "Inter", Helvetica, Arial, sans-serif;
+      }
+
+    </style>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+
+</html>

--- a/packages/core/e-charts/sandbox/index.ts
+++ b/packages/core/e-charts/sandbox/index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+const app = createApp(App)
+
+app.mount('#app')

--- a/packages/core/e-charts/sandbox/tsconfig.json
+++ b/packages/core/e-charts/sandbox/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.vue",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/core/e-charts/src/components/ECharts.cy.ts
+++ b/packages/core/e-charts/src/components/ECharts.cy.ts
@@ -1,0 +1,11 @@
+// Cypress component test spec file
+
+import ECharts from './ECharts.vue'
+
+describe('<ECharts />', () => {
+  it('TODO: This is an example test', () => {
+    cy.mount(ECharts)
+
+    cy.get('.kong-ui-public-e-charts').should('be.visible')
+  })
+})

--- a/packages/core/e-charts/src/components/ECharts.spec.ts
+++ b/packages/core/e-charts/src/components/ECharts.spec.ts
@@ -1,0 +1,13 @@
+// Vitest unit test spec file
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ECharts from './ECharts.vue'
+
+describe('<ECharts />', () => {
+  it('renders', () => {
+    const wrapper = mount(ECharts)
+
+    expect(wrapper.isVisible()).toBe(true)
+  })
+})

--- a/packages/core/e-charts/src/components/ECharts.vue
+++ b/packages/core/e-charts/src/components/ECharts.vue
@@ -1,0 +1,16 @@
+<template>
+  <!-- The <div> tag here is just a placeholder for your component content. -->
+  <!-- We recommend wrapping your component with a unique class when possible, as shown below. -->
+  <div class="kong-ui-public-e-charts">
+    <p>This is the <b>ECharts</b> content.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style lang="scss" scoped>
+.kong-ui-public-e-charts {
+  // Add component styles as needed
+}
+</style>

--- a/packages/core/e-charts/src/global-components.d.ts
+++ b/packages/core/e-charts/src/global-components.d.ts
@@ -1,0 +1,2 @@
+// Import globally available components
+import '@kong/kongponents/dist/types/global-components'

--- a/packages/core/e-charts/src/index.ts
+++ b/packages/core/e-charts/src/index.ts
@@ -1,0 +1,17 @@
+// import type { App } from 'vue'
+import ECharts from './components/ECharts.vue'
+
+// Export Vue plugin
+// We rarely want to export components as a plugin as we prefer to support proper tree-shaking in the host application. Only enable if you're packing a Vue plugin.
+// export default {
+//   // Customize Vue plugin options as desired
+//   // Providing a `name` property allows for customizing the registered
+//   // name of your component (useful if exporting a single component).
+//   install: (app: App, options: { name?: string, [key: string]: any } = {}): void => {
+//     app.component(options.name || 'ECharts', ECharts)
+//   },
+// }
+
+export { ECharts }
+
+export * from './types'

--- a/packages/core/e-charts/src/locales/en.json
+++ b/packages/core/e-charts/src/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "header": {
+    "title": "Title of the header",
+    "content": "Content of the header"
+  }
+}

--- a/packages/core/e-charts/src/types/index.ts
+++ b/packages/core/e-charts/src/types/index.ts
@@ -1,0 +1,7 @@
+// Export all types and interfaces from this index.ts
+// The actual types and interfaces should be contained in separate files within this folder.
+
+// Example:
+// export * from './component-types'
+
+export {}

--- a/packages/core/e-charts/tsconfig.build.json
+++ b/packages/core/e-charts/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.cy.ts",
+    "src/**/*.spec.ts",
+    "sandbox",
+    "dist"
+  ]
+}

--- a/packages/core/e-charts/tsconfig.json
+++ b/packages/core/e-charts/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "declarationDir": "dist/types",
+    "types": [
+      "node",
+      "vite/client",
+      "cypress",
+      "cypress/vue",
+      "../../../cypress/support"
+    ]
+  },
+  "include": [
+    "src/**/*",
+    "sandbox/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/core/e-charts/vite.config.ts
+++ b/packages/core/e-charts/vite.config.ts
@@ -1,0 +1,32 @@
+import sharedViteConfig, { sanitizePackageName } from '../../../vite.config.shared'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig, mergeConfig } from 'vite'
+
+// Package name MUST always match the kebab-case package name inside the component's package.json file and the name of your `/packages/{package-name}` directory
+const packageName = 'e-charts'
+const sanitizedPackageName = sanitizePackageName(packageName)
+
+// Merge the shared Vite config with the local one defined below
+const config = mergeConfig(sharedViteConfig, defineConfig({
+  build: {
+    lib: {
+      // The kebab-case name of the exposed global variable. MUST be in the format `kong-ui-public-{package-name}`
+      // Example: name: 'kong-ui-public-demo-component'
+      name: `kong-ui-public-${sanitizedPackageName}`,
+      entry: resolve(dirname(fileURLToPath(import.meta.url)), './src/index.ts'),
+      fileName: (format) => `${sanitizedPackageName}.${format}.js`,
+      cssFileName: 'style',
+    },
+  },
+}))
+
+// If we are trying to preview a build of the local `package/e-charts/sandbox` directory,
+// unset the lib, rollupOptions.external and rollupOptions.output.globals properties
+if (process.env.USE_SANDBOX) {
+  config.build.lib = undefined
+  config.build.rollupOptions.external = undefined
+  config.build.rollupOptions.output.global = undefined
+}
+
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,18 @@ importers:
         specifier: ^3.5.41
         version: 3.5.41(typescript@5.9.3)
 
+  packages/core/e-charts:
+    devDependencies:
+      '@kong/design-tokens':
+        specifier: 3.3.1
+        version: 3.3.1
+      '@kong/kongponents':
+        specifier: 9.64.15
+        version: 9.64.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-router@5.3.1(@vue/compiler-sfc@3.5.41)(esbuild@0.28.1)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup@4.62.2)(vite@7.3.6(@types/node@24.13.3)(jiti@2.5.1)(lightningcss@1.33.0)(sass-embedded@1.80.3)(sass@1.104.0)(terser@5.51.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))(webpack@5.110.3))(vue@3.5.41(typescript@5.9.3))
+      vue:
+        specifier: ^3.5.41
+        version: 3.5.41(typescript@5.9.3)
+
   packages/core/entities-config-editor:
     devDependencies:
       '@kong/design-tokens':
@@ -14962,24 +14974,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@1.20.6(supports-color@7.2.0):
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9(supports-color@7.2.0)
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.1
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.15.3
-      raw-body: 2.5.3
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   bonjour-service@1.4.3:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -15379,19 +15373,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  compression@1.8.1(supports-color@7.2.0):
-    dependencies:
-      bytes: 3.1.2
-      compressible: 2.0.18
-      debug: 2.6.9(supports-color@7.2.0)
-      negotiator: 0.6.4
-      on-headers: 1.1.0
-      safe-buffer: 5.2.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   concat-map@0.0.1: {}
 
@@ -15901,13 +15882,6 @@ snapshots:
       ms: 2.0.0
     optionalDependencies:
       supports-color: 10.2.2
-
-  debug@2.6.9(supports-color@7.2.0):
-    dependencies:
-      ms: 2.0.0
-    optionalDependencies:
-      supports-color: 7.2.0
-    optional: true
 
   debug@3.2.7(supports-color@8.1.1):
     dependencies:
@@ -16568,43 +16542,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@4.22.2(supports-color@7.2.0):
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.6(supports-color@7.2.0)
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.0.7
-      debug: 2.6.9(supports-color@7.2.0)
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.3.2(supports-color@7.2.0)
-      fresh: 0.5.2
-      http-errors: 2.0.1
-      merge-descriptors: 1.0.3
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.13
-      proxy-addr: 2.0.7
-      qs: 6.15.3
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.19.2(supports-color@7.2.0)
-      serve-static: 1.16.3(supports-color@7.2.0)
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   exsolve@1.0.8: {}
 
   ext@1.7.0:
@@ -16712,19 +16649,6 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-
-  finalhandler@1.3.2(supports-color@7.2.0):
-    dependencies:
-      debug: 2.6.9(supports-color@7.2.0)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   find-node-modules@2.1.3:
     dependencies:
@@ -17261,19 +17185,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy-middleware@2.0.10(@types/express@4.17.25)(debug@4.4.3(supports-color@7.2.0)):
-    dependencies:
-      '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@7.2.0))
-      is-glob: 4.0.3
-      is-plain-obj: 3.0.0
-      micromatch: 4.0.8
-    optionalDependencies:
-      '@types/express': 4.17.25
-    transitivePeerDependencies:
-      - debug
-    optional: true
-
   http-proxy@1.18.1(debug@4.4.3(supports-color@10.2.2)):
     dependencies:
       eventemitter3: 4.0.7
@@ -17281,15 +17192,6 @@ snapshots:
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
-
-  http-proxy@1.18.1(debug@4.4.3(supports-color@7.2.0)):
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
-      requires-port: 1.0.0
-    transitivePeerDependencies:
-      - debug
-    optional: true
 
   http-signature@1.4.0:
     dependencies:
@@ -20271,25 +20173,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@0.19.2(supports-color@7.2.0):
-    dependencies:
-      debug: 2.6.9(supports-color@7.2.0)
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.1
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   serialize-error@8.1.0:
     dependencies:
       type-fest: 0.20.2
@@ -20306,19 +20189,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-index@1.9.2(supports-color@7.2.0):
-    dependencies:
-      accepts: 1.3.8
-      batch: 0.6.1
-      debug: 2.6.9(supports-color@7.2.0)
-      escape-html: 1.0.3
-      http-errors: 1.8.1
-      mime-types: 2.1.35
-      parseurl: 1.3.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   serve-static@1.16.3(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
@@ -20327,16 +20197,6 @@ snapshots:
       send: 0.19.2(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
-
-  serve-static@1.16.3(supports-color@7.2.0):
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 0.19.2(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   set-function-length@1.2.2:
     dependencies:
@@ -20571,18 +20431,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy-transport@3.0.0(supports-color@7.2.0):
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      detect-node: 2.1.0
-      hpack.js: 2.1.6
-      obuf: 1.1.2
-      readable-stream: 3.6.2
-      wbuf: 1.7.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   spdy@4.0.2(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -20592,17 +20440,6 @@ snapshots:
       spdy-transport: 3.0.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
-
-  spdy@4.0.2(supports-color@7.2.0):
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      handle-thing: 2.0.1
-      http-deceiver: 1.2.7
-      select-hose: 2.0.0
-      spdy-transport: 3.0.0(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   speakingurl@14.0.1: {}
 
@@ -21915,7 +21752,7 @@ snapshots:
       js-yaml: 5.4.1
       json5: 2.2.3
       webpack-bundle-analyzer: 5.3.2
-      webpack-dev-server: 5.2.6(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)(tslib@2.8.1)(webpack-cli@7.2.2)(webpack@5.110.3)
+      webpack-dev-server: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@7.2.2)(webpack@5.110.3)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.110.3):
     dependencies:
@@ -21969,47 +21806,6 @@ snapshots:
       - supports-color
       - tslib
       - utf-8-validate
-
-  webpack-dev-server@5.2.6(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)(tslib@2.8.1)(webpack-cli@7.2.2)(webpack@5.110.3):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.25
-      '@types/express-serve-static-core': 4.19.9
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.10
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.18.1
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.4.3
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.8.1(supports-color@7.2.0)
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.2(supports-color@7.2.0)
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3(supports-color@7.2.0))
-      ipaddr.js: 2.4.0
-      launch-editor: 2.14.1
-      open: 10.2.0
-      p-retry: 6.2.1
-      schema-utils: 4.3.3
-      selfsigned: 5.5.0
-      serve-index: 1.9.2(supports-color@7.2.0)
-      sockjs: 0.3.24
-      spdy: 4.0.2(supports-color@7.2.0)
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.110.3)
-      ws: 8.21.3
-    optionalDependencies:
-      webpack: 5.110.3(@swc/core@1.15.7)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.26)(uglify-js@3.19.3)(webpack-cli@7.2.2)
-      webpack-cli: 7.2.2(js-yaml@5.4.1)(json5@2.2.3)(webpack-bundle-analyzer@5.3.2)(webpack-dev-server@5.2.6)(webpack@5.110.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - tslib
-      - utf-8-validate
-    optional: true
 
   webpack-merge@6.0.1:
     dependencies:


### PR DESCRIPTION
# Summary

**Background:**
there is a new requirement in AI observability world ([Jira](https://konghq.atlassian.net/browse/OLLY-1320)), where we need to add some new chart types that aren't supported by our existing analytics chart library (i.e. chart-js)
Hence, we want to explore using the [Apache e-charts](https://echarts.apache.org/en/index.html) package for them (it's free, open-source, has well maintained [vue package](https://vue-echarts.dev/), and covers all our new chart type requirements)

**Why not add it in exisitng analytics-charts package?**
although for now we'll use it inside analytics dashboards, but as soon as next month onwards, we need to use it in other parts of Konnect e.g. AI gateway MFE, AI observability L1 items like conversations, etc. Also, it'll be a very thin wrapper around e-charts package itself, unlike the current analytics-charts components that are heavily custom built around analytics APIs. Moreover, analytics-charts already bundles chart-js so adding another charting package will bump up the bundle size to too big.

Hence, spinning up a separate new core package for this.

Resolves: https://konghq.atlassian.net/browse/OLLY-1320